### PR TITLE
handle serialization for query objects with IEnumerable properties

### DIFF
--- a/Refit.Tests/RequestBuilder.cs
+++ b/Refit.Tests/RequestBuilder.cs
@@ -129,6 +129,8 @@ namespace Refit.Tests
         public string TestAlias1 {get; set;}
 
         public string TestAlias2 {get; set;}
+
+        public IEnumerable<int> TestCollection { get; set; }
     }
 
 
@@ -219,6 +221,19 @@ namespace Refit.Tests
             var uri = new Uri(new Uri("http://api"), output.RequestUri);
 
             Assert.Equal("/foo?test-query-alias=one&TestAlias2=two", uri.PathAndQuery);
+        }
+
+        [Fact]
+        public void ObjectQueryParameterWithInnerCollectionHasCorrectQuerystring()
+        {
+            var fixture = new RequestBuilderImplementation<IDummyHttpApi>();
+            var factory = fixture.BuildRequestFactoryForMethod(nameof(IDummyHttpApi.ComplexTypeQueryWithInnerCollection));
+
+            var param = new ComplexQueryObject { TestCollection = new[] { 1, 2, 3 } };
+            var output = factory(new object[] { param });
+            var uri = new Uri(new Uri("http://api"), output.RequestUri);
+
+            Assert.Equal("/foo?TestCollection=1%2C2%2C3", uri.PathAndQuery);
         }
 
         [Fact]
@@ -708,6 +723,9 @@ namespace Refit.Tests
 
         [Post("/foo")]
         Task PostWithComplexTypeQuery([Query]ComplexQueryObject queryParams);
+
+        [Get("/foo")]
+        Task ComplexTypeQueryWithInnerCollection([Query]ComplexQueryObject queryParams);
 
         [Get("/api/{obj.someProperty}")]
         Task QueryWithOptionalParametersPathBoundObject(PathBoundObject obj, [Query]string text = null, [Query]int? optionalId = null, [Query(CollectionFormat = CollectionFormat.Multi)]string[] filters = null);

--- a/Refit/RequestBuilderImplementation.cs
+++ b/Refit/RequestBuilderImplementation.cs
@@ -592,45 +592,14 @@ namespace Refit
                         var attr = queryAttribute ?? new QueryAttribute();
                         if (DoNotConvertToQueryMap(param))
                         {
-                            if (!(param is string) && param is IEnumerable paramValues)
-                            {
-                                switch (attr.CollectionFormat)
-                                {
-                                    case CollectionFormat.Multi:
-                                        foreach (var paramValue in paramValues)
-                                        {
-                                            queryParamsToAdd.Add(new KeyValuePair<string, string>(
-                                                restMethod.QueryParameterMap[i],
-                                                settings.UrlParameterFormatter.Format(paramValue, restMethod.ParameterInfoMap[i], restMethod.ParameterInfoMap[i].ParameterType)));
-                                        }
-                                        continue;
-                                    default:
-                                        var delimiter = attr.CollectionFormat == CollectionFormat.Ssv ? " "
-                                            : attr.CollectionFormat == CollectionFormat.Tsv ? "\t"
-                                            : attr.CollectionFormat == CollectionFormat.Pipes ? "|"
-                                            : ",";
-
-                                        // Missing a "default" clause was preventing the collection from serializing at all, as it was hitting "continue" thus causing an off-by-one error
-
-                                        var formattedValues = paramValues
-                                            .Cast<object>()
-                                            .Select(v => settings.UrlParameterFormatter.Format(v, restMethod.ParameterInfoMap[i], restMethod.ParameterInfoMap[i].ParameterType));
-
-                                        queryParamsToAdd.Add(new KeyValuePair<string, string>(
-                                            restMethod.QueryParameterMap[i],
-                                            string.Join(delimiter, formattedValues)));
-                                        continue;
-                                }
-                            }
-
-                            queryParamsToAdd.Add(new KeyValuePair<string, string>(restMethod.QueryParameterMap[i], settings.UrlParameterFormatter.Format(param, restMethod.ParameterInfoMap[i], restMethod.ParameterInfoMap[i].ParameterType)));
+                            queryParamsToAdd.AddRange(ParseQueryParameter(param, restMethod.ParameterInfoMap[i], restMethod.QueryParameterMap[i], attr));
                         }
                         else
                         {
                             foreach (var kvp in BuildQueryMap(param, attr.Delimiter, parameterInfo))
                             {
                                 var path = !string.IsNullOrWhiteSpace(attr.Prefix) ? $"{attr.Prefix}{attr.Delimiter}{kvp.Key}" : kvp.Key;
-                                queryParamsToAdd.Add(new KeyValuePair<string, string>(path, settings.UrlParameterFormatter.Format(kvp.Value, restMethod.ParameterInfoMap[i], restMethod.ParameterInfoMap[i].ParameterType)));
+                                queryParamsToAdd.AddRange(ParseQueryParameter(kvp.Value, restMethod.ParameterInfoMap[i], path, attr));
                             }
                         }
 
