### PR TITLE
Fix for build errors for spaces in solution path

### DIFF
--- a/Refit/targets/refit.targets
+++ b/Refit/targets/refit.targets
@@ -2,10 +2,10 @@
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup Condition="'$(OS)' == 'Windows_NT'">
-    <PreBuildEvent>$(SolutionDir)packages\refit.2.0.1\tools\InterfaceStubGenerator.exe "$(ProjectDir)RefitStubs.cs" "@(Compile)"</PreBuildEvent>
+    <PreBuildEvent>"$(SolutionDir)packages\refit.2.0.1\tools\InterfaceStubGenerator.exe" "$(ProjectDir)RefitStubs.cs" "@(Compile)"</PreBuildEvent>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(OS)' != 'Windows_NT'">
-    <PreBuildEvent>mono $(SolutionDir)packages/refit.2.0.1/tools/InterfaceStubGenerator.exe "$(ProjectDir)RefitStubs.cs" "@(Compile)"</PreBuildEvent>
+    <PreBuildEvent>mono "$(SolutionDir)packages/refit.2.0.1/tools/InterfaceStubGenerator.exe" "$(ProjectDir)RefitStubs.cs" "@(Compile)"</PreBuildEvent>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Some dummies like me have spaces in their solution paths, which breaks the call out to `InterfaceStubGenerator.exe`
