### PR TITLE
Update docs because of #425

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ There are four possibilities for supplying the body data, depending on the
 type of the parameter:
 
 * If the type is `Stream`, the content will be streamed via `StreamContent`
-* If the type is `string`, the string will be used directly as the content
+* If the type is `string`, the string will be used directly as the content unless `[Body(BodySerializationMethod.Json)]` is set which will send it as a `StringContent`
 * If the parameter has the attribute `[Body(BodySerializationMethod.UrlEncoded)]`, 
   the content will be URL-encoded (see [form posts](#form-posts) below)
 * For all other types, the object will be serialized using the content serializer specified in 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Docs update


**What is the current behavior? (You can also link to an open issue here)**
The docs does not explain how to send a string as a `StringContent` in the body content.


**What is the new behavior (if this is a feature change)?**
The docs explains how to send a string as a `StringContent` taking into account #425


**What might this PR break?**
Nothing


**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:

