### PR TITLE
Include System.Collections.Generic and System.Linq in the using directives

### DIFF
--- a/InterfaceStubGenerator/GeneratedInterfaceStubTemplate.mustache
+++ b/InterfaceStubGenerator/GeneratedInterfaceStubTemplate.mustache
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Net.Http;
+using System.Collections.Generic;
+using System.Linq;
 {{#UsingList}}
 using {{Item}};
 {{/UsingList}}

--- a/InterfaceStubGenerator/InterfaceStubGenerator.cs
+++ b/InterfaceStubGenerator/InterfaceStubGenerator.cs
@@ -70,7 +70,7 @@ namespace Refit.Generator
                         .Select(x => x.Name.ToString());
                 })
                 .Distinct()
-                .Where(x => x != "System" && x != "System.Net.Http")
+                .Where(x => x != "System" && x != "System.Net.Http" && x != "System.Collections.Generic" && x != "System.Linq")
                 .Select(x => new UsingDeclaration() { Item = x });
 
             var ret = new TemplateInformation() {


### PR DESCRIPTION
Refit itself needs these using directives for `Dictionary` and `ToDictionary`
