### PR TITLE
Specify Content-Length when serializing JSON with System.Text.Json

### DIFF
--- a/Refit.Tests/SerializedContentTests.cs
+++ b/Refit.Tests/SerializedContentTests.cs
@@ -146,5 +146,25 @@ namespace Refit.Tests
             Assert.Equal(model.ShortNameForAlias, result.ShortNameForAlias);
             Assert.Equal(model.ShortNameForJsonProperty, result.ShortNameForJsonProperty);
         }
+
+        [Fact]
+        public async Task StreamDeserialization_UsingSystemTextJsonContentSerializer_SetsCorrectHeaders()
+        {
+            var model = new TestAliasObject
+            {
+                ShortNameForAlias = nameof(StreamDeserialization_UsingSystemTextJsonContentSerializer),
+                ShortNameForJsonProperty = nameof(TestAliasObject)
+            };
+
+            var serializer = new SystemTextJsonContentSerializer();
+
+            var json = await serializer.SerializeAsync(model);
+
+            Assert.NotNull(json.Headers.ContentLength);
+            Assert.True(json.Headers.ContentLength.Value > 0);
+            Assert.NotNull(json.Headers.ContentType);
+            Assert.Equal("utf-8", json.Headers.ContentType.CharSet);
+            Assert.Equal("application/json", json.Headers.ContentType.MediaType);
+        }
     }
 }

--- a/Refit/SystemTextJsonContentSerializer.cs
+++ b/Refit/SystemTextJsonContentSerializer.cs
@@ -44,10 +44,13 @@ namespace Refit
 
             JsonSerializer.Serialize(utf8JsonWriter, item, jsonSerializerOptions);
 
-            var content = new StreamContent(utf8BufferWriter.DetachStream())
+            var stream = utf8BufferWriter.DetachStream();
+
+            var content = new StreamContent(stream)
             {
                 Headers =
                 {
+                    ContentLength = stream.Length,
                     ContentType = new MediaTypeHeaderValue("application/json") { CharSet = Encoding.UTF8.WebName }
                 }
             };


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Specify the `Content-Length`, as it is known, when serializing JSON using System.Text.Json for compatibility with systems that do not support chunked encoding.

Otherwise to leverage the new deserializer while maintaining compatibility for serialization in my application, I would have to wrap the content serializer in a custom implementation (because it has no virtual methods to override) and revert to the serialization behaviour I had for System.Text.Json before the new content serializer was available:

```csharp
public Task<HttpContent> SerializeAsync<T>(T item)
{
    string json = JsonSerializer.Serialize(item, SerializerOptions);
    var content = new StringContent(json, Encoding.UTF8, "application/json");

    return Task.FromResult<HttpContent>(content);
}
```

**What is the current behavior?**

In some cases requests are sent with `Transfer-Encoding: chunked` which causes HTTP errors when sending content to older systems that do not support chunked encoding.

The `Content-Length` is not sent because the pooled `Stream` does not support `CanSeek`:

https://github.com/reactiveui/refit/blob/d5e55c0b9cdf7e26c241a7f55e7d0f05b2295090/Refit/Buffers/PooledBufferWriter.Stream.cs#L54

https://github.com/dotnet/runtime/blob/ba80c1df68a9ac4887a2ea81a6a20ecdc821d148/src/libraries/System.Net.Http/src/System/Net/Http/StreamContent.cs#L76-L88

**What is the new behavior?**

Specify the `ContentLength` property on the headers of the returned `StreamContent` so that the `Content-Length` HTTP request header is sent.

**What might this PR break?**

This change should be safe as it replicates the behaviour of the existing `JsonContentSerializer` and `NewtonsoftJsonContentSerializer` classes:

https://github.com/reactiveui/refit/blob/d5e55c0b9cdf7e26c241a7f55e7d0f05b2295090/Refit/JsonContentSerializer.cs#L33-L37

https://github.com/reactiveui/refit/blob/d5e55c0b9cdf7e26c241a7f55e7d0f05b2295090/Refit/NewtonsoftJsonContentSerializer.cs#L37-L42

I followed through the code for the `HttpContent` classes to find how `Content-Length` was being set using `StringContent` in the previous content serializer:

https://github.com/dotnet/runtime/blob/ba80c1df68a9ac4887a2ea81a6a20ecdc821d148/src/libraries/System.Net.Http/src/System/Net/Http/StringContent.cs#L13

https://github.com/dotnet/runtime/blob/ba80c1df68a9ac4887a2ea81a6a20ecdc821d148/src/libraries/System.Net.Http/src/System/Net/Http/ByteArrayContent.cs#L66-L70

https://github.com/dotnet/runtime/blob/4b03513e20e0caf9ee34817eb74356903f1bb33e/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpContentHeaders.cs#L80-L85

**Please check if the PR fulfills these requirements**

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

/cc @Sergio0694 
