### PR TITLE
Add .Net Framework 4.0.3 as a supported target

### DIFF
--- a/Refit/FormValueDictionary.cs
+++ b/Refit/FormValueDictionary.cs
@@ -74,7 +74,7 @@ namespace Refit
         PropertyInfo[] GetProperties(Type type)
         {
             return type.GetProperties(BindingFlags.Instance | BindingFlags.Public)
-                       .Where(p => p.CanRead && p.GetMethod.IsPublic)
+                       .Where(p => p.CanRead && p.GetGetMethod(true).IsPublic)
                        .ToArray();
         }
     }

--- a/Refit/Net403Stubs.cs
+++ b/Refit/Net403Stubs.cs
@@ -1,0 +1,191 @@
+﻿#if NET403
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace Refit
+{
+    public static class TypeExtensions
+    {
+        public static Type GetTypeInfo(this Type type)
+        {
+            return type;
+        }
+    }
+
+    public static class PropertyInforExtensions
+    {
+        public static object GetValue(this PropertyInfo info, object @object)
+        {
+            return info.GetValue(@object, BindingFlags.Default, null, null, null);
+        }
+    }
+
+    public static class CustomAttributeExtensions
+    {
+        #region APIs that return a single attribute
+        public static Attribute GetCustomAttribute(this Assembly element, Type attributeType)
+        {
+            return Attribute.GetCustomAttribute(element, attributeType);
+        }
+        public static Attribute GetCustomAttribute(this Module element, Type attributeType)
+        {
+            return Attribute.GetCustomAttribute(element, attributeType);
+        }
+        public static Attribute GetCustomAttribute(this MemberInfo element, Type attributeType)
+        {
+            return Attribute.GetCustomAttribute(element, attributeType);
+        }
+        public static Attribute GetCustomAttribute(this ParameterInfo element, Type attributeType)
+        {
+            return Attribute.GetCustomAttribute(element, attributeType);
+        }
+
+        public static T GetCustomAttribute<T>(this Assembly element) where T : Attribute
+        {
+            return (T)GetCustomAttribute(element, typeof(T));
+        }
+        public static T GetCustomAttribute<T>(this Module element) where T : Attribute
+        {
+            return (T)GetCustomAttribute(element, typeof(T));
+        }
+        public static T GetCustomAttribute<T>(this MemberInfo element) where T : Attribute
+        {
+            return (T)GetCustomAttribute(element, typeof(T));
+        }
+        public static T GetCustomAttribute<T>(this ParameterInfo element) where T : Attribute
+        {
+            return (T)GetCustomAttribute(element, typeof(T));
+        }
+
+        public static Attribute GetCustomAttribute(this MemberInfo element, Type attributeType, bool inherit)
+        {
+            return Attribute.GetCustomAttribute(element, attributeType, inherit);
+        }
+        public static Attribute GetCustomAttribute(this ParameterInfo element, Type attributeType, bool inherit)
+        {
+            return Attribute.GetCustomAttribute(element, attributeType, inherit);
+        }
+
+        public static T GetCustomAttribute<T>(this MemberInfo element, bool inherit) where T : Attribute
+        {
+            return (T)GetCustomAttribute(element, typeof(T), inherit);
+        }
+        public static T GetCustomAttribute<T>(this ParameterInfo element, bool inherit) where T : Attribute
+        {
+            return (T)GetCustomAttribute(element, typeof(T), inherit);
+        }
+        #endregion
+
+        #region APIs that return all attributes
+        public static IEnumerable<Attribute> GetCustomAttributes(this Assembly element)
+        {
+            return Attribute.GetCustomAttributes(element);
+        }
+        public static IEnumerable<Attribute> GetCustomAttributes(this Module element)
+        {
+            return Attribute.GetCustomAttributes(element);
+        }
+        public static IEnumerable<Attribute> GetCustomAttributes(this MemberInfo element)
+        {
+            return Attribute.GetCustomAttributes(element);
+        }
+        public static IEnumerable<Attribute> GetCustomAttributes(this ParameterInfo element)
+        {
+            return Attribute.GetCustomAttributes(element);
+        }
+
+        public static IEnumerable<Attribute> GetCustomAttributes(this MemberInfo element, bool inherit)
+        {
+            return Attribute.GetCustomAttributes(element, inherit);
+        }
+        public static IEnumerable<Attribute> GetCustomAttributes(this ParameterInfo element, bool inherit)
+        {
+            return Attribute.GetCustomAttributes(element, inherit);
+        }
+        #endregion
+
+        #region APIs that return all attributes of a particular type
+        public static IEnumerable<Attribute> GetCustomAttributes(this Assembly element, Type attributeType)
+        {
+            return Attribute.GetCustomAttributes(element, attributeType);
+        }
+        public static IEnumerable<Attribute> GetCustomAttributes(this Module element, Type attributeType)
+        {
+            return Attribute.GetCustomAttributes(element, attributeType);
+        }
+        public static IEnumerable<Attribute> GetCustomAttributes(this MemberInfo element, Type attributeType)
+        {
+            return Attribute.GetCustomAttributes(element, attributeType);
+        }
+        public static IEnumerable<Attribute> GetCustomAttributes(this ParameterInfo element, Type attributeType)
+        {
+            return Attribute.GetCustomAttributes(element, attributeType);
+        }
+
+        public static IEnumerable<T> GetCustomAttributes<T>(this Assembly element) where T : Attribute
+        {
+            return (IEnumerable<T>)GetCustomAttributes(element, typeof(T));
+        }
+        public static IEnumerable<T> GetCustomAttributes<T>(this Module element) where T : Attribute
+        {
+            return (IEnumerable<T>)GetCustomAttributes(element, typeof(T));
+        }
+        public static IEnumerable<T> GetCustomAttributes<T>(this MemberInfo element) where T : Attribute
+        {
+            return (IEnumerable<T>)GetCustomAttributes(element, typeof(T));
+        }
+        public static IEnumerable<T> GetCustomAttributes<T>(this ParameterInfo element) where T : Attribute
+        {
+            return (IEnumerable<T>)GetCustomAttributes(element, typeof(T));
+        }
+
+        public static IEnumerable<Attribute> GetCustomAttributes(this MemberInfo element, Type attributeType, bool inherit)
+        {
+            return Attribute.GetCustomAttributes(element, attributeType, inherit);
+        }
+        public static IEnumerable<Attribute> GetCustomAttributes(this ParameterInfo element, Type attributeType, bool inherit)
+        {
+            return Attribute.GetCustomAttributes(element, attributeType, inherit);
+        }
+
+        public static IEnumerable<T> GetCustomAttributes<T>(this MemberInfo element, bool inherit) where T : Attribute
+        {
+            return (IEnumerable<T>)GetCustomAttributes(element, typeof(T), inherit);
+        }
+        public static IEnumerable<T> GetCustomAttributes<T>(this ParameterInfo element, bool inherit) where T : Attribute
+        {
+            return (IEnumerable<T>)GetCustomAttributes(element, typeof(T), inherit);
+        }
+        #endregion
+
+        #region IsDefined
+        public static bool IsDefined(this Assembly element, Type attributeType)
+        {
+            return Attribute.IsDefined(element, attributeType);
+        }
+        public static bool IsDefined(this Module element, Type attributeType)
+        {
+            return Attribute.IsDefined(element, attributeType);
+        }
+        public static bool IsDefined(this MemberInfo element, Type attributeType)
+        {
+            return Attribute.IsDefined(element, attributeType);
+        }
+        public static bool IsDefined(this ParameterInfo element, Type attributeType)
+        {
+            return Attribute.IsDefined(element, attributeType);
+        }
+
+        public static bool IsDefined(this MemberInfo element, Type attributeType, bool inherit)
+        {
+            return Attribute.IsDefined(element, attributeType, inherit);
+        }
+        public static bool IsDefined(this ParameterInfo element, Type attributeType, bool inherit)
+        {
+            return Attribute.IsDefined(element, attributeType, inherit);
+        }
+        #endregion
+    }
+}
+#endif

