### PR TITLE
Fix default CollectionFormat for FormValueMultimap

### DIFF
--- a/Refit.Tests/FormValueMultimapTests.cs
+++ b/Refit.Tests/FormValueMultimapTests.cs
@@ -80,7 +80,7 @@ namespace Refit.Tests
         }
 
         [Fact]
-        public void DefaultCollectionFormatCanBeSpecifiedInSettings()
+        public void DefaultCollectionFormatCanBeSpecifiedInSettings_Multi()
         {
             var settingsWithCollectionFormat = new RefitSettings
             {
@@ -108,6 +108,44 @@ namespace Refit.Tests
                 new KeyValuePair<string, string>("F", "1"),
                 new KeyValuePair<string, string>("F", "2"),
                 new KeyValuePair<string, string>("F", "3"),
+            };
+
+            var actual = new FormValueMultimap(source, settingsWithCollectionFormat);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [InlineData(CollectionFormat.Csv, "1,2,3")]
+        [InlineData(CollectionFormat.Pipes, "1|2|3")]
+        [InlineData(CollectionFormat.Ssv, "1 2 3")]
+        [InlineData(CollectionFormat.Tsv, "1\t2\t3")]
+        public void DefaultCollectionFormatCanBeSpecifiedInSettings(CollectionFormat format, string expectedFormat)
+        {
+            var settingsWithCollectionFormat = new RefitSettings
+            {
+                CollectionFormat = format
+            };
+            var source = new ObjectWithRepeatedFieldsTestClass
+            {
+                // Members have explicit CollectionFormat
+                A = new List<int> { 1, 2 },
+                B = new HashSet<string> { "set1", "set2" },
+                C = new HashSet<int> { 1, 2 },
+                D = new List<double> { 0.1, 1.0 },
+                E = new List<bool> { true, false },
+
+                // Member has no explicit CollectionFormat
+                F = new[] { 1, 2, 3 }
+            };
+            var expected = new List<KeyValuePair<string, string>> {
+                new KeyValuePair<string, string>("A", "01"),
+                new KeyValuePair<string, string>("A", "02"),
+                new KeyValuePair<string, string>("B", "set1,set2"),
+                new KeyValuePair<string, string>("C", "01 02"),
+                new KeyValuePair<string, string>("D", "0.10\t1.00"),
+                new KeyValuePair<string, string>("E", "True|False"),
+                new KeyValuePair<string, string>("F", expectedFormat),
             };
 
             var actual = new FormValueMultimap(source, settingsWithCollectionFormat);

--- a/Refit/FormValueMultimap.cs
+++ b/Refit/FormValueMultimap.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Text.Json.Serialization;
+
 using Newtonsoft.Json;
 
 namespace Refit
@@ -76,9 +77,13 @@ namespace Refit
                                 case CollectionFormat.Ssv:
                                 case CollectionFormat.Tsv:
                                 case CollectionFormat.Pipes:
-                                    var delimiter = attrib.CollectionFormat == CollectionFormat.Csv ? ","
-                                        : attrib.CollectionFormat == CollectionFormat.Ssv ? " "
-                                        : attrib.CollectionFormat == CollectionFormat.Tsv ? "\t" : "|";
+                                    var delimiter = collectionFormat switch
+                                    {
+                                        CollectionFormat.Csv => ",",
+                                        CollectionFormat.Ssv => " ",
+                                        CollectionFormat.Tsv => "\t",
+                                        _ => "|"
+                                    };
 
                                     var formattedValues = enumerable
                                         .Cast<object>()


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Fixes handling of CollectionFormat in RefitSettings for FormValueMultimap.



**What is the current behavior?**
If CollectionFormat in RefitSettings is Csv, Ssv or Tsv, and explicit CollectionFormat is not specified in QueryAttribute, collection delimiter is `|`.



**What is the new behavior?**
Handles appropriately - `,` for Ccv, ` ` for Ssv, `\t` for Tsv. 


**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

