### PR TITLE
Allow specifying default CollectionFormat

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,15 @@ Search(new [] {10, 20, 30})
 >>> "/users/list?ages=10%2C20%2C30"
 ```
 
+You can also specify collection format in `RefitSettings`, that will be used by default, unless explicitly defined in `Query` attribute.
+
+```csharp
+var gitHubApi = RestService.For<IGitHubApi>("https://api.github.com",
+    new RefitSettings {
+        CollectionFormat = CollectionFormat.Multi
+    });
+```
+
 ### Unescape Querystring parameters
 
 Use the `QueryUriFormat` attribute to specify if the query parameters should be url escaped

--- a/Refit.Tests/RefitStubs.Net46.cs
+++ b/Refit.Tests/RefitStubs.Net46.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Net.Http;
 using System.Collections.Generic;
+using Refit.Tests.RefitInternalGenerated;
 
 /* ******** Hey You! *********
  *
@@ -29,7 +30,6 @@ namespace Refit.Tests.RefitInternalGenerated
 
 namespace Refit.Tests
 {
-    using Refit.Tests.RefitInternalGenerated;
     using System.IO;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis;
@@ -100,7 +100,6 @@ namespace Refit.Tests
 
 namespace Refit.Tests
 {
-    using Refit.Tests.RefitInternalGenerated;
     using System.IO;
     using System.Net;
     using System.Reactive.Linq;
@@ -148,7 +147,6 @@ namespace Refit.Tests
 
 namespace Refit.Tests
 {
-    using Refit.Tests.RefitInternalGenerated;
     using System.Threading.Tasks;
     using Refit;
     using static System.Math;
@@ -207,7 +205,6 @@ namespace Refit.Tests
 
 namespace Refit.Tests
 {
-    using Refit.Tests.RefitInternalGenerated;
     using System.Threading.Tasks;
     using Refit;
     using static System.Math;
@@ -242,7 +239,6 @@ namespace Refit.Tests
 
 namespace Refit.Tests
 {
-    using Refit.Tests.RefitInternalGenerated;
     using System.Threading.Tasks;
     using Refit;
     using static System.Math;
@@ -285,7 +281,6 @@ namespace Refit.Tests
 
 namespace Refit.Tests
 {
-    using Refit.Tests.RefitInternalGenerated;
     using System.Threading.Tasks;
     using Refit;
     using static System.Math;
@@ -344,7 +339,6 @@ namespace Refit.Tests
 
 namespace Refit.Tests
 {
-    using Refit.Tests.RefitInternalGenerated;
     using System.Threading.Tasks;
     using Refit;
     using static System.Math;
@@ -379,7 +373,6 @@ namespace Refit.Tests
 
 namespace Refit.Tests
 {
-    using Refit.Tests.RefitInternalGenerated;
     using System.IO;
     using System.Net;
     using System.Reactive.Linq;
@@ -517,7 +510,6 @@ namespace Refit.Tests
 
 namespace Refit.Tests
 {
-    using Refit.Tests.RefitInternalGenerated;
     using System.IO;
     using System.Net;
     using System.Reactive.Linq;
@@ -559,7 +551,6 @@ namespace Refit.Tests
 
 namespace Refit.Tests
 {
-    using Refit.Tests.RefitInternalGenerated;
     using System.IO;
     using System.Net;
     using System.Reactive.Linq;
@@ -617,7 +608,6 @@ namespace Refit.Tests
 
 namespace Refit.Tests
 {
-    using Refit.Tests.RefitInternalGenerated;
     using System.IO;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis;
@@ -693,7 +683,6 @@ namespace Refit.Tests
 
 namespace Refit.Tests
 {
-    using Refit.Tests.RefitInternalGenerated;
     using System.IO;
     using System.Net;
     using System.Reactive.Linq;
@@ -735,7 +724,6 @@ namespace Refit.Tests
 
 namespace Refit.Tests
 {
-    using Refit.Tests.RefitInternalGenerated;
     using System.Threading.Tasks;
     using Refit;
     using static System.Math;
@@ -818,7 +806,6 @@ namespace Refit.Tests
 
 namespace Refit.Tests
 {
-    using Refit.Tests.RefitInternalGenerated;
     using System.Threading.Tasks;
     using Refit;
     using static System.Math;
@@ -893,7 +880,6 @@ namespace Refit.Tests
 
 namespace Refit.Tests
 {
-    using Refit.Tests.RefitInternalGenerated;
     using System.Threading.Tasks;
     using Refit;
     using static System.Math;
@@ -971,7 +957,6 @@ namespace Refit.Tests
 
 namespace Refit.Tests
 {
-    using Refit.Tests.RefitInternalGenerated;
     using System.Threading.Tasks;
     using Refit;
     using static System.Math;
@@ -1041,7 +1026,6 @@ namespace Refit.Tests
 
 namespace Refit.Tests
 {
-    using Refit.Tests.RefitInternalGenerated;
     using System.Text;
     using System.Threading.Tasks;
     using Refit;
@@ -1173,7 +1157,6 @@ namespace Refit.Tests
 
 namespace Refit.Tests
 {
-    using Refit.Tests.RefitInternalGenerated;
     using System.IO;
     using System.Net;
     using System.Reactive.Linq;
@@ -1251,7 +1234,6 @@ namespace Refit.Tests
 
 namespace Refit.Tests
 {
-    using Refit.Tests.RefitInternalGenerated;
     using System.IO;
     using System.Net;
     using System.Reactive.Linq;
@@ -1301,7 +1283,6 @@ namespace Refit.Tests
 
 namespace Refit.Tests
 {
-    using Refit.Tests.RefitInternalGenerated;
     using System.Net;
     using System.Text;
     using System.Threading.Tasks;
@@ -1340,7 +1321,6 @@ namespace Refit.Tests
 
 namespace Refit.Tests
 {
-    using Refit.Tests.RefitInternalGenerated;
     using System.Net;
     using System.Text;
     using System.Threading.Tasks;
@@ -1386,7 +1366,6 @@ namespace Refit.Tests
 
 namespace Refit.Tests
 {
-    using Refit.Tests.RefitInternalGenerated;
     using System.Threading.Tasks;
     using SomeType =  CollisionA.SomeType;
     using CollisionB;
@@ -1422,7 +1401,6 @@ namespace Refit.Tests
 
 namespace Refit.Tests
 {
-    using Refit.Tests.RefitInternalGenerated;
     using System.Text;
     using System.Threading.Tasks;
     using Refit;
@@ -1514,7 +1492,6 @@ namespace Refit.Tests
 
 namespace Refit.Tests
 {
-    using Refit.Tests.RefitInternalGenerated;
     using System.IO;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis;
@@ -1563,7 +1540,6 @@ namespace Refit.Tests
 
 namespace Refit.Tests
 {
-    using Refit.Tests.RefitInternalGenerated;
     using System.IO;
     using System.Net;
     using System.Reactive.Linq;
@@ -1605,7 +1581,6 @@ namespace Refit.Tests
 
 namespace Refit.Tests
 {
-    using Refit.Tests.RefitInternalGenerated;
     using System.IO;
     using System.Net;
     using System.Reactive.Linq;
@@ -1679,7 +1654,6 @@ namespace Refit.Tests
 
 namespace Refit.Tests
 {
-    using Refit.Tests.RefitInternalGenerated;
     using System.IO;
     using System.Net;
     using System.Reflection;
@@ -1817,7 +1791,6 @@ namespace Refit.Tests
 
 namespace AutoGeneratedIServiceWithoutNamespace
 {
-    using Refit.Tests.RefitInternalGenerated;
     using System.Text;
     using System.Threading.Tasks;
     using Refit;
@@ -1860,7 +1833,6 @@ namespace AutoGeneratedIServiceWithoutNamespace
 
 namespace Refit.Tests
 {
-    using Refit.Tests.RefitInternalGenerated;
     using System.IO;
     using System.Net;
     using System.Reactive.Linq;
@@ -1910,7 +1882,6 @@ namespace Refit.Tests
 
 namespace Refit.Tests
 {
-    using Refit.Tests.RefitInternalGenerated;
     using System.IO;
     using System.Net;
     using System.Reactive.Linq;
@@ -1952,7 +1923,6 @@ namespace Refit.Tests
 
 namespace Refit.Tests
 {
-    using Refit.Tests.RefitInternalGenerated;
     using System.Threading.Tasks;
     using CollisionA;
     using Refit;
@@ -1987,7 +1957,6 @@ namespace Refit.Tests
 
 namespace Refit.Tests
 {
-    using Refit.Tests.RefitInternalGenerated;
     using System.Threading.Tasks;
     using CollisionB;
     using Refit;
@@ -2022,7 +1991,6 @@ namespace Refit.Tests
 
 namespace Refit.Tests
 {
-    using Refit.Tests.RefitInternalGenerated;
     using System.Net;
     using System.Threading.Tasks;
     using Refit;
@@ -2111,7 +2079,6 @@ namespace Refit.Tests
 
 namespace Refit.Tests
 {
-    using Refit.Tests.RefitInternalGenerated;
     using System.Net;
     using System.Threading.Tasks;
     using Refit;
@@ -2156,7 +2123,6 @@ namespace Refit.Tests
 
 namespace Refit.Tests
 {
-    using Refit.Tests.RefitInternalGenerated;
     using System.IO;
     using System.Net;
     using System.Reactive.Linq;

--- a/Refit.Tests/RefitStubs.NetCore2.cs
+++ b/Refit.Tests/RefitStubs.NetCore2.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Net.Http;
 using System.Collections.Generic;
+using Refit.Tests.RefitInternalGenerated;
 
 /* ******** Hey You! *********
  *
@@ -29,7 +30,6 @@ namespace Refit.Tests.RefitInternalGenerated
 
 namespace Refit.Tests
 {
-    using Refit.Tests.RefitInternalGenerated;
     using System.IO;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis;
@@ -100,7 +100,6 @@ namespace Refit.Tests
 
 namespace Refit.Tests
 {
-    using Refit.Tests.RefitInternalGenerated;
     using System.IO;
     using System.Net;
     using System.Reactive.Linq;
@@ -148,7 +147,6 @@ namespace Refit.Tests
 
 namespace Refit.Tests
 {
-    using Refit.Tests.RefitInternalGenerated;
     using System.Threading.Tasks;
     using Refit;
     using static System.Math;
@@ -207,7 +205,6 @@ namespace Refit.Tests
 
 namespace Refit.Tests
 {
-    using Refit.Tests.RefitInternalGenerated;
     using System.Threading.Tasks;
     using Refit;
     using static System.Math;
@@ -242,7 +239,6 @@ namespace Refit.Tests
 
 namespace Refit.Tests
 {
-    using Refit.Tests.RefitInternalGenerated;
     using System.Threading.Tasks;
     using Refit;
     using static System.Math;
@@ -285,7 +281,6 @@ namespace Refit.Tests
 
 namespace Refit.Tests
 {
-    using Refit.Tests.RefitInternalGenerated;
     using System.Threading.Tasks;
     using Refit;
     using static System.Math;
@@ -344,7 +339,6 @@ namespace Refit.Tests
 
 namespace Refit.Tests
 {
-    using Refit.Tests.RefitInternalGenerated;
     using System.Threading.Tasks;
     using Refit;
     using static System.Math;
@@ -379,7 +373,6 @@ namespace Refit.Tests
 
 namespace Refit.Tests
 {
-    using Refit.Tests.RefitInternalGenerated;
     using System.IO;
     using System.Net;
     using System.Reactive.Linq;
@@ -517,7 +510,6 @@ namespace Refit.Tests
 
 namespace Refit.Tests
 {
-    using Refit.Tests.RefitInternalGenerated;
     using System.IO;
     using System.Net;
     using System.Reactive.Linq;
@@ -559,7 +551,6 @@ namespace Refit.Tests
 
 namespace Refit.Tests
 {
-    using Refit.Tests.RefitInternalGenerated;
     using System.IO;
     using System.Net;
     using System.Reactive.Linq;
@@ -617,7 +608,6 @@ namespace Refit.Tests
 
 namespace Refit.Tests
 {
-    using Refit.Tests.RefitInternalGenerated;
     using System.IO;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis;
@@ -693,7 +683,6 @@ namespace Refit.Tests
 
 namespace Refit.Tests
 {
-    using Refit.Tests.RefitInternalGenerated;
     using System.IO;
     using System.Net;
     using System.Reactive.Linq;
@@ -735,7 +724,6 @@ namespace Refit.Tests
 
 namespace Refit.Tests
 {
-    using Refit.Tests.RefitInternalGenerated;
     using System.Threading.Tasks;
     using Refit;
     using static System.Math;
@@ -818,7 +806,6 @@ namespace Refit.Tests
 
 namespace Refit.Tests
 {
-    using Refit.Tests.RefitInternalGenerated;
     using System.Threading.Tasks;
     using Refit;
     using static System.Math;
@@ -893,7 +880,6 @@ namespace Refit.Tests
 
 namespace Refit.Tests
 {
-    using Refit.Tests.RefitInternalGenerated;
     using System.Threading.Tasks;
     using Refit;
     using static System.Math;
@@ -971,7 +957,6 @@ namespace Refit.Tests
 
 namespace Refit.Tests
 {
-    using Refit.Tests.RefitInternalGenerated;
     using System.Threading.Tasks;
     using Refit;
     using static System.Math;
@@ -1041,7 +1026,6 @@ namespace Refit.Tests
 
 namespace Refit.Tests
 {
-    using Refit.Tests.RefitInternalGenerated;
     using System.Text;
     using System.Threading.Tasks;
     using Refit;
@@ -1173,7 +1157,6 @@ namespace Refit.Tests
 
 namespace Refit.Tests
 {
-    using Refit.Tests.RefitInternalGenerated;
     using System.IO;
     using System.Net;
     using System.Reactive.Linq;
@@ -1251,7 +1234,6 @@ namespace Refit.Tests
 
 namespace Refit.Tests
 {
-    using Refit.Tests.RefitInternalGenerated;
     using System.IO;
     using System.Net;
     using System.Reactive.Linq;
@@ -1301,7 +1283,6 @@ namespace Refit.Tests
 
 namespace Refit.Tests
 {
-    using Refit.Tests.RefitInternalGenerated;
     using System.Net;
     using System.Text;
     using System.Threading.Tasks;
@@ -1340,7 +1321,6 @@ namespace Refit.Tests
 
 namespace Refit.Tests
 {
-    using Refit.Tests.RefitInternalGenerated;
     using System.Net;
     using System.Text;
     using System.Threading.Tasks;
@@ -1386,7 +1366,6 @@ namespace Refit.Tests
 
 namespace Refit.Tests
 {
-    using Refit.Tests.RefitInternalGenerated;
     using System.Threading.Tasks;
     using SomeType =  CollisionA.SomeType;
     using CollisionB;
@@ -1422,7 +1401,6 @@ namespace Refit.Tests
 
 namespace Refit.Tests
 {
-    using Refit.Tests.RefitInternalGenerated;
     using System.Text;
     using System.Threading.Tasks;
     using Refit;
@@ -1514,7 +1492,6 @@ namespace Refit.Tests
 
 namespace Refit.Tests
 {
-    using Refit.Tests.RefitInternalGenerated;
     using System.IO;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis;
@@ -1563,7 +1540,6 @@ namespace Refit.Tests
 
 namespace Refit.Tests
 {
-    using Refit.Tests.RefitInternalGenerated;
     using System.IO;
     using System.Net;
     using System.Reactive.Linq;
@@ -1605,7 +1581,6 @@ namespace Refit.Tests
 
 namespace Refit.Tests
 {
-    using Refit.Tests.RefitInternalGenerated;
     using System.IO;
     using System.Net;
     using System.Reactive.Linq;
@@ -1679,7 +1654,6 @@ namespace Refit.Tests
 
 namespace Refit.Tests
 {
-    using Refit.Tests.RefitInternalGenerated;
     using System.IO;
     using System.Net;
     using System.Reflection;
@@ -1817,7 +1791,6 @@ namespace Refit.Tests
 
 namespace AutoGeneratedIServiceWithoutNamespace
 {
-    using Refit.Tests.RefitInternalGenerated;
     using System.Text;
     using System.Threading.Tasks;
     using Refit;
@@ -1860,7 +1833,6 @@ namespace AutoGeneratedIServiceWithoutNamespace
 
 namespace Refit.Tests
 {
-    using Refit.Tests.RefitInternalGenerated;
     using System.IO;
     using System.Net;
     using System.Reactive.Linq;
@@ -1910,7 +1882,6 @@ namespace Refit.Tests
 
 namespace Refit.Tests
 {
-    using Refit.Tests.RefitInternalGenerated;
     using System.IO;
     using System.Net;
     using System.Reactive.Linq;
@@ -1952,7 +1923,6 @@ namespace Refit.Tests
 
 namespace Refit.Tests
 {
-    using Refit.Tests.RefitInternalGenerated;
     using System.Threading.Tasks;
     using CollisionA;
     using Refit;
@@ -1987,7 +1957,6 @@ namespace Refit.Tests
 
 namespace Refit.Tests
 {
-    using Refit.Tests.RefitInternalGenerated;
     using System.Threading.Tasks;
     using CollisionB;
     using Refit;
@@ -2022,7 +1991,6 @@ namespace Refit.Tests
 
 namespace Refit.Tests
 {
-    using Refit.Tests.RefitInternalGenerated;
     using System.Net;
     using System.Threading.Tasks;
     using Refit;
@@ -2111,7 +2079,6 @@ namespace Refit.Tests
 
 namespace Refit.Tests
 {
-    using Refit.Tests.RefitInternalGenerated;
     using System.Net;
     using System.Threading.Tasks;
     using Refit;
@@ -2156,7 +2123,6 @@ namespace Refit.Tests
 
 namespace Refit.Tests
 {
-    using Refit.Tests.RefitInternalGenerated;
     using System.IO;
     using System.Net;
     using System.Reactive.Linq;

--- a/Refit.Tests/RequestBuilder.cs
+++ b/Refit.Tests/RequestBuilder.cs
@@ -1,15 +1,15 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Net.Http;
 using System.Net;
+using System.Net.Http;
 using System.Reflection;
-using System.Threading.Tasks;
-using System.Threading;
-using Xunit;
-using System.Collections;
 using System.Runtime.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
 
 namespace Refit.Tests
 {
@@ -126,9 +126,9 @@ namespace Refit.Tests
     public class ComplexQueryObject
     {
         [AliasAs("test-query-alias")]
-        public string TestAlias1 {get; set;}
+        public string TestAlias1 { get; set; }
 
-        public string TestAlias2 {get; set;}
+        public string TestAlias2 { get; set; }
 
         public IEnumerable<int> TestCollection { get; set; }
     }
@@ -1433,6 +1433,34 @@ namespace Refit.Tests
             Assert.Equal("/query?q=Select+Id+From+Account&filter=*", uri.PathAndQuery);
         }
 
+        [Fact]
+        public void QueryStringWithArrayCanBeFormattedByDefaultSetting()
+        {
+            var fixture = new RequestBuilderImplementation<IDummyHttpApi>(new RefitSettings
+            {
+                CollectionFormat = CollectionFormat.Multi
+            });
+
+            var factory = fixture.BuildRequestFactoryForMethod("QueryWithArray");
+            var output = factory(new object[] { new[] { 1, 2, 3 } });
+
+            Assert.Equal("/query?numbers=1&numbers=2&numbers=3", output.RequestUri.PathAndQuery);
+        }
+
+        [Fact]
+        public void DefaultCollectionFormatCanBeOverridenByQueryAttribute()
+        {
+            var fixture = new RequestBuilderImplementation<IDummyHttpApi>(new RefitSettings
+            {
+                CollectionFormat = CollectionFormat.Multi
+            });
+
+            var factory = fixture.BuildRequestFactoryForMethod("QueryWithArrayFormattedAsCsv");
+            var output = factory(new object[] { new[] { 1, 2, 3 } });
+
+            Assert.Equal("/query?numbers=1%2C2%2C3", output.RequestUri.PathAndQuery);
+        }
+
         [Theory]
         [InlineData("QueryWithArrayFormattedAsMulti", "/query?numbers=1&numbers=2&numbers=3")]
         [InlineData("QueryWithArrayFormattedAsCsv", "/query?numbers=1%2C2%2C3")]
@@ -1653,7 +1681,7 @@ namespace Refit.Tests
             var fixture = new RequestBuilderImplementation<IDummyHttpApi>();
             var factory = fixture.BuildRequestFactoryForMethod(nameof(IDummyHttpApi.Blob_Post_Byte));
 
-            var bytes = new byte[10] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+            var bytes = new byte[10] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
 
             var bap = new ByteArrayPart(bytes, "theBytes");
 
@@ -1661,7 +1689,7 @@ namespace Refit.Tests
 
             var uri = new Uri(new Uri("http://api"), output.RequestUri);
 
-            Assert.Equal("/blobstorage/the/path", uri.PathAndQuery);            
+            Assert.Equal("/blobstorage/the/path", uri.PathAndQuery);
         }
 
         [Fact]
@@ -1676,7 +1704,7 @@ namespace Refit.Tests
             var controlIdParam = "theControlId";
             var secretValue = "theSecret";
 
-            
+
 
             var output = factory(new object[] { authHeader, langHeader, searchParam, controlIdParam, secretValue });
 

--- a/Refit/Attributes.cs
+++ b/Refit/Attributes.cs
@@ -1,8 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Net.Http;
-using System.Threading.Tasks;
 
 namespace Refit
 {
@@ -109,7 +106,7 @@ namespace Refit
             BoundaryText = boundaryText;
         }
 
-}
+    }
 
     public enum BodySerializationMethod
     {
@@ -216,47 +213,12 @@ namespace Refit
             : base("Authorization: " + scheme) { }
     }
 
-    /// <summary>
-    /// Collection format defined in https://swagger.io/docs/specification/2-0/describing-parameters/ 
-    /// </summary>
-    public enum CollectionFormat
-    {
-        /// <summary>
-        /// Values formatted with <see cref="RefitSettings.UrlParameterFormatter"/> or
-        /// <see cref="RefitSettings.FormUrlEncodedParameterFormatter"/>.
-        /// </summary>
-        RefitParameterFormatter,
-
-        /// <summary>
-        /// Comma-separated values
-        /// </summary>
-        Csv,
-
-        /// <summary>
-        /// Space-separated values
-        /// </summary>
-        Ssv,
-
-        /// <summary>
-        /// Tab-separated values
-        /// </summary>
-        Tsv,
-
-        /// <summary>
-        /// Pipe-separated values
-        /// </summary>
-        Pipes,
-
-        /// <summary>
-        /// Multiple parameter instances
-        /// </summary>
-        Multi
-    }
-
     [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Property)] // Property is to allow for form url encoded data
 
     public class QueryAttribute : Attribute
     {
+        CollectionFormat? collectionFormat;
+
         public QueryAttribute() { }
 
         public QueryAttribute(string delimiter)
@@ -323,9 +285,16 @@ namespace Refit
         public string Format { get; set; }
 
         /// <summary>
-        /// Specifies how the collection should be encoded. The default behavior is <c>RefitParameterFormatter</c>.
+        /// Specifies how the collection should be encoded.
         /// </summary>
-        public CollectionFormat CollectionFormat { get; set; } = CollectionFormat.RefitParameterFormatter;
+        public CollectionFormat CollectionFormat
+        {
+            // Cannot make property nullable due to Attribute restrictions
+            get => collectionFormat.GetValueOrDefault();
+            set => collectionFormat = value;
+        }
+
+        public bool IsCollectionFormatSpecified => collectionFormat.HasValue;
     }
 
     [AttributeUsage(AttributeTargets.Method)]

--- a/Refit/CollectionFormat.cs
+++ b/Refit/CollectionFormat.cs
@@ -1,0 +1,39 @@
+﻿namespace Refit
+{
+    /// <summary>
+    /// Collection format defined in https://swagger.io/docs/specification/2-0/describing-parameters/ 
+    /// </summary>
+    public enum CollectionFormat
+    {
+        /// <summary>
+        /// Values formatted with <see cref="RefitSettings.UrlParameterFormatter"/> or
+        /// <see cref="RefitSettings.FormUrlEncodedParameterFormatter"/>.
+        /// </summary>
+        RefitParameterFormatter,
+
+        /// <summary>
+        /// Comma-separated values
+        /// </summary>
+        Csv,
+
+        /// <summary>
+        /// Space-separated values
+        /// </summary>
+        Ssv,
+
+        /// <summary>
+        /// Tab-separated values
+        /// </summary>
+        Tsv,
+
+        /// <summary>
+        /// Pipe-separated values
+        /// </summary>
+        Pipes,
+
+        /// <summary>
+        /// Multiple parameter instances
+        /// </summary>
+        Multi
+    }
+}

--- a/Refit/FormValueMultimap.cs
+++ b/Refit/FormValueMultimap.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Collections;
-using System.Reflection;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using Newtonsoft.Json;
 
 namespace Refit
@@ -59,7 +59,11 @@ namespace Refit
 
                         if (value is IEnumerable enumerable)
                         {
-                            switch (attrib?.CollectionFormat)
+                            var collectionFormat = attrib != null && attrib.IsCollectionFormatSpecified
+                                ? attrib.CollectionFormat
+                                : settings.CollectionFormat;
+
+                            switch (collectionFormat)
                             {
                                 case CollectionFormat.Multi:
                                     foreach (var item in enumerable)

--- a/Refit/RefitSettings.cs
+++ b/Refit/RefitSettings.cs
@@ -41,6 +41,7 @@ namespace Refit
         public IContentSerializer ContentSerializer { get; set; }
         public IUrlParameterFormatter UrlParameterFormatter { get; set; }
         public IFormUrlEncodedParameterFormatter FormUrlEncodedParameterFormatter { get; set; }
+        public CollectionFormat CollectionFormat { get; set; } = CollectionFormat.RefitParameterFormatter;
         public bool Buffered { get; set; } = true;
     }
 

--- a/Refit/RequestBuilderImplementation.cs
+++ b/Refit/RequestBuilderImplementation.cs
@@ -1,16 +1,16 @@
 ﻿using System;
 using System.Collections;
-using System.Reflection;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
-using System.Threading.Tasks;
+using System.Reflection;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
+using System.Threading.Tasks;
 using System.Web;
-using System.Collections.Concurrent;
 
 namespace Refit
 {
@@ -454,7 +454,7 @@ namespace Refit
                 var urlTarget = (basePath == "/" ? string.Empty : basePath) + restMethod.RelativePath;
                 var queryParamsToAdd = new List<KeyValuePair<string, string>>();
                 var headersToAdd = new Dictionary<string, string>(restMethod.Headers);
-                RestMethodParameterInfo parameterInfo = null;                
+                RestMethodParameterInfo parameterInfo = null;
 
                 for (var i = 0; i < paramList.Length; i++)
                 {
@@ -687,7 +687,11 @@ namespace Refit
         {
             if (!(param is string) && param is IEnumerable paramValues)
             {
-                switch (queryAttribute.CollectionFormat)
+                var collectionFormat = queryAttribute.IsCollectionFormatSpecified
+                    ? queryAttribute.CollectionFormat
+                    : settings.CollectionFormat;
+
+                switch (collectionFormat)
                 {
                     case CollectionFormat.Multi:
                         foreach (var paramValue in paramValues)
@@ -700,9 +704,9 @@ namespace Refit
                         break;
 
                     default:
-                        var delimiter = queryAttribute.CollectionFormat == CollectionFormat.Ssv ? " "
-                            : queryAttribute.CollectionFormat == CollectionFormat.Tsv ? "\t"
-                            : queryAttribute.CollectionFormat == CollectionFormat.Pipes ? "|"
+                        var delimiter = collectionFormat == CollectionFormat.Ssv ? " "
+                            : collectionFormat == CollectionFormat.Tsv ? "\t"
+                            : collectionFormat == CollectionFormat.Pipes ? "|"
                             : ",";
 
                         // Missing a "default" clause was preventing the collection from serializing at all, as it was hitting "continue" thus causing an off-by-one error


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

fixes #840 

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Allow specifying default `CollectionFormat` in RefitSettings.



**What is the current behavior?**
<!-- You can also link to an open issue here. -->
`CollectionFormat` is needed to be set for each query parameter if non-csv is needed.



**What is the new behavior?**
<!-- If this is a feature change -->
You can specify `CollectionFormat` in `RefitSettings`, which will be applied unless explicitly specified in `QueryAttribute`.





**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


