### PR TITLE
MakeGenericMethod throws ArgumentNullException

### DIFF
--- a/Refit-Tests/RestService.cs
+++ b/Refit-Tests/RestService.cs
@@ -46,6 +46,9 @@ namespace Refit.Tests
     {
         [Get("/users/{username}")]
         Task<User> GetUser(string userName);
+
+        [Get("/")]
+        Task<HttpResponseMessage> GetIndex();
     }
 
     [TestFixture]
@@ -59,6 +62,17 @@ namespace Refit.Tests
 
             result.Wait();
             Assert.AreEqual("octocat", result.Result.login);
+        }
+
+        [Test]
+        public void ShouldRetHttpResponseMessage() 
+        {
+            var fixture = RestService.For<IGitHubApi>("https://api.github.com");
+            var result = fixture.GetIndex();
+
+            result.Wait();
+            Assert.IsNotNull(result.Result);
+            Assert.IsTrue(result.Result.IsSuccessStatusCode);
         }
     }
 }

--- a/Refit/RequestBuilderImplementation.cs
+++ b/Refit/RequestBuilderImplementation.cs
@@ -164,7 +164,7 @@ namespace Refit
             return async (client, paramList) => {
                 var rq = factory(paramList);
                 var resp = await client.SendAsync(rq);
-                if (restMethod.SerializedReturnType == null) {
+                if (restMethod.SerializedReturnType == typeof(HttpResponseMessage)) {
                     return resp as T;
                 }
 
@@ -419,7 +419,6 @@ namespace Refit
 
             ReturnType = methodInfo.ReturnType;
             SerializedReturnType = methodInfo.ReturnType.GetGenericArguments()[0];
-            if (SerializedReturnType == typeof(HttpResponseMessage)) SerializedReturnType = null;
             return;
 
         bogusMethod:


### PR DESCRIPTION
Title pretty much sums it up, was crashing in a project on this line: https://github.com/paulcbetts/refit/blob/master/Refit/RequestBuilderImplementation.cs#L129

``` text
An exception of type 'System.ArgumentNullException' occurred in mscorlib.dll but was not handled in user code

Additional information: Value cannot be null.
```
