### PR TITLE
fix #641 NullReferenceException on Error, when Response.Content.Headers is null

### DIFF
--- a/Refit.Tests/ResponseTests.cs
+++ b/Refit.Tests/ResponseTests.cs
@@ -99,7 +99,24 @@ namespace Refit.Tests
             Assert.Equal(1, actualException.Content.Status);
             Assert.Equal("title", actualException.Content.Title);
             Assert.Equal("type", actualException.Content.Type);
+        }
 
+        [Fact]
+        public async Task BadRequestWithEmptyContent_ShouldReturnApiException()
+        {
+            var expectedResponse = new HttpResponseMessage(HttpStatusCode.BadRequest)
+            {
+                Content = new StringContent("Hello world")
+            };
+            expectedResponse.Content.Headers.Clear();
+
+            mockHandler.Expect(HttpMethod.Get, "http://api/aliasTest")
+                .Respond(req => expectedResponse);
+
+            var actualException = await Assert.ThrowsAsync<ApiException>(() => fixture.GetTestObject());
+
+            Assert.NotNull(actualException.Content);
+            Assert.Equal("Hello world", actualException.Content);
         }
     }
 }

--- a/Refit/ApiException.cs
+++ b/Refit/ApiException.cs
@@ -57,7 +57,7 @@ namespace Refit
                 exception.ContentHeaders = response.Content.Headers;
                 exception.Content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 
-                if (response.Content.Headers.ContentType.MediaType.Equals("application/problem+json"))
+                if (response.Content.Headers?.ContentType?.MediaType?.Equals("application/problem+json") ?? false)
                 {
                     exception = await ValidationApiException.Create(exception).ConfigureAwait(false);
                 }


### PR DESCRIPTION
fixes #641 