### PR TITLE
Provide additional information during errors

### DIFF
--- a/Refit/RestMethodInfo.cs
+++ b/Refit/RestMethodInfo.cs
@@ -94,7 +94,7 @@ namespace Refit
 
             var ctParams = methodInfo.GetParameters().Where(p => p.ParameterType == typeof(CancellationToken)).ToList();
             if(ctParams.Count > 1) {
-                throw new ArgumentException("Argument list can only contain a single CancellationToken");
+                throw new ArgumentException($"Argument list to method \"{methodInfo.Name}\" can only contain a single CancellationToken");
             }
 
             CancellationToken = ctParams.FirstOrDefault();
@@ -117,7 +117,7 @@ namespace Refit
             return;
 
         bogusPath:
-            throw new ArgumentException("URL path must be of the form '/foo/bar/baz'");
+            throw new ArgumentException($"URL path {relativePath} must be of the form '/foo/bar/baz'");
         }
 
         Dictionary<int, string> BuildParameterMap(string relativePath, List<ParameterInfo> parameterInfo)
@@ -137,7 +137,7 @@ namespace Refit
             foreach (var match in parameterizedParts) {
                 var name = match.Groups[1].Value.ToLowerInvariant();
                 if (!paramValidationDict.ContainsKey(name)) {
-                    throw new ArgumentException(string.Format("URL has parameter {0}, but no method parameter matches", name));
+                    throw new ArgumentException($"URL {relativePath} has parameter {name}, but no method parameter matches");
                 }
 
                 ret.Add(parameterInfo.IndexOf(paramValidationDict[name]), name);
@@ -290,7 +290,7 @@ namespace Refit
             return;
 
         bogusMethod:
-            throw new ArgumentException("All REST Methods must return either Task<T> or IObservable<T>");
+            throw new ArgumentException($"Method \"{methodInfo.Name}\" is invalid. All REST Methods must return either Task<T> or IObservable<T>");
         }     
     }
 }


### PR DESCRIPTION
This ought to help developers diagnose where the error occurred. The current stack trace provides no actionable information and requires going through the whole Interface searching for violations.

```
Unhandled Exception: System.ArgumentException: URL has parameter member, but no method parameter matches
   at Refit.RestMethodInfo.BuildParameterMap(String relativePath, List`1 parameterInfo) in D:\a\1\s\Refit\RestMethodInfo.cs:line 143
   at Refit.RestMethodInfo..ctor(Type targetInterface, MethodInfo methodInfo, RefitSettings refitSettings) in D:\a\1\s\Refit\RestMethodInfo.cs:line 64
   at Refit.RequestBuilderImplementation`1..ctor(RefitSettings refitSettings) in D:\a\1\s\Refit\RequestBuilderImplementation.cs:line 58
   at Refit.RequestBuilderFactory.Create[T](RefitSettings settings) in D:\a\1\s\Refit\RequestBuilderFactory.cs:line 17
   at Refit.RequestBuilder.ForType[T](RefitSettings settings) in D:\a\1\s\Refit\RequestBuilder.cs:line 24
   at Refit.RestService.For[T](HttpClient client, RefitSettings settings) in D:\a\1\s\Refit\RestService.cs:line 28
   at Refit.RestService.For[T](HttpClient client) in D:\a\1\s\Refit\RestService.cs:line 33
   at MyCode.Program.Main(String[] args) in /Users/me/Documents/MyCode/MyCode/Program.cs:line 16
```