### PR TITLE
Clarify header "redefinition"

### DIFF
--- a/README.md
+++ b/README.md
@@ -552,7 +552,24 @@ var users = await GetUsers();
 var user = await GetUser("octocat");
 
 // X-Emoji: :trollface:
-await CreateUser(user, ":trollface:"); 
+await CreateUser(user, ":trollface:");
+```
+
+**Note:** This redefining behavior only applies to headers _with the same name_. Headers with different names are not replaced. The following code will result in all headers being included:
+
+```csharp
+[Headers("Header-A: 1")]
+public interface ISomeApi
+{
+    [Headers("Header-B: 2")]
+    [Post("/post")]
+    Task PostTheThing([Header("Header-C")] int c);
+}
+
+// Header-A: 1
+// Header-B: 2
+// Header-C: 3
+var user = await api.PostTheThing(3);
 ```
 
 #### Removing headers


### PR DESCRIPTION
There was some confusion in #693 on what "redefinition" of headers means and how it applies to headers with different names.

I've added some documentation which should make this clearer.

Fixes #693