### PR TITLE
Unescape Querystring parameters #277

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ Refit currently supports the following platforms and any .NET Standard 1.4 targe
 * UWP
 * Xamarin.Android
 * Xamarin.Mac
-* Xamarin.iOS 
-* Desktop .NET 4.6.1 
+* Xamarin.iOS
+* Desktop .NET 4.6.1
 * .NET Core
 
 #### Note about .NET Core
@@ -64,7 +64,7 @@ You can also specify query parameters in the URL:
 
 A request URL can be updated dynamically using replacement blocks and
 parameters on the method. A replacement block is an alphanumeric string
-surrounded by { and }. 
+surrounded by { and }.
 
 If the name of your parameter doesn't match the name in the URL path, use the
 `AliasAs` attribute.
@@ -164,6 +164,19 @@ Search(new [] {10, 20, 30})
 >>> "/users/list?ages=10%2C20%2C30"
 ```
 
+### Unescape Querystring parameters
+
+Use the `QueryUriFormat` attribute to specify if the query parameters should be url escaped
+
+```csharp
+[Get("/query")]
+[QueryUriFormat(UriFormat.Unescaped)]
+Task Query(string q);
+
+Query("Select+Id,Name+From+Account")
+>>> "/query?q=Select+Id,Name+From+Account"
+```
+
 ### Body content
 
 One of the parameters in your method can be used as the body, by using the
@@ -179,18 +192,18 @@ type of the parameter:
 
 * If the type is `Stream`, the content will be streamed via `StreamContent`
 * If the type is `string`, the string will be used directly as the content unless `[Body(BodySerializationMethod.Json)]` is set which will send it as a `StringContent`
-* If the parameter has the attribute `[Body(BodySerializationMethod.UrlEncoded)]`, 
+* If the parameter has the attribute `[Body(BodySerializationMethod.UrlEncoded)]`,
   the content will be URL-encoded (see [form posts](#form-posts) below)
-* For all other types, the object will be serialized using the content serializer specified in 
+* For all other types, the object will be serialized using the content serializer specified in
 RefitSettings (JSON is the default).
 
 #### Buffering and the `Content-Length` header
 
 By default, Refit streams the body content without buffering it. This means you can
-stream a file from disk, for example, without incurring the overhead of loading 
-the whole file into memory. The downside of this is that no `Content-Length` header 
+stream a file from disk, for example, without incurring the overhead of loading
+the whole file into memory. The downside of this is that no `Content-Length` header
 is set _on the request_. If your API needs you to send a `Content-Length` header with
-the request, you can disable this streaming behavior by setting the `buffered` argument 
+the request, you can disable this streaming behavior by setting the `buffered` argument
 of the `[Body]` attribute to `true`:
 
 ```csharp
@@ -199,13 +212,13 @@ Task CreateUser([Body(buffered: true)] User user);
 
 #### JSON content
 
-JSON requests and responses are serialized/deserialized using Json.NET. 
-By default, Refit will use the serializer settings that can be configured 
+JSON requests and responses are serialized/deserialized using Json.NET.
+By default, Refit will use the serializer settings that can be configured
 by setting _Newtonsoft.Json.JsonConvert.DefaultSettings_:
 
 ```csharp
-JsonConvert.DefaultSettings = 
-    () => new JsonSerializerSettings() { 
+JsonConvert.DefaultSettings =
+    () => new JsonSerializerSettings() {
         ContractResolver = new CamelCasePropertyNamesContractResolver(),
         Converters = {new StringEnumConverter()}
     };
@@ -215,16 +228,16 @@ await PostSomeStuff(new { Day = DayOfWeek.Saturday });
 ```
 
 As these are global settings they will affect your entire application. It
