### PR TITLE
Fix cache key construct for CachedRequestBuilderImplementation

### DIFF
--- a/Refit.Tests/RequestBuilder.cs
+++ b/Refit.Tests/RequestBuilder.cs
@@ -1470,6 +1470,31 @@ namespace Refit.Tests
 
             Assert.Equal(expected, output.SendContent);
         }
+
+        private class RequestBuilderMock : IRequestBuilder
+        {
+            public int CallCount { get; private set; }
+
+            public Func<HttpClient, object[], object> BuildRestResultFuncForMethod(string methodName, Type[] parameterTypes = null, Type[] genericArgumentTypes = null)
+            {
+                CallCount++;
+                return null;
+            }
+        }
+
+        [Fact]
+        public void CachedRequestBuilderCallInternalBuilderForParametersWithSameNamesButDifferentNamespaces()
+        {
+            var internalBuilder = new RequestBuilderMock();
+            var cachedBuilder = new CachedRequestBuilderImplementation(internalBuilder);
+
+            cachedBuilder.BuildRestResultFuncForMethod("TestMethodName", new[] { typeof(CollisionA.SomeType) });
+            cachedBuilder.BuildRestResultFuncForMethod("TestMethodName", new[] { typeof(CollisionB.SomeType) });
+            cachedBuilder.BuildRestResultFuncForMethod("TestMethodName", null, new[] { typeof(CollisionA.SomeType) });
+            cachedBuilder.BuildRestResultFuncForMethod("TestMethodName", null, new[] { typeof(CollisionB.SomeType) });
+
+            Assert.Equal(4, internalBuilder.CallCount);
+        }
     }
 
     static class RequestBuilderTestExtensions

--- a/Refit/CachedRequestBuilderImplementation.cs
+++ b/Refit/CachedRequestBuilderImplementation.cs
@@ -45,7 +45,7 @@ namespace Refit
                 return "";
             }
 
-            return string.Join(", ", parameterTypes.Select(t => t.Name));
+            return string.Join(", ", parameterTypes.Select(t => t.FullName));
         }
 
         string GetGenericString(Type[] genericArgumentTypes)
@@ -55,7 +55,7 @@ namespace Refit
                 return "";
             }
 
-            return "<" + string.Join(", ", genericArgumentTypes.Select(t => t.Name)) + ">";
+            return "<" + string.Join(", ", genericArgumentTypes.Select(t => t.FullName)) + ">";
         }
     }
 }


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
Fix cache key generation in CachedRequestBuilderImplementation
https://github.com/reactiveui/refit/issues/769

**What is the current behavior?**
Generic and method arguments in cache key use type name without namespace

**What is the new behavior?**
Generic and method arguments in cache key use full type name