### PR TITLE
Fix for #802 casing bug on object bound to url

### DIFF
--- a/Refit.Tests/RefitStubs.Net46.cs
+++ b/Refit.Tests/RefitStubs.Net46.cs
@@ -418,6 +418,14 @@ namespace Refit.Tests
         }
 
         /// <inheritdoc />
+        Task IApiBindPathToObject.GetFooBarsWithDifferentCasing(PathBoundObject requestParams)
+        {
+            var arguments = new object[] { requestParams };
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBarsWithDifferentCasing", new Type[] { typeof(PathBoundObject) });
+            return (Task)func(Client, arguments);
+        }
+
+        /// <inheritdoc />
         Task IApiBindPathToObject.GetBarsByFoo(string id, PathBoundObject request)
         {
             var arguments = new object[] { id, request };

--- a/Refit.Tests/RefitStubs.NetCore2.cs
+++ b/Refit.Tests/RefitStubs.NetCore2.cs
@@ -418,6 +418,14 @@ namespace Refit.Tests
         }
 
         /// <inheritdoc />
+        Task IApiBindPathToObject.GetFooBarsWithDifferentCasing(PathBoundObject requestParams)
+        {
+            var arguments = new object[] { requestParams };
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBarsWithDifferentCasing", new Type[] { typeof(PathBoundObject) });
+            return (Task)func(Client, arguments);
+        }
+
+        /// <inheritdoc />
         Task IApiBindPathToObject.GetBarsByFoo(string id, PathBoundObject request)
         {
             var arguments = new object[] { id, request };

--- a/Refit.Tests/RestService.cs
+++ b/Refit.Tests/RestService.cs
@@ -56,6 +56,9 @@ namespace Refit.Tests
         [Get("/foos/{request.someProperty}/bar/{request.someProperty2}")]
         Task GetFooBars(PathBoundObject request);
 
+        [Get("/foos/{Requestparams.SomeProperty}/bar/{requestParams.SoMeProPerty2}")]
+        Task GetFooBarsWithDifferentCasing(PathBoundObject requestParams);
+
         [Get("/foos/{id}/{request.someProperty}/bar/{request.someProperty2}")]
         Task GetBarsByFoo(string id, PathBoundObject request);
 
@@ -64,6 +67,7 @@ namespace Refit.Tests
 
         [Get("/foos/{request.someProperty}/bar")]
         Task GetBarsByFoo(PathBoundObject request);
+
 
         [Get("/foos/{request.someProperty}/bar/{request.someProperty3}")]
         Task GetFooBarsDerived(PathBoundDerivedObject request);
@@ -274,6 +278,28 @@ namespace Refit.Tests
             var fixture = RestService.For<IApiBindPathToObject>("http://foo", settings);
 
             await fixture.GetFooBars(new PathBoundObject()
+            {
+                SomeProperty = 1,
+                SomeProperty2 = "barNone"
+            });
+            mockHttp.VerifyNoOutstandingExpectation();
+        }
+
+        [Fact]
+        public async Task GetWithPathBoundObjectDifferentCasing()
+        {
+            var mockHttp = new MockHttpMessageHandler();
+            mockHttp.Expect(HttpMethod.Get, "http://foo/foos/1/bar/barNone")
+                    .WithExactQueryString("")
+                    .Respond("application/json", "Ok");
+
+            var settings = new RefitSettings
+            {
+                HttpMessageHandlerFactory = () => mockHttp
+            };
+            var fixture = RestService.For<IApiBindPathToObject>("http://foo", settings);
+
+            await fixture.GetFooBarsWithDifferentCasing(new PathBoundObject()
             {
                 SomeProperty = 1,
                 SomeProperty2 = "barNone"

--- a/Refit/RestMethodInfo.cs
+++ b/Refit/RestMethodInfo.cs
@@ -160,7 +160,7 @@ bogusPath:
                 //if the param is an lets make a dictionary for all it's potential parameters
                 var objectParamValidationDict = parameterInfo.Where(x => x.ParameterType.GetTypeInfo().IsClass)
                                                                  .SelectMany(x => GetParameterProperties(x).Select(p => Tuple.Create(x, p)))
-                                                                 .GroupBy(i => $"{i.Item1.Name}.{GetUrlNameForProperty(i.Item2).ToLowerInvariant()}")
+                                                                 .GroupBy(i => $"{i.Item1.Name}.{GetUrlNameForProperty(i.Item2)}".ToLowerInvariant())
                                                                  .ToDictionary(k => k.Key, v => v.First());
                 foreach (var match in parameterizedParts)
                 {


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Fixes #802 


**What is the current behavior?**
<!-- You can also link to an open issue here. -->



**What is the new behavior?**
<!-- If this is a feature change -->
Allows any casing in the parameter binding to the object


**What might this PR break?**



**Please check if the PR fulfills these requirements**
- [ x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