-might be beneficial to isolate the settings for calls to a particular API. 
-When creating a Refit generated live interface, you may optionally pass a 
-`RefitSettings` that will allow you to specify what serializer settings you 
+might be beneficial to isolate the settings for calls to a particular API.
+When creating a Refit generated live interface, you may optionally pass a
+`RefitSettings` that will allow you to specify what serializer settings you
 would like. This allows you to have different serializer settings for separate
 APIs:
 
 ```csharp
 var gitHubApi = RestService.For<IGitHubApi>("https://api.github.com",
     new RefitSettings {
-        ContentSerializer = new JsonContentSerializer( 
+        ContentSerializer = new JsonContentSerializer(
             new JsonSerializerSettings {
                 ContractResolver = new SnakeCasePropertyNamesContractResolver()
         }
@@ -232,28 +245,28 @@ var gitHubApi = RestService.For<IGitHubApi>("https://api.github.com",
 
 var otherApi = RestService.For<IOtherApi>("https://api.example.com",
     new RefitSettings {
-        ContentSerializer = new JsonContentSerializer( 
+        ContentSerializer = new JsonContentSerializer(
             new JsonSerializerSettings {
                 ContractResolver = new CamelCasePropertyNamesContractResolver()
         }
     )});
 ```
 
-Property serialization/deserialization can be customised using Json.NET's 
+Property serialization/deserialization can be customised using Json.NET's
 JsonProperty attribute:
 
-```csharp 
-public class Foo 
+```csharp
+public class Foo
 {
     // Works like [AliasAs("b")] would in form posts (see below)
-    [JsonProperty(PropertyName="b")] 
+    [JsonProperty(PropertyName="b")]
     public string Bar { get; set; }
-} 
+}
 ```
 
 #### XML Content
 
-XML requests and responses are serialized/deserialized using _System.Xml.Serialization.XmlSerializer_. 
+XML requests and responses are serialized/deserialized using _System.Xml.Serialization.XmlSerializer_.
 By default, Refit will use JSON content serialization, to use XML content configure the ContentSerializer to use the `XmlContentSerializer`:
 
 ```csharp
@@ -308,9 +321,9 @@ public interface IMeasurementProtocolApi
 }
 
 var data = new Dictionary<string, object> {
-    {"v", 1}, 
-    {"tid", "UA-1234-5"}, 
-    {"cid", new Guid("d1e9ea6b-2e8b-4699-93e0-0bcbd26c206c")}, 
+    {"v", 1},
+    {"tid", "UA-1234-5"},
+    {"cid", new Guid("d1e9ea6b-2e8b-4699-93e0-0bcbd26c206c")},
     {"t", "event"},
 };
 
