### PR TITLE
Small refactoring for typeIsCollection variable

### DIFF
--- a/Refit/RequestBuilderImplementation.cs
+++ b/Refit/RequestBuilderImplementation.cs
@@ -565,12 +565,7 @@ namespace Refit
                     // Check to see if it's an IEnumerable
                     var itemValue = paramList[i];
                     var enumerable = itemValue as IEnumerable<object>;
-                    var typeIsCollection = false;
-
-                    if (enumerable != null)
-                    {
-                        typeIsCollection = true;
-                    }
+                    var typeIsCollection = enumerable != null;
 
                     if (typeIsCollection)
                     {


### PR DESCRIPTION
If we can reduce the number of `if`, why don't we do this? :)

The main point is removing useless if, because we can use `==` instead of it.