### PR TITLE
Split extensions into separate project

### DIFF
--- a/.vsts-shared.yml
+++ b/.vsts-shared.yml
@@ -24,12 +24,21 @@ steps:
 - task: DotNetCoreCLI@2
   inputs:
     command: pack
-    packagesToPack: '**/Refit.*.csproj;-:**/*.Tests.csproj'
+    packagesToPack: Refit/Refit.csproj
     configuration: $(BuildConfiguration)
     packDirectory: $(Build.ArtifactStagingDirectory)\artifacts
     nobuild: true
     verbosityPack: Minimal
   displayName: Pack
+
+- task: DotNetCoreCLI@2
+  inputs:
+    command: pack
+    packagesToPack: Refit.HttpClientFactory/Refit.HttpClientFactory.csproj
+    configuration: $(BuildConfiguration)
+    packDirectory: $(Build.ArtifactStagingDirectory)\artifacts    
+    verbosityPack: Minimal
+  displayName: Pack Extensions
 
 - task: DotNetCoreCLI@2
   inputs:

--- a/.vsts-shared.yml
+++ b/.vsts-shared.yml
@@ -17,14 +17,18 @@ steps:
 - task: DotNetCoreCLI@2
   inputs:
     command: build
-    projects: Refit/Refit.csproj
+    projects: |      
+      Refit/Refit.HttpClientFactory.csproj
+      Refit/Refit.csproj
     arguments: -c $(BuildConfiguration)   
   displayName: Build
   
 - task: DotNetCoreCLI@2
   inputs:
     command: pack
-    packagesToPack: Refit/Refit.csproj
+    packagesToPack: |
+      Refit/Refit.csproj
+      Refit/Refit.HttpClientFactory.csproj
     configuration: $(BuildConfiguration)
     packDirectory: $(Build.ArtifactStagingDirectory)\artifacts
     nobuild: true

--- a/.vsts-shared.yml
+++ b/.vsts-shared.yml
@@ -17,18 +17,14 @@ steps:
 - task: DotNetCoreCLI@2
   inputs:
     command: build
-    projects: |      
-      Refit/Refit.HttpClientFactory.csproj
-      Refit/Refit.csproj
+    projects: Refit/Refit.csproj
     arguments: -c $(BuildConfiguration)   
   displayName: Build
   
 - task: DotNetCoreCLI@2
   inputs:
     command: pack
-    packagesToPack: |
-      Refit/Refit.csproj
-      Refit/Refit.HttpClientFactory.csproj
+    packagesToPack: '**/Refit.*.csproj;-:**/*.Tests.csproj'
     configuration: $(BuildConfiguration)
     packDirectory: $(Build.ArtifactStagingDirectory)\artifacts
     nobuild: true