@@ -318,8 +331,8 @@ var data = new Dictionary<string, object> {
 await api.Collect(data);
 ```
 
-Or you can just pass any object and all _public, readable_ properties will 
-be serialized as form fields in the request. This approach allows you to alias 
+Or you can just pass any object and all _public, readable_ properties will
+be serialized as form fields in the request. This approach allows you to alias
 property names using `[AliasAs("whatever")]` which can help if the API has
 cryptic field names:
 
@@ -334,30 +347,30 @@ public class Measurement
 {
     // Properties can be read-only and [AliasAs] isn't required
     public int v { get { return 1; } }
- 
+
     [AliasAs("tid")]
     public string WebPropertyId { get; set; }
 
     [AliasAs("cid")]
     public Guid ClientId { get; set; }
 
-    [AliasAs("t")] 
+    [AliasAs("t")]
     public string Type { get; set; }
 
     public object IgnoreMe { private get; set; }
 }
 
-var measurement = new Measurement { 
-    WebPropertyId = "UA-1234-5", 
-    ClientId = new Guid("d1e9ea6b-2e8b-4699-93e0-0bcbd26c206c"), 
-    Type = "event" 
-}; 
+var measurement = new Measurement {
+    WebPropertyId = "UA-1234-5",
+    ClientId = new Guid("d1e9ea6b-2e8b-4699-93e0-0bcbd26c206c"),
+    Type = "event"
+};
 
 // Serialized as: v=1&tid=UA-1234-5&cid=d1e9ea6b-2e8b-4699-93e0-0bcbd26c206c&t=event
 await api.Collect(measurement);
-``` 
+```
 
-If you have a type that has `[JsonProperty(PropertyName)]` attributes setting property aliases, Refit will use those too (`[AliasAs]` will take precedence where you have both). 
+If you have a type that has `[JsonProperty(PropertyName)]` attributes setting property aliases, Refit will use those too (`[AliasAs]` will take precedence where you have both).
 This means that the following type will serialize as `one=value1&two=value2`:
 
 ```csharp
@@ -380,7 +393,7 @@ public class SomeObject
 
 #### Static headers
 
-You can set one or more static request headers for a request applying a `Headers` 
+You can set one or more static request headers for a request applying a `Headers`
 attribute to the method:
 
 ```csharp
@@ -389,7 +402,7 @@ attribute to the method:
 Task<User> GetUser(string user);
 ```
 
-Static headers can also be added to _every request in the API_ by applying the 
+Static headers can also be added to _every request in the API_ by applying the
 `Headers` attribute to the interface:
 
 ```csharp
@@ -398,7 +411,7 @@ public interface IGitHubApi
 {
     [Get("/users/{user}")]
     Task<User> GetUser(string user);
-    
+
     [Post("/users/new")]
     Task CreateUser([Body] User user);
 }
@@ -414,13 +427,13 @@ with a dynamic value to a request by applying a `Header` attribute to a paramete
 Task<User> GetUser(string user, [Header("Authorization")] string authorization);
 
 // Will add the header "Authorization: token OAUTH-TOKEN" to the request
-var user = await GetUser("octocat", "token OAUTH-TOKEN"); 
+var user = await GetUser("octocat", "token OAUTH-TOKEN");
 ```
 
 #### Authorization (Dynamic Headers redux)
 The most common reason to use headers is for authorization. Today most API's use some flavor of oAuth with access tokens that expire and refresh tokens that are longer lived.
 
-One way to encapsulate these kinds of token usage, a custom `HttpClientHandler` can be inserted instead.  
+One way to encapsulate these kinds of token usage, a custom `HttpClientHandler` can be inserted instead.
 There are two classes for doing this: one is `AuthenticatedHttpClientHandler`, which takes a `Func<Task<string>>` parameter, where a signature can be generated without knowing about the request.
 The other is `AuthenticatedParameterizedHttpClientHandler`, which takes a `Func<HttpRequestMessage, Task<string>>` parameter, where the signature requires information about the request (see earlier notes about Twitter's API)
 
@@ -487,14 +500,14 @@ This class is used like so (example uses the [ADAL](http://msdn.microsoft.com/en
 class LoginViewModel
 {
     AuthenticationContext context = new AuthenticationContext(...);
-    
+
     private async Task<string> GetToken()
     {
         // The AcquireTokenAsync call will prompt with a UI if necessary
         // Or otherwise silently use a refresh token to return
-        // a valid access token	
+        // a valid access token
         var token = await context.AcquireTokenAsync("http://my.service.uri/app", "clientId", new Uri("callback://complete"));
-        
+
         return token;
     }
 
@@ -516,13 +529,13 @@ interface IMyRestService
 }
 ```
 
-In the above example, any time a method that requires authentication is called, the `AuthenticatedHttpClientHandler` will try to get a fresh access token. It's up to the app to provide one, checking the expiration time of an existing access token and obtaining a new one if needed. 
+In the above example, any time a method that requires authentication is called, the `AuthenticatedHttpClientHandler` will try to get a fresh access token. It's up to the app to provide one, checking the expiration time of an existing access token and obtaining a new one if needed.
 
 #### Redefining headers
 
-Unlike Retrofit, where headers do not overwrite each other and are all added to 
-the request regardless of how many times the same header is defined, Refit takes 
-a similar approach to the approach ASP.NET MVC takes with action filters &mdash; 
+Unlike Retrofit, where headers do not overwrite each other and are all added to
+the request regardless of how many times the same header is defined, Refit takes
+a similar approach to the approach ASP.NET MVC takes with action filters &mdash;
 **redefining a header will replace it**, in the following order of precedence:
 
 * `Headers` attribute on the interface _(lowest priority)_
@@ -535,11 +548,11 @@ public interface IGitHubApi
 {
     [Get("/users/list")]
     Task<List> GetUsers();
-    
+
     [Get("/users/{user}")]
     [Headers("X-Emoji: :smile_cat:")]
     Task<User> GetUser(string user);
-    
+
     [Post("/users/new")]
     [Headers("X-Emoji: :metal:")]
     Task CreateUser([Body] User user, [Header("X-Emoji")] string emoji);
@@ -574,8 +587,8 @@ var user = await api.PostTheThing(3);
 
 #### Removing headers
 
-Headers defined on an interface or method can be removed by redefining 
-a static header without a value (i.e. without `: <value>`) or passing `null` for 
+Headers defined on an interface or method can be removed by redefining
+a static header without a value (i.e. without `: <value>`) or passing `null` for
 a dynamic header. _Empty strings will be included as empty headers._
 
 ```csharp
@@ -585,11 +598,11 @@ public interface IGitHubApi
     [Get("/users/list")]
     [Headers("X-Emoji")] // Remove the X-Emoji header
     Task<List> GetUsers();
-    
+
     [Get("/users/{user}")]
     [Headers("X-Emoji:")] // Redefine the X-Emoji header as empty
     Task<User> GetUser(string user);
-    
+
     [Post("/users/new")]
     Task CreateUser([Body] User user, [Header("X-Emoji")] string emoji);
 }
@@ -597,14 +610,14 @@ public interface IGitHubApi
 // No X-Emoji header
 var users = await GetUsers();
 
-// X-Emoji: 
+// X-Emoji:
 var user = await GetUser("octocat");
 
 // No X-Emoji header
-await CreateUser(user, null); 
+await CreateUser(user, null);
 
-// X-Emoji: 
-await CreateUser(user, ""); 
+// X-Emoji:
+await CreateUser(user, "");
 ```
 
 ### Multipart uploads
@@ -701,10 +714,10 @@ public interface IReallyExcitingCrudApi<T, in TKey> where T : class
 Which can be used like this:
 
 ```csharp
-// The "/users" part here is kind of important if you want it to work for more 
+// The "/users" part here is kind of important if you want it to work for more
 // than one type (unless you have a different domain for each type)
-var api = RestService.For<IReallyExcitingCrudApi<User, string>>("http://api.example.com/users"); 
-``` 
+var api = RestService.For<IReallyExcitingCrudApi<User, string>>("http://api.example.com/users");
+```
 ### Interface inheritance
 
 When multiple services that need to be kept separate share a number of APIs, it is possible to leverage interface inheritance to avoid having to define the same Refit methods multiple times in different services:
@@ -771,7 +784,7 @@ Here `IAmInterfaceC.Foo` would use the header attribute inherited from `IAmInter
 
 ### Using HttpClientFactory
 
-Refit has first class support for the ASP.Net Core 2.1 HttpClientFactory. Add a reference to `Refit.HttpClientFactory` and call 
+Refit has first class support for the ASP.Net Core 2.1 HttpClientFactory. Add a reference to `Refit.HttpClientFactory` and call
 the provided extension method in your `ConfigureServices` method to configure your Refit interface:
 
 ```csharp
@@ -782,9 +795,9 @@ services.AddRefitClient<IWebApi>()
         // .SetHandlerLifetime(TimeSpan.FromMinutes(2));
 ```
 
-Optionally, a `RefitSettings` object can be included: 
+Optionally, a `RefitSettings` object can be included:
 ```csharp
-var settings = new RefitSettings(); 
+var settings = new RefitSettings();
 // Configure refit settings here
 
 services.AddRefitClient<IWebApi>(settings)
@@ -827,7 +840,7 @@ try
 }
 catch (ValidationApiException validationException)
 {
-   // handle validation here by using validationException.Content, 
+   // handle validation here by using validationException.Content,
    // which is type of ProblemDetails according to RFC 7807
 }
 catch (ApiException exception)

--- a/Refit.Tests/RequestBuilder.cs
+++ b/Refit.Tests/RequestBuilder.cs
@@ -630,6 +630,14 @@ namespace Refit.Tests
 
         [Get("/api/{id}")]
         Task QueryWithOptionalParameters(int id, [Query]string text = null, [Query]int? optionalId = null, [Query(CollectionFormat = CollectionFormat.Multi)]string[] filters = null);
+
+        [Get("/query")]
+        [QueryUriFormat(UriFormat.Unescaped)]
+        Task UnescapedQueryParams(string q);
+
+        [Get("/query")]
+        [QueryUriFormat(UriFormat.Unescaped)]
+        Task UnescapedQueryParamsWithFilter(string q, string filter);
     }
 
     interface ICancellableMethods
@@ -1296,6 +1304,30 @@ namespace Refit.Tests
 
             var uri = new Uri(new Uri("http://api"), output.RequestUri);
             Assert.Equal("/query?numbers=1%2C2%2C3", uri.PathAndQuery);
+        }
+
+        [Fact]
+        public void QueryStringWithArrayCanBeFormattedByAttribute()
+        {
+            var fixture = new RequestBuilderImplementation<IDummyHttpApi>();
+
+            var factory = fixture.BuildRequestFactoryForMethod("UnescapedQueryParams");
+            var output = factory(new object[] { "Select+Id+From+Account" });
+
+            var uri = new Uri(new Uri("http://api"), output.RequestUri);
+            Assert.Equal("/query?q=Select+Id+From+Account", uri.PathAndQuery);
+        }
+
+        [Fact]
+        public void QueryStringWithArrayCanBeFormattedByAttributeWithMultiple()
+        {
+            var fixture = new RequestBuilderImplementation<IDummyHttpApi>();
+
+            var factory = fixture.BuildRequestFactoryForMethod("UnescapedQueryParamsWithFilter");
+            var output = factory(new object[] { "Select+Id+From+Account", "*" });
+
+            var uri = new Uri(new Uri("http://api"), output.RequestUri);
+            Assert.Equal("/query?q=Select+Id+From+Account&filter=*", uri.PathAndQuery);
         }
 
         [Theory]