--- a/Refit/PushStreamContent.cs
+++ b/Refit/PushStreamContent.cs
@@ -110,7 +110,11 @@ namespace System.Net.Http
             {
                 onStreamAvailable(stream, content, transportContext);
                 // https://github.com/ASP-NET-MVC/aspnetwebstack/blob/5118a14040b13f95bf778d1fc4522eb4ea2eef18/src/Common/TaskHelpers.cs#L10
+#if NET403
+                return TaskEx.FromResult<AsyncVoid>(default);
+#else
                 return Task.FromResult<AsyncVoid>(default);
+#endif
             };
         }
 
@@ -260,7 +264,11 @@ namespace System.Net.Http
             return innerStream.Read(buffer, offset, count);
         }
 
+#if NET403
+        public Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+#else
         public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+#endif
         {
             return innerStream.ReadAsync(buffer, offset, count, cancellationToken);
         }
@@ -275,12 +283,21 @@ namespace System.Net.Http
             innerStream.Flush();
         }
 
+#if NET403
+
+        public Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
+#else
         public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
+#endif
         {
             return innerStream.CopyToAsync(destination, bufferSize, cancellationToken);
         }
+#if NET403
 
+        public Task FlushAsync(CancellationToken cancellationToken)
+#else
         public override Task FlushAsync(CancellationToken cancellationToken)
