### PR TITLE
Updating documentation for RFC 7807 support

### DIFF
--- a/index.md
+++ b/index.md
@@ -520,18 +520,19 @@ var api = RestService.For<IReallyExcitingCrudApi<User, string>>("http://api.exam
 To encapsulate any exceptions that may come from a service, you can catch an `ApiException` which contains request- and response information. Refit also supports the catching of validation exceptions that are thrown by a service implementing the RFC 7807 specification for problem details due to bad requests. For specific information on the problem details of the validation exception, simply catch `ValidationApiException`:
 
 ```csharp
-//...
+// ...
 try
 {
    var result = await awesomeApi.GetFooAsync("bar");
 }
 catch (ValidationApiException validationException)
 {
-   //handle validation here by using validationException.Content, which is type of ProblemDetails according to RFC 7807
+   // handle validation here by using validationException.Content, 
+   // which is type of ProblemDetails according to RFC 7807
 }
 catch (ApiException exception)
 {
-   //other exception handling
+   // other exception handling
 }
-//...
+// ...
 ```

--- a/index.md
+++ b/index.md
@@ -514,3 +514,24 @@ Which can be used like this:
 // than one type (unless you have a different domain for each type)
 var api = RestService.For<IReallyExcitingCrudApi<User, string>>("http://api.example.com/users"); 
 ``` 
+
+### Handling exceptions
+
+To encapsulate any exceptions that may come from a service, you can catch an `ApiException` which contains request- and response information. Refit also supports the catching of validation exceptions that are thrown by a service implementing the RFC 7807 specification for problem details due to bad requests. For specific information on the problem details of the validation exception, simply catch `ValidationApiException`:
+
+```csharp
+//...
+try
+{
+   var result = await awesomeApi.GetFooAsync("bar");
+}
+catch (ValidationApiException validationException)
+{
+   //handle validation here by using validationException.Content, which is type of ProblemDetails according to RFC 7807
+}
+catch (ApiException exception)
+{
+   //other exception handling
+}
+//...
+```


### PR DESCRIPTION
Added documentation to cover the usage of `ApiException` in scenarios where RFC 7807 is implemented.