### PR TITLE
Fix query collection format inside object

### DIFF
--- a/Refit/RequestBuilderImplementation.cs
+++ b/Refit/RequestBuilderImplementation.cs
@@ -355,9 +355,20 @@ namespace Refit
 
                 // Look to see if the property has a Query attribute, and if so, format it accordingly
                 var queryAttribute = propertyInfo.GetCustomAttribute<QueryAttribute>();
-                if (queryAttribute != null)
+                if (queryAttribute != null && queryAttribute.Format != null)
                 {
-                    obj = settings.FormUrlEncodedParameterFormatter.Format(obj, queryAttribute?.Format);
+                    obj = settings.FormUrlEncodedParameterFormatter.Format(obj, queryAttribute.Format);
+                }
+
+                // If obj is IEnumerable - format it accounting for Query attribute and CollectionFormat
+                if (!(obj is string) && obj is IEnumerable ienu)
+                {
+                    foreach (var value in ParseEnumerableQueryParameterValue(ienu, propertyInfo, propertyInfo.PropertyType, queryAttribute))
+                    {
+                        kvps.Add(new KeyValuePair<string, object>(key, value));
+                    }
+
+                    continue;
                 }
 
                 if (DoNotConvertToQueryMap(obj))
@@ -372,14 +383,6 @@ namespace Refit
                         foreach (var keyValuePair in BuildQueryMap(idict, delimiter))
                         {
                             kvps.Add(new KeyValuePair<string, object>($"{key}{delimiter}{keyValuePair.Key}", keyValuePair.Value));
-                        }
-
-                        break;
-
-                    case IEnumerable ienu:
-                        foreach (var o in ienu)
-                        {
-                            kvps.Add(new KeyValuePair<string, object>(key, o));
                         }
 
                         break;
@@ -684,41 +687,47 @@ namespace Refit
         {
             if (!(param is string) && param is IEnumerable paramValues)
             {
-                var collectionFormat = queryAttribute.IsCollectionFormatSpecified
-                    ? queryAttribute.CollectionFormat
-                    : settings.CollectionFormat;
-
-                switch (collectionFormat)
+                foreach (var value in ParseEnumerableQueryParameterValue(paramValues, parameterInfo, parameterInfo.ParameterType, queryAttribute))
                 {
-                    case CollectionFormat.Multi:
-                        foreach (var paramValue in paramValues)
-                        {
-                            yield return new KeyValuePair<string, string>(
-                                queryPath,
-                                settings.UrlParameterFormatter.Format(paramValue, parameterInfo, parameterInfo.ParameterType));
-                        }
-
-                        break;
-
-                    default:
-                        var delimiter = collectionFormat == CollectionFormat.Ssv ? " "
-                            : collectionFormat == CollectionFormat.Tsv ? "\t"
-                            : collectionFormat == CollectionFormat.Pipes ? "|"
-                            : ",";
-
-                        // Missing a "default" clause was preventing the collection from serializing at all, as it was hitting "continue" thus causing an off-by-one error
-                        var formattedValues = paramValues
-                            .Cast<object>()
-                            .Select(v => settings.UrlParameterFormatter.Format(v, parameterInfo, parameterInfo.ParameterType));
-
-                        yield return new KeyValuePair<string, string>(queryPath, string.Join(delimiter, formattedValues));
-
-                        break;
+                    yield return new KeyValuePair<string, string>(queryPath, value);
                 }
             }
             else
             {
                 yield return new KeyValuePair<string, string>(queryPath, settings.UrlParameterFormatter.Format(param, parameterInfo, parameterInfo.ParameterType));
+            }
+        }
+
+        IEnumerable<string> ParseEnumerableQueryParameterValue(IEnumerable paramValues, ICustomAttributeProvider customAttributeProvider, Type type, QueryAttribute queryAttribute)
+        {
+            var collectionFormat = queryAttribute != null && queryAttribute.IsCollectionFormatSpecified
+                ? queryAttribute.CollectionFormat
+                : settings.CollectionFormat;
+
+            switch (collectionFormat)
+            {
+                case CollectionFormat.Multi:
+                    foreach (var paramValue in paramValues)
+                    {
+                        yield return settings.UrlParameterFormatter.Format(paramValue, customAttributeProvider, type);
+                    }
+
+                    break;
+
+                default:
+                    var delimiter = collectionFormat == CollectionFormat.Ssv ? " "
+                        : collectionFormat == CollectionFormat.Tsv ? "\t"
+                        : collectionFormat == CollectionFormat.Pipes ? "|"
+                        : ",";
+
+                    // Missing a "default" clause was preventing the collection from serializing at all, as it was hitting "continue" thus causing an off-by-one error
+                    var formattedValues = paramValues
+                        .Cast<object>()
+                        .Select(v => settings.UrlParameterFormatter.Format(v, customAttributeProvider, type));
+
+                    yield return string.Join(delimiter, formattedValues);
+
+                    break;
             }
         }
 


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
Fixes #894



**What is the current behavior?**
a) If query attribute is present on query object property, value is simply converted ToString.
b) `CollectionFormat` (both in `RefitSettings` and in `QueryAttribute`) is ignored when used on query object property. Interesting enough, it differs depending on item type - for enum or int it is Csv (because that is default), for object - Multi (because that how it is defined in `BuildQueryMap` method - no idea why).



**What is the new behavior?**
a) Value is formatted to string only when explicit Format is defined in Query attribute.
b) Collections in query objects are formatted same as regular query collections - accounting for CollectionFormat in RefitSettings and in QueryAttribute.



**What might this PR break?**



**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:
Extracted part with collection values formatting from `ParseQueryParameter` to separate method `ParseEnumerableQueryParameterValue` to be able to reuse inside of `BuildQueryMap`.

Also updated RequestBuilder tests to use nameof for method names - much easier to see where particular method is used, hope you don't mind.