+#endif
         {
             return innerStream.FlushAsync(cancellationToken);
         }
@@ -295,7 +312,11 @@ namespace System.Net.Http
             innerStream.Write(buffer, offset, count);
         }
 
+#if NET403
+        public Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+#else
         public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+#endif
         {
             return innerStream.WriteAsync(buffer, offset, count, cancellationToken);
         }

--- a/Refit/Refit.csproj
+++ b/Refit/Refit.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Product>Refit ($(TargetFramework))</Product>
-    <TargetFrameworks>netstandard1.4;net461;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net403;netstandard1.4;net461;netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile Condition=" '$(Configuration)' == 'Release' ">true</GenerateDocumentationFile>
     <DebugType>embedded</DebugType>
   </PropertyGroup>
@@ -25,7 +25,14 @@
     <Reference Include="System.Net.Http" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'net403'">
+    <Reference Include="System.Web" />
+    <PackageReference Include="Microsoft.Net.Http" Version="2.2.29" />
+    <PackageReference Include="Microsoft.Bcl.Async" Version="1.0.168" />
+  </ItemGroup>
+
   <ItemGroup Label="Package">
+    <None Include="targets\refit.targets" PackagePath="build\net403" Pack="true" />
     <None Include="targets\refit.targets" PackagePath="build\net461" Pack="true" />
     <None Include="targets\refit.targets" PackagePath="build\netstandard1.4" Pack="true" />
     <None Include="..\InterfaceStubGenerator.BuildTasks\bin\$(Configuration)\net46\publish\**\*.*" LinkBase="build\MSBuildFull46" PackagePath="build\MSBuildFull46" Pack="true" />

--- a/Refit/RequestBuilderImplementation.cs
+++ b/Refit/RequestBuilderImplementation.cs
@@ -306,7 +306,7 @@ namespace Refit
             var kvps = new List<KeyValuePair<string, object>>();
 
             var props = @object.GetType().GetProperties(BindingFlags.Instance | BindingFlags.Public)
-                .Where(p => p.CanRead && p.GetMethod.IsPublic);
+                .Where(p => p.CanRead && p.GetGetMethod(true).IsPublic);
 
             foreach (var propertyInfo in props)
             {


### PR DESCRIPTION
With the Multi-targeting capability of the new VS2017 project tooling, it is much easier to add backwards compatibility to projects.  This opens refit up to an even wider array of consumers (we need it for calling APIs from WPF kiosk applications running on Windows XP Embedded (yes, I know!) )

This PR adds support to refit for .Net Framework 4.0.3 by adding conditional compilation shims where appropriate and adding .Net 4.0.3 specific package references for async and HttpClient.  

Note that any project using refit will still need to be built on a machine with net462 so that the build tasks are correctly called.