### PR TITLE
Trim trailing / for HttpClient-supplied base addresses

### DIFF
--- a/Refit.Tests/RequestBuilder.cs
+++ b/Refit.Tests/RequestBuilder.cs
@@ -1743,7 +1743,7 @@ namespace Refit.Tests
 
     static class RequestBuilderTestExtensions
     {
-        public static Func<object[], HttpRequestMessage> BuildRequestFactoryForMethod(this IRequestBuilder builder, string methodName)
+        public static Func<object[], HttpRequestMessage> BuildRequestFactoryForMethod(this IRequestBuilder builder, string methodName, string baseAddress = "http://api/")
         {
             var factory = builder.BuildRestResultFuncForMethod(methodName);
             var testHttpMessageHandler = new TestHttpMessageHandler();
@@ -1751,14 +1751,14 @@ namespace Refit.Tests
 
             return paramList =>
             {
-                var task = (Task)factory(new HttpClient(testHttpMessageHandler) { BaseAddress = new Uri("http://api/") }, paramList);
+                var task = (Task)factory(new HttpClient(testHttpMessageHandler) { BaseAddress = new Uri(baseAddress) }, paramList);
                 task.Wait();
                 return testHttpMessageHandler.RequestMessage;
             };
         }
 
 
-        public static Func<object[], TestHttpMessageHandler> RunRequest(this IRequestBuilder builder, string methodName, string returnContent = null)
+        public static Func<object[], TestHttpMessageHandler> RunRequest(this IRequestBuilder builder, string methodName, string returnContent = null, string baseAddress = "http://api/")
         {
             var factory = builder.BuildRestResultFuncForMethod(methodName);
             var testHttpMessageHandler = new TestHttpMessageHandler();
@@ -1769,7 +1769,7 @@ namespace Refit.Tests
 
             return paramList =>
             {
-                var task = (Task)factory(new HttpClient(testHttpMessageHandler) { BaseAddress = new Uri("http://api/") }, paramList);
+                var task = (Task)factory(new HttpClient(testHttpMessageHandler) { BaseAddress = new Uri(baseAddress) }, paramList);
                 task.Wait();
                 return testHttpMessageHandler;
             };

--- a/Refit.Tests/RestService.cs
+++ b/Refit.Tests/RestService.cs
@@ -264,6 +264,42 @@ namespace Refit.Tests
         }
 
         [Fact]
+        public async Task GetWithNoParametersTest()
+        {
+            var mockHttp = new MockHttpMessageHandler();
+            mockHttp.Expect(HttpMethod.Get, "http://foo/someendpoint")
+                    .WithExactQueryString("")
+                    .Respond("application/json", "Ok");
+
+            var settings = new RefitSettings
+            {
+                HttpMessageHandlerFactory = () => mockHttp
+            };
+            var fixture = RestService.For<ITrimTrailingForwardSlashApi>("http://foo", settings);
+
+            await fixture.Get();
+            mockHttp.VerifyNoOutstandingExpectation();
+        }
+
+        [Fact]
+        public async Task GetWithNoParametersTestTrailingSlashInBase()
+        {
+            var mockHttp = new MockHttpMessageHandler();
+            mockHttp.Expect(HttpMethod.Get, "http://foo/someendpoint")
+                    .WithExactQueryString("")
+                    .Respond("application/json", "Ok");
+
+            var settings = new RefitSettings
+            {
+                HttpMessageHandlerFactory = () => mockHttp
+            };
+            var fixture = RestService.For<ITrimTrailingForwardSlashApi>("http://foo/", settings);
+
+            await fixture.Get();
+            mockHttp.VerifyNoOutstandingExpectation();
+        }   
+
+        [Fact]
         public async Task GetWithPathBoundObject()
         {
             var mockHttp = new MockHttpMessageHandler();
@@ -1656,6 +1692,22 @@ namespace Refit.Tests
             var fixture = RestService.For<ITrimTrailingForwardSlashApi>(inputBaseAddress);
 
             Assert.Equal(fixture.Client.BaseAddress.AbsoluteUri, expectedBaseAddress);
+        }
+
+        [Fact]
+        public void ShouldTrimTrailingForwardSlashFromBaseUrlInHttpClient()
+        {
+            var expectedBaseAddress = new Uri("http://example.com/api");
+            var inputBaseAddress = new Uri("http://example.com/api/");
+
+            var client = new HttpClient()
+            {
+                BaseAddress = inputBaseAddress
+            };
+
+            var fixture = RestService.For<ITrimTrailingForwardSlashApi>(client);
+
+            Assert.Equal(expectedBaseAddress.AbsoluteUri, fixture.Client.BaseAddress.AbsoluteUri);
         }
 
         [Fact]

--- a/Refit/RestService.cs
+++ b/Refit/RestService.cs
@@ -10,9 +10,7 @@ namespace Refit
 
         public static T For<T>(HttpClient client, IRequestBuilder<T> builder)
         {
-            var generatedType = TypeMapping.GetOrAdd(typeof(T), GetGeneratedType<T>());
-
-            return (T)Activator.CreateInstance(generatedType, client, builder);
+            return (T)For(typeof(T), client, builder);            
         }
 
         public static T For<T>(HttpClient client, RefitSettings settings)
@@ -37,6 +35,12 @@ namespace Refit
         {
             var generatedType = TypeMapping.GetOrAdd(refitInterfaceType, GetGeneratedType(refitInterfaceType));
 
+            // Ensure base url of supplied HttpClient doesn't contain a /
+            if(client.BaseAddress?.AbsoluteUri.EndsWith("/") == true)
+            {
+                client.BaseAddress = new Uri(client.BaseAddress.AbsoluteUri.TrimEnd('/'));
+            }
+
             return Activator.CreateInstance(generatedType, client, builder);
         }
 
@@ -52,7 +56,7 @@ namespace Refit
         public static object For(Type refitInterfaceType, string hostUrl, RefitSettings settings)
         {
             var client = CreateHttpClient(hostUrl, settings);
-
+            
             return For(refitInterfaceType, client, settings);
         }
 
@@ -87,12 +91,7 @@ namespace Refit
                 }
             }
 
-            return new HttpClient(innerHandler ?? new HttpClientHandler()) { BaseAddress = new Uri(hostUrl.TrimEnd('/')) };
-        }
-
-        static Type GetGeneratedType<T>()
-        {
-            return GetGeneratedType(typeof(T));
+            return new HttpClient(innerHandler ?? new HttpClientHandler()) { BaseAddress = new Uri(hostUrl) };
         }
 
         static Type GetGeneratedType(Type refitInterfaceType)


### PR DESCRIPTION
Fixes #823 by ensuring that a trailing / is trimmed on an HttpClient provided base address. This was already the case for string supplied urls.