### PR TITLE
Downgrade version of Microsoft.Extensions.Http to version 2.1.1

### DIFF
--- a/Refit.HttpClientFactory/Refit.HttpClientFactory.csproj
+++ b/Refit.HttpClientFactory/Refit.HttpClientFactory.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Refit\Refit.csproj" PrivateAssets="Analyzers" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="2.1.1" />
   </ItemGroup>
 
 </Project>

--- a/Refit.Tests/Refit.Tests.csproj
+++ b/Refit.Tests/Refit.Tests.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="1.2.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Downgrade version of package Microsoft.Extensions.Http from version 3.1.1 to version 2.1.1 giving control of referencing a greater version to the user instead of forcing an upgrade that may introduce breaking changes.

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

Forces version 3.1.1 of Microsoft.Extensions.Http package

**What is the new behavior?**
<!-- If this is a feature change -->

Allows to use versions of package Microsoft.Extensions.Http from version 2.1.1 upguard
