### PR TITLE
don't include null values in the query string

### DIFF
--- a/Refit/RequestBuilderImplementation.cs
+++ b/Refit/RequestBuilderImplementation.cs
@@ -84,8 +84,7 @@ namespace Refit
                         continue;
                     }
 
-                    if (paramList[i] != null)
-                    {
+                    if (paramList[i] != null) {
                         queryParamsToAdd[restMethod.QueryParameterMap[i]] = paramList[i].ToString();
                     }
                 }


### PR DESCRIPTION
I'm attempting to use this assembly for my API and to pass (optional) oData query parameters.

For example:

``` cs
Task<IList<TimesheetLineModel>> Get([AliasAs("id")] int businessId, [AliasAs("$orderby")] string orderBy = null, [AliasAs("$filter")] string filter = null);
```

In the case where I don't supply a value for those orderBy/filter parameters, they shouldn't be included in the query string.

At the moment, it just dies with a null reference exception.