--- a/README.md
+++ b/README.md
@@ -582,7 +582,8 @@ var api = RestService.For<IReallyExcitingCrudApi<User, string>>("http://api.exam
 
 ### Using HttpClientFactory
 
-Refit has first class support for the ASP.Net Core 2.1 HttpClientFactory. Simply call the provided extension method in your `ConfigureServices` method to configure your Refit interface:
+Refit has first class support for the ASP.Net Core 2.1 HttpClientFactory. Add a reference to `Refit.HttpClientFactory` and call 
+the provided extension method in your `ConfigureServices` method to configure your Refit interface:
 
 ```csharp
 services.AddRefitClient<IWebApi>()

--- a/Refit.HttpClientFactory/HttpClientFactoryExtensions.cs
+++ b/Refit.HttpClientFactory/HttpClientFactoryExtensions.cs
@@ -1,5 +1,4 @@
-﻿#if NETSTANDARD2_0
-using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Extensions.DependencyInjection;
 
 namespace Refit
 {
@@ -14,4 +13,3 @@ namespace Refit
         }
     }
 }
-#endif

--- a/Refit.HttpClientFactory/Refit.HttpClientFactory.csproj
+++ b/Refit.HttpClientFactory/Refit.HttpClientFactory.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <Product>Refit HTTP Client Factory Extensions</Product>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <DebugType>embedded</DebugType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Refit\Refit.csproj" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="2.1.0" />
+  </ItemGroup>
+
+</Project>

--- a/Refit.Tests/Refit.Tests.csproj
+++ b/Refit.Tests/Refit.Tests.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="System.Reactive" Version="4.0.0" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="4.0.0" />
     <ProjectReference Include="..\InterfaceStubGenerator.App\InterfaceStubGenerator.App.csproj" />
+    <ProjectReference Include="..\Refit.HttpClientFactory\Refit.HttpClientFactory.csproj" />
     <ProjectReference Include="..\Refit\Refit.csproj" />
   </ItemGroup>
 

--- a/Refit.sln
+++ b/Refit.sln
@@ -30,6 +30,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "InterfaceStubGenerator.App"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "InterfaceStubGenerator.BuildTasks", "InterfaceStubGenerator.BuildTasks\InterfaceStubGenerator.BuildTasks.csproj", "{DE66466A-4912-4352-B973-E544D3073DDC}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Refit.HttpClientFactory", "Refit.HttpClientFactory\Refit.HttpClientFactory.csproj", "{01AE14AC-88D1-49C4-A612-2F9B2DEB5DEA}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -122,6 +124,22 @@ Global
 		{DE66466A-4912-4352-B973-E544D3073DDC}.Release|x64.Build.0 = Release|Any CPU
 		{DE66466A-4912-4352-B973-E544D3073DDC}.Release|x86.ActiveCfg = Release|Any CPU
 		{DE66466A-4912-4352-B973-E544D3073DDC}.Release|x86.Build.0 = Release|Any CPU
+		{01AE14AC-88D1-49C4-A612-2F9B2DEB5DEA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{01AE14AC-88D1-49C4-A612-2F9B2DEB5DEA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{01AE14AC-88D1-49C4-A612-2F9B2DEB5DEA}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{01AE14AC-88D1-49C4-A612-2F9B2DEB5DEA}.Debug|ARM.Build.0 = Debug|Any CPU
+		{01AE14AC-88D1-49C4-A612-2F9B2DEB5DEA}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{01AE14AC-88D1-49C4-A612-2F9B2DEB5DEA}.Debug|x64.Build.0 = Debug|Any CPU
+		{01AE14AC-88D1-49C4-A612-2F9B2DEB5DEA}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{01AE14AC-88D1-49C4-A612-2F9B2DEB5DEA}.Debug|x86.Build.0 = Debug|Any CPU
+		{01AE14AC-88D1-49C4-A612-2F9B2DEB5DEA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{01AE14AC-88D1-49C4-A612-2F9B2DEB5DEA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{01AE14AC-88D1-49C4-A612-2F9B2DEB5DEA}.Release|ARM.ActiveCfg = Release|Any CPU
+		{01AE14AC-88D1-49C4-A612-2F9B2DEB5DEA}.Release|ARM.Build.0 = Release|Any CPU
+		{01AE14AC-88D1-49C4-A612-2F9B2DEB5DEA}.Release|x64.ActiveCfg = Release|Any CPU
+		{01AE14AC-88D1-49C4-A612-2F9B2DEB5DEA}.Release|x64.Build.0 = Release|Any CPU
+		{01AE14AC-88D1-49C4-A612-2F9B2DEB5DEA}.Release|x86.ActiveCfg = Release|Any CPU
+		{01AE14AC-88D1-49C4-A612-2F9B2DEB5DEA}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Refit/Refit.csproj
+++ b/Refit/Refit.csproj
@@ -8,7 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Condition="'$(TargetFramework)' == 'netstandard1.4' " Include="System.Net.Http" Version="4.3.3" />
     <Compile Remove="Features\**\*.*" />
@@ -18,10 +17,6 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.4' ">
     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="1.1.2" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.5.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="Microsoft.Extensions.Http" Version="2.1.0" />
   </ItemGroup>
   
   <ItemGroup Condition="'$(TargetFramework)' == 'net461'">


### PR DESCRIPTION
This is to prevent adding a lot of dependencies to projects not using HTTP Client Factory and enable it for ASP.NET Core running on .NET 4.6.1.