### PR TITLE
Support for URL encoded form posts.

### DIFF
--- a/Refit/Attributes.cs
+++ b/Refit/Attributes.cs
@@ -70,7 +70,7 @@ namespace Refit
     }
 
     public enum BodySerializationMethod {
-        Json, Xml,
+        Json, UrlEncoded
     }
 
     [AttributeUsage(AttributeTargets.Parameter)]


### PR DESCRIPTION
I'm not sure if this is done yet. So far there's only support for URL encoded form data in the request body -- not the response. I've never come across an API that responds with form data. The Slack API is the only API I can think of that accepts form data, but it responds with JSON.

The other thing I'm not sure what to do about is XML. There was a `BodySerializationMethod.Xml` but I removed it because, as far as I can tell, refit doesn't support XML at all yet. There was definitely nothing referring to that enum value anyway.
