### PR TITLE
disable unassigned warnings for fields in the PreserveAttribute class

### DIFF
--- a/InterfaceStubGenerator/GeneratedInterfaceStubTemplate.mustache
+++ b/InterfaceStubGenerator/GeneratedInterfaceStubTemplate.mustache
@@ -17,12 +17,14 @@ namespace RefitInternalGenerated
     [AttributeUsage (AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Enum | AttributeTargets.Constructor | AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Event | AttributeTargets.Interface | AttributeTargets.Delegate)]
     sealed class PreserveAttribute : Attribute
     {
+#pragma warning disable 0649
         //
         // Fields
         //
         public bool AllMembers;
 
         public bool Conditional;
+#pragma warning enable 0649
     }
 }
 


### PR DESCRIPTION
Resolves issue #76 whereby visual studio would spew warnings
that RefitInternalGenerated.PreserveAttribute.X is never
assigned.
