### PR TITLE
BugFix/ Get order params with Array

### DIFF
--- a/Refit.Tests/RequestBuilder.cs
+++ b/Refit.Tests/RequestBuilder.cs
@@ -500,7 +500,7 @@ namespace Refit.Tests
         }
 
         [Fact]
-        public void Test()
+        public void ParameterMappingWithHeaderQueryParamAndQueryArrayParam()
         {
             var input = typeof(IRestMethodInfoTests);
             var fixture = new RestMethodInfo(input, input.GetMethods().First(x => x.Name == "FetchSomeStuffWithDynamicHeaderQueryParamAndArrayQueryParam"));

--- a/Refit.Tests/RequestBuilder.cs
+++ b/Refit.Tests/RequestBuilder.cs
@@ -302,7 +302,7 @@ namespace Refit.Tests
             var input = typeof(IRestMethodInfoTests);
             var fixture = new RestMethodInfo(input, input.GetMethods().First(x => x.Name == "FetchSomeStuffWithQueryParam"));
             Assert.Equal(Tuple.Create("id", ParameterType.Normal), fixture.ParameterMap[0]);
-            Assert.Equal("search", fixture.QueryParameterMap[1]);
+            Assert.Equal("search", fixture.QueryParameterMap[0]);
             Assert.Null(fixture.BodyParameterInfo);
         }
 

--- a/Refit.Tests/RequestBuilder.cs
+++ b/Refit.Tests/RequestBuilder.cs
@@ -56,6 +56,9 @@ namespace Refit.Tests
         [Get("/foo/bar/{id}")]
         Task<string> FetchSomeStuffWithDynamicHeader(int id, [Header("Authorization")] string authorization);
 
+        [Get("/foo")]
+        Task<string> FetchSomeStuffWithDynamicHeaderQueryParamAndArrayQueryParam([Header("Authorization")] string authorization, int id, [Query(CollectionFormat.Multi)] string[] someArray);
+
         [Post("/foo/{id}")]
         Task<bool> OhYeahValueTypes(int id, [Body] int whatever);
 
@@ -494,6 +497,17 @@ namespace Refit.Tests
             var fixture = new RestMethodInfo(input, input.GetMethods().First(x => x.Name == nameof(IRestMethodInfoTests.PostReturnsNonApiResponse)));
 
             Assert.False(fixture.IsApiResponse);
+        }
+
+        [Fact]
+        public void Test()
+        {
+            var input = typeof(IRestMethodInfoTests);
+            var fixture = new RestMethodInfo(input, input.GetMethods().First(x => x.Name == "FetchSomeStuffWithDynamicHeaderQueryParamAndArrayQueryParam"));
+
+            Assert.Equal("GET", fixture.HttpMethod.Method);
+            Assert.Equal(2, fixture.QueryParameterMap.Count);
+            Assert.Equal(1, fixture.HeaderParameterMap.Count);
         }
     }
 

--- a/Refit/RestMethodInfo.cs
+++ b/Refit/RestMethodInfo.cs
@@ -122,7 +122,7 @@ namespace Refit
                     continue;
                 }
 
-                QueryParameterMap[i] = GetUrlNameForParameter(parameterList[i]);
+                QueryParameterMap.Add(QueryParameterMap.Count, GetUrlNameForParameter(parameterList[i]));
             }
 
             var ctParams = methodInfo.GetParameters().Where(p => p.ParameterType == typeof(CancellationToken)).ToList();


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Bug fix

**What is the current behavior?**
A request like :
`[Header("Authorization")] string authorization, int id, [Query(CollectionFormat.Multi)] string[] someArray`
With first a dynamic header, after some query param and in the end one or several Array Query param cause an exception in RestMethodInfo.cs line 124 for duplicate key in QueryParameterMap

We have to place Array in first and header(s) in the end but it's not a "production" solution

**What is the new behavior?**
Order is not a potential issue, all params are add in QueryParameterMap without duplicate key


**What might this PR break?**
Maybe other Get request with query params but all tests are OK


**Please check if the PR fulfills these requirements**
- a new test was add, and the bug fix turn this test OK

**Other information**:
I found this issue in a real build project, and that was a specific case but so hard to found why. The params order is not specify in any part of the documentation so i suppose it doen't have to impact the request builder. Refit is really a good package, i hope this will help !