@@ -712,6 +681,44 @@ namespace Refit
                 ret.RequestUri = new Uri(uri.Uri.GetComponents(UriComponents.PathAndQuery, uriFormat), UriKind.Relative);
                 return ret;
             };
+        }
+
+        IEnumerable<KeyValuePair<string, string>> ParseQueryParameter(object param, ParameterInfo parameterInfo, string queryPath, QueryAttribute queryAttribute)
+        {
+            if (!(param is string) && param is IEnumerable paramValues)
+            {
+                switch (queryAttribute.CollectionFormat)
+                {
+                    case CollectionFormat.Multi:
+                        foreach (var paramValue in paramValues)
+                        {
+                            yield return new KeyValuePair<string, string>(
+                                queryPath,
+                                settings.UrlParameterFormatter.Format(paramValue, parameterInfo, parameterInfo.ParameterType));
+                        }
+
+                        break;
+
+                    default:
+                        var delimiter = queryAttribute.CollectionFormat == CollectionFormat.Ssv ? " "
+                            : queryAttribute.CollectionFormat == CollectionFormat.Tsv ? "\t"
+                            : queryAttribute.CollectionFormat == CollectionFormat.Pipes ? "|"
+                            : ",";
+
+                        // Missing a "default" clause was preventing the collection from serializing at all, as it was hitting "continue" thus causing an off-by-one error
+                        var formattedValues = paramValues
+                            .Cast<object>()
+                            .Select(v => settings.UrlParameterFormatter.Format(v, parameterInfo, parameterInfo.ParameterType));
+
+                        yield return new KeyValuePair<string, string>(queryPath, string.Join(delimiter, formattedValues));
+
+                        break;
+                }
+            }
+            else
+            {
+                yield return new KeyValuePair<string, string>(queryPath, settings.UrlParameterFormatter.Format(param, parameterInfo, parameterInfo.ParameterType));
+            }
         }
 
         Func<HttpClient, object[], IObservable<T>> BuildRxFuncForMethod<T, TBody>(RestMethodInfo restMethod)


### PR DESCRIPTION
**What kind of change does this PR introduce?**
This PR modifies the Refit request builder to handle serialization of query objects that contain `IEnumerable` properties. This PR addresses the following issues:

https://github.com/reactiveui/refit/issues/587
https://github.com/reactiveui/refit/issues/522

**What is the current behavior?**
Currently, an `IEnumerable` property on a query object will translate to the query string as the type name. For example, the following query object
```
class QueryObject
{
    IEnumerable<int> TestIntCollection { get; set; }
}
```
will translate as `?testIntCollection=System.Int32%5B%5D`.


**What is the new behavior?**
`IEnumerable` properties on query objects will be serialized in the same manner as `IEnumerable` parameters passed directly.


**What might this PR break?**
No foreseen impacts to existing uses.


**Please check if the PR fulfills these requirements**
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)