### PR TITLE
Revert "Ensure we have an emtpy byte array so that a content-length of 0 is sent"

### DIFF
--- a/Refit.Tests/RefitStubs.Net46.cs
+++ b/Refit.Tests/RefitStubs.Net46.cs
@@ -621,14 +621,6 @@ namespace Refit.Tests
             var func = requestBuilder.BuildRestResultFuncForMethod("Head", new Type[] {  });
             return (Task)func(Client, arguments);
         }
-
-        /// <inheritdoc />
-        Task IBodylessApi.PostWithoutContentType(string someQueryString)
-        {
-            var arguments = new object[] { someQueryString };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostWithoutContentType", new Type[] { typeof(string) });
-            return (Task)func(Client, arguments);
-        }
     }
 }
 

--- a/Refit.Tests/RefitStubs.NetCore2.cs
+++ b/Refit.Tests/RefitStubs.NetCore2.cs
@@ -621,14 +621,6 @@ namespace Refit.Tests
             var func = requestBuilder.BuildRestResultFuncForMethod("Head", new Type[] {  });
             return (Task)func(Client, arguments);
         }
-
-        /// <inheritdoc />
-        Task IBodylessApi.PostWithoutContentType(string someQueryString)
-        {
-            var arguments = new object[] { someQueryString };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostWithoutContentType", new Type[] { typeof(string) });
-            return (Task)func(Client, arguments);
-        }
     }
 }
 

--- a/Refit.Tests/RefitStubs.NetCore3.cs
+++ b/Refit.Tests/RefitStubs.NetCore3.cs
@@ -621,14 +621,6 @@ namespace Refit.Tests
             var func = requestBuilder.BuildRestResultFuncForMethod("Head", new Type[] {  });
             return (Task)func(Client, arguments);
         }
-
-        /// <inheritdoc />
-        Task IBodylessApi.PostWithoutContentType(string someQueryString)
-        {
-            var arguments = new object[] { someQueryString };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostWithoutContentType", new Type[] { typeof(string) });
-            return (Task)func(Client, arguments);
-        }
     }
 }
 

--- a/Refit.Tests/RestService.cs
+++ b/Refit.Tests/RestService.cs
@@ -237,9 +237,6 @@ namespace Refit.Tests
         [Head("/nobody")]
         [Headers("Content-Type: application/x-www-form-urlencoded; charset=UTF-8")]
         Task Head();
-
-        [Post("/nobody")]
-        Task PostWithoutContentType(string someQueryString);
     }
 
     public interface ITrimTrailingForwardSlashApi
@@ -299,30 +296,6 @@ namespace Refit.Tests
             var fixture = RestService.For<IBodylessApi>("http://foo", settings);
 
             await fixture.Post();
-
-            mockHttp.VerifyNoOutstandingExpectation();
-        }
-
-        [Fact]
-        public async Task CanPostWithoutBodyButWithAQueryStringHasContentLength()
-        {
-            var mockHttp = new MockHttpMessageHandler();
-            var settings = new RefitSettings
-            {
-                HttpMessageHandlerFactory = () => mockHttp
-            };
-
-            mockHttp.Expect(HttpMethod.Post, "http://foo/nobody?someQueryString=query")
-                // The content length header is set automatically by the HttpContent instance,
-                // so checking the header as a string doesn't work
-                .With(r => r.Content?.Headers.ContentLength == 0)
-                // But we added content type ourselves, so this should work
-                .WithContent("")
-                .Respond("application/json", "Ok");
-
-            var fixture = RestService.For<IBodylessApi>("http://foo", settings);
-
-            await fixture.PostWithoutContentType("query");
 
             mockHttp.VerifyNoOutstandingExpectation();
         }

--- a/Refit/RequestBuilderImplementation.cs
+++ b/Refit/RequestBuilderImplementation.cs
@@ -639,19 +639,18 @@ namespace Refit
 
                 // NB: We defer setting headers until the body has been
                 // added so any custom content headers don't get left out.
-
-                // For methods other than GET/HEAD, ensure we have a blank body
-                // So that Content-Length is set
-
-                // We could have content headers, so we need to make
-                // sure we have an HttpContent object to add them to,
-                // provided the HttpClient will allow it for the method
-                if (ret.Content == null && !BodylessMethods.Contains(ret.Method))
-                    ret.Content = new ByteArrayContent(new byte[0]);
-
-                foreach (var header in headersToAdd)
+                if (headersToAdd.Count > 0)
                 {
-                    SetHeader(ret, header.Key, header.Value);
+                    // We could have content headers, so we need to make
+                    // sure we have an HttpContent object to add them to,
+                    // provided the HttpClient will allow it for the method
+                    if (ret.Content == null && !BodylessMethods.Contains(ret.Method))
+                        ret.Content = new ByteArrayContent(new byte[0]);
+
+                    foreach (var header in headersToAdd)
+                    {
+                        SetHeader(ret, header.Key, header.Value);
+                    }
                 }
 
                 // NB: The URI methods in .NET are dumb. Also, we do this 


### PR DESCRIPTION
Reverts reactiveui/refit#863

No reason to send 0 length content length if there are no specific content-headers that need to be sent.

Content-Length is only required for HTTP/1.0, not 1.1+

