### PR TITLE
 Add support for url form encoding collections

### DIFF
--- a/Refit.Tests/FormValueDictionaryTests.cs
+++ b/Refit.Tests/FormValueDictionaryTests.cs
@@ -49,11 +49,54 @@ namespace Refit.Tests
             Assert.Equal(expected, actual);
         }
 
+        [Fact]
+        public void LoadFromObjectWithCollections()
+        {
+            var source = new ObjectWithRepeatedFieldsTestClass
+            {
+                A = new List<string> { "list1", "list2" },
+                B = new HashSet<string> { "set1", "set2" },
+                C = new HashSet<int> { 1, 2 },
+                D = new List<double> { 0.1, 1.0 },
+                E = new List<bool> { true, false }
+            };
+            var expected = new List<KeyValuePair<string, string>> {
+                new KeyValuePair<string, string>("A", "list1"),
+                new KeyValuePair<string, string>("A", "list2"),
+                new KeyValuePair<string, string>("B", "set1,set2"),
+                new KeyValuePair<string, string>("C", "1 2"),
+
+                // The default behavior is to truncate perfectly round doubles. This is not a requirement.
+                new KeyValuePair<string, string>("D", "0.1\t1"),
+
+                // The default behavior is to capitalize booleans. This is not a requirement.
+                new KeyValuePair<string, string>("E", "True|False")
+            };
+
+            var actual = new FormValueDictionary(source, settings);
+
+            Assert.Equal(expected, actual);
+        }
+
         public class ObjectTestClass
         {
             public string A { get; set; }
             public string B { get; set; }
             public string C { get; set; }
+        }
+
+        public class ObjectWithRepeatedFieldsTestClass
+        {
+            [Query(CollectionFormat.Multi)]
+            public IList<string> A { get; set; }
+            [Query(CollectionFormat.Csv)]
+            public ISet<string> B { get; set; }
+            [Query(CollectionFormat.Ssv)]
+            public HashSet<int> C { get; set; }
+            [Query(CollectionFormat.Tsv)]
+            public IList<double> D { get; set; }
+            [Query(CollectionFormat.Pipes)]
+            public IList<bool> E { get; set; }
         }
 
         [Fact]

--- a/Refit.Tests/FormValueDictionaryTests.cs
+++ b/Refit.Tests/FormValueDictionaryTests.cs
@@ -54,20 +54,18 @@ namespace Refit.Tests
         {
             var source = new ObjectWithRepeatedFieldsTestClass
             {
-                A = new List<string> { "list1", "list2" },
+                A = new List<int> { 1, 2 },
                 B = new HashSet<string> { "set1", "set2" },
                 C = new HashSet<int> { 1, 2 },
                 D = new List<double> { 0.1, 1.0 },
                 E = new List<bool> { true, false }
             };
             var expected = new List<KeyValuePair<string, string>> {
-                new KeyValuePair<string, string>("A", "list1"),
-                new KeyValuePair<string, string>("A", "list2"),
+                new KeyValuePair<string, string>("A", "01"),
+                new KeyValuePair<string, string>("A", "02"),
                 new KeyValuePair<string, string>("B", "set1,set2"),
-                new KeyValuePair<string, string>("C", "1 2"),
-
-                // The default behavior is to truncate perfectly round doubles. This is not a requirement.
-                new KeyValuePair<string, string>("D", "0.1\t1"),
+                new KeyValuePair<string, string>("C", "01 02"),
+                new KeyValuePair<string, string>("D", "0.10\t1.00"),
 
                 // The default behavior is to capitalize booleans. This is not a requirement.
                 new KeyValuePair<string, string>("E", "True|False")
@@ -87,13 +85,13 @@ namespace Refit.Tests
 
         public class ObjectWithRepeatedFieldsTestClass
         {
-            [Query(CollectionFormat.Multi)]
-            public IList<string> A { get; set; }
+            [Query(CollectionFormat.Multi, Format = "00")]
+            public IList<int> A { get; set; }
             [Query(CollectionFormat.Csv)]
             public ISet<string> B { get; set; }
-            [Query(CollectionFormat.Ssv)]
+            [Query(CollectionFormat.Ssv, Format = "00")]
             public HashSet<int> C { get; set; }
-            [Query(CollectionFormat.Tsv)]
+            [Query(CollectionFormat.Tsv, Format = "0.00")]
             public IList<double> D { get; set; }
             [Query(CollectionFormat.Pipes)]
             public IList<bool> E { get; set; }

--- a/Refit.Tests/FormValueMultimapTests.cs
+++ b/Refit.Tests/FormValueMultimapTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using System.Runtime.Serialization;
 using Newtonsoft.Json;
 using Xunit;
@@ -155,7 +156,7 @@ namespace Refit.Tests
 
             Assert.DoesNotContain("Foo", target.Keys);
             Assert.Contains("f", target.Keys);
-            Assert.Equal("abc", target["f"]);
+            Assert.Equal("abc", target.FirstOrDefault(entry => entry.Key == "f").Value);
         }
 
         [Fact]
@@ -170,7 +171,7 @@ namespace Refit.Tests
 
             Assert.DoesNotContain("Bar", target.Keys);
             Assert.Contains("b", target.Keys);
-            Assert.Equal("xyz", target["b"]);
+            Assert.Equal("xyz", target.FirstOrDefault(entry => entry.Key == "b").Value);
         }
 
         [Fact]
@@ -185,7 +186,7 @@ namespace Refit.Tests
 
             Assert.DoesNotContain("Bar", target.Keys);
             Assert.Contains("prefix-fr", target.Keys);
-            Assert.Equal("4.0", target["prefix-fr"]);
+            Assert.Equal("4.0", target.FirstOrDefault(entry => entry.Key == "prefix-fr").Value);
         }
 
 
