### PR TITLE
Relax Json.NET version requirements

### DIFF
--- a/Refit/Refit.csproj
+++ b/Refit/Refit.csproj
@@ -8,15 +8,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
-    <PackageReference Condition="'$(TargetFramework)' == 'netstandard1.4' " Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <Compile Remove="Features\**\*.*" />
     <None Include="Features\**\*.*" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.4' ">
     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="1.1.2" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.5.0" />
+    <PackageReference Include="System.Runtime.Serialization.Formatters" Version="4.3.0" />
     <PackageReference Include="System.Xml.XmlSerializer" Version="4.3.0 " />
   </ItemGroup>
   


### PR DESCRIPTION
This change downgrades the Newtonsoft.Json package reference (i.e. Json.NET) to a minimum of 9.01. We're not using any of the newer APIs, and all our tests pass, so I think this is okay. :rocket:

It required adding an explicit dependency on `System.Runtime.Serialization.Formatters` to the netstandard 1.4 version, and in the process of adding that I cleaned up the 1.4 specific package references in the project a tiny bit.

My only concern here is the [fairly large number of fixes in Json.NET between 9.0.1 and 12.0.2](https://github.com/JamesNK/Newtonsoft.Json/releases). This change won't stop stop anyone from referencing a later version though -- explicitly or otherwise. It just might open us up to some annoying bug reports. (As stated in the referenced issue, most people will be using a later version than 9.0.1 anyway.)

So this fixes #670, I think :joy:

**What kind of change does this PR introduce?**

-  Downgrades the `Newtonsoft.Json` package reference to a minimum of 9.01



**What is the current behavior?**

- A dependency on `Newtonsoft.Json` 12.0.1 or higher (see #670.)



**What is the new behavior?**

- People using Azure Functions (or any other library with a strict requirement on a lower version than 12.0.1 but >= 9.0.1 will be able to use the latest version of Refit. 



**What might this PR break?**

It could expose us to bug reports for any of [the issues fixed in Json.NET since 9.0.1](https://github.com/JamesNK/Newtonsoft.Json/releases).

**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features) _Sort of. The old ones all run._
- [x] Docs have been added / updated (for bug fixes / features) _Not really applicable._
