### PR TITLE
Fixes #687

### DIFF
--- a/Refit/RestMethodInfo.cs
+++ b/Refit/RestMethodInfo.cs
@@ -106,14 +106,15 @@ namespace Refit
 
                 if (parameterList[i].GetCustomAttribute<QueryAttribute>() != null)
                 {
-                    var complexType = parameterList[i].ParameterType;
-                    if (complexType.IsArray || complexType.GetInterfaces().Contains(typeof(IEnumerable)))
+                    var typeInfo = parameterList[i].ParameterType.GetTypeInfo();
+                    var isValueType = typeInfo.IsValueType && !typeInfo.IsPrimitive && !typeInfo.IsEnum;
+                    if (typeInfo.IsArray || parameterList[i].ParameterType.GetInterfaces().Contains(typeof(IEnumerable)) || isValueType)
                     {
                         QueryParameterMap.Add(QueryParameterMap.Count, GetUrlNameForParameter(parameterList[i]));
                     }
                     else
                     {
-                        foreach (var member in complexType.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+                        foreach (var member in parameterList[i].ParameterType.GetProperties(BindingFlags.Public | BindingFlags.Instance))
                         {
                             QueryParameterMap.Add(QueryParameterMap.Count, GetUrlNameForMember(member));
                         }


### PR DESCRIPTION
**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Bug fix for #687.

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

Nullable<T> and DateTime types are handled as complex POCO parameters and therefore their properties are added incorrectly to querystrings.

**What is the new behavior?**
<!-- If this is a feature change -->

Structs are explicitly handled as simple types and flattened with ToString(). Further, fixed a break where no option for CollectionFormat in querystring collections, results in a loop counter increase, and therefore an off-by-X error (compensated with a counter in the URL parser).
Also, replaced the dictionary key referencing with ElementAt calls for correct index location.

**What might this PR break?**

All tests pass.

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**: