### PR TITLE
Added interfaces to ApiResponse

### DIFF
--- a/Refit.Tests/RequestBuilder.cs
+++ b/Refit.Tests/RequestBuilder.cs
@@ -440,7 +440,7 @@ namespace Refit.Tests
             Assert.True(fixture.BodyParameterInfo.Item2); // buffered default
             Assert.Equal(1, fixture.BodyParameterInfo.Item3);
 
-            Assert.Equal(typeof(bool), fixture.SerializedReturnType);
+            Assert.Equal(typeof(bool), fixture.ReturnResultType);
         }
 
         [Fact]
@@ -455,7 +455,7 @@ namespace Refit.Tests
             Assert.False(fixture.BodyParameterInfo.Item2); // unbuffered specified
             Assert.Equal(1, fixture.BodyParameterInfo.Item3);
 
-            Assert.Equal(typeof(bool), fixture.SerializedReturnType);
+            Assert.Equal(typeof(bool), fixture.ReturnResultType);
         }
 
         [Fact]
@@ -470,7 +470,7 @@ namespace Refit.Tests
             Assert.True(fixture.BodyParameterInfo.Item2);
             Assert.Equal(1, fixture.BodyParameterInfo.Item3);
 
-            Assert.Equal(typeof(bool), fixture.SerializedReturnType);
+            Assert.Equal(typeof(bool), fixture.ReturnResultType);
         }
 
         [Fact]
@@ -482,7 +482,7 @@ namespace Refit.Tests
             Assert.Equal(ParameterType.Normal, fixture.ParameterMap[0].Type);
 
             Assert.Equal(typeof(Task), fixture.ReturnType);
-            Assert.Equal(typeof(void), fixture.SerializedReturnType);
+            Assert.Equal(typeof(void), fixture.ReturnResultType);
         }
 
         [Fact]

--- a/Refit/ApiResponse.cs
+++ b/Refit/ApiResponse.cs
@@ -14,7 +14,7 @@ namespace Refit
         }
     }
 
-    public sealed class ApiResponse<T> : IApiResponse<T>
+    public sealed class ApiResponse<out T> : IApiResponse<T>
     {
         readonly HttpResponseMessage response;
         bool disposed;

--- a/Refit/ApiResponse.cs
+++ b/Refit/ApiResponse.cs
@@ -14,7 +14,7 @@ namespace Refit
         }
     }
 
-    public sealed class ApiResponse<T> : IDisposable
+    public sealed class ApiResponse<T> : IApiResponse<T>
     {
         readonly HttpResponseMessage response;
         bool disposed;
@@ -65,5 +65,22 @@ namespace Refit
 
             response.Dispose();
         }
+    }
+
+    public interface IApiResponse<T> : IApiResponse
+    {
+        T Content { get; }
+    }
+
+    public interface IApiResponse : IDisposable
+    {
+        HttpResponseHeaders Headers { get; }
+        HttpContentHeaders ContentHeaders { get; }
+        bool IsSuccessStatusCode { get; }
+        string ReasonPhrase { get; }
+        HttpRequestMessage RequestMessage { get; }
+        HttpStatusCode StatusCode { get; }
+        Version Version { get; }
+        ApiException Error { get; }
     }
 }

--- a/Refit/ApiResponse.cs
+++ b/Refit/ApiResponse.cs
@@ -14,7 +14,7 @@ namespace Refit
         }
     }
 
-    public sealed class ApiResponse<out T> : IApiResponse<T>
+    public sealed class ApiResponse<T> : IApiResponse<T>
     {
         readonly HttpResponseMessage response;
         bool disposed;
@@ -67,7 +67,7 @@ namespace Refit
         }
     }
 
-    public interface IApiResponse<T> : IApiResponse
+    public interface IApiResponse<out T> : IApiResponse
     {
         T Content { get; }
     }

--- a/Refit/ApiResponse.cs
+++ b/Refit/ApiResponse.cs
@@ -8,9 +8,9 @@ namespace Refit
 {
     static class ApiResponse
     {
-        internal static T Create<T>(HttpResponseMessage resp, object content, ApiException error = null)
+        internal static T Create<T, TBody>(HttpResponseMessage resp, object content, ApiException error = null)
         {
-            return (T)Activator.CreateInstance(typeof(T), resp, content, error);
+            return (T)Activator.CreateInstance(typeof(ApiResponse<TBody>), resp, content, error);
         }
     }
 

--- a/Refit/RestMethodInfo.cs
+++ b/Refit/RestMethodInfo.cs
@@ -30,9 +30,9 @@ namespace Refit
         public Dictionary<int, ParameterInfo> ParameterInfoMap { get; set; }
         public Dictionary<int, RestMethodParameterInfo> ParameterMap { get; set; }
         public Type ReturnType { get; set; }
-        public Type SerializedReturnType { get; set; }
+        public Type ReturnResultType { get; set; }
+        public Type DeserializedResultType { get; set; }
         public RefitSettings RefitSettings { get; set; }
-        public Type SerializedGenericArgument { get; set; }
         public bool IsApiResponse { get; }
 
         static readonly Regex ParameterRegex = new Regex(@"{(.*?)}");
@@ -112,8 +112,10 @@ namespace Refit
 
             CancellationToken = ctParams.FirstOrDefault();
 
-            IsApiResponse = SerializedReturnType.GetTypeInfo().IsGenericType &&
-                                SerializedReturnType.GetGenericTypeDefinition() == typeof(ApiResponse<>);
+            IsApiResponse = ReturnResultType.GetTypeInfo().IsGenericType &&
+                            (ReturnResultType.GetGenericTypeDefinition() == typeof(ApiResponse<>)
+                             || ReturnResultType.GetGenericTypeDefinition()  == typeof(IApiResponse<>)
+                             || ReturnResultType == typeof(IApiResponse));
         }
 
         private PropertyInfo[] GetParameterProperties(ParameterInfo parameter)
@@ -242,7 +244,7 @@ bogusPath:
                 .FirstOrDefault();
 
             // also check for AliasAs
-            return nameAttr?.Name ?? paramInfo.GetCustomAttributes<AliasAsAttribute>(true).FirstOrDefault()?.Name;           
+            return nameAttr?.Name ?? paramInfo.GetCustomAttributes<AliasAsAttribute>(true).FirstOrDefault()?.Name;
         }
 
         Tuple<BodySerializationMethod, bool, int> FindBodyParameter(IList<ParameterInfo> parameterList, bool isMultipart, HttpMethod method)
@@ -317,7 +319,7 @@ bogusPath:
                 ? methodInfo.DeclaringType.GetTypeInfo().GetCustomAttributes(true)
                 : new Attribute[0];
 
-            // Headers set on the declaring type have to come first, 
+            // Headers set on the declaring type have to come first,
             // so headers set on the method can replace them. Switching
             // the order here will break stuff.
             var headers = inheritedAttributes.Concat(declaringTypeAttributes).Concat(methodInfo.GetCustomAttributes(true))
@@ -362,34 +364,33 @@ bogusPath:
 
         void DetermineReturnTypeInfo(MethodInfo methodInfo)
         {
-            if (methodInfo.ReturnType.GetTypeInfo().IsGenericType == false)
+            var returnType = methodInfo.ReturnType;
+            if (returnType.IsGenericType && (methodInfo.ReturnType.GetGenericTypeDefinition() != typeof(Task<>)
+                                             || methodInfo.ReturnType.GetGenericTypeDefinition() != typeof(IObservable<>)))
             {
-                if (methodInfo.ReturnType != typeof(Task))
+                ReturnType = returnType;
+                ReturnResultType = returnType.GetGenericArguments()[0];
+
+                if (ReturnResultType.IsGenericType &&
+                    (ReturnResultType.GetGenericTypeDefinition() == typeof(ApiResponse<>)
+                     || ReturnResultType.GetGenericTypeDefinition() == typeof(IApiResponse<>)))
                 {
-                    goto bogusMethod;
+                        DeserializedResultType = ReturnResultType.GetGenericArguments()[0];
                 }
-
-                ReturnType = methodInfo.ReturnType;
-                SerializedReturnType = typeof(void);
-                return;
+                else if (ReturnResultType == typeof(IApiResponse))
+                {
+                    DeserializedResultType = typeof(HttpContent);
+                }else
+                    DeserializedResultType = ReturnResultType;
             }
-
-            var genericType = methodInfo.ReturnType.GetGenericTypeDefinition();
-            if (genericType != typeof(Task<>) && genericType != typeof(IObservable<>))
+            else if (returnType == typeof(Task))
             {
-                goto bogusMethod;
+                ReturnType = methodInfo.ReturnType;
+                ReturnResultType = typeof(void);
+                DeserializedResultType = typeof(void);
             }
-
-            ReturnType = methodInfo.ReturnType;
-            SerializedReturnType = methodInfo.ReturnType.GetGenericArguments()[0];
-
-            if (SerializedReturnType.GetTypeInfo().IsGenericType)
-                SerializedGenericArgument = SerializedReturnType.GetGenericArguments()[0];
-
-            return;
-
-bogusMethod:
-            throw new ArgumentException($"Method \"{methodInfo.Name}\" is invalid. All REST Methods must return either Task<T> or IObservable<T>");
+            else
+                throw new ArgumentException($"Method \"{methodInfo.Name}\" is invalid. All REST Methods must return either Task<T> or IObservable<T>");
         }
     }
 }


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
It's fixing #545 by making `ApiResponse` implement interface `IApiResponse` and `IApiResponse<T>`. 

The rationale behind it is that `IApiResponse` interface allows to access the `ApiResponse`'s various properties without requiring a strongly typed variable. `IApiResponse<T>` gives the additional access to the content and easier/simpler testing.

A byproduct of the PR/refactor is that the result no longer needs boxing to be returned.

**What is the current behavior?**
1. `ApiResponse<T>` with no interface


**What is the new behavior?**
1. `ApiResponse<T>` has `IApiResponse<T>` an `IApiResponse` implemented
2. `Task<IApiResponse<T>>`, `Task<IApiResponse>`, `IObservable<IApiResponse<T>>`, `IObservable<IApiResponse>` would all be valid return types of a RestMethod


**What might this PR break?**
Mainly the part `BuildCancellableTaskFuncForMethod<T, TBody>`


**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:
While a small/straightforward refactor, the feature would be really practical in situations where you use a form of dynamic proxy, which right now forces you to use reflection.

Not sure what tests or docs should be added and updated. I'm not attached to the naming of the changes either. If anything needs changes I don't mind handling it either.