@@ -202,7 +203,7 @@ namespace Refit.Tests
             Assert.DoesNotContain("Bar", target.Keys);
             Assert.DoesNotContain("z", target.Keys);
             Assert.Contains("a", target.Keys);
-            Assert.Equal("123", target["a"]);
+            Assert.Equal("123", target.FirstOrDefault(entry => entry.Key == "a").Value);
         }
 
 

--- a/Refit.Tests/FormValueMultimapTests.cs
+++ b/Refit.Tests/FormValueMultimapTests.cs
@@ -5,14 +5,14 @@ using Xunit;
 
 namespace Refit.Tests
 {
-    public class FormValueDictionaryTests
+    public class FormValueMultimapTests
     {
         readonly RefitSettings settings = new RefitSettings();
 
         [Fact]
         public void EmptyIfNullPassedIn()
         {
-            var target = new FormValueDictionary(null, settings);
+            var target = new FormValueMultimap(null, settings);
             Assert.Empty(target);
         }
 
@@ -25,7 +25,7 @@ namespace Refit.Tests
                 { "xyz", "123" }
             };
 
-            var target = new FormValueDictionary(source, settings);
+            var target = new FormValueMultimap(source, settings);
 
             Assert.Equal(source, target);
         }
@@ -44,7 +44,7 @@ namespace Refit.Tests
                 { "B", "2" },
             };
 
-            var actual = new FormValueDictionary(source, settings);
+            var actual = new FormValueMultimap(source, settings);
 
             Assert.Equal(expected, actual);
         }
@@ -71,7 +71,7 @@ namespace Refit.Tests
                 new KeyValuePair<string, string>("E", "True|False")
             };
 
-            var actual = new FormValueDictionary(source, settings);
+            var actual = new FormValueMultimap(source, settings);
 
             Assert.Equal(expected, actual);
         }
@@ -110,7 +110,7 @@ namespace Refit.Tests
                 { "C", "FooBar" }
             };
 
-            var actual = new FormValueDictionary(source, settings);
+            var actual = new FormValueMultimap(source, settings);
 
             Assert.Equal(expected, actual);
         }
@@ -137,7 +137,7 @@ namespace Refit.Tests
                 { "xyz", "123" }
             };
 
-            var actual = new FormValueDictionary(source, settings);
+            var actual = new FormValueMultimap(source, settings);
 
 
             Assert.Equal(expected, actual);
@@ -151,7 +151,7 @@ namespace Refit.Tests
                 Foo = "abc"
             };
 
-            var target = new FormValueDictionary(source, settings);
+            var target = new FormValueMultimap(source, settings);
 
             Assert.DoesNotContain("Foo", target.Keys);
             Assert.Contains("f", target.Keys);
@@ -166,7 +166,7 @@ namespace Refit.Tests
                 Bar = "xyz"
             };
 
-            var target = new FormValueDictionary(source, settings);
+            var target = new FormValueMultimap(source, settings);
 
             Assert.DoesNotContain("Bar", target.Keys);
             Assert.Contains("b", target.Keys);