--- a/Refit.Tests/RequestBuilder.cs
+++ b/Refit.Tests/RequestBuilder.cs
@@ -1312,10 +1312,10 @@ namespace Refit.Tests
             var fixture = new RequestBuilderImplementation<IDummyHttpApi>();
 
             var factory = fixture.BuildRequestFactoryForMethod("UnescapedQueryParams");
-            var output = factory(new object[] { "Select+Id+From+Account" });
+            var output = factory(new object[] { "Select+Id,Name+From+Account" });
 
             var uri = new Uri(new Uri("http://api"), output.RequestUri);
-            Assert.Equal("/query?q=Select+Id+From+Account", uri.PathAndQuery);
+            Assert.Equal("/query?q=Select+Id,Name+From+Account", uri.PathAndQuery);
         }
 
         [Fact]

--- a/Refit/Attributes.cs
+++ b/Refit/Attributes.cs
@@ -121,7 +121,7 @@ namespace Refit
         UrlEncoded,
 
         /// <summary>
-        /// Encodes everything using the ContentSerializer in RefitSettings 
+        /// Encodes everything using the ContentSerializer in RefitSettings
         /// </summary>
         Serialized
     }
@@ -208,7 +208,7 @@ namespace Refit
     }
 
     /// <summary>
-    /// Collection format defined in https://swagger.io/docs/specification/2-0/describing-parameters/ 
+    /// Collection format defined in https://swagger.io/docs/specification/2-0/describing-parameters/
     /// </summary>
     public enum CollectionFormat
     {
@@ -280,7 +280,7 @@ namespace Refit
         public string Delimiter { get; protected set; } = ".";
 
         /// <summary>
-        /// Used to customize the name of the encoded value.  
+        /// Used to customize the name of the encoded value.
         /// </summary>
         /// <remarks>
         /// Gets combined with <see cref="Delimiter"/> in the format <code>var name = $"{Prefix}{Delimiter}{originalFieldName}"</code>
@@ -317,5 +317,20 @@ namespace Refit
         /// Specifies how the collection should be encoded. The default behavior is <c>RefitParameterFormatter</c>.
         /// </summary>
         public CollectionFormat CollectionFormat { get; set; } = CollectionFormat.RefitParameterFormatter;
+    }
+
+    [AttributeUsage(AttributeTargets.Method)]
+
+    public class QueryUriFormatAttribute : Attribute
+    {
+        public QueryUriFormatAttribute(UriFormat uriFormat)
+        {
+            UriFormat = uriFormat;
+        }
+
+        /// <summary>
+        /// Specifies how the Query Params should be encoded.
+        /// </summary>
+        public UriFormat UriFormat { get; }
     }
 }

--- a/Refit/RequestBuilderImplementation.cs
+++ b/Refit/RequestBuilderImplementation.cs
@@ -156,7 +156,7 @@ namespace Refit
             {
                 // NB: This jacked up reflection code is here because it's
                 // difficult to upcast Task<object> to an arbitrary T, especially
-                // if you need to AOT everything, so we need to reflectively 
+                // if you need to AOT everything, so we need to reflectively
                 // invoke buildTaskFuncForMethod.
                 var taskFuncMi = typeof(RequestBuilderImplementation).GetMethod(nameof(BuildTaskFuncForMethod), BindingFlags.NonPublic | BindingFlags.Instance);
                 var taskFunc = (MulticastDelegate)(restMethod.IsApiResponse ?
@@ -254,8 +254,8 @@ namespace Refit
                     {
                         disposeResponse = false; // caller has to dispose
 
-                        // NB: This double-casting manual-boxing hate crime is the only way to make 
-                        // this work without a 'class' generic constraint. It could blow up at runtime 
+                        // NB: This double-casting manual-boxing hate crime is the only way to make
+                        // this work without a 'class' generic constraint. It could blow up at runtime
                         // and would be A Bad Idea if we hadn't already vetted the return type.
                         return (T)(object)resp;
                     }
@@ -312,7 +312,7 @@ namespace Refit
                     }
 
                     //  Unfortunate side-effect of having no 'class' or 'T : TBody' constraints.
-                    //  However, we know that T must be the same as TBody because IsApiResponse != true so 
+                    //  However, we know that T must be the same as TBody because IsApiResponse != true so
                     //  this code is safe at runtime.
                     return (T)(object)body;
                 }
@@ -656,8 +656,8 @@ namespace Refit
                     }
                 }
 
-                // NB: The URI methods in .NET are dumb. Also, we do this 
-                // UriBuilder business so that we preserve any hardcoded query 
+                // NB: The URI methods in .NET are dumb. Also, we do this
+                // UriBuilder business so that we preserve any hardcoded query
                 // parameters as well as add the parameterized ones.
                 var uri = new UriBuilder(new Uri(new Uri("http://api"), urlTarget));
                 var query = HttpUtility.ParseQueryString(uri.Query ?? "");
@@ -676,8 +676,8 @@ namespace Refit
                 {
                     uri.Query = null;
                 }
-
-                ret.RequestUri = new Uri(uri.Uri.GetComponents(UriComponents.PathAndQuery, UriFormat.UriEscaped), UriKind.Relative);
+                var uriFormat = restMethod.MethodInfo.GetCustomAttribute<QueryUriFormatAttribute>()?.UriFormat ?? UriFormat.UriEscaped;
+                ret.RequestUri = new Uri(uri.Uri.GetComponents(UriComponents.PathAndQuery, uriFormat), UriKind.Relative);
                 return ret;
             };
         }
@@ -785,11 +785,11 @@ namespace Refit
         static void SetHeader(HttpRequestMessage request, string name, string value)
         {
             // Clear any existing version of this header that might be set, because
-            // we want to allow removal/redefinition of headers. 
+            // we want to allow removal/redefinition of headers.
             // We also don't want to double up content headers which may have been
             // set for us automatically.
 
-            // NB: We have to enumerate the header names to check existence because 
+            // NB: We have to enumerate the header names to check existence because
             // Contains throws if it's the wrong header type for the collection.
             if (request.Headers.Any(x => x.Key == name))
             {


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Unescape Querystring parameters #277



**What is the current behavior?**
All query parameters are escaped by default.



**What is the new behavior?**
Default behavior can be overridden by an attribute guard.



**What might this PR break?**
Query string behavior.


**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:
N/A
