### PR TITLE
Fixed deadlock when serializing content

### DIFF
--- a/Refit.Tests/MultipartTests.cs
+++ b/Refit.Tests/MultipartTests.cs
@@ -409,7 +409,7 @@ namespace Refit.Tests
         {
             if (!(Activator.CreateInstance(contentSerializerType) is IContentSerializer serializer))
             {
-                throw new ArithmeticException($"{contentSerializerType.FullName} does not implement {nameof(IContentSerializer)}");
+                throw new ArgumentException($"{contentSerializerType.FullName} does not implement {nameof(IContentSerializer)}");
             }
 
             var model1 = new ModelObject
@@ -452,7 +452,7 @@ namespace Refit.Tests
         {
             if (!(Activator.CreateInstance(contentSerializerType) is IContentSerializer serializer))
             {
-                throw new ArithmeticException($"{contentSerializerType.FullName} does not implement {nameof(IContentSerializer)}");
+                throw new ArgumentException($"{contentSerializerType.FullName} does not implement {nameof(IContentSerializer)}");
             }
 
             var model1 = new ModelObject

--- a/Refit.Tests/SerializedContentTests.cs
+++ b/Refit.Tests/SerializedContentTests.cs
@@ -1,0 +1,114 @@
+﻿using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Xunit;
+using System.Threading;
+
+namespace Refit.Tests
+{
+    public class SerializedContentTests
+    {
+        const string BaseAddress = "https://api/";
+
+        [Theory]
+        [InlineData(typeof(JsonContentSerializer))]
+        [InlineData(typeof(XmlContentSerializer))]
+        public async Task WhenARequestRequiresABodyThenItDoesNotDeadlock(Type contentSerializerType)
+        {
+            if (!(Activator.CreateInstance(contentSerializerType) is IContentSerializer serializer))
+            {
+                throw new ArgumentException($"{contentSerializerType.FullName} does not implement {nameof(IContentSerializer)}"); 
+            }
+
+            var handler = new MockPushStreamContentHttpMessageHandler
+            {
+                Asserts = async content => new StringContent(await content.ReadAsStringAsync().ConfigureAwait(false))
+            };
+
+            var settings = new RefitSettings()
+            {
+                HttpMessageHandlerFactory = () => handler,
+                ContentSerializer = serializer
+            };
+
+            var fixture = RestService.For<IGitHubApi>(BaseAddress, settings);
+
+            var fixtureTask = await RunTaskWithATimeLimit(fixture.CreateUser(new User())).ConfigureAwait(false);
+            Assert.True(fixtureTask.IsCompleted);
+            Assert.Equal(TaskStatus.RanToCompletion, fixtureTask.Status);
+        }
+
+        [Theory]
+        [InlineData(typeof(JsonContentSerializer))]
+        [InlineData(typeof(XmlContentSerializer))]
+        public async Task WhenARequestRequiresABodyThenItIsSerialized(Type contentSerializerType)
+        {
+            if (!(Activator.CreateInstance(contentSerializerType) is IContentSerializer serializer))
+            {
+                throw new ArgumentException($"{contentSerializerType.FullName} does not implement {nameof(IContentSerializer)}");
+            }
+
+            var model = new User
+            {
+                Name = "Wile E. Coyote",
+                CreatedAt = new DateTime(1949, 9, 16).ToString(),
+                Company = "ACME",
+            };
+
+            var handler = new MockPushStreamContentHttpMessageHandler
+            {
+                Asserts = async content =>
+                {
+                    var stringContent = new StringContent(await content.ReadAsStringAsync().ConfigureAwait(false));
+                    var user = await serializer.DeserializeAsync<User>(content).ConfigureAwait(false);
+                    Assert.NotSame(model, user);
+                    Assert.Equal(model.Name, user.Name);
+                    Assert.Equal(model.CreatedAt, user.CreatedAt);
+                    Assert.Equal(model.Company, user.Company);
+
+                    //  return some content so that the serializer doesn't complain
+                    return stringContent;
+                }
+            };
+
+            var settings = new RefitSettings()
+            {
+                HttpMessageHandlerFactory = () => handler,
+                ContentSerializer = serializer
+            };
+
+            var fixture = RestService.For<IGitHubApi>(BaseAddress, settings);
+
+            var fixtureTask = await RunTaskWithATimeLimit(fixture.CreateUser(model)).ConfigureAwait(false);
+
+            Assert.True(fixtureTask.IsCompleted);
+        }
+
+        /// <summary>
+        /// Runs the task to completion or until the timeout occurs
+        /// </summary>
+        private static async Task<Task<User>> RunTaskWithATimeLimit(Task<User> fixtureTask)
+        {
+            var circuitBreakerTask = Task.Delay(TimeSpan.FromSeconds(30));
+            await Task.WhenAny(fixtureTask, circuitBreakerTask);
+            return fixtureTask;
+        }
+
+        class MockPushStreamContentHttpMessageHandler : HttpMessageHandler
+        {
+            public Func<PushStreamContent, Task<HttpContent>> Asserts { get; set; }
+
+            protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                var content = request.Content as PushStreamContent;
+                Assert.IsType<PushStreamContent>(content);
+                Assert.NotNull(Asserts);
+
+                var responseContent = await Asserts(content).ConfigureAwait(false);
+
+                return new HttpResponseMessage(HttpStatusCode.OK) { Content = responseContent };
+            }
+        }
+    }
+}

--- a/Refit/RequestBuilderImplementation.cs
+++ b/Refit/RequestBuilderImplementation.cs
@@ -475,7 +475,12 @@ namespace Refit
                                     {
                                         case false:
                                             ret.Content = new PushStreamContent(
-                                                async (stream, _, __) => { await content.CopyToAsync(stream).ConfigureAwait(false); }, content.Headers.ContentType);
+                                                async (stream, _, __) => {
+                                                    using (stream)
+                                                    {
+                                                        await content.CopyToAsync(stream).ConfigureAwait(false);
+                                                    }
+                                                }, content.Headers.ContentType);
                                             break;
                                         case true:
                                             ret.Content = content;


### PR DESCRIPTION
This fixes an issue that was discovered after pull request #571 was merged to master (MyGet version 4.6.66).

A request which contains a body that should be serialized (and is not a multi-part request) will deadlock in the PushStreamContent at: https://github.com/reactiveui/refit/blob/3fce69b9a7a59a98cf607c7e5c62876e4dcd1165/Refit/PushStreamContent.cs#L142

The PushStreamContent content type provides a stream to write to, but in order for it to complete the request it blocks until the stream is closed. The original implementation did this implicitly because a StreamWriter was used within a using block:

https://github.com/reactiveui/refit/blob/e2e797552b34f2071bc4833280cf3d61150d97bd/Refit/RequestBuilderImplementation.cs#L474-L481

I've added additional tests to make sure that the request doesn't block and it also checks the other flow through the RequestBuilderImplementation class where the request is not a multi-part request. I also fixed a typo in existing tests where a wrong exception was thrown.