### PR TITLE
Unescape Querystring parameters #277

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,19 @@ Search(new [] {10, 20, 30})
 >>> "/users/list?ages=10%2C20%2C30"
 ```
 
+### Unescape Querystring parameters
+
+Use the `QueryUriFormat` attribute to specify if the query parameters should be url escaped
+
+```csharp
+[Get("/query")]
+[QueryUriFormat(UriFormat.Unescaped)]
+Task Query(string q);
+
+Query("Select+Id,Name+From+Account")
+>>> "/query?q=Select+Id,Name+From+Account"
+```
+
 ### Body content
 
 One of the parameters in your method can be used as the body, by using the

--- a/Refit.Tests/RequestBuilder.cs
+++ b/Refit.Tests/RequestBuilder.cs
@@ -715,6 +715,14 @@ namespace Refit.Tests
         [Headers("Accept:application/json", "X-API-V: 125")]
         [Get("/api/someModule/deviceList?controlId={control_id}")]
         Task QueryWithHeadersBeforeData([Header("Authorization")] string authorization, [Header("X-Lng")] string twoLetterLang, string search, [AliasAs("control_id")] string controlId, string secret);
+
+        [Get("/query")]
+        [QueryUriFormat(UriFormat.Unescaped)]
+        Task UnescapedQueryParams(string q);
+
+        [Get("/query")]
+        [QueryUriFormat(UriFormat.Unescaped)]
+        Task UnescapedQueryParamsWithFilter(string q, string filter);
     }
 
     interface ICancellableMethods
@@ -1381,6 +1389,30 @@ namespace Refit.Tests
 
             var uri = new Uri(new Uri("http://api"), output.RequestUri);
             Assert.Equal("/query?numbers=1%2C2%2C3", uri.PathAndQuery);
+        }
+
+        [Fact]
+        public void QueryStringWithArrayCanBeFormattedByAttribute()
+        {
+            var fixture = new RequestBuilderImplementation<IDummyHttpApi>();
+
+            var factory = fixture.BuildRequestFactoryForMethod("UnescapedQueryParams");
+            var output = factory(new object[] { "Select+Id,Name+From+Account" });
+
+            var uri = new Uri(new Uri("http://api"), output.RequestUri);
+            Assert.Equal("/query?q=Select+Id,Name+From+Account", uri.PathAndQuery);
+        }
+
+        [Fact]
+        public void QueryStringWithArrayCanBeFormattedByAttributeWithMultiple()
+        {
+            var fixture = new RequestBuilderImplementation<IDummyHttpApi>();
+
+            var factory = fixture.BuildRequestFactoryForMethod("UnescapedQueryParamsWithFilter");
+            var output = factory(new object[] { "Select+Id+From+Account", "*" });
+
+            var uri = new Uri(new Uri("http://api"), output.RequestUri);
+            Assert.Equal("/query?q=Select+Id+From+Account&filter=*", uri.PathAndQuery);
         }
 
         [Theory]

--- a/Refit/Attributes.cs
+++ b/Refit/Attributes.cs
@@ -327,4 +327,19 @@ namespace Refit
         /// </summary>
         public CollectionFormat CollectionFormat { get; set; } = CollectionFormat.RefitParameterFormatter;
     }
+
+    [AttributeUsage(AttributeTargets.Method)]
+
+    public class QueryUriFormatAttribute : Attribute
+    {
+        public QueryUriFormatAttribute(UriFormat uriFormat)
+        {
+            UriFormat = uriFormat;
+        }
+
+        /// <summary>
+        /// Specifies how the Query Params should be encoded.
+        /// </summary>
+        public UriFormat UriFormat { get; }
+    }
 }

--- a/Refit/RequestBuilderImplementation.cs
+++ b/Refit/RequestBuilderImplementation.cs
@@ -708,7 +708,8 @@ namespace Refit
                     uri.Query = null;
                 }
 
-                ret.RequestUri = new Uri(uri.Uri.GetComponents(UriComponents.PathAndQuery, UriFormat.UriEscaped), UriKind.Relative);
+                var uriFormat = restMethod.MethodInfo.GetCustomAttribute<QueryUriFormatAttribute>()?.UriFormat ?? UriFormat.UriEscaped;
+                ret.RequestUri = new Uri(uri.Uri.GetComponents(UriComponents.PathAndQuery, uriFormat), UriKind.Relative);
                 return ret;
             };
         }


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Unescape Querystring parameters #277

**What is the current behavior?**
All query parameters are escaped by default.

**What is the new behavior?**
Default behavior can be overridden by an attribute guard.

**What might this PR break?**
Query string behavior.

**Please check if the PR fulfills these requirements**
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

**Other information**:
N/A

Big thanks to @deesejohn for originally opening this & submitting a PR that I can't re-open.