### PR TITLE
Allow spaces after attribute names.

### DIFF
--- a/InterfaceStubGenerator/InterfaceStubGenerator.cs
+++ b/InterfaceStubGenerator/InterfaceStubGenerator.cs
@@ -65,7 +65,7 @@ namespace Refit.Generator
             // but what if somebody is dumb and uses a constant?
             // Could be turtles all the way down.
             return method.AttributeLists.SelectMany(a => a.Attributes)
-                .Any(a => httpMethodAttributeNames.Contains(a.Name.ToFullString().Split('.').Last()) &&
+                .Any(a => httpMethodAttributeNames.Contains(a.Name.ToString().Split('.').Last()) &&
                     a.ArgumentList.Arguments.Count == 1 &&
                     a.ArgumentList.Arguments[0].Expression.CSharpKind() == SyntaxKind.StringLiteralExpression);
         }

--- a/Refit-Tests/InterfaceStubGenerator.cs
+++ b/Refit-Tests/InterfaceStubGenerator.cs
@@ -69,6 +69,7 @@ namespace Refit.Tests
             Assert.IsFalse(result["NoConstantsAllowed"]);
             Assert.IsFalse(result["NotARefitMethod"]);
             Assert.IsTrue(result["ReadOne"]);
+            Assert.IsTrue(result["SpacesShouldntBreakMe"]);
         }
 
         [Test]
@@ -132,6 +133,9 @@ namespace Refit.Tests
 
         [Get(ThisIsDumbButMightHappen.PeopleDoWeirdStuff)]
         Task NoConstantsAllowed();
+
+        [Get  ("spaces-shouldnt-break-me")]
+        Task SpacesShouldntBreakMe();
     }
 
     public interface IAmNotARefitInterface

--- a/Refit-Tests/RefitStubs.cs
+++ b/Refit-Tests/RefitStubs.cs
@@ -138,6 +138,12 @@ namespace Refit.Tests
             throw new NotImplementedException("Either this method has no Refit HTTP method attribute or you've used something other than a string literal for the 'path' argument.");
         }
 
+        public virtual Task SpacesShouldntBreakMe()
+        {
+            var arguments = new object[] {  };
+            return (Task) methodImpls["SpacesShouldntBreakMe"](Client, arguments);
+        }
+
     }
 }
 


### PR DESCRIPTION
Using `AttributeSyntax.ToFullString()` was breaking detection of Refit attributes if there was a space between the attribute name and the bracket, because the "full" string includes trivia.

Replacing with `AttributeSyntax.ToString()` fixed that problem and didn't break any other tests so I think it's good.

Fixes #73.
