### PR TITLE
Support round-tripping route parameter syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,20 @@ Task<List<User>> GroupList([AliasAs("id")] int groupId, [AliasAs("sort")] string
 GroupList(4, "desc");
 >>> "/group/4/users?sort=desc"
 ```
+
+Round-tripping route parameter syntax: Forward slashes aren't encoded when using a double-asterisk (\*\*) catch-all parameter syntax.
+
+During link generation, the routing system encodes the value captured in a double-asterisk (\*\*) catch-all parameter (for example, {**myparametername}) except the forward slashes.
+
+The type of round-tripping route parameter must be string.
+
+```csharp
+[Get("/search/{**page}")]
+Task<List<Page>> Search(string page);
+
+Search("admin/products");
+>>> "/search/admin/products"
+```
 ### Dynamic Querystring Parameters
 
 If you specify an `object` as a query parameter, all public properties which are not null are used as query parameters. 

--- a/Refit.Tests/RequestBuilder.cs
+++ b/Refit.Tests/RequestBuilder.cs
@@ -25,6 +25,12 @@ namespace Refit.Tests
         [Get("/foo/bar/{id}")]
         Task<string> FetchSomeStuff(int id);
 
+        [Get("/foo/bar/{**path}/{id}")]
+        Task<string> FetchSomeStuffWithRoundTrippingParam(string path, int id);
+
+        [Get("/foo/bar/{**path}/{id}")]
+        Task<string> FetchSomeStuffWithNonStringRoundTrippingParam(int path, int id);
+
         [Get("/foo/bar/{id}?baz=bamf")]
         Task<string> FetchSomeStuffWithHardcodedQueryParam(int id);
 
@@ -205,9 +211,33 @@ namespace Refit.Tests
         {
             var input = typeof(IRestMethodInfoTests);
             var fixture = new RestMethodInfo(input, input.GetMethods().First(x => x.Name == "FetchSomeStuff"));
-            Assert.Equal("id", fixture.ParameterMap[0]);
+            Assert.Equal(Tuple.Create("id", ParameterType.Normal), fixture.ParameterMap[0]);
             Assert.Empty(fixture.QueryParameterMap);
             Assert.Null(fixture.BodyParameterInfo);
+        }
+
+        [Fact]
+        public void ParameterMappingWithRoundTrippingSmokeTest()
+        {
+            var input = typeof(IRestMethodInfoTests);
+            var fixture = new RestMethodInfo(input, input.GetMethods().First(x => x.Name == "FetchSomeStuffWithRoundTrippingParam"));
+            Assert.Equal(Tuple.Create("path", ParameterType.RoundTripping), fixture.ParameterMap[0]);
+            Assert.Equal(Tuple.Create("id", ParameterType.Normal), fixture.ParameterMap[1]);
+            Assert.Empty(fixture.QueryParameterMap);
+            Assert.Null(fixture.BodyParameterInfo);
+        }
+
+        [Fact]
+        public void ParameterMappingWithNonStringRoundTrippingShouldThrow()
+        {
+            var input = typeof(IRestMethodInfoTests);
+            Assert.Throws<ArgumentException>(() =>
+            {
+                var fixture = new RestMethodInfo(
+                    input,
+                    input.GetMethods().First(x => x.Name == "FetchSomeStuffWithNonStringRoundTrippingParam")
+                    );
+            });
         }
 
         [Fact]
@@ -215,7 +245,7 @@ namespace Refit.Tests
         {
             var input = typeof(IRestMethodInfoTests);
             var fixture = new RestMethodInfo(input, input.GetMethods().First(x => x.Name == "FetchSomeStuffWithQueryParam"));
-            Assert.Equal("id", fixture.ParameterMap[0]);
+            Assert.Equal(Tuple.Create("id", ParameterType.Normal), fixture.ParameterMap[0]);
             Assert.Equal("search", fixture.QueryParameterMap[1]);
             Assert.Null(fixture.BodyParameterInfo);
         }
@@ -225,7 +255,7 @@ namespace Refit.Tests
         {
             var input = typeof(IRestMethodInfoTests);
             var fixture = new RestMethodInfo(input, input.GetMethods().First(x => x.Name == "FetchSomeStuffWithHardcodedQueryParam"));
-            Assert.Equal("id", fixture.ParameterMap[0]);
+            Assert.Equal(Tuple.Create("id", ParameterType.Normal), fixture.ParameterMap[0]);
             Assert.Empty(fixture.QueryParameterMap);
             Assert.Null(fixture.BodyParameterInfo);
         }
@@ -235,7 +265,7 @@ namespace Refit.Tests
         {
             var input = typeof(IRestMethodInfoTests);
             var fixture = new RestMethodInfo(input, input.GetMethods().First(x => x.Name == "FetchSomeStuffWithAlias"));
-            Assert.Equal("id", fixture.ParameterMap[0]);
+            Assert.Equal(Tuple.Create("id", ParameterType.Normal), fixture.ParameterMap[0]);
             Assert.Empty(fixture.QueryParameterMap);
             Assert.Null(fixture.BodyParameterInfo);
         }
@@ -245,8 +275,8 @@ namespace Refit.Tests
         {
             var input = typeof(IRestMethodInfoTests);
             var fixture = new RestMethodInfo(input, input.GetMethods().First(x => x.Name == "FetchAnImage"));
-            Assert.Equal("width", fixture.ParameterMap[0]);
-            Assert.Equal("height", fixture.ParameterMap[1]);
+            Assert.Equal(Tuple.Create("width", ParameterType.Normal), fixture.ParameterMap[0]);
+            Assert.Equal(Tuple.Create("height", ParameterType.Normal), fixture.ParameterMap[1]);
             Assert.Empty(fixture.QueryParameterMap);
             Assert.Null(fixture.BodyParameterInfo);
         }
@@ -256,7 +286,7 @@ namespace Refit.Tests
         {
             var input = typeof(IRestMethodInfoTests);
             var fixture = new RestMethodInfo(input, input.GetMethods().First(x => x.Name == "FetchSomeStuffWithBody"));
-            Assert.Equal("id", fixture.ParameterMap[0]);
+            Assert.Equal(Tuple.Create("id", ParameterType.Normal), fixture.ParameterMap[0]);
 
             Assert.NotNull(fixture.BodyParameterInfo);
             Assert.Empty(fixture.QueryParameterMap);
@@ -268,7 +298,7 @@ namespace Refit.Tests
         {
             var input = typeof(IRestMethodInfoTests);
             var fixture = new RestMethodInfo(input, input.GetMethods().First(x => x.Name == "PostSomeUrlEncodedStuff"));
-            Assert.Equal("id", fixture.ParameterMap[0]);
+            Assert.Equal(Tuple.Create("id", ParameterType.Normal), fixture.ParameterMap[0]);
 
             Assert.NotNull(fixture.BodyParameterInfo);
             Assert.Empty(fixture.QueryParameterMap);
@@ -280,7 +310,7 @@ namespace Refit.Tests
         {
             var input = typeof(IRestMethodInfoTests);
             var fixture = new RestMethodInfo(input, input.GetMethods().First(x => x.Name == "FetchSomeStuffWithHardcodedHeaders"));
-            Assert.Equal("id", fixture.ParameterMap[0]);
+            Assert.Equal(Tuple.Create("id", ParameterType.Normal), fixture.ParameterMap[0]);
             Assert.Empty(fixture.QueryParameterMap);
             Assert.Null(fixture.BodyParameterInfo);
 
@@ -296,7 +326,7 @@ namespace Refit.Tests
         {
             var input = typeof(IRestMethodInfoTests);
             var fixture = new RestMethodInfo(input, input.GetMethods().First(x => x.Name == "FetchSomeStuffWithDynamicHeader"));
-            Assert.Equal("id", fixture.ParameterMap[0]);
+            Assert.Equal(Tuple.Create("id", ParameterType.Normal), fixture.ParameterMap[0]);
             Assert.Empty(fixture.QueryParameterMap);
             Assert.Null(fixture.BodyParameterInfo);
 
@@ -311,7 +341,7 @@ namespace Refit.Tests
         {
             var input = typeof(IRestMethodInfoTests);
             var fixture = new RestMethodInfo(input, input.GetMethods().First(x => x.Name == "OhYeahValueTypes"));
-            Assert.Equal("id", fixture.ParameterMap[0]);
+            Assert.Equal(Tuple.Create("id", ParameterType.Normal), fixture.ParameterMap[0]);
             Assert.Empty(fixture.QueryParameterMap);
             Assert.Equal(BodySerializationMethod.Default, fixture.BodyParameterInfo.Item1);
             Assert.True(fixture.BodyParameterInfo.Item2); // buffered default
@@ -325,7 +355,7 @@ namespace Refit.Tests
         {
             var input = typeof(IRestMethodInfoTests);
             var fixture = new RestMethodInfo(input, input.GetMethods().First(x => x.Name == "OhYeahValueTypesUnbuffered"));
-            Assert.Equal("id", fixture.ParameterMap[0]);
+            Assert.Equal(Tuple.Create("id", ParameterType.Normal), fixture.ParameterMap[0]);
             Assert.Empty(fixture.QueryParameterMap);
             Assert.Equal(BodySerializationMethod.Default, fixture.BodyParameterInfo.Item1);
             Assert.False(fixture.BodyParameterInfo.Item2); // unbuffered specified
@@ -339,7 +369,7 @@ namespace Refit.Tests
         {
             var input = typeof(IRestMethodInfoTests);
             var fixture = new RestMethodInfo(input, input.GetMethods().First(x => x.Name == "PullStreamMethod"));
-            Assert.Equal("id", fixture.ParameterMap[0]);
+            Assert.Equal(Tuple.Create("id", ParameterType.Normal), fixture.ParameterMap[0]);
             Assert.Empty(fixture.QueryParameterMap);
             Assert.Equal(BodySerializationMethod.Default, fixture.BodyParameterInfo.Item1);
             Assert.True(fixture.BodyParameterInfo.Item2);
@@ -353,7 +383,7 @@ namespace Refit.Tests
         {
             var input = typeof(IRestMethodInfoTests);
             var fixture = new RestMethodInfo(input, input.GetMethods().First(x => x.Name == "VoidPost"));
-            Assert.Equal("id", fixture.ParameterMap[0]);
+            Assert.Equal(Tuple.Create("id", ParameterType.Normal), fixture.ParameterMap[0]);
 
             Assert.Equal(typeof(Task), fixture.ReturnType);
             Assert.Equal(typeof(void), fixture.SerializedReturnType);

--- a/Refit.Tests/RequestBuilder.cs
+++ b/Refit.Tests/RequestBuilder.cs
@@ -453,6 +453,9 @@ namespace Refit.Tests
         [Get("/foo/bar/{id}")]
         Task<string> FetchSomeStuff(int id);
 
+        [Get("/foo/bar/{**path}/{id}")]
+        Task<string> FetchSomeStuffWithRoundTrippingParam(string path, int id);
+
         [Get("/foo/bar/{id}?baz=bamf")]
         Task<string> FetchSomeStuffWithHardcodedQueryParameter(int id);
 
@@ -853,6 +856,22 @@ namespace Refit.Tests
 
             var uri = new Uri(new Uri("http://api"), output.RequestUri);
             Assert.Equal("/foo/bar/6?baz=bamf&search_for=foo", uri.PathAndQuery);
+        }
+
+        [Theory]
+        [InlineData("aaa/bbb", "/foo/bar/aaa/bbb/1")]
+        [InlineData("aaa/bbb/ccc", "/foo/bar/aaa/bbb/ccc/1")]
+        [InlineData("aaa", "/foo/bar/aaa/1")]
+        [InlineData("aa a/bb-b", "/foo/bar/aa%20a/bb-b/1")]
+        public void RoundTrippingParameterizedQueryParamsShouldBeInUrl(string path, string expectedQuery)
+        {
+            var fixture = new RequestBuilderImplementation<IDummyHttpApi>();
+
+            var factory = fixture.BuildRequestFactoryForMethod("FetchSomeStuffWithRoundTrippingParam");
+            var output = factory(new object[] { path, 1 });
+
+            var uri = new Uri(new Uri("http://api"), output.RequestUri);
+            Assert.Equal(expectedQuery, uri.PathAndQuery);
         }
 
         [Fact]

--- a/Refit/RequestBuilderImplementation.cs
+++ b/Refit/RequestBuilderImplementation.cs
@@ -445,11 +445,33 @@ namespace Refit
                     // if part of REST resource URL, substitute it in
                     if (restMethod.ParameterMap.ContainsKey(i))
                     {
+                        string pattern;
+                        string replacement;
+                        if (restMethod.ParameterMap[i].Item2 == ParameterType.RoundTripping)
+                        {
+                            pattern = $@"{{\*\*{restMethod.ParameterMap[i].Item1}}}";
+                            var paramValue = paramList[i] as string;
+                            replacement = string.Join(
+                                "/",
+                                paramValue.Split('/')
+                                    .Select(s =>
+                                        Uri.EscapeDataString(
+                                            settings.UrlParameterFormatter.Format(s, restMethod.ParameterInfoMap[i]) ?? string.Empty
+                                        )
+                                    )
+                            );
+                        }
+                        else
+                        {
+                            pattern = "{" + restMethod.ParameterMap[i].Item1 + "}";
+                            replacement = Uri.EscapeDataString(settings.UrlParameterFormatter
+                                    .Format(paramList[i], restMethod.ParameterInfoMap[i]) ?? string.Empty);
+                        }
+
                         urlTarget = Regex.Replace(
                             urlTarget,
-                            "{" + restMethod.ParameterMap[i] + "}",
-                            Uri.EscapeDataString(settings.UrlParameterFormatter
-                                    .Format(paramList[i], restMethod.ParameterInfoMap[i]) ?? string.Empty),
+                            pattern,
+                            replacement,
                             RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
                         continue;
                     }


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Feature



**What is the current behavior?**
<!-- You can also link to an open issue here. -->



**What is the new behavior?**
Round-tripping route parameter syntax is a new feature from [ASP.NET Core](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/routing?view=aspnetcore-2.2#differences-from-earlier-versions-of-routing):
Forward slashes aren't encoded when using a double-asterisk (\*\*) catch-all parameter syntax.
During link generation, the routing system encodes the value captured in a double-asterisk (\*\*) catch-all parameter (for example, {**myparametername}) except the forward slashes.

Route | Param | Link
----- | ----- | ----
/search/{**page} | page = "admin/products" | /search/admin/products



**What might this PR break?**



**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:

