### PR TITLE
ApiResponse property ContentHeaders

### DIFF
--- a/Refit/ApiResponse.cs
+++ b/Refit/ApiResponse.cs
@@ -30,6 +30,7 @@ namespace Refit
 
         public T Content { get; }
         public HttpResponseHeaders Headers => response.Headers;
+        public HttpContentHeaders ContentHeaders => response.Content?.Headers;
         public bool IsSuccessStatusCode => response.IsSuccessStatusCode;
         public string ReasonPhrase => response.ReasonPhrase;
         public HttpRequestMessage RequestMessage => response.RequestMessage;


### PR DESCRIPTION
Expose the content headers also in the ApiResponse.

Fixes #577 