@@ -181,7 +181,7 @@ namespace Refit.Tests
                 Frob = 4
             };
 
-            var target = new FormValueDictionary(source, settings);
+            var target = new FormValueMultimap(source, settings);
 
             Assert.DoesNotContain("Bar", target.Keys);
             Assert.Contains("prefix-fr", target.Keys);
@@ -197,7 +197,7 @@ namespace Refit.Tests
                 Baz = "123"
             };
 
-            var target = new FormValueDictionary(source, settings);
+            var target = new FormValueMultimap(source, settings);
 
             Assert.DoesNotContain("Bar", target.Keys);
             Assert.DoesNotContain("z", target.Keys);
@@ -214,7 +214,7 @@ namespace Refit.Tests
                 { "xyz", null }
             };
 
-            var target = new FormValueDictionary(source, settings);
+            var target = new FormValueMultimap(source, settings);
 
             Assert.Single(target);
             Assert.Contains("foo", target.Keys);
@@ -237,7 +237,7 @@ namespace Refit.Tests
             };
 
 
-            var actual = new FormValueDictionary(source, settings);
+            var actual = new FormValueMultimap(source, settings);
 
             Assert.Equal(expected, actual);
         }

--- a/Refit/Attributes.cs
+++ b/Refit/Attributes.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
@@ -260,8 +260,24 @@ namespace Refit
         public string Delimiter { get; protected set; } = ".";
         public string Prefix { get; protected set; }
 
+        /// <summary>
+        /// Used to customize the formatting of the encoded value.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// interface IServerApi
+        /// {
+        ///   [Get("/expenses")]
+        ///   Task addExpense([Query(Format="0.00")] double expense);
+        /// }
+        /// </code>
+        /// Calling <c>serverApi.addExpense(5)</c> will result in a URI of <c>{baseUri}/expenses?expense=5.00</c>.
+        /// </example>
         public string Format { get; set; }
 
+        /// <summary>
+        /// Specifies how the collection should be encoded. The default behavior is <c>RefitParameterFormatter</c>.
+        /// </summary>
         public CollectionFormat CollectionFormat { get; set; } = CollectionFormat.RefitParameterFormatter;
     }
 }

--- a/Refit/FormValueDictionary.cs
+++ b/Refit/FormValueDictionary.cs
@@ -7,6 +7,12 @@ using Newtonsoft.Json;
 
 namespace Refit
 {
+    /// <summary>
+    /// Transforms a form source from a .NET representation to the appropriate HTTP form encoded representation.
+    /// </summary>
+    /// <remarks>Performs field renaming and value formatting as specified in <see cref="QueryAttribute"/>s and
+    /// <see cref="RefitSettings.FormUrlEncodedParameterFormatter"/>. Note that this is not a true dictionary, rather, a
+    /// form of MultiMap. A given key may appear multiple times with the same or different values.</remarks>
     class FormValueDictionary : IEnumerable<KeyValuePair<string, string>>
     {
         static readonly Dictionary<Type, PropertyInfo[]> propertyCache
@@ -54,7 +60,7 @@ namespace Refit
                             switch (attrib?.CollectionFormat) {
                                 case CollectionFormat.Multi:
                                     foreach (var item in enumerable) {
-                                        Add(fieldName, settings.FormUrlEncodedParameterFormatter.Format(item, null));
+                                        Add(fieldName, settings.FormUrlEncodedParameterFormatter.Format(item, attrib.Format));
                                     }
                                     break;
                                 case CollectionFormat.Csv:
@@ -67,7 +73,7 @@ namespace Refit
 
                                     var formattedValues = enumerable
                                         .Cast<object>()
-                                        .Select(v => settings.FormUrlEncodedParameterFormatter.Format(v, null));
+                                        .Select(v => settings.FormUrlEncodedParameterFormatter.Format(v, attrib.Format));
                                     Add(fieldName, string.Join(delimiter, formattedValues));
                                     break;
                                 default:

--- a/Refit/FormValueDictionary.cs
+++ b/Refit/FormValueDictionary.cs
@@ -3,15 +3,16 @@ using System.Collections;
 using System.Reflection;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
 using Newtonsoft.Json;
 
 namespace Refit
 {
-    class FormValueDictionary : Dictionary<string, string>
+    class FormValueDictionary : IEnumerable<KeyValuePair<string, string>>
     {
         static readonly Dictionary<Type, PropertyInfo[]> propertyCache
             = new Dictionary<Type, PropertyInfo[]>();
+
+        private readonly IList<KeyValuePair<string, string>> formEntries = new List<KeyValuePair<string, string>>();
 
         public FormValueDictionary(object source, RefitSettings settings)
         {
@@ -22,9 +23,8 @@ namespace Refit
                 foreach (var key in dictionary.Keys)
                 {
                     var value = dictionary[key];
-                    if (value != null && key != null)
-                    {
-                        Add(key.ToString(),  settings.FormUrlEncodedParameterFormatter.Format(value, null));
+                    if (value != null) {
+                        Add(key.ToString(), settings.FormUrlEncodedParameterFormatter.Format(value, null));
                     }
                 }
 
@@ -45,13 +45,72 @@ namespace Refit
                     var value = property.GetValue(source, null);
                     if (value != null)
                     {
+                        var fieldName = GetFieldNameForProperty(property);
+
                         // see if there's a query attribute
                         var attrib = property.GetCustomAttribute<QueryAttribute>(true);
 
-                        Add(GetFieldNameForProperty(property), settings.FormUrlEncodedParameterFormatter.Format(value, attrib?.Format));
+                        if (value is IEnumerable enumerable) {
+                            switch (attrib?.CollectionFormat) {
+                                case CollectionFormat.Multi:
+                                    foreach (var item in enumerable) {
+                                        Add(fieldName, settings.FormUrlEncodedParameterFormatter.Format(item, null));
+                                    }
+                                    break;
+                                case CollectionFormat.Csv:
+                                case CollectionFormat.Ssv:
+                                case CollectionFormat.Tsv:
+                                case CollectionFormat.Pipes:
+                                    var delimiter = attrib.CollectionFormat == CollectionFormat.Csv ?  ","
+                                        : attrib.CollectionFormat == CollectionFormat.Ssv ? " "
+                                        : attrib.CollectionFormat == CollectionFormat.Tsv ? "\t" : "|";
+
+                                    var formattedValues = enumerable
+                                        .Cast<object>()
+                                        .Select(v => settings.FormUrlEncodedParameterFormatter.Format(v, null));
+                                    Add(fieldName, string.Join(delimiter, formattedValues));
+                                    break;
+                                default:
+                                    Add(fieldName, settings.FormUrlEncodedParameterFormatter.Format(value, attrib?.Format));
+                                    break;
+                            }
+                        }
+                        else
+                        {
+                            Add(fieldName, settings.FormUrlEncodedParameterFormatter.Format(value, attrib?.Format));
+                        }
+
                     }
                 }
             }
+        }
+
+        /// <summary>
+        /// Returns a key for each entry. If multiple entries share the same key, the key is returned multiple times.
+        /// </summary>
+        public IEnumerable<string> Keys => this.Select(it => it.Key);
+
+        /// <summary>
+        /// Returns the value of the first entry found with the matching key. Multiple additional entries may use the
+        /// same key, but will not be considered. Returns <c>null</c> if no matching entry is found.
+        /// </summary>
+        public string this[string key]
+        {
+            get
+            {
+                foreach (var item in this) {
+                    if (key == item.Key) {
+                        return item.Value;
+                    }
+                }
+
+                return null;
+            }
+        }
+
+        private void Add(string key, string value)
+        {
+            formEntries.Add(new KeyValuePair<string, string>(key, value));
         }
 
         string GetFieldNameForProperty(PropertyInfo propertyInfo)
@@ -76,6 +135,16 @@ namespace Refit
             return type.GetProperties(BindingFlags.Instance | BindingFlags.Public)
                        .Where(p => p.CanRead && p.GetMethod.IsPublic)
                        .ToArray();
+        }
+
+        public IEnumerator<KeyValuePair<string, string>> GetEnumerator()
+        {
+            return formEntries.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
         }
     }
 }

--- a/Refit/FormValueMultimap.cs
+++ b/Refit/FormValueMultimap.cs
@@ -99,24 +99,6 @@ namespace Refit
         /// </summary>
         public IEnumerable<string> Keys => this.Select(it => it.Key);
 
-        /// <summary>
-        /// Returns the value of the first entry found with the matching key. Multiple additional entries may use the
-        /// same key, but will not be considered. Returns <c>null</c> if no matching entry is found.
-        /// </summary>
-        public string this[string key]
-        {
-            get
-            {
-                foreach (var item in this) {
-                    if (key == item.Key) {
-                        return item.Value;
-                    }
-                }
-
-                return null;
-            }
-        }
-
         private void Add(string key, string value)
         {
             formEntries.Add(new KeyValuePair<string, string>(key, value));

--- a/Refit/FormValueMultimap.cs
+++ b/Refit/FormValueMultimap.cs
@@ -11,16 +11,16 @@ namespace Refit
     /// Transforms a form source from a .NET representation to the appropriate HTTP form encoded representation.
     /// </summary>
     /// <remarks>Performs field renaming and value formatting as specified in <see cref="QueryAttribute"/>s and
-    /// <see cref="RefitSettings.FormUrlEncodedParameterFormatter"/>. Note that this is not a true dictionary, rather, a
-    /// form of MultiMap. A given key may appear multiple times with the same or different values.</remarks>
-    class FormValueDictionary : IEnumerable<KeyValuePair<string, string>>
+    /// <see cref="RefitSettings.FormUrlEncodedParameterFormatter"/>. A given key may appear multiple times with the
+    /// same or different values.</remarks>
+    class FormValueMultimap : IEnumerable<KeyValuePair<string, string>>
     {
         static readonly Dictionary<Type, PropertyInfo[]> propertyCache
             = new Dictionary<Type, PropertyInfo[]>();
 
         private readonly IList<KeyValuePair<string, string>> formEntries = new List<KeyValuePair<string, string>>();
 
-        public FormValueDictionary(object source, RefitSettings settings)
+        public FormValueMultimap(object source, RefitSettings settings)
         {
             if (source == null) return;
 
@@ -56,10 +56,13 @@ namespace Refit
                         // see if there's a query attribute
                         var attrib = property.GetCustomAttribute<QueryAttribute>(true);
 
-                        if (value is IEnumerable enumerable) {
-                            switch (attrib?.CollectionFormat) {
+                        if (value is IEnumerable enumerable)
+                        {
+                            switch (attrib?.CollectionFormat)
+                            {
                                 case CollectionFormat.Multi:
-                                    foreach (var item in enumerable) {
+                                    foreach (var item in enumerable)
+                                    {
                                         Add(fieldName, settings.FormUrlEncodedParameterFormatter.Format(item, attrib.Format));
                                     }
                                     break;

--- a/Refit/RefitSettings.cs
+++ b/Refit/RefitSettings.cs
@@ -78,7 +78,7 @@ namespace Refit
             var parameterType = parameterValue.GetType();
 
             EnumMemberAttribute enummember = null;
-            if (parameterValue != null && parameterType.GetTypeInfo().IsEnum)
+            if (parameterType.GetTypeInfo().IsEnum)
             {
                 var cached = enumMemberCache.GetOrAdd(parameterType, t => new ConcurrentDictionary<string, EnumMemberAttribute>());
                 enummember = cached.GetOrAdd(parameterValue.ToString(), val => parameterType.GetMember(val).First().GetCustomAttribute<EnumMemberAttribute>());

--- a/Refit/RequestBuilderImplementation.cs
+++ b/Refit/RequestBuilderImplementation.cs
@@ -463,7 +463,7 @@ namespace Refit
                             switch (restMethod.BodyParameterInfo.Item1)
                             {
                                 case BodySerializationMethod.UrlEncoded:
-                                    ret.Content = paramList[i] is string str ? (HttpContent)new StringContent(Uri.EscapeDataString(str), Encoding.UTF8, "application/x-www-form-urlencoded") :  new FormUrlEncodedContent(new FormValueDictionary(paramList[i], settings));
+                                    ret.Content = paramList[i] is string str ? (HttpContent)new StringContent(Uri.EscapeDataString(str), Encoding.UTF8, "application/x-www-form-urlencoded") :  new FormUrlEncodedContent(new FormValueMultimap(paramList[i], settings));
                                     break;
                                 case BodySerializationMethod.Default:
                                 case BodySerializationMethod.Json:


### PR DESCRIPTION
 When form encoding objects that have a property that is an IEnumerable type, use the QueryAttribute and it's CollectionFormat to determine how to encode the object.

 In general, this feature could be fleshed out much more deeply. Future work could include respecting custom formats and delimiters specified on the QueryAttribute, as well as support for collections stored in dictionaries that are form encoded.