### PR TITLE
feat: Add support for ProblemDetails extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -843,8 +843,11 @@ try
 }
 catch (ValidationApiException validationException)
 {
-   // handle validation here by using validationException.Content, 
+   // handle validation here by using validationException.Content,
    // which is type of ProblemDetails according to RFC 7807
+
+   // If the response contains additional properties on the problem details,
+   // they will be added to the validationException.Content.Extensions collection.
 }
 catch (ApiException exception)
 {

--- a/Refit.Tests/ResponseTests.cs
+++ b/Refit.Tests/ResponseTests.cs
@@ -104,6 +104,42 @@ namespace Refit.Tests
         }
 
         [Fact]
+        public async Task WhenProblemDetailsResponseContainsExtensions_ShouldHydrateExtensions()
+        {
+            var expectedContent = new
+            {
+                Detail = "detail",
+                Instance = "instance",
+                Status = 1,
+                Title = "title",
+                Type = "type",
+                Foo = "bar",
+                Baz = 123d,
+            };
+
+            var expectedResponse = new HttpResponseMessage(HttpStatusCode.BadRequest)
+            {
+                Content = new StringContent(JsonConvert.SerializeObject(expectedContent))
+            };
+
+            expectedResponse.Content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/problem+json");
+            mockHandler.Expect(HttpMethod.Get, "http://api/aliasTest")
+                .Respond(req => expectedResponse);
+
+            var actualException = await Assert.ThrowsAsync<ValidationApiException>(() => fixture.GetTestObject());
+            Assert.NotNull(actualException.Content);
+            Assert.Equal("detail", actualException.Content.Detail);
+            Assert.Equal("instance", actualException.Content.Instance);
+            Assert.Equal(1, actualException.Content.Status);
+            Assert.Equal("title", actualException.Content.Title);
+            Assert.Equal("type", actualException.Content.Type);
+
+            Assert.Collection(actualException.Content.Extensions,
+                kvp => Assert.Equal(new KeyValuePair<string, object>(nameof(expectedContent.Foo), expectedContent.Foo), kvp),
+                kvp => Assert.Equal(new KeyValuePair<string, object>(nameof(expectedContent.Baz), expectedContent.Baz), kvp));
+        }
+
+        [Fact]
         public async Task BadRequestWithEmptyContent_ShouldReturnApiException()
         {
             var expectedResponse = new HttpResponseMessage(HttpStatusCode.BadRequest)

--- a/Refit/ProblemDetails.cs
+++ b/Refit/ProblemDetails.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace Refit
 {
@@ -11,6 +13,12 @@ namespace Refit
         /// Collection of resulting errors for the request.
         /// </summary>
         public Dictionary<string, string[]> Errors { get; set; } = new Dictionary<string, string[]>();
+
+        /// <summary>
+        /// Collection of ProblemDetails extensions
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> Extensions { get; } = new Dictionary<string, object>(StringComparer.Ordinal);
 
         /// <summary>
         /// A URI reference that identifies the problem type.


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Updates the ProblemDetails to support extensions to the spec. This behaves the same as the MS implementation of ProblemDetails extensions: https://github.com/aspnet/Mvc/blob/master/src/Microsoft.AspNetCore.Mvc.Core/ProblemDetails.cs#L62

This means additional properties on the response will be populated in the new Extensions property.
I have chosen to not change the behaviour of the Errors property in case it's a breaking change for other users.

**What is the current behavior?**
Extension problem details extension properties are ignored

**What is the new behavior?**
Extension properties on the problem details response are populated in to new property

**What might this PR break?**
It shouldn't cause any regressions with this being additive.

**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:
If you'd like to discuss further I'm "syrus" on reactivex.slack.com