### PR TITLE
Speed/memory optimizations, better caching

### DIFF
--- a/InterfaceStubGenerator.Core/GeneratedInterfaceStubTemplate.mustache
+++ b/InterfaceStubGenerator.Core/GeneratedInterfaceStubTemplate.mustache
@@ -62,12 +62,28 @@ namespace {{Namespace}}
         }
         {{#MethodList}}
 
+        {{#MethodTypeParameters}}
+        private static class TypeHelper_{{Id}}<{{.}}>
+        {
+            public static readonly Type[] ArgumentTypes = new Type[] { {{ArgumentTypesList}} };
+            public static readonly Type[] TypeParameters = new Type[] { {{MethodTypeParameterList}} };
+        }
+        {{/MethodTypeParameters}}
+        {{^MethodTypeParameters}}
+        private static readonly Type[] ArgumentTypes_{{Id}} = new Type[] { {{ArgumentTypesList}} };
+        {{/MethodTypeParameters}}
+
         /// <inheritdoc />
         {{ReturnType}} {{InterfaceName}}{{#TypeParameters}}<{{.}}>{{/TypeParameters}}.{{Name}}{{#MethodTypeParameters}}<{{.}}>{{/MethodTypeParameters}}({{ArgumentListWithTypes}})
         {
             {{#IsRefitMethod}}
             var arguments = new object[] { {{ArgumentList}} };
-            var func = requestBuilder.BuildRestResultFuncForMethod("{{Name}}", new Type[] { {{ArgumentTypesList}} }{{#MethodTypeParameterList}}, new Type[] { {{.}} }{{/MethodTypeParameterList}});
+            {{#MethodTypeParameters}}
+            var func = requestBuilder.BuildRestResultFuncForMethod("{{Name}}", TypeHelper_{{Id}}<{{.}}>.ArgumentTypes, TypeHelper_{{Id}}<{{.}}>.TypeParameters);
+            {{/MethodTypeParameters}}
+            {{^MethodTypeParameters}}
+            var func = requestBuilder.BuildRestResultFuncForMethod("{{Name}}", ArgumentTypes_{{Id}});
+            {{/MethodTypeParameters}}
             return ({{ReturnType}})func(Client, arguments);
             {{/IsRefitMethod}}
             {{^IsRefitMethod}}

--- a/InterfaceStubGenerator.Core/GeneratedInterfaceStubTemplate.mustache
+++ b/InterfaceStubGenerator.Core/GeneratedInterfaceStubTemplate.mustache
@@ -77,7 +77,7 @@ namespace {{Namespace}}
         {{ReturnType}} {{InterfaceName}}{{#TypeParameters}}<{{.}}>{{/TypeParameters}}.{{Name}}{{#MethodTypeParameters}}<{{.}}>{{/MethodTypeParameters}}({{ArgumentListWithTypes}})
         {
             {{#IsRefitMethod}}
-            var arguments = new object[] { {{ArgumentList}} };
+            var arguments = {{#ArgumentList}}new object[] { {{ArgumentList}} }{{/ArgumentList}}{{^ArgumentList}}Array.Empty<object>(){{/ArgumentList}};
             {{#MethodTypeParameters}}
             var func = requestBuilder.BuildRestResultFuncForMethod("{{Name}}", TypeHelper_{{Id}}<{{.}}>.ArgumentTypes, TypeHelper_{{Id}}<{{.}}>.TypeParameters);
             {{/MethodTypeParameters}}

--- a/InterfaceStubGenerator.Core/GeneratedInterfaceStubTemplate.mustache
+++ b/InterfaceStubGenerator.Core/GeneratedInterfaceStubTemplate.mustache
@@ -65,12 +65,12 @@ namespace {{Namespace}}
         {{#MethodTypeParameters}}
         private static class TypeHelper_{{Id}}<{{.}}>
         {
-            public static readonly Type[] ArgumentTypes = new Type[] { {{ArgumentTypesList}} };
-            public static readonly Type[] TypeParameters = new Type[] { {{MethodTypeParameterList}} };
+            public static readonly Type[] ArgumentTypes = {{#ArgumentTypesList}}new Type[] { {{ArgumentTypesList}} }{{/ArgumentTypesList}}{{^ArgumentTypesList}}Array.Empty<Type>(){{/ArgumentTypesList}};
+            public static readonly Type[] TypeParameters = {{#MethodTypeParameterList}}new Type[] { {{MethodTypeParameterList}} }{{/MethodTypeParameterList}}{{^MethodTypeParameterList}}Array.Empty<Type>(){{/MethodTypeParameterList}};
         }
         {{/MethodTypeParameters}}
         {{^MethodTypeParameters}}
-        private static readonly Type[] ArgumentTypes_{{Id}} = new Type[] { {{ArgumentTypesList}} };
+        private static readonly Type[] ArgumentTypes_{{Id}} = {{#ArgumentTypesList}}new Type[] { {{ArgumentTypesList}} }{{/ArgumentTypesList}}{{^ArgumentTypesList}}Array.Empty<Type>(){{/ArgumentTypesList}};
         {{/MethodTypeParameters}}
 
         /// <inheritdoc />

--- a/InterfaceStubGenerator.Core/InterfaceStubGenerator.cs
+++ b/InterfaceStubGenerator.Core/InterfaceStubGenerator.cs
@@ -424,6 +424,7 @@ namespace Refit.Generator
         public string ArgumentList => ArgumentListInfo != null ? string.Join(", ", ArgumentListInfo.Select(y => y.Name)) : null;
         public string ArgumentListWithTypes => ArgumentListInfo != null ? string.Join(", ", ArgumentListInfo.Select(y => $"{y.TypeInfo} {y.Name}")) : null;
         public string ArgumentTypesList => ArgumentListInfo != null ? string.Join(", ", ArgumentListInfo.Select(y => y.TypeInfo.ToString() is var typeName && typeName.EndsWith("?") ? $"ToNullable(typeof({typeName.Remove(typeName.Length - 1)}))" : $"typeof({typeName})")) : null;
+        public string Id { get; } = Guid.NewGuid().ToString("N");
         public bool IsRefitMethod { get; set; }
         public string Name { get; set; }
         public TypeInfo ReturnTypeInfo { get; set; }

--- a/Refit.Tests/RefitStubs.Net46.cs
+++ b/Refit.Tests/RefitStubs.Net46.cs
@@ -62,21 +62,27 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_83ba3bddcdd9498591042b9a4f8f34e3 = new Type[] {  };
+
         /// <inheritdoc />
         Task IAmARefitInterfaceButNobodyUsesMe.RefitMethod()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("RefitMethod", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("RefitMethod", ArgumentTypes_83ba3bddcdd9498591042b9a4f8f34e3);
             return (Task)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_a8781381f08c45f0acce03cbb3e6fc3c = new Type[] {  };
 
         /// <inheritdoc />
         Task IAmARefitInterfaceButNobodyUsesMe.AnotherRefitMethod()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("AnotherRefitMethod", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("AnotherRefitMethod", ArgumentTypes_a8781381f08c45f0acce03cbb3e6fc3c);
             return (Task)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_6cf8a1b44faf4dcab6e5cb730b95a5d5 = new Type[] {  };
 
         /// <inheritdoc />
         Task IAmARefitInterfaceButNobodyUsesMe.NoConstantsAllowed()
@@ -84,19 +90,23 @@ namespace Refit.Tests
             throw new NotImplementedException("Either this method has no Refit HTTP method attribute or you've used something other than a string literal for the 'path' argument.");
         }
 
+        private static readonly Type[] ArgumentTypes_54c658601c4d481bae3c861bc15679ea = new Type[] {  };
+
         /// <inheritdoc />
         Task IAmARefitInterfaceButNobodyUsesMe.SpacesShouldntBreakMe()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("SpacesShouldntBreakMe", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("SpacesShouldntBreakMe", ArgumentTypes_54c658601c4d481bae3c861bc15679ea);
             return (Task)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_555c53653b54415495b35826a6518b73 = new Type[] { typeof(int), typeof(string), typeof(float) };
 
         /// <inheritdoc />
         Task IAmARefitInterfaceButNobodyUsesMe.ReservedWordsForParameterNames(int @int, string @string, float @long)
         {
             var arguments = new object[] { @int, @string, @long };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReservedWordsForParameterNames", new Type[] { typeof(int), typeof(string), typeof(float) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReservedWordsForParameterNames", ArgumentTypes_555c53653b54415495b35826a6518b73);
             return (Task)func(Client, arguments);
         }
     }
@@ -137,13 +147,17 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_99caeed32c7346bca61b2890b41fb08d = new Type[] {  };
+
         /// <inheritdoc />
         Task IAmHalfRefit.Post()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Post", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Post", ArgumentTypes_99caeed32c7346bca61b2890b41fb08d);
             return (Task)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_8ab0e4a9a65c4cf1b4f3662fc97652e8 = new Type[] {  };
 
         /// <inheritdoc />
         Task IAmHalfRefit.Get()
@@ -177,35 +191,43 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_cc7f6f63f1de4f89b8d8146af63d973b = new Type[] {  };
+
         /// <inheritdoc />
         Task<string> IAmInterface.Pang()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Pang", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Pang", ArgumentTypes_cc7f6f63f1de4f89b8d8146af63d973b);
             return (Task<string>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_073f543697d04a24a6b4efa4162fea55 = new Type[] {  };
 
         /// <inheritdoc />
         Task<string> IAmInterfaceB.Pong()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Pong", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Pong", ArgumentTypes_073f543697d04a24a6b4efa4162fea55);
             return (Task<string>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_7d65499a2d404824bbd952cfc48ef31a = new Type[] {  };
 
         /// <inheritdoc />
         Task<string> IAmInterfaceD.Test()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Test", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Test", ArgumentTypes_7d65499a2d404824bbd952cfc48ef31a);
             return (Task<string>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_0bcf298e07f345d48b46966077b9cb53 = new Type[] {  };
 
         /// <inheritdoc />
         Task<string> IAmInterfaceA.Ping()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Ping", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Ping", ArgumentTypes_0bcf298e07f345d48b46966077b9cb53);
             return (Task<string>)func(Client, arguments);
         }
     }
@@ -235,11 +257,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_7497c638afff4a3c894aee80c9d12c09 = new Type[] {  };
+
         /// <inheritdoc />
         Task<string> IAmInterfaceA.Ping()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Ping", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Ping", ArgumentTypes_7497c638afff4a3c894aee80c9d12c09);
             return (Task<string>)func(Client, arguments);
         }
     }
@@ -269,19 +293,23 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_fc591f1a688a40f8af143687399cd457 = new Type[] {  };
+
         /// <inheritdoc />
         Task<string> IAmInterfaceB.Pong()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Pong", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Pong", ArgumentTypes_fc591f1a688a40f8af143687399cd457);
             return (Task<string>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_3e2e337cd23f4f2ba995861c726d7ee8 = new Type[] {  };
 
         /// <inheritdoc />
         Task<string> IAmInterfaceD.Test()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Test", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Test", ArgumentTypes_3e2e337cd23f4f2ba995861c726d7ee8);
             return (Task<string>)func(Client, arguments);
         }
     }
@@ -311,35 +339,43 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_368950e82d4f41fdaada942bf65aacd9 = new Type[] {  };
+
         /// <inheritdoc />
         Task<string> IAmInterfaceC.Pang()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Pang", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Pang", ArgumentTypes_368950e82d4f41fdaada942bf65aacd9);
             return (Task<string>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_04104020f0e84675a7349921d4838a07 = new Type[] {  };
 
         /// <inheritdoc />
         Task<string> IAmInterfaceB.Pong()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Pong", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Pong", ArgumentTypes_04104020f0e84675a7349921d4838a07);
             return (Task<string>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_f34a5f3809f348248afd45e96e75f2aa = new Type[] {  };
 
         /// <inheritdoc />
         Task<string> IAmInterfaceD.Test()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Test", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Test", ArgumentTypes_f34a5f3809f348248afd45e96e75f2aa);
             return (Task<string>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_581797a447dc44c3ba148eb86b78e298 = new Type[] {  };
 
         /// <inheritdoc />
         Task<string> IAmInterfaceA.Ping()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Ping", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Ping", ArgumentTypes_581797a447dc44c3ba148eb86b78e298);
             return (Task<string>)func(Client, arguments);
         }
     }
@@ -369,11 +405,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_1a99196dc62f4f6fa994b4de0786bc70 = new Type[] {  };
+
         /// <inheritdoc />
         Task<string> IAmInterfaceD.Test()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Test", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Test", ArgumentTypes_1a99196dc62f4f6fa994b4de0786bc70);
             return (Task<string>)func(Client, arguments);
         }
     }
@@ -414,123 +452,153 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_d82084ee808e4632aedb7fcbe2aa5651 = new Type[] { typeof(PathBoundObject) };
+
         /// <inheritdoc />
         Task IApiBindPathToObject.GetFooBars(PathBoundObject request)
         {
             var arguments = new object[] { request };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBars", new Type[] { typeof(PathBoundObject) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBars", ArgumentTypes_d82084ee808e4632aedb7fcbe2aa5651);
             return (Task)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_a0bb7060eae94ffdb5bfae4fc57dc78f = new Type[] { typeof(PathBoundObject) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetFooBarsWithDifferentCasing(PathBoundObject requestParams)
         {
             var arguments = new object[] { requestParams };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBarsWithDifferentCasing", new Type[] { typeof(PathBoundObject) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBarsWithDifferentCasing", ArgumentTypes_a0bb7060eae94ffdb5bfae4fc57dc78f);
             return (Task)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_621299e359434bfaa57dde7a77a5f6a0 = new Type[] { typeof(string), typeof(PathBoundObject) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetBarsByFoo(string id, PathBoundObject request)
         {
             var arguments = new object[] { id, request };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetBarsByFoo", new Type[] { typeof(string), typeof(PathBoundObject) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetBarsByFoo", ArgumentTypes_621299e359434bfaa57dde7a77a5f6a0);
             return (Task)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_dc13f668316146828c8af4aea31545ee = new Type[] { typeof(PathBoundObject), typeof(string) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetFooBars(PathBoundObject request, string someProperty)
         {
             var arguments = new object[] { request, someProperty };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBars", new Type[] { typeof(PathBoundObject), typeof(string) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBars", ArgumentTypes_dc13f668316146828c8af4aea31545ee);
             return (Task)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_38c22b0c6ac1414393310bf4d3ced164 = new Type[] { typeof(PathBoundObject) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetBarsByFoo(PathBoundObject request)
         {
             var arguments = new object[] { request };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetBarsByFoo", new Type[] { typeof(PathBoundObject) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetBarsByFoo", ArgumentTypes_38c22b0c6ac1414393310bf4d3ced164);
             return (Task)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_b5f62109b6124e56baebeb70c6d89955 = new Type[] { typeof(PathBoundObjectWithQueryFormat) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetBarsWithCustomQueryFormat(PathBoundObjectWithQueryFormat request)
         {
             var arguments = new object[] { request };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetBarsWithCustomQueryFormat", new Type[] { typeof(PathBoundObjectWithQueryFormat) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetBarsWithCustomQueryFormat", ArgumentTypes_b5f62109b6124e56baebeb70c6d89955);
             return (Task)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_e8af68fb098e4478999a4dcbd54544a1 = new Type[] { typeof(PathBoundDerivedObject) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetFooBarsDerived(PathBoundDerivedObject request)
         {
             var arguments = new object[] { request };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBarsDerived", new Type[] { typeof(PathBoundDerivedObject) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBarsDerived", ArgumentTypes_e8af68fb098e4478999a4dcbd54544a1);
             return (Task)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_17ac3b976a114118811521b0e6df4392 = new Type[] { typeof(PathBoundList) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetFoos(PathBoundList request)
         {
             var arguments = new object[] { request };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetFoos", new Type[] { typeof(PathBoundList) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetFoos", ArgumentTypes_17ac3b976a114118811521b0e6df4392);
             return (Task)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_caf6b9954a5c4fc7a0363e8355c55213 = new Type[] { typeof(List<int>) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetFoos2(List<int> Values)
         {
             var arguments = new object[] { Values };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetFoos2", new Type[] { typeof(List<int>) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetFoos2", ArgumentTypes_caf6b9954a5c4fc7a0363e8355c55213);
             return (Task)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_f0284c703604497c8addac33ea883865 = new Type[] { typeof(PathBoundObject), typeof(object) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.PostFooBar(PathBoundObject request, object someObject)
         {
             var arguments = new object[] { request, someObject };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBar", new Type[] { typeof(PathBoundObject), typeof(object) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBar", ArgumentTypes_f0284c703604497c8addac33ea883865);
             return (Task)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_bf9de5acb4664da9affb2da854cb9814 = new Type[] { typeof(PathBoundObjectWithQuery) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetFooBars(PathBoundObjectWithQuery request)
         {
             var arguments = new object[] { request };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBars", new Type[] { typeof(PathBoundObjectWithQuery) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBars", ArgumentTypes_bf9de5acb4664da9affb2da854cb9814);
             return (Task)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_30b0ebdc104b4d13878f478e59db18b0 = new Type[] { typeof(PathBoundObject), typeof(ModelObject) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IApiBindPathToObject.PostFooBar(PathBoundObject request, ModelObject someQueryParams)
         {
             var arguments = new object[] { request, someQueryParams };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBar", new Type[] { typeof(PathBoundObject), typeof(ModelObject) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBar", ArgumentTypes_30b0ebdc104b4d13878f478e59db18b0);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_52bed48dbfe5444fa5c9a6d6c97ce393 = new Type[] { typeof(PathBoundObject), typeof(ModelObject), typeof(StreamPart) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IApiBindPathToObject.PostFooBarStreamPart(PathBoundObject request, ModelObject someQueryParams, StreamPart stream)
         {
             var arguments = new object[] { request, someQueryParams, stream };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBarStreamPart", new Type[] { typeof(PathBoundObject), typeof(ModelObject), typeof(StreamPart) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBarStreamPart", ArgumentTypes_52bed48dbfe5444fa5c9a6d6c97ce393);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_a6bdb4b5cf164da7bd18d48cf71f1692 = new Type[] { typeof(PathBoundObject), typeof(StreamPart) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IApiBindPathToObject.PostFooBarStreamPart(PathBoundObject request, StreamPart stream)
         {
             var arguments = new object[] { request, stream };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBarStreamPart", new Type[] { typeof(PathBoundObject), typeof(StreamPart) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBarStreamPart", ArgumentTypes_a6bdb4b5cf164da7bd18d48cf71f1692);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_bab0280614e846aebec8e15044bafe2a = new Type[] { typeof(PathBoundObjectWithQuery), typeof(StreamPart) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IApiBindPathToObject.PostFooBarStreamPart(PathBoundObjectWithQuery request, StreamPart stream)
         {
             var arguments = new object[] { request, stream };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBarStreamPart", new Type[] { typeof(PathBoundObjectWithQuery), typeof(StreamPart) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBarStreamPart", ArgumentTypes_bab0280614e846aebec8e15044bafe2a);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
     }
@@ -571,11 +639,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_a08be4a8b6e14351a7dd354be8502d04 = new Type[] { typeof(decimal) };
+
         /// <inheritdoc />
         Task<string> IApiWithDecimal.GetWithDecimal(decimal value)
         {
             var arguments = new object[] { value };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetWithDecimal", new Type[] { typeof(decimal) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetWithDecimal", ArgumentTypes_a08be4a8b6e14351a7dd354be8502d04);
             return (Task<string>)func(Client, arguments);
         }
     }
@@ -616,27 +686,33 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_ef099a8790e346158ad36ec72488d09d = new Type[] {  };
+
         /// <inheritdoc />
         Task IBodylessApi.Post()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Post", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Post", ArgumentTypes_ef099a8790e346158ad36ec72488d09d);
             return (Task)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_6bf7cf31fa9347a2898b86769079159c = new Type[] {  };
 
         /// <inheritdoc />
         Task IBodylessApi.Get()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_6bf7cf31fa9347a2898b86769079159c);
             return (Task)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_8bb2bb21fef2447da5f28e9ac6438653 = new Type[] {  };
 
         /// <inheritdoc />
         Task IBodylessApi.Head()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Head", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Head", ArgumentTypes_8bb2bb21fef2447da5f28e9ac6438653);
             return (Task)func(Client, arguments);
         }
     }
@@ -677,43 +753,53 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_abf7b391a3104791a915ea66be2dce9f = new Type[] { typeof(T) };
+
         /// <inheritdoc />
         Task<T> IBoringCrudApi<T, TKey>.Create(T paylod)
         {
             var arguments = new object[] { paylod };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Create", new Type[] { typeof(T) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_abf7b391a3104791a915ea66be2dce9f);
             return (Task<T>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_47928ca44645467aa4ee03cb247199b8 = new Type[] {  };
 
         /// <inheritdoc />
         Task<List<T>> IBoringCrudApi<T, TKey>.ReadAll()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_47928ca44645467aa4ee03cb247199b8);
             return (Task<List<T>>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_11dafea69f6247e19fc107e130ce21a5 = new Type[] { typeof(TKey) };
 
         /// <inheritdoc />
         Task<T> IBoringCrudApi<T, TKey>.ReadOne(TKey key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", new Type[] { typeof(TKey) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_11dafea69f6247e19fc107e130ce21a5);
             return (Task<T>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_9701bbddfdfd4de1afed9f4c321d8da5 = new Type[] { typeof(TKey), typeof(T) };
 
         /// <inheritdoc />
         Task IBoringCrudApi<T, TKey>.Update(TKey key, T payload)
         {
             var arguments = new object[] { key, payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Update", new Type[] { typeof(TKey), typeof(T) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_9701bbddfdfd4de1afed9f4c321d8da5);
             return (Task)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_f9587170441840b8a7016420cc73f917 = new Type[] { typeof(TKey) };
 
         /// <inheritdoc />
         Task IBoringCrudApi<T, TKey>.Delete(TKey key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", new Type[] { typeof(TKey) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_f9587170441840b8a7016420cc73f917);
             return (Task)func(Client, arguments);
         }
     }
@@ -754,11 +840,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_e8e104f1fe2849b7b5d4031b7809553b = new Type[] { typeof(string) };
+
         /// <inheritdoc />
         Task<bool> IBrokenWebApi.PostAValue(string derp)
         {
             var arguments = new object[] { derp };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostAValue", new Type[] { typeof(string) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostAValue", ArgumentTypes_e8e104f1fe2849b7b5d4031b7809553b);
             return (Task<bool>)func(Client, arguments);
         }
     }
@@ -787,11 +875,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_6d3f119a4aec4cf5a11bf85c940897d9 = new Type[] {  };
+
         /// <inheritdoc />
         CustomReferenceType? ICustomNullableReferenceService.Get()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_6d3f119a4aec4cf5a11bf85c940897d9);
             return (CustomReferenceType?)func(Client, arguments);
         }
     }
@@ -820,11 +910,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_a4be7d7886714e72ad68b1ef16c8e062 = new Type[] {  };
+
         /// <inheritdoc />
         CustomValueType? ICustomNullableValueService.Get()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_a4be7d7886714e72ad68b1ef16c8e062);
             return (CustomValueType?)func(Client, arguments);
         }
     }
@@ -853,11 +945,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_1c1bc578e93a4d50adc08ea05cae067d = new Type[] { ToNullable(typeof(CustomReferenceType)), ToNullable(typeof(CustomValueType)) };
+
         /// <inheritdoc />
         Task ICustomReferenceAndValueParametersService.Get(CustomReferenceType? reference, CustomValueType? value)
         {
             var arguments = new object[] { reference, value };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", new Type[] { ToNullable(typeof(CustomReferenceType)), ToNullable(typeof(CustomValueType)) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_1c1bc578e93a4d50adc08ea05cae067d);
             return (Task)func(Client, arguments);
         }
 
@@ -890,59 +984,73 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_7d5c0af5fae3474a931ac051a2e0921a = new Type[] {  };
+
         /// <inheritdoc />
         Task IDataApiA.PingA()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PingA", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("PingA", ArgumentTypes_7d5c0af5fae3474a931ac051a2e0921a);
             return (Task)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_343e53168d8244108bc7395d52cb8014 = new Type[] { typeof(DataEntity) };
 
         /// <inheritdoc />
         Task<DataEntity> IDataCrudApi<DataEntity>.Copy(DataEntity payload)
         {
             var arguments = new object[] { payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Copy", new Type[] { typeof(DataEntity) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Copy", ArgumentTypes_343e53168d8244108bc7395d52cb8014);
             return (Task<DataEntity>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_30b1609eb5564127b70bb74219f62ad5 = new Type[] { typeof(DataEntity) };
 
         /// <inheritdoc />
         Task<DataEntity> IDataCrudApi<DataEntity, long>.Create(DataEntity payload)
         {
             var arguments = new object[] { payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Create", new Type[] { typeof(DataEntity) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_30b1609eb5564127b70bb74219f62ad5);
             return (Task<DataEntity>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_45166a4875424f7c85ed171ec9e09244 = new Type[] {  };
 
         /// <inheritdoc />
         Task<List<DataEntity>> IDataCrudApi<DataEntity, long>.ReadAll()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_45166a4875424f7c85ed171ec9e09244);
             return (Task<List<DataEntity>>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_4959a4c16d2c4930818be7064dc72929 = new Type[] { typeof(long) };
 
         /// <inheritdoc />
         Task<DataEntity> IDataCrudApi<DataEntity, long>.ReadOne(long key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", new Type[] { typeof(long) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_4959a4c16d2c4930818be7064dc72929);
             return (Task<DataEntity>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_d678905a66f146daafdbf572bf9926e0 = new Type[] { typeof(long), typeof(DataEntity) };
 
         /// <inheritdoc />
         Task IDataCrudApi<DataEntity, long>.Update(long key, DataEntity payload)
         {
             var arguments = new object[] { key, payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Update", new Type[] { typeof(long), typeof(DataEntity) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_d678905a66f146daafdbf572bf9926e0);
             return (Task)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_27c3a88882aa41c5abe76eda1061f56e = new Type[] { typeof(long) };
 
         /// <inheritdoc />
         Task IDataCrudApi<DataEntity, long>.Delete(long key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", new Type[] { typeof(long) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_27c3a88882aa41c5abe76eda1061f56e);
             return (Task)func(Client, arguments);
         }
     }
@@ -973,51 +1081,63 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_d521cbce8d9c407ea398a7a94e77f8ef = new Type[] {  };
+
         /// <inheritdoc />
         Task IDataApiB.PingB()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PingB", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("PingB", ArgumentTypes_d521cbce8d9c407ea398a7a94e77f8ef);
             return (Task)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_99873a955a29497e9732b1606bb5b671 = new Type[] { typeof(DataEntity) };
 
         /// <inheritdoc />
         Task<DataEntity> IDataCrudApi<DataEntity, int>.Create(DataEntity payload)
         {
             var arguments = new object[] { payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Create", new Type[] { typeof(DataEntity) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_99873a955a29497e9732b1606bb5b671);
             return (Task<DataEntity>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_402fb50857d14d9987a4e09a81ac346d = new Type[] {  };
 
         /// <inheritdoc />
         Task<List<DataEntity>> IDataCrudApi<DataEntity, int>.ReadAll()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_402fb50857d14d9987a4e09a81ac346d);
             return (Task<List<DataEntity>>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_64a9eb0dedff40c1ab6edb3a196a1974 = new Type[] { typeof(int) };
 
         /// <inheritdoc />
         Task<DataEntity> IDataCrudApi<DataEntity, int>.ReadOne(int key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", new Type[] { typeof(int) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_64a9eb0dedff40c1ab6edb3a196a1974);
             return (Task<DataEntity>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_47174a46e1314d29975117db45d101e1 = new Type[] { typeof(int), typeof(DataEntity) };
 
         /// <inheritdoc />
         Task IDataCrudApi<DataEntity, int>.Update(int key, DataEntity payload)
         {
             var arguments = new object[] { key, payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Update", new Type[] { typeof(int), typeof(DataEntity) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_47174a46e1314d29975117db45d101e1);
             return (Task)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_594d40ee267647e68885da682ba3cd7b = new Type[] { typeof(int) };
 
         /// <inheritdoc />
         Task IDataCrudApi<DataEntity, int>.Delete(int key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", new Type[] { typeof(int) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_594d40ee267647e68885da682ba3cd7b);
             return (Task)func(Client, arguments);
         }
     }
@@ -1051,51 +1171,63 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_1eea269d486a4dceba6fcf08dbe5df5e = new Type[] { typeof(T) };
+
         /// <inheritdoc />
         Task<T> IDataCrudApi<T>.Copy(T payload)
         {
             var arguments = new object[] { payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Copy", new Type[] { typeof(T) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Copy", ArgumentTypes_1eea269d486a4dceba6fcf08dbe5df5e);
             return (Task<T>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_37f940e1cc1a40c88e51f4f231fa6833 = new Type[] { typeof(T) };
 
         /// <inheritdoc />
         Task<T> IDataCrudApi<T, long>.Create(T payload)
         {
             var arguments = new object[] { payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Create", new Type[] { typeof(T) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_37f940e1cc1a40c88e51f4f231fa6833);
             return (Task<T>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_7f04796b527a4bc995d3bf3f0b5f08d3 = new Type[] {  };
 
         /// <inheritdoc />
         Task<List<T>> IDataCrudApi<T, long>.ReadAll()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_7f04796b527a4bc995d3bf3f0b5f08d3);
             return (Task<List<T>>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_7c52f39c7c7140f3a3b9d34edb51545f = new Type[] { typeof(long) };
 
         /// <inheritdoc />
         Task<T> IDataCrudApi<T, long>.ReadOne(long key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", new Type[] { typeof(long) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_7c52f39c7c7140f3a3b9d34edb51545f);
             return (Task<T>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_3afc97de14eb466d979e2ce7658c545f = new Type[] { typeof(long), typeof(T) };
 
         /// <inheritdoc />
         Task IDataCrudApi<T, long>.Update(long key, T payload)
         {
             var arguments = new object[] { key, payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Update", new Type[] { typeof(long), typeof(T) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_3afc97de14eb466d979e2ce7658c545f);
             return (Task)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_3518f113c0c946d7a2b0a93b6810c696 = new Type[] { typeof(long) };
 
         /// <inheritdoc />
         Task IDataCrudApi<T, long>.Delete(long key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", new Type[] { typeof(long) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_3518f113c0c946d7a2b0a93b6810c696);
             return (Task)func(Client, arguments);
         }
     }
@@ -1129,43 +1261,53 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_2dd8932f23e94674b9cceeae76894962 = new Type[] { typeof(T) };
+
         /// <inheritdoc />
         Task<T> IDataCrudApi<T, TKey>.Create(T payload)
         {
             var arguments = new object[] { payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Create", new Type[] { typeof(T) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_2dd8932f23e94674b9cceeae76894962);
             return (Task<T>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_5ff0e2178f414b799c966af528d795f5 = new Type[] {  };
 
         /// <inheritdoc />
         Task<List<T>> IDataCrudApi<T, TKey>.ReadAll()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_5ff0e2178f414b799c966af528d795f5);
             return (Task<List<T>>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_1a59a45c18b64c0596ded74cd7a24ace = new Type[] { typeof(TKey) };
 
         /// <inheritdoc />
         Task<T> IDataCrudApi<T, TKey>.ReadOne(TKey key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", new Type[] { typeof(TKey) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_1a59a45c18b64c0596ded74cd7a24ace);
             return (Task<T>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_a31476e793b6496dac5bf496db2295e5 = new Type[] { typeof(TKey), typeof(T) };
 
         /// <inheritdoc />
         Task IDataCrudApi<T, TKey>.Update(TKey key, T payload)
         {
             var arguments = new object[] { key, payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Update", new Type[] { typeof(TKey), typeof(T) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_a31476e793b6496dac5bf496db2295e5);
             return (Task)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_da65613142d8419c867a4892a4548edc = new Type[] { typeof(TKey) };
 
         /// <inheritdoc />
         Task IDataCrudApi<T, TKey>.Delete(TKey key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", new Type[] { typeof(TKey) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_da65613142d8419c867a4892a4548edc);
             return (Task)func(Client, arguments);
         }
     }
@@ -1194,11 +1336,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_91c724a303774144ab71158c5ece12cb = new Type[] { ToNullable(typeof(System.Collections.Generic.List<string>)) };
+
         /// <inheritdoc />
         Task IGenericNullableReferenceParameterService.Get(System.Collections.Generic.List<string>? reference)
         {
             var arguments = new object[] { reference };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", new Type[] { ToNullable(typeof(System.Collections.Generic.List<string>)) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_91c724a303774144ab71158c5ece12cb);
             return (Task)func(Client, arguments);
         }
 
@@ -1229,11 +1373,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_3803f0c715de41b2b35f466e26eac0c1 = new Type[] {  };
+
         /// <inheritdoc />
         Task<string>? IGenericNullableReferenceService.Get()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_3803f0c715de41b2b35f466e26eac0c1);
             return (Task<string>?)func(Client, arguments);
         }
     }
@@ -1262,11 +1408,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_6b7a6439a51249f8ac3e84009bc1e2bf = new Type[] {  };
+
         /// <inheritdoc />
         ValueTask<int>? IGenericNullableValueService.Get()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_6b7a6439a51249f8ac3e84009bc1e2bf);
             return (ValueTask<int>?)func(Client, arguments);
         }
     }
@@ -1295,11 +1443,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_7edc88dc73034c4fbbe0ccdc9cdbffe7 = new Type[] { ToNullable(typeof(System.Collections.Generic.List<string?>)) };
+
         /// <inheritdoc />
         Task IGenericNullableWithNullableReferenceParameterService.Get(System.Collections.Generic.List<string?>? reference)
         {
             var arguments = new object[] { reference };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", new Type[] { ToNullable(typeof(System.Collections.Generic.List<string?>)) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_7edc88dc73034c4fbbe0ccdc9cdbffe7);
             return (Task)func(Client, arguments);
         }
 
@@ -1330,11 +1480,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_c5ecfbdc7c7744029e0f8e0c707d4cb8 = new Type[] {  };
+
         /// <inheritdoc />
         Task<string?>? IGenericNullableWithNullableReferenceService.Get()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_c5ecfbdc7c7744029e0f8e0c707d4cb8);
             return (Task<string?>?)func(Client, arguments);
         }
     }
@@ -1363,11 +1515,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_c418000d8ad649fc9a8c27b444aa92aa = new Type[] {  };
+
         /// <inheritdoc />
         ValueTask<int?>? IGenericNullableWithNullableValueService.Get()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_c418000d8ad649fc9a8c27b444aa92aa);
             return (ValueTask<int?>?)func(Client, arguments);
         }
     }
@@ -1396,11 +1550,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_0f614393c6ea49e18c9c28e3dd3c2180 = new Type[] { typeof(System.Collections.Generic.List<string?>) };
+
         /// <inheritdoc />
         Task IGenericWithNullableReferenceParameterService.Get(System.Collections.Generic.List<string?> reference)
         {
             var arguments = new object[] { reference };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", new Type[] { typeof(System.Collections.Generic.List<string?>) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_0f614393c6ea49e18c9c28e3dd3c2180);
             return (Task)func(Client, arguments);
         }
     }
@@ -1429,11 +1585,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_607ae3a809a74c7e8c9009c1e1cd3c21 = new Type[] {  };
+
         /// <inheritdoc />
         Task<int?> IGenericWithNullableValueService.Get()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_607ae3a809a74c7e8c9009c1e1cd3c21);
             return (Task<int?>)func(Client, arguments);
         }
     }
@@ -1462,11 +1620,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_4cec3e99456b4e6eb5fdd0fee3340519 = new Type[] {  };
+
         /// <inheritdoc />
         Task<string?> IGenericWithResultService.Get()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_4cec3e99456b4e6eb5fdd0fee3340519);
             return (Task<string?>)func(Client, arguments);
         }
     }
@@ -1501,107 +1661,133 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_825344cd83164381a710b05f132cd285 = new Type[] { typeof(string) };
+
         /// <inheritdoc />
         Task<User> IGitHubApi.GetUser(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUser", new Type[] { typeof(string) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUser", ArgumentTypes_825344cd83164381a710b05f132cd285);
             return (Task<User>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_a6ad0ccd63ae410caebec92bdfc469fa = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         IObservable<User> IGitHubApi.GetUserObservable(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserObservable", new Type[] { typeof(string) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserObservable", ArgumentTypes_a6ad0ccd63ae410caebec92bdfc469fa);
             return (IObservable<User>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_0982d186f6f8463f9841376247ab81b4 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         IObservable<User> IGitHubApi.GetUserCamelCase(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserCamelCase", new Type[] { typeof(string) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserCamelCase", ArgumentTypes_0982d186f6f8463f9841376247ab81b4);
             return (IObservable<User>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_176c28f24e834c5fb204b915b429b051 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<List<User>> IGitHubApi.GetOrgMembers(string orgName)
         {
             var arguments = new object[] { orgName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetOrgMembers", new Type[] { typeof(string) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetOrgMembers", ArgumentTypes_176c28f24e834c5fb204b915b429b051);
             return (Task<List<User>>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_3e8a2a65a8934444b64df820a5e51301 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<UserSearchResult> IGitHubApi.FindUsers(string q)
         {
             var arguments = new object[] { q };
-            var func = requestBuilder.BuildRestResultFuncForMethod("FindUsers", new Type[] { typeof(string) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("FindUsers", ArgumentTypes_3e8a2a65a8934444b64df820a5e51301);
             return (Task<UserSearchResult>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_c7334dae5eea4961a4ef24a94f922510 = new Type[] {  };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IGitHubApi.GetIndex()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndex", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndex", ArgumentTypes_c7334dae5eea4961a4ef24a94f922510);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_27eb29e21a114838ac1362a6eac4b0d1 = new Type[] {  };
 
         /// <inheritdoc />
         IObservable<string> IGitHubApi.GetIndexObservable()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndexObservable", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndexObservable", ArgumentTypes_27eb29e21a114838ac1362a6eac4b0d1);
             return (IObservable<string>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_749bdd3f18a5417d8524d4509ac3b369 = new Type[] {  };
 
         /// <inheritdoc />
         Task<User> IGitHubApi.NothingToSeeHere()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("NothingToSeeHere", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("NothingToSeeHere", ArgumentTypes_749bdd3f18a5417d8524d4509ac3b369);
             return (Task<User>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_8b73e68672d84d06b8881b930d41f9a8 = new Type[] {  };
 
         /// <inheritdoc />
         Task<ApiResponse<User>> IGitHubApi.NothingToSeeHereWithMetadata()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("NothingToSeeHereWithMetadata", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("NothingToSeeHereWithMetadata", ArgumentTypes_8b73e68672d84d06b8881b930d41f9a8);
             return (Task<ApiResponse<User>>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_da60ed58c3d045f3886c9d1ffe10518a = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<ApiResponse<User>> IGitHubApi.GetUserWithMetadata(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserWithMetadata", new Type[] { typeof(string) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserWithMetadata", ArgumentTypes_da60ed58c3d045f3886c9d1ffe10518a);
             return (Task<ApiResponse<User>>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_944cb854ea8a4f7bb308f6d39eb0f171 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         IObservable<ApiResponse<User>> IGitHubApi.GetUserObservableWithMetadata(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserObservableWithMetadata", new Type[] { typeof(string) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserObservableWithMetadata", ArgumentTypes_944cb854ea8a4f7bb308f6d39eb0f171);
             return (IObservable<ApiResponse<User>>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_db10a7fa440c47e4a6073b08e3005d2b = new Type[] { typeof(User) };
 
         /// <inheritdoc />
         Task<User> IGitHubApi.CreateUser(User user)
         {
             var arguments = new object[] { user };
-            var func = requestBuilder.BuildRestResultFuncForMethod("CreateUser", new Type[] { typeof(User) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("CreateUser", ArgumentTypes_db10a7fa440c47e4a6073b08e3005d2b);
             return (Task<User>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_654763b56bfb4b4284772da72f372e2b = new Type[] { typeof(User) };
 
         /// <inheritdoc />
         Task<ApiResponse<User>> IGitHubApi.CreateUserWithMetadata(User user)
         {
             var arguments = new object[] { user };
-            var func = requestBuilder.BuildRestResultFuncForMethod("CreateUserWithMetadata", new Type[] { typeof(User) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("CreateUserWithMetadata", ArgumentTypes_654763b56bfb4b4284772da72f372e2b);
             return (Task<ApiResponse<User>>)func(Client, arguments);
         }
     }
@@ -1646,43 +1832,57 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_ecebe7833dd44c0d96c11e51a43070b5 = new Type[] { typeof(TParam), typeof(THeader) };
+
         /// <inheritdoc />
         Task<TResponse> IHttpBinApi<TResponse, TParam, THeader>.Get(TParam param, THeader header)
         {
             var arguments = new object[] { param, header };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", new Type[] { typeof(TParam), typeof(THeader) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_ecebe7833dd44c0d96c11e51a43070b5);
             return (Task<TResponse>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_2bec4fc6318e4d599242c196a243775f = new Type[] { typeof(TParam) };
 
         /// <inheritdoc />
         Task<TResponse> IHttpBinApi<TResponse, TParam, THeader>.GetQuery(TParam param)
         {
             var arguments = new object[] { param };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetQuery", new Type[] { typeof(TParam) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetQuery", ArgumentTypes_2bec4fc6318e4d599242c196a243775f);
             return (Task<TResponse>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_3fbd2156290e4091a751dcede3ecc9a8 = new Type[] { typeof(TParam) };
 
         /// <inheritdoc />
         Task<TResponse> IHttpBinApi<TResponse, TParam, THeader>.PostQuery(TParam param)
         {
             var arguments = new object[] { param };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostQuery", new Type[] { typeof(TParam) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostQuery", ArgumentTypes_3fbd2156290e4091a751dcede3ecc9a8);
             return (Task<TResponse>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_7d02a05c8f44435a9ec84d4733664772 = new Type[] { typeof(TParam) };
 
         /// <inheritdoc />
         Task<TResponse> IHttpBinApi<TResponse, TParam, THeader>.GetQueryWithIncludeParameterName(TParam param)
         {
             var arguments = new object[] { param };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetQueryWithIncludeParameterName", new Type[] { typeof(TParam) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetQueryWithIncludeParameterName", ArgumentTypes_7d02a05c8f44435a9ec84d4733664772);
             return (Task<TResponse>)func(Client, arguments);
+        }
+
+        private static class TypeHelper_58cfbf92175c47d1abbe8cdb9ef4c08c<TValue>
+        {
+            public static readonly Type[] ArgumentTypes = new Type[] { typeof(TParam) };
+            public static readonly Type[] TypeParameters = new Type[] { typeof(TValue) };
         }
 
         /// <inheritdoc />
         Task<TValue> IHttpBinApi<TResponse, TParam, THeader>.GetQuery1<TValue>(TParam param)
         {
             var arguments = new object[] { param };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetQuery1", new Type[] { typeof(TParam) }, new Type[] { typeof(TValue) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetQuery1", TypeHelper_58cfbf92175c47d1abbe8cdb9ef4c08c<TValue>.ArgumentTypes, TypeHelper_58cfbf92175c47d1abbe8cdb9ef4c08c<TValue>.TypeParameters);
             return (Task<TValue>)func(Client, arguments);
         }
     }
@@ -1723,19 +1923,23 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_916233bede5448c287b2c3cbdb5bfbde = new Type[] { typeof(HttpContent) };
+
         /// <inheritdoc />
         Task<HttpContent> IHttpContentApi.PostFileUpload(HttpContent content)
         {
             var arguments = new object[] { content };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostFileUpload", new Type[] { typeof(HttpContent) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostFileUpload", ArgumentTypes_916233bede5448c287b2c3cbdb5bfbde);
             return (Task<HttpContent>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_337c1407a71d495d88de5fcd8487bbd2 = new Type[] { typeof(HttpContent) };
 
         /// <inheritdoc />
         Task<ApiResponse<HttpContent>> IHttpContentApi.PostFileUploadWithMetadata(HttpContent content)
         {
             var arguments = new object[] { content };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostFileUploadWithMetadata", new Type[] { typeof(HttpContent) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostFileUploadWithMetadata", ArgumentTypes_337c1407a71d495d88de5fcd8487bbd2);
             return (Task<ApiResponse<HttpContent>>)func(Client, arguments);
         }
     }
@@ -1777,11 +1981,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_a3fa247f3e984a6ebc8ff5152208dfa3 = new Type[] {  };
+
         /// <inheritdoc />
         Task<TestAliasObject> ResponseTests.IMyAliasService.GetTestObject()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetTestObject", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetTestObject", ArgumentTypes_a3fa247f3e984a6ebc8ff5152208dfa3);
             return (Task<TestAliasObject>)func(Client, arguments);
         }
     }
@@ -1817,19 +2023,23 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_0c64af5faa0441f2bc8e4a2a2c83361b = new Type[] {  };
+
         /// <inheritdoc />
         Task<string> AuthenticatedClientHandlerTests.IMyAuthenticatedService.GetUnauthenticated()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUnauthenticated", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUnauthenticated", ArgumentTypes_0c64af5faa0441f2bc8e4a2a2c83361b);
             return (Task<string>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_3fe3a5722572445f91da95a9ec09d02f = new Type[] {  };
 
         /// <inheritdoc />
         Task<string> AuthenticatedClientHandlerTests.IMyAuthenticatedService.GetAuthenticated()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetAuthenticated", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetAuthenticated", ArgumentTypes_3fe3a5722572445f91da95a9ec09d02f);
             return (Task<string>)func(Client, arguments);
         }
     }
@@ -1860,11 +2070,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_d6586b4240b5463bb75e1a334a6a1518 = new Type[] {  };
+
         /// <inheritdoc />
         Task<SomeType> INamespaceCollisionApi.SomeRequest()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", ArgumentTypes_d6586b4240b5463bb75e1a334a6a1518);
             return (Task<SomeType>)func(Client, arguments);
         }
     }
@@ -1896,11 +2108,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_57c9155b70384c79a6c00be75a46b20d = new Type[] {  };
+
         /// <inheritdoc />
         Task<SomeOtherType> INamespaceOverlapApi.SomeRequest()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", ArgumentTypes_57c9155b70384c79a6c00be75a46b20d);
             return (Task<SomeOtherType>)func(Client, arguments);
         }
     }
@@ -1935,67 +2149,83 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_6787694a254e497bb0fc8402d88ec5b0 = new Type[] { typeof(string) };
+
         /// <inheritdoc />
         Task<User> TestNested.INestedGitHubApi.GetUser(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUser", new Type[] { typeof(string) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUser", ArgumentTypes_6787694a254e497bb0fc8402d88ec5b0);
             return (Task<User>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_9349c66e870d4d4990c6838e127dd66d = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         IObservable<User> TestNested.INestedGitHubApi.GetUserObservable(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserObservable", new Type[] { typeof(string) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserObservable", ArgumentTypes_9349c66e870d4d4990c6838e127dd66d);
             return (IObservable<User>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_eebf863635d7438d9f2cc187f9edfbf7 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         IObservable<User> TestNested.INestedGitHubApi.GetUserCamelCase(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserCamelCase", new Type[] { typeof(string) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserCamelCase", ArgumentTypes_eebf863635d7438d9f2cc187f9edfbf7);
             return (IObservable<User>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_168d950ea0c84b26885467be85b61fab = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<List<User>> TestNested.INestedGitHubApi.GetOrgMembers(string orgName)
         {
             var arguments = new object[] { orgName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetOrgMembers", new Type[] { typeof(string) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetOrgMembers", ArgumentTypes_168d950ea0c84b26885467be85b61fab);
             return (Task<List<User>>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_b970f988241d490495aab63b5b6b6f81 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<UserSearchResult> TestNested.INestedGitHubApi.FindUsers(string q)
         {
             var arguments = new object[] { q };
-            var func = requestBuilder.BuildRestResultFuncForMethod("FindUsers", new Type[] { typeof(string) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("FindUsers", ArgumentTypes_b970f988241d490495aab63b5b6b6f81);
             return (Task<UserSearchResult>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_12b0613a1e674ac1a13bab221350fb9e = new Type[] {  };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> TestNested.INestedGitHubApi.GetIndex()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndex", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndex", ArgumentTypes_12b0613a1e674ac1a13bab221350fb9e);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_892b0da4f9c7450d85b1ac3efb7d268e = new Type[] {  };
 
         /// <inheritdoc />
         IObservable<string> TestNested.INestedGitHubApi.GetIndexObservable()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndexObservable", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndexObservable", ArgumentTypes_892b0da4f9c7450d85b1ac3efb7d268e);
             return (IObservable<string>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_169d18dcad944458974aaa3f2113a1b6 = new Type[] {  };
 
         /// <inheritdoc />
         Task TestNested.INestedGitHubApi.NothingToSeeHere()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("NothingToSeeHere", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("NothingToSeeHere", ArgumentTypes_169d18dcad944458974aaa3f2113a1b6);
             return (Task)func(Client, arguments);
         }
     }
@@ -2033,19 +2263,31 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static class TypeHelper_c12dfdbf764f4632bc0b02521e408c77<T>
+        {
+            public static readonly Type[] ArgumentTypes = new Type[] { typeof(T) };
+            public static readonly Type[] TypeParameters = new Type[] { typeof(T) };
+        }
+
         /// <inheritdoc />
         Task INonGenericInterfaceWithGenericMethod.PostMessage<T>(T message)
         {
             var arguments = new object[] { message };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostMessage", new Type[] { typeof(T) }, new Type[] { typeof(T) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostMessage", TypeHelper_c12dfdbf764f4632bc0b02521e408c77<T>.ArgumentTypes, TypeHelper_c12dfdbf764f4632bc0b02521e408c77<T>.TypeParameters);
             return (Task)func(Client, arguments);
+        }
+
+        private static class TypeHelper_27934246c0974dce8f11d9ffff3dc4d2<T, U, V>
+        {
+            public static readonly Type[] ArgumentTypes = new Type[] { typeof(T), typeof(U), typeof(V) };
+            public static readonly Type[] TypeParameters = new Type[] { typeof(T), typeof(U), typeof(V) };
         }
 
         /// <inheritdoc />
         Task INonGenericInterfaceWithGenericMethod.PostMessage<T, U, V>(T message, U param1, V param2)
         {
             var arguments = new object[] { message, param1, param2 };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostMessage", new Type[] { typeof(T), typeof(U), typeof(V) }, new Type[] { typeof(T), typeof(U), typeof(V) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostMessage", TypeHelper_27934246c0974dce8f11d9ffff3dc4d2<T, U, V>.ArgumentTypes, TypeHelper_27934246c0974dce8f11d9ffff3dc4d2<T, U, V>.TypeParameters);
             return (Task)func(Client, arguments);
         }
     }
@@ -2086,11 +2328,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_a1a8c9620a9e4348871dab2d3bbffb46 = new Type[] {  };
+
         /// <inheritdoc />
         Task<RootObject> INpmJs.GetCongruence()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetCongruence", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetCongruence", ArgumentTypes_a1a8c9620a9e4348871dab2d3bbffb46);
             return (Task<RootObject>)func(Client, arguments);
         }
     }
@@ -2119,11 +2363,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_e67e85252dd54696a64b61da843b861a = new Type[] {  };
+
         /// <inheritdoc />
         string? INullableReferenceService.Get()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_e67e85252dd54696a64b61da843b861a);
             return (string?)func(Client, arguments);
         }
     }
@@ -2152,11 +2398,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_d734543f219b4468a3e27385f2882225 = new Type[] {  };
+
         /// <inheritdoc />
         int? INullableValueService.Get()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_d734543f219b4468a3e27385f2882225);
             return (int?)func(Client, arguments);
         }
     }
@@ -2186,11 +2434,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_71fa7deb0cd54d74918d11543b6687bc = new Type[] {  };
+
         /// <inheritdoc />
         Task<SomeType> IReducedUsingInsideNamespaceApi.SomeRequest()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", ArgumentTypes_71fa7deb0cd54d74918d11543b6687bc);
             return (Task<SomeType>)func(Client, arguments);
         }
     }
@@ -2219,11 +2469,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_405cdc425a40429f85710b845a796aa9 = new Type[] { ToNullable(typeof(string)), ToNullable(typeof(int)) };
+
         /// <inheritdoc />
         Task IReferenceAndValueParametersService.Get(string? reference, int? value)
         {
             var arguments = new object[] { reference, value };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", new Type[] { ToNullable(typeof(string)), ToNullable(typeof(int)) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_405cdc425a40429f85710b845a796aa9);
             return (Task)func(Client, arguments);
         }
 
@@ -2266,11 +2518,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_ad5d0c7deacd4242ba81c90c81cac767 = new Type[] {  };
+
         /// <inheritdoc />
         Task IRefitInterfaceWithStaticMethod.Get()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_ad5d0c7deacd4242ba81c90c81cac767);
             return (Task)func(Client, arguments);
         }
     }
@@ -2311,43 +2565,57 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_3f32dbbb00e44199a6379367fc3bf24a = new Type[] {  };
+
         /// <inheritdoc />
         Task IRequestBin.Post()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Post", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Post", ArgumentTypes_3f32dbbb00e44199a6379367fc3bf24a);
             return (Task)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_20bc364aa548409f9a25fae9b11fcd34 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task IRequestBin.PostRawStringDefault(string str)
         {
             var arguments = new object[] { str };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostRawStringDefault", new Type[] { typeof(string) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostRawStringDefault", ArgumentTypes_20bc364aa548409f9a25fae9b11fcd34);
             return (Task)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_780a63f341274e4f96d551245c1a5269 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task IRequestBin.PostRawStringJson(string str)
         {
             var arguments = new object[] { str };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostRawStringJson", new Type[] { typeof(string) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostRawStringJson", ArgumentTypes_780a63f341274e4f96d551245c1a5269);
             return (Task)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_7c5225ba686a4e7dbb598eb731f0d2ab = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task IRequestBin.PostRawStringUrlEncoded(string str)
         {
             var arguments = new object[] { str };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostRawStringUrlEncoded", new Type[] { typeof(string) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostRawStringUrlEncoded", ArgumentTypes_7c5225ba686a4e7dbb598eb731f0d2ab);
             return (Task)func(Client, arguments);
+        }
+
+        private static class TypeHelper_b6c4f825f7c941b8b7b1a53b257b6498<T>
+        {
+            public static readonly Type[] ArgumentTypes = new Type[] { typeof(T) };
+            public static readonly Type[] TypeParameters = new Type[] { typeof(T) };
         }
 
         /// <inheritdoc />
         Task IRequestBin.PostGeneric<T>(T param)
         {
             var arguments = new object[] { param };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostGeneric", new Type[] { typeof(T) }, new Type[] { typeof(T) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostGeneric", TypeHelper_b6c4f825f7c941b8b7b1a53b257b6498<T>.ArgumentTypes, TypeHelper_b6c4f825f7c941b8b7b1a53b257b6498<T>.TypeParameters);
             return (Task)func(Client, arguments);
         }
     }
@@ -2388,107 +2656,133 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_022e0c52d10e49b3af23a6fc56123085 = new Type[] { typeof(Stream) };
+
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadStream(Stream stream)
         {
             var arguments = new object[] { stream };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStream", new Type[] { typeof(Stream) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStream", ArgumentTypes_022e0c52d10e49b3af23a6fc56123085);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_debe5c4f6d274399927c00dc8acde720 = new Type[] { typeof(Stream) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadStreamWithCustomBoundary(Stream stream)
         {
             var arguments = new object[] { stream };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStreamWithCustomBoundary", new Type[] { typeof(Stream) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStreamWithCustomBoundary", ArgumentTypes_debe5c4f6d274399927c00dc8acde720);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_81b1d3f22adb4daa919bb9e7067a57ce = new Type[] { typeof(StreamPart) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadStreamPart(StreamPart stream)
         {
             var arguments = new object[] { stream };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStreamPart", new Type[] { typeof(StreamPart) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStreamPart", ArgumentTypes_81b1d3f22adb4daa919bb9e7067a57ce);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_cd2d6e95caa540d8b0385c96a6b9a946 = new Type[] { typeof(ModelObject), typeof(StreamPart) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadStreamPart(ModelObject someQueryParams, StreamPart stream)
         {
             var arguments = new object[] { someQueryParams, stream };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStreamPart", new Type[] { typeof(ModelObject), typeof(StreamPart) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStreamPart", ArgumentTypes_cd2d6e95caa540d8b0385c96a6b9a946);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_f93d628e070048b4a839c9453343b5e9 = new Type[] { typeof(byte[]) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadBytes(byte[] bytes)
         {
             var arguments = new object[] { bytes };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadBytes", new Type[] { typeof(byte[]) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadBytes", ArgumentTypes_f93d628e070048b4a839c9453343b5e9);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_ba32fe9faf3c4535a9fd4fbd3ed85324 = new Type[] { typeof(ByteArrayPart) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadBytesPart(ByteArrayPart bytes)
         {
             var arguments = new object[] { bytes };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadBytesPart", new Type[] { typeof(ByteArrayPart) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadBytesPart", ArgumentTypes_ba32fe9faf3c4535a9fd4fbd3ed85324);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_ce2900d9ef5b4451a2d39e805bc738ab = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadString(string someString)
         {
             var arguments = new object[] { someString };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadString", new Type[] { typeof(string) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadString", ArgumentTypes_ce2900d9ef5b4451a2d39e805bc738ab);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_7e6c500f4c114966bb186f60cbd4ac67 = new Type[] { typeof(IEnumerable<FileInfo>), typeof(FileInfo) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadFileInfo(IEnumerable<FileInfo> fileInfos, FileInfo anotherFile)
         {
             var arguments = new object[] { fileInfos, anotherFile };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadFileInfo", new Type[] { typeof(IEnumerable<FileInfo>), typeof(FileInfo) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadFileInfo", ArgumentTypes_7e6c500f4c114966bb186f60cbd4ac67);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_ac6f09f630d249e7a8f8754543e31e12 = new Type[] { typeof(IEnumerable<FileInfoPart>), typeof(FileInfoPart) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadFileInfoPart(IEnumerable<FileInfoPart> fileInfos, FileInfoPart anotherFile)
         {
             var arguments = new object[] { fileInfos, anotherFile };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadFileInfoPart", new Type[] { typeof(IEnumerable<FileInfoPart>), typeof(FileInfoPart) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadFileInfoPart", ArgumentTypes_ac6f09f630d249e7a8f8754543e31e12);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_c8cbb75b99b9467faae9259be8059afa = new Type[] { typeof(ModelObject) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadJsonObject(ModelObject theObject)
         {
             var arguments = new object[] { theObject };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadJsonObject", new Type[] { typeof(ModelObject) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadJsonObject", ArgumentTypes_c8cbb75b99b9467faae9259be8059afa);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_63c296818dfb460f85120318d1e5384c = new Type[] { typeof(IEnumerable<ModelObject>) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadJsonObjects(IEnumerable<ModelObject> theObjects)
         {
             var arguments = new object[] { theObjects };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadJsonObjects", new Type[] { typeof(IEnumerable<ModelObject>) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadJsonObjects", ArgumentTypes_63c296818dfb460f85120318d1e5384c);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_7c66b0c3fa44406dbbd9d9b0777c24ad = new Type[] { typeof(IEnumerable<ModelObject>), typeof(AnotherModel), typeof(FileInfo), typeof(AnEnum), typeof(string), typeof(int) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadMixedObjects(IEnumerable<ModelObject> theObjects, AnotherModel anotherModel, FileInfo aFile, AnEnum anEnum, string aString, int anInt)
         {
             var arguments = new object[] { theObjects, anotherModel, aFile, anEnum, aString, anInt };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadMixedObjects", new Type[] { typeof(IEnumerable<ModelObject>), typeof(AnotherModel), typeof(FileInfo), typeof(AnEnum), typeof(string), typeof(int) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadMixedObjects", ArgumentTypes_7c66b0c3fa44406dbbd9d9b0777c24ad);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_af0cb5e4253d4d9fbabf78d8819f1757 = new Type[] { typeof(HttpContent) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadHttpContent(HttpContent content)
         {
             var arguments = new object[] { content };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadHttpContent", new Type[] { typeof(HttpContent) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadHttpContent", ArgumentTypes_af0cb5e4253d4d9fbabf78d8819f1757);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
     }
@@ -2520,19 +2814,23 @@ namespace AutoGeneratedIServiceWithoutNamespace
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_a5b1c9617d3448d6a297222a1f322444 = new Type[] {  };
+
         /// <inheritdoc />
         Task IServiceWithoutNamespace.GetRoot()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetRoot", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetRoot", ArgumentTypes_a5b1c9617d3448d6a297222a1f322444);
             return (Task)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_c67c289b273049f5a87a4b07c1ccb3b5 = new Type[] {  };
 
         /// <inheritdoc />
         Task IServiceWithoutNamespace.PostRoot()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostRoot", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostRoot", ArgumentTypes_c67c289b273049f5a87a4b07c1ccb3b5);
             return (Task)func(Client, arguments);
         }
     }
@@ -2573,19 +2871,23 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_715c065eccca40ebae0c314aff747e56 = new Type[] { typeof(string) };
+
         /// <inheritdoc />
         Task<Stream> IStreamApi.GetRemoteFile(string filename)
         {
             var arguments = new object[] { filename };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetRemoteFile", new Type[] { typeof(string) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetRemoteFile", ArgumentTypes_715c065eccca40ebae0c314aff747e56);
             return (Task<Stream>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_7a4fedfcb81d407b8b281d63b73ca901 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<ApiResponse<Stream>> IStreamApi.GetRemoteFileWithMetadata(string filename)
         {
             var arguments = new object[] { filename };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetRemoteFileWithMetadata", new Type[] { typeof(string) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetRemoteFileWithMetadata", ArgumentTypes_7a4fedfcb81d407b8b281d63b73ca901);
             return (Task<ApiResponse<Stream>>)func(Client, arguments);
         }
     }
@@ -2626,11 +2928,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_b116cf541e2541578b2e064960fa92ba = new Type[] {  };
+
         /// <inheritdoc />
         Task ITrimTrailingForwardSlashApi.Get()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_b116cf541e2541578b2e064960fa92ba);
             return (Task)func(Client, arguments);
         }
     }
@@ -2660,11 +2964,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_e37a999a807c438eb98af353cd60ea3d = new Type[] {  };
+
         /// <inheritdoc />
         Task<SomeType> ITypeCollisionApiA.SomeARequest()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("SomeARequest", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("SomeARequest", ArgumentTypes_e37a999a807c438eb98af353cd60ea3d);
             return (Task<SomeType>)func(Client, arguments);
         }
     }
@@ -2694,11 +3000,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_8aa2159361be4a1189fd52e38f64a8f9 = new Type[] {  };
+
         /// <inheritdoc />
         Task<SomeType> ITypeCollisionApiB.SomeBRequest()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("SomeBRequest", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("SomeBRequest", ArgumentTypes_8aa2159361be4a1189fd52e38f64a8f9);
             return (Task<SomeType>)func(Client, arguments);
         }
     }
@@ -2737,59 +3045,85 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_1fc54f1d4f09409bac79946e82735947 = new Type[] {  };
+
         /// <inheritdoc />
         Task<string> IUseOverloadedGenericMethods<TResponse, TParam, THeader>.Get()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_1fc54f1d4f09409bac79946e82735947);
             return (Task<string>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_5d185f5fecb94fc383a8c03b79f4de49 = new Type[] { typeof(TParam), typeof(THeader) };
 
         /// <inheritdoc />
         Task<TResponse> IUseOverloadedGenericMethods<TResponse, TParam, THeader>.Get(TParam param, THeader header)
         {
             var arguments = new object[] { param, header };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", new Type[] { typeof(TParam), typeof(THeader) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_5d185f5fecb94fc383a8c03b79f4de49);
             return (Task<TResponse>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_85eb479c09d44a928ecc44e88c098f8b = new Type[] { typeof(THeader), typeof(TParam) };
 
         /// <inheritdoc />
         Task<TResponse> IUseOverloadedGenericMethods<TResponse, TParam, THeader>.Get(THeader param, TParam header)
         {
             var arguments = new object[] { param, header };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", new Type[] { typeof(THeader), typeof(TParam) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_85eb479c09d44a928ecc44e88c098f8b);
             return (Task<TResponse>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_c59f4caa124b4685b41113d3a2837299 = new Type[] { typeof(int) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IUseOverloadedGenericMethods<TResponse, TParam, THeader>.Get(int httpstatuscode)
         {
             var arguments = new object[] { httpstatuscode };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", new Type[] { typeof(int) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_c59f4caa124b4685b41113d3a2837299);
             return (Task<HttpResponseMessage>)func(Client, arguments);
+        }
+
+        private static class TypeHelper_0e9925d4bbf94c6c80e4667d829268f4<TValue>
+        {
+            public static readonly Type[] ArgumentTypes = new Type[] { typeof(int) };
+            public static readonly Type[] TypeParameters = new Type[] { typeof(TValue) };
         }
 
         /// <inheritdoc />
         Task<TValue> IUseOverloadedGenericMethods<TResponse, TParam, THeader>.Get<TValue>(int someVal)
         {
             var arguments = new object[] { someVal };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", new Type[] { typeof(int) }, new Type[] { typeof(TValue) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", TypeHelper_0e9925d4bbf94c6c80e4667d829268f4<TValue>.ArgumentTypes, TypeHelper_0e9925d4bbf94c6c80e4667d829268f4<TValue>.TypeParameters);
             return (Task<TValue>)func(Client, arguments);
+        }
+
+        private static class TypeHelper_ef1437730af24bbf932827a41806c3bf<TValue, TInput>
+        {
+            public static readonly Type[] ArgumentTypes = new Type[] { typeof(TInput) };
+            public static readonly Type[] TypeParameters = new Type[] { typeof(TValue), typeof(TInput) };
         }
 
         /// <inheritdoc />
         Task<TValue> IUseOverloadedGenericMethods<TResponse, TParam, THeader>.Get<TValue, TInput>(TInput input)
         {
             var arguments = new object[] { input };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", new Type[] { typeof(TInput) }, new Type[] { typeof(TValue), typeof(TInput) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", TypeHelper_ef1437730af24bbf932827a41806c3bf<TValue, TInput>.ArgumentTypes, TypeHelper_ef1437730af24bbf932827a41806c3bf<TValue, TInput>.TypeParameters);
             return (Task<TValue>)func(Client, arguments);
+        }
+
+        private static class TypeHelper_4a35c21d0bd34370ac49759c69b91cb6<TInput1, TInput2>
+        {
+            public static readonly Type[] ArgumentTypes = new Type[] { typeof(TInput1), typeof(TInput2) };
+            public static readonly Type[] TypeParameters = new Type[] { typeof(TInput1), typeof(TInput2) };
         }
 
         /// <inheritdoc />
         Task IUseOverloadedGenericMethods<TResponse, TParam, THeader>.Get<TInput1, TInput2>(TInput1 input1, TInput2 input2)
         {
             var arguments = new object[] { input1, input2 };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", new Type[] { typeof(TInput1), typeof(TInput2) }, new Type[] { typeof(TInput1), typeof(TInput2) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", TypeHelper_4a35c21d0bd34370ac49759c69b91cb6<TInput1, TInput2>.ArgumentTypes, TypeHelper_4a35c21d0bd34370ac49759c69b91cb6<TInput1, TInput2>.TypeParameters);
             return (Task)func(Client, arguments);
         }
     }
@@ -2824,19 +3158,23 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_098f13f83f014549a9f28abc4ea987bd = new Type[] {  };
+
         /// <inheritdoc />
         Task<string> IUseOverloadedMethods.Get()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_098f13f83f014549a9f28abc4ea987bd);
             return (Task<string>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_e17c788bddcc4478a61433ce8714057a = new Type[] { typeof(int) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IUseOverloadedMethods.Get(int httpstatuscode)
         {
             var arguments = new object[] { httpstatuscode };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", new Type[] { typeof(int) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_e17c788bddcc4478a61433ce8714057a);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
     }
@@ -2877,11 +3215,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_f7bae16e5c2841e2b3a695e2944e84fb = new Type[] {  };
+
         /// <inheritdoc />
         Task IValidApi.Get()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_f7bae16e5c2841e2b3a695e2944e84fb);
             return (Task)func(Client, arguments);
         }
     }
@@ -2911,11 +3251,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_fe61066f6f7c4a9291502841634b933e = new Type[] {  };
+
         /// <inheritdoc />
         Task<SomeType> NamespaceWithGlobalAliasApi.SomeRequest()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", ArgumentTypes_fe61066f6f7c4a9291502841634b933e);
             return (Task<SomeType>)func(Client, arguments);
         }
     }

--- a/Refit.Tests/RefitStubs.Net46.cs
+++ b/Refit.Tests/RefitStubs.Net46.cs
@@ -62,27 +62,27 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_a48bc2b6f2be46ab971cb42e5cdcb30b = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_d949573dee2148e5a3f01d2f6c511671 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IAmARefitInterfaceButNobodyUsesMe.RefitMethod()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("RefitMethod", ArgumentTypes_a48bc2b6f2be46ab971cb42e5cdcb30b);
+            var func = requestBuilder.BuildRestResultFuncForMethod("RefitMethod", ArgumentTypes_d949573dee2148e5a3f01d2f6c511671);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_af508c51c82b497c97e0c3d11206cd3d = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_6b1f39999a6c44b5813b509b86afc235 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IAmARefitInterfaceButNobodyUsesMe.AnotherRefitMethod()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("AnotherRefitMethod", ArgumentTypes_af508c51c82b497c97e0c3d11206cd3d);
+            var func = requestBuilder.BuildRestResultFuncForMethod("AnotherRefitMethod", ArgumentTypes_6b1f39999a6c44b5813b509b86afc235);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_ecc1c19be1fb4e5fab2677517343e6be = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_405e6c6a3af54f339db979363c2b8e42 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IAmARefitInterfaceButNobodyUsesMe.NoConstantsAllowed()
@@ -90,23 +90,23 @@ namespace Refit.Tests
             throw new NotImplementedException("Either this method has no Refit HTTP method attribute or you've used something other than a string literal for the 'path' argument.");
         }
 
-        private static readonly Type[] ArgumentTypes_d1e3a2494f414806aa55790955510242 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_71a448969dfa44238f73b7e73bf4ad9b = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IAmARefitInterfaceButNobodyUsesMe.SpacesShouldntBreakMe()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("SpacesShouldntBreakMe", ArgumentTypes_d1e3a2494f414806aa55790955510242);
+            var func = requestBuilder.BuildRestResultFuncForMethod("SpacesShouldntBreakMe", ArgumentTypes_71a448969dfa44238f73b7e73bf4ad9b);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_ff452461fe6b475e8d9679a3c43cbd05 = new Type[] { typeof(int), typeof(string), typeof(float) };
+        private static readonly Type[] ArgumentTypes_12796b3e5d36439282bd5082744f78bf = new Type[] { typeof(int), typeof(string), typeof(float) };
 
         /// <inheritdoc />
         Task IAmARefitInterfaceButNobodyUsesMe.ReservedWordsForParameterNames(int @int, string @string, float @long)
         {
             var arguments = new object[] { @int, @string, @long };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReservedWordsForParameterNames", ArgumentTypes_ff452461fe6b475e8d9679a3c43cbd05);
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReservedWordsForParameterNames", ArgumentTypes_12796b3e5d36439282bd5082744f78bf);
             return (Task)func(Client, arguments);
         }
     }
@@ -147,17 +147,17 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_253a8552186f499ebd4944d3b293ce4a = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_372757d9f1ff4838acf693fdcfe768cd = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IAmHalfRefit.Post()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Post", ArgumentTypes_253a8552186f499ebd4944d3b293ce4a);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Post", ArgumentTypes_372757d9f1ff4838acf693fdcfe768cd);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_15ad005be3e4429c94ece17334e35954 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_89900dde2a3e4be9b63daabb3a98f928 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IAmHalfRefit.Get()
@@ -191,43 +191,43 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_26b79b10676a4718a1d22d6b4265f341 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_c5a06fe299834cc18c792d4a8ee91e12 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> IAmInterface.Pang()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Pang", ArgumentTypes_26b79b10676a4718a1d22d6b4265f341);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Pang", ArgumentTypes_c5a06fe299834cc18c792d4a8ee91e12);
             return (Task<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_ea7fd87b0904493bb73a5f26cadbe9ff = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_d175517191f84e3fbf46337f3f83147a = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> IAmInterfaceB.Pong()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Pong", ArgumentTypes_ea7fd87b0904493bb73a5f26cadbe9ff);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Pong", ArgumentTypes_d175517191f84e3fbf46337f3f83147a);
             return (Task<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_6b8219c660d74f8a8a51932dfcc6d178 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_96c7cc0542964b65ba2f2078b136d9b1 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> IAmInterfaceD.Test()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Test", ArgumentTypes_6b8219c660d74f8a8a51932dfcc6d178);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Test", ArgumentTypes_96c7cc0542964b65ba2f2078b136d9b1);
             return (Task<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_6743d27257914fb381c1c8aa9b709ccc = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_b040951162a04bd986dee737de2baff7 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> IAmInterfaceA.Ping()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Ping", ArgumentTypes_6743d27257914fb381c1c8aa9b709ccc);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Ping", ArgumentTypes_b040951162a04bd986dee737de2baff7);
             return (Task<string>)func(Client, arguments);
         }
     }
@@ -257,13 +257,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_731032c67ebd41e4a855b0306eada0cf = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_4710a70bbc4544d984f106326ca2acd5 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> IAmInterfaceA.Ping()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Ping", ArgumentTypes_731032c67ebd41e4a855b0306eada0cf);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Ping", ArgumentTypes_4710a70bbc4544d984f106326ca2acd5);
             return (Task<string>)func(Client, arguments);
         }
     }
@@ -293,23 +293,23 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_27ecbf31ccc1487ead2be33be23b820f = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_db260836205444aeb40c8f0a65cdd7ea = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> IAmInterfaceB.Pong()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Pong", ArgumentTypes_27ecbf31ccc1487ead2be33be23b820f);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Pong", ArgumentTypes_db260836205444aeb40c8f0a65cdd7ea);
             return (Task<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_6a559b86d4d6469d953625b166a1c43b = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_532c96f3299544e49984a49606b30480 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> IAmInterfaceD.Test()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Test", ArgumentTypes_6a559b86d4d6469d953625b166a1c43b);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Test", ArgumentTypes_532c96f3299544e49984a49606b30480);
             return (Task<string>)func(Client, arguments);
         }
     }
@@ -339,43 +339,43 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_372d2c0b672e4952b8073dd144cddccc = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_42f8f82df25d4552a6c1bc19ee065f4a = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> IAmInterfaceC.Pang()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Pang", ArgumentTypes_372d2c0b672e4952b8073dd144cddccc);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Pang", ArgumentTypes_42f8f82df25d4552a6c1bc19ee065f4a);
             return (Task<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_88957aae34f6406288cc3a707794b4af = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_c41160ece21647ce9fe5e561c71abc3f = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> IAmInterfaceB.Pong()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Pong", ArgumentTypes_88957aae34f6406288cc3a707794b4af);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Pong", ArgumentTypes_c41160ece21647ce9fe5e561c71abc3f);
             return (Task<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_c6f018a7630e41eead454301e161e7a3 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_6c9814fae45a416b916f23b951e5b9a4 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> IAmInterfaceD.Test()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Test", ArgumentTypes_c6f018a7630e41eead454301e161e7a3);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Test", ArgumentTypes_6c9814fae45a416b916f23b951e5b9a4);
             return (Task<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_0d0382f9d6e749ec988e7e6e10d61e64 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_4b06a92d5f02475783c9e71a5908cbbd = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> IAmInterfaceA.Ping()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Ping", ArgumentTypes_0d0382f9d6e749ec988e7e6e10d61e64);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Ping", ArgumentTypes_4b06a92d5f02475783c9e71a5908cbbd);
             return (Task<string>)func(Client, arguments);
         }
     }
@@ -405,13 +405,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_b9d9dcb9a51c4391bffd33b81e02d82c = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_95b3b87155624554a10396f579495a26 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> IAmInterfaceD.Test()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Test", ArgumentTypes_b9d9dcb9a51c4391bffd33b81e02d82c);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Test", ArgumentTypes_95b3b87155624554a10396f579495a26);
             return (Task<string>)func(Client, arguments);
         }
     }
@@ -452,153 +452,153 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_2f182ae8f9a3496c960012d4d4ee6ba2 = new Type[] { typeof(PathBoundObject) };
+        private static readonly Type[] ArgumentTypes_a5da556eb23a44a08480265cede3de23 = new Type[] { typeof(PathBoundObject) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetFooBars(PathBoundObject request)
         {
             var arguments = new object[] { request };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBars", ArgumentTypes_2f182ae8f9a3496c960012d4d4ee6ba2);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBars", ArgumentTypes_a5da556eb23a44a08480265cede3de23);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_70f28ea9f4bb47958bd85e3c13de91e4 = new Type[] { typeof(PathBoundObject) };
+        private static readonly Type[] ArgumentTypes_801c8ed0210b4b5e992d0c6c3aa01248 = new Type[] { typeof(PathBoundObject) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetFooBarsWithDifferentCasing(PathBoundObject requestParams)
         {
             var arguments = new object[] { requestParams };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBarsWithDifferentCasing", ArgumentTypes_70f28ea9f4bb47958bd85e3c13de91e4);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBarsWithDifferentCasing", ArgumentTypes_801c8ed0210b4b5e992d0c6c3aa01248);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_376b4d7cbe2a4a8f9e2f66121c2e349e = new Type[] { typeof(string), typeof(PathBoundObject) };
+        private static readonly Type[] ArgumentTypes_641630c67d4844eabef82920f3b7d88e = new Type[] { typeof(string), typeof(PathBoundObject) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetBarsByFoo(string id, PathBoundObject request)
         {
             var arguments = new object[] { id, request };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetBarsByFoo", ArgumentTypes_376b4d7cbe2a4a8f9e2f66121c2e349e);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetBarsByFoo", ArgumentTypes_641630c67d4844eabef82920f3b7d88e);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_5e4cbced83af4fcea89dfdb1e4e6f255 = new Type[] { typeof(PathBoundObject), typeof(string) };
+        private static readonly Type[] ArgumentTypes_211ea9fced2a4144815573f578a4c2b5 = new Type[] { typeof(PathBoundObject), typeof(string) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetFooBars(PathBoundObject request, string someProperty)
         {
             var arguments = new object[] { request, someProperty };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBars", ArgumentTypes_5e4cbced83af4fcea89dfdb1e4e6f255);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBars", ArgumentTypes_211ea9fced2a4144815573f578a4c2b5);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_f1edf614fee1483b8de881052edd50e9 = new Type[] { typeof(PathBoundObject) };
+        private static readonly Type[] ArgumentTypes_2bb42cb50236410db9f9c5be171cbf07 = new Type[] { typeof(PathBoundObject) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetBarsByFoo(PathBoundObject request)
         {
             var arguments = new object[] { request };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetBarsByFoo", ArgumentTypes_f1edf614fee1483b8de881052edd50e9);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetBarsByFoo", ArgumentTypes_2bb42cb50236410db9f9c5be171cbf07);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_d56f182b10754740b3a2575394a67742 = new Type[] { typeof(PathBoundObjectWithQueryFormat) };
+        private static readonly Type[] ArgumentTypes_9afecfaf2e6844fc83117be3ef1fbfd1 = new Type[] { typeof(PathBoundObjectWithQueryFormat) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetBarsWithCustomQueryFormat(PathBoundObjectWithQueryFormat request)
         {
             var arguments = new object[] { request };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetBarsWithCustomQueryFormat", ArgumentTypes_d56f182b10754740b3a2575394a67742);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetBarsWithCustomQueryFormat", ArgumentTypes_9afecfaf2e6844fc83117be3ef1fbfd1);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_a769470349f1438092c892b6b0db2c6a = new Type[] { typeof(PathBoundDerivedObject) };
+        private static readonly Type[] ArgumentTypes_ddc6d9996f5d4afb887848e3585d8276 = new Type[] { typeof(PathBoundDerivedObject) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetFooBarsDerived(PathBoundDerivedObject request)
         {
             var arguments = new object[] { request };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBarsDerived", ArgumentTypes_a769470349f1438092c892b6b0db2c6a);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBarsDerived", ArgumentTypes_ddc6d9996f5d4afb887848e3585d8276);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_aff1c21c921a4b798582c7145c33de42 = new Type[] { typeof(PathBoundList) };
+        private static readonly Type[] ArgumentTypes_1d1ce21a1a7444d39b7ccabf81dafb17 = new Type[] { typeof(PathBoundList) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetFoos(PathBoundList request)
         {
             var arguments = new object[] { request };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetFoos", ArgumentTypes_aff1c21c921a4b798582c7145c33de42);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetFoos", ArgumentTypes_1d1ce21a1a7444d39b7ccabf81dafb17);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_29f3c556ba6d48d3b7bc674e275e58f2 = new Type[] { typeof(List<int>) };
+        private static readonly Type[] ArgumentTypes_81a7737769064a6889cc327063d31268 = new Type[] { typeof(List<int>) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetFoos2(List<int> Values)
         {
             var arguments = new object[] { Values };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetFoos2", ArgumentTypes_29f3c556ba6d48d3b7bc674e275e58f2);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetFoos2", ArgumentTypes_81a7737769064a6889cc327063d31268);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_5448f950e324489d91466cae0c4b76ea = new Type[] { typeof(PathBoundObject), typeof(object) };
+        private static readonly Type[] ArgumentTypes_be99457e3c0d402eabe6195e0042d017 = new Type[] { typeof(PathBoundObject), typeof(object) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.PostFooBar(PathBoundObject request, object someObject)
         {
             var arguments = new object[] { request, someObject };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBar", ArgumentTypes_5448f950e324489d91466cae0c4b76ea);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBar", ArgumentTypes_be99457e3c0d402eabe6195e0042d017);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_5b5c5ef67a424e0b9d37dd1f314cc2c0 = new Type[] { typeof(PathBoundObjectWithQuery) };
+        private static readonly Type[] ArgumentTypes_44e97b905be14b768c6bd0fbb96317a9 = new Type[] { typeof(PathBoundObjectWithQuery) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetFooBars(PathBoundObjectWithQuery request)
         {
             var arguments = new object[] { request };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBars", ArgumentTypes_5b5c5ef67a424e0b9d37dd1f314cc2c0);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBars", ArgumentTypes_44e97b905be14b768c6bd0fbb96317a9);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_a06b1cefaa4c4fda9f0c3158a974e20d = new Type[] { typeof(PathBoundObject), typeof(ModelObject) };
+        private static readonly Type[] ArgumentTypes_e3073de87d394935b5e7c464d857fd3e = new Type[] { typeof(PathBoundObject), typeof(ModelObject) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IApiBindPathToObject.PostFooBar(PathBoundObject request, ModelObject someQueryParams)
         {
             var arguments = new object[] { request, someQueryParams };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBar", ArgumentTypes_a06b1cefaa4c4fda9f0c3158a974e20d);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBar", ArgumentTypes_e3073de87d394935b5e7c464d857fd3e);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_b8fa2614d06e4ff2aeb882159ecad81c = new Type[] { typeof(PathBoundObject), typeof(ModelObject), typeof(StreamPart) };
+        private static readonly Type[] ArgumentTypes_e97da96314aa44a989bb485f3f07185f = new Type[] { typeof(PathBoundObject), typeof(ModelObject), typeof(StreamPart) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IApiBindPathToObject.PostFooBarStreamPart(PathBoundObject request, ModelObject someQueryParams, StreamPart stream)
         {
             var arguments = new object[] { request, someQueryParams, stream };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBarStreamPart", ArgumentTypes_b8fa2614d06e4ff2aeb882159ecad81c);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBarStreamPart", ArgumentTypes_e97da96314aa44a989bb485f3f07185f);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_365ef833dac44adfa151c34c5b779f4d = new Type[] { typeof(PathBoundObject), typeof(StreamPart) };
+        private static readonly Type[] ArgumentTypes_702ba8eb14934b25847853b65688a954 = new Type[] { typeof(PathBoundObject), typeof(StreamPart) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IApiBindPathToObject.PostFooBarStreamPart(PathBoundObject request, StreamPart stream)
         {
             var arguments = new object[] { request, stream };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBarStreamPart", ArgumentTypes_365ef833dac44adfa151c34c5b779f4d);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBarStreamPart", ArgumentTypes_702ba8eb14934b25847853b65688a954);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_14036959e3994adda130822fe08de2c8 = new Type[] { typeof(PathBoundObjectWithQuery), typeof(StreamPart) };
+        private static readonly Type[] ArgumentTypes_1d98e34cba4a46138b20d3f3029eafcf = new Type[] { typeof(PathBoundObjectWithQuery), typeof(StreamPart) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IApiBindPathToObject.PostFooBarStreamPart(PathBoundObjectWithQuery request, StreamPart stream)
         {
             var arguments = new object[] { request, stream };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBarStreamPart", ArgumentTypes_14036959e3994adda130822fe08de2c8);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBarStreamPart", ArgumentTypes_1d98e34cba4a46138b20d3f3029eafcf);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
     }
@@ -639,13 +639,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_f2401111d63c4016af79e87a5168bb77 = new Type[] { typeof(decimal) };
+        private static readonly Type[] ArgumentTypes_65ae94e6fd41479f80d1168bb16e2755 = new Type[] { typeof(decimal) };
 
         /// <inheritdoc />
         Task<string> IApiWithDecimal.GetWithDecimal(decimal value)
         {
             var arguments = new object[] { value };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetWithDecimal", ArgumentTypes_f2401111d63c4016af79e87a5168bb77);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetWithDecimal", ArgumentTypes_65ae94e6fd41479f80d1168bb16e2755);
             return (Task<string>)func(Client, arguments);
         }
     }
@@ -686,33 +686,33 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_d82e4c1202674bfb9e81331999c1ba1d = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_da1e18efa4eb4fbeb3df8b08cef6fe2b = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IBodylessApi.Post()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Post", ArgumentTypes_d82e4c1202674bfb9e81331999c1ba1d);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Post", ArgumentTypes_da1e18efa4eb4fbeb3df8b08cef6fe2b);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_fd8089bbab69431e9d28b70d38a9af6b = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_a412d7e6fac74645ac75ca5726400813 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IBodylessApi.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_fd8089bbab69431e9d28b70d38a9af6b);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_a412d7e6fac74645ac75ca5726400813);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_e1f8a071b55040d2bb87a60ee74f6ce6 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_478e9cbb3f734d7aa671facdd584de5d = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IBodylessApi.Head()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Head", ArgumentTypes_e1f8a071b55040d2bb87a60ee74f6ce6);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Head", ArgumentTypes_478e9cbb3f734d7aa671facdd584de5d);
             return (Task)func(Client, arguments);
         }
     }
@@ -753,53 +753,53 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_0dbe008f1eef47fe91608889a8e1cbbd = new Type[] { typeof(T) };
+        private static readonly Type[] ArgumentTypes_de1da531a3d444a8b3c1ee09a7b9423a = new Type[] { typeof(T) };
 
         /// <inheritdoc />
         Task<T> IBoringCrudApi<T, TKey>.Create(T paylod)
         {
             var arguments = new object[] { paylod };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_0dbe008f1eef47fe91608889a8e1cbbd);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_de1da531a3d444a8b3c1ee09a7b9423a);
             return (Task<T>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_e5bfb3a3cd7a42a08ea9eeabfacbf41c = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_fea3eaaa5bb34bd7bf34b9445444b706 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<List<T>> IBoringCrudApi<T, TKey>.ReadAll()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_e5bfb3a3cd7a42a08ea9eeabfacbf41c);
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_fea3eaaa5bb34bd7bf34b9445444b706);
             return (Task<List<T>>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_7e07c8d0fedf40c2ba3f9391f9d72281 = new Type[] { typeof(TKey) };
+        private static readonly Type[] ArgumentTypes_a2c2e5858546478293dfe4e40b8e27b8 = new Type[] { typeof(TKey) };
 
         /// <inheritdoc />
         Task<T> IBoringCrudApi<T, TKey>.ReadOne(TKey key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_7e07c8d0fedf40c2ba3f9391f9d72281);
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_a2c2e5858546478293dfe4e40b8e27b8);
             return (Task<T>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_69fd881ce4664fe6bf9e7f93db6a7010 = new Type[] { typeof(TKey), typeof(T) };
+        private static readonly Type[] ArgumentTypes_3e14d8dc65b9477799ff19d3de30e99f = new Type[] { typeof(TKey), typeof(T) };
 
         /// <inheritdoc />
         Task IBoringCrudApi<T, TKey>.Update(TKey key, T payload)
         {
             var arguments = new object[] { key, payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_69fd881ce4664fe6bf9e7f93db6a7010);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_3e14d8dc65b9477799ff19d3de30e99f);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_8de5ef10fe0b442a8827a0ffc36b4ea0 = new Type[] { typeof(TKey) };
+        private static readonly Type[] ArgumentTypes_74a83767854c4127b5ccdade33175198 = new Type[] { typeof(TKey) };
 
         /// <inheritdoc />
         Task IBoringCrudApi<T, TKey>.Delete(TKey key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_8de5ef10fe0b442a8827a0ffc36b4ea0);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_74a83767854c4127b5ccdade33175198);
             return (Task)func(Client, arguments);
         }
     }
@@ -840,13 +840,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_806b36fbd50d42e49c52cba474d5cdd9 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_c921a0a4e3974b2ebb645b77c7115917 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<bool> IBrokenWebApi.PostAValue(string derp)
         {
             var arguments = new object[] { derp };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostAValue", ArgumentTypes_806b36fbd50d42e49c52cba474d5cdd9);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostAValue", ArgumentTypes_c921a0a4e3974b2ebb645b77c7115917);
             return (Task<bool>)func(Client, arguments);
         }
     }
@@ -875,13 +875,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_ba89a9ca7434410aad38ab87e5615c8a = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_f89dd05ddeb44f0bb4800664fe2543db = Array.Empty<Type>();
 
         /// <inheritdoc />
         CustomReferenceType? ICustomNullableReferenceService.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_ba89a9ca7434410aad38ab87e5615c8a);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_f89dd05ddeb44f0bb4800664fe2543db);
             return (CustomReferenceType?)func(Client, arguments);
         }
     }
@@ -910,13 +910,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_bed68500aa4a41469c7f2f83df276a30 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_d1e3039fccd34383b66f7bdfb7b977b1 = Array.Empty<Type>();
 
         /// <inheritdoc />
         CustomValueType? ICustomNullableValueService.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_bed68500aa4a41469c7f2f83df276a30);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_d1e3039fccd34383b66f7bdfb7b977b1);
             return (CustomValueType?)func(Client, arguments);
         }
     }
@@ -945,13 +945,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_4b4ec04556314aeaa6ead2d624ba9ecb = new Type[] { ToNullable(typeof(CustomReferenceType)), ToNullable(typeof(CustomValueType)) };
+        private static readonly Type[] ArgumentTypes_17fd015c6f7d424d81de0bcc87338900 = new Type[] { ToNullable(typeof(CustomReferenceType)), ToNullable(typeof(CustomValueType)) };
 
         /// <inheritdoc />
         Task ICustomReferenceAndValueParametersService.Get(CustomReferenceType? reference, CustomValueType? value)
         {
             var arguments = new object[] { reference, value };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_4b4ec04556314aeaa6ead2d624ba9ecb);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_17fd015c6f7d424d81de0bcc87338900);
             return (Task)func(Client, arguments);
         }
 
@@ -984,73 +984,73 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_93306ecc2dc64b2c9751dc3c227022d4 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_1ecfb5b41cf444a2832302798f96ce0a = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IDataApiA.PingA()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("PingA", ArgumentTypes_93306ecc2dc64b2c9751dc3c227022d4);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PingA", ArgumentTypes_1ecfb5b41cf444a2832302798f96ce0a);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_b8056e174c1a463f8aec91e08d30700b = new Type[] { typeof(DataEntity) };
+        private static readonly Type[] ArgumentTypes_3c0cfa4092ee49fcb5a0b8b2815aea8c = new Type[] { typeof(DataEntity) };
 
         /// <inheritdoc />
         Task<DataEntity> IDataCrudApi<DataEntity>.Copy(DataEntity payload)
         {
             var arguments = new object[] { payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Copy", ArgumentTypes_b8056e174c1a463f8aec91e08d30700b);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Copy", ArgumentTypes_3c0cfa4092ee49fcb5a0b8b2815aea8c);
             return (Task<DataEntity>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_e229e168b3d54e0f9d88812ae6b428f6 = new Type[] { typeof(DataEntity) };
+        private static readonly Type[] ArgumentTypes_9c15c96e441b477eaca6770b6e6cf9af = new Type[] { typeof(DataEntity) };
 
         /// <inheritdoc />
         Task<DataEntity> IDataCrudApi<DataEntity, long>.Create(DataEntity payload)
         {
             var arguments = new object[] { payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_e229e168b3d54e0f9d88812ae6b428f6);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_9c15c96e441b477eaca6770b6e6cf9af);
             return (Task<DataEntity>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_f6f30f0cdd4842478bff919ac007ce01 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_17af67c89a844204b31a3f019eba3ae7 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<List<DataEntity>> IDataCrudApi<DataEntity, long>.ReadAll()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_f6f30f0cdd4842478bff919ac007ce01);
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_17af67c89a844204b31a3f019eba3ae7);
             return (Task<List<DataEntity>>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_08d9d80a0f03466c9dd3e8c35531581e = new Type[] { typeof(long) };
+        private static readonly Type[] ArgumentTypes_72e70e75e0db43f0b75ed85a68db593a = new Type[] { typeof(long) };
 
         /// <inheritdoc />
         Task<DataEntity> IDataCrudApi<DataEntity, long>.ReadOne(long key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_08d9d80a0f03466c9dd3e8c35531581e);
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_72e70e75e0db43f0b75ed85a68db593a);
             return (Task<DataEntity>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_b2db3c73b5a94212b4b47b35229e1959 = new Type[] { typeof(long), typeof(DataEntity) };
+        private static readonly Type[] ArgumentTypes_323b8ca82f434267b925805759aa5a1b = new Type[] { typeof(long), typeof(DataEntity) };
 
         /// <inheritdoc />
         Task IDataCrudApi<DataEntity, long>.Update(long key, DataEntity payload)
         {
             var arguments = new object[] { key, payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_b2db3c73b5a94212b4b47b35229e1959);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_323b8ca82f434267b925805759aa5a1b);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_b39b4de3dfd247049fc457558882fe47 = new Type[] { typeof(long) };
+        private static readonly Type[] ArgumentTypes_8075d45ee070434c929937f95edeca93 = new Type[] { typeof(long) };
 
         /// <inheritdoc />
         Task IDataCrudApi<DataEntity, long>.Delete(long key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_b39b4de3dfd247049fc457558882fe47);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_8075d45ee070434c929937f95edeca93);
             return (Task)func(Client, arguments);
         }
     }
@@ -1081,63 +1081,63 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_846549be564c45e5beae993074d12e09 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_eab20877d532430eb4420e006960956f = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IDataApiB.PingB()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("PingB", ArgumentTypes_846549be564c45e5beae993074d12e09);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PingB", ArgumentTypes_eab20877d532430eb4420e006960956f);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_9d0b0f1fe19442efb8b8763c8ba11ae8 = new Type[] { typeof(DataEntity) };
+        private static readonly Type[] ArgumentTypes_21b3f1fa245f4606a1abef0bf61b9f74 = new Type[] { typeof(DataEntity) };
 
         /// <inheritdoc />
         Task<DataEntity> IDataCrudApi<DataEntity, int>.Create(DataEntity payload)
         {
             var arguments = new object[] { payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_9d0b0f1fe19442efb8b8763c8ba11ae8);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_21b3f1fa245f4606a1abef0bf61b9f74);
             return (Task<DataEntity>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_7159f821444a47739a9bc138cbf42c6c = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_7f782c8768ca44d28e3bf157494b6e01 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<List<DataEntity>> IDataCrudApi<DataEntity, int>.ReadAll()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_7159f821444a47739a9bc138cbf42c6c);
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_7f782c8768ca44d28e3bf157494b6e01);
             return (Task<List<DataEntity>>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_b92ed93815aa452eb29b89a600a04dd4 = new Type[] { typeof(int) };
+        private static readonly Type[] ArgumentTypes_ca2d18a8dea34216959861ce79966250 = new Type[] { typeof(int) };
 
         /// <inheritdoc />
         Task<DataEntity> IDataCrudApi<DataEntity, int>.ReadOne(int key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_b92ed93815aa452eb29b89a600a04dd4);
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_ca2d18a8dea34216959861ce79966250);
             return (Task<DataEntity>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_6c6a24e0970a4ee782934be15f900978 = new Type[] { typeof(int), typeof(DataEntity) };
+        private static readonly Type[] ArgumentTypes_095dcaf535074ea6b06037857c75d8ed = new Type[] { typeof(int), typeof(DataEntity) };
 
         /// <inheritdoc />
         Task IDataCrudApi<DataEntity, int>.Update(int key, DataEntity payload)
         {
             var arguments = new object[] { key, payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_6c6a24e0970a4ee782934be15f900978);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_095dcaf535074ea6b06037857c75d8ed);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_0b3b83da5a0d493eb911c9e668af0787 = new Type[] { typeof(int) };
+        private static readonly Type[] ArgumentTypes_634730b8ad4e42f4a11d9f0ae6e3f467 = new Type[] { typeof(int) };
 
         /// <inheritdoc />
         Task IDataCrudApi<DataEntity, int>.Delete(int key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_0b3b83da5a0d493eb911c9e668af0787);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_634730b8ad4e42f4a11d9f0ae6e3f467);
             return (Task)func(Client, arguments);
         }
     }
@@ -1171,63 +1171,63 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_da6a19bb599748748b4872ba4496436d = new Type[] { typeof(T) };
+        private static readonly Type[] ArgumentTypes_225894f33c97485896ac8b3785bf1d08 = new Type[] { typeof(T) };
 
         /// <inheritdoc />
         Task<T> IDataCrudApi<T>.Copy(T payload)
         {
             var arguments = new object[] { payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Copy", ArgumentTypes_da6a19bb599748748b4872ba4496436d);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Copy", ArgumentTypes_225894f33c97485896ac8b3785bf1d08);
             return (Task<T>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_8d155d02a1b04e16b49052b75dffa65f = new Type[] { typeof(T) };
+        private static readonly Type[] ArgumentTypes_17dc4af01d6d4a4e989b2cc8d5b80374 = new Type[] { typeof(T) };
 
         /// <inheritdoc />
         Task<T> IDataCrudApi<T, long>.Create(T payload)
         {
             var arguments = new object[] { payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_8d155d02a1b04e16b49052b75dffa65f);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_17dc4af01d6d4a4e989b2cc8d5b80374);
             return (Task<T>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_191b7aa802ac471490cfe925747a53dc = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_ef0de279380542e1b94c830ebc233959 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<List<T>> IDataCrudApi<T, long>.ReadAll()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_191b7aa802ac471490cfe925747a53dc);
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_ef0de279380542e1b94c830ebc233959);
             return (Task<List<T>>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_d708c41165e443169b73224d9ee83f28 = new Type[] { typeof(long) };
+        private static readonly Type[] ArgumentTypes_a192dff9462f4ee49ca1a630eb21e837 = new Type[] { typeof(long) };
 
         /// <inheritdoc />
         Task<T> IDataCrudApi<T, long>.ReadOne(long key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_d708c41165e443169b73224d9ee83f28);
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_a192dff9462f4ee49ca1a630eb21e837);
             return (Task<T>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_a861038879ad48d580d3f3cbabd82918 = new Type[] { typeof(long), typeof(T) };
+        private static readonly Type[] ArgumentTypes_562f019925484fd5a34728e2c28acd7f = new Type[] { typeof(long), typeof(T) };
 
         /// <inheritdoc />
         Task IDataCrudApi<T, long>.Update(long key, T payload)
         {
             var arguments = new object[] { key, payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_a861038879ad48d580d3f3cbabd82918);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_562f019925484fd5a34728e2c28acd7f);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_d1bdd89197ce4e5daf7459f10f333e29 = new Type[] { typeof(long) };
+        private static readonly Type[] ArgumentTypes_8ffe1a8b4c114aa59efdbe54201538b4 = new Type[] { typeof(long) };
 
         /// <inheritdoc />
         Task IDataCrudApi<T, long>.Delete(long key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_d1bdd89197ce4e5daf7459f10f333e29);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_8ffe1a8b4c114aa59efdbe54201538b4);
             return (Task)func(Client, arguments);
         }
     }
@@ -1261,53 +1261,53 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_0b93f0bbee924c8db162e60147dd0734 = new Type[] { typeof(T) };
+        private static readonly Type[] ArgumentTypes_b6884e571ad64162b6fc4508d9019626 = new Type[] { typeof(T) };
 
         /// <inheritdoc />
         Task<T> IDataCrudApi<T, TKey>.Create(T payload)
         {
             var arguments = new object[] { payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_0b93f0bbee924c8db162e60147dd0734);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_b6884e571ad64162b6fc4508d9019626);
             return (Task<T>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_09569e9fe23a4b16ad1668d742ae6686 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_7ef9bcac29ce4618a3640050bb8b76dc = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<List<T>> IDataCrudApi<T, TKey>.ReadAll()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_09569e9fe23a4b16ad1668d742ae6686);
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_7ef9bcac29ce4618a3640050bb8b76dc);
             return (Task<List<T>>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_6983f40f12a24026aa83fead1cf70a57 = new Type[] { typeof(TKey) };
+        private static readonly Type[] ArgumentTypes_5682ebb78dae4935844353a07132abe8 = new Type[] { typeof(TKey) };
 
         /// <inheritdoc />
         Task<T> IDataCrudApi<T, TKey>.ReadOne(TKey key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_6983f40f12a24026aa83fead1cf70a57);
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_5682ebb78dae4935844353a07132abe8);
             return (Task<T>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_0efe952a63114f2d950a09e668f4fcad = new Type[] { typeof(TKey), typeof(T) };
+        private static readonly Type[] ArgumentTypes_ef67ac14fb7445d1b3305aa95b3bf3e3 = new Type[] { typeof(TKey), typeof(T) };
 
         /// <inheritdoc />
         Task IDataCrudApi<T, TKey>.Update(TKey key, T payload)
         {
             var arguments = new object[] { key, payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_0efe952a63114f2d950a09e668f4fcad);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_ef67ac14fb7445d1b3305aa95b3bf3e3);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_026922b66caf4828bb795aea04b7bfc2 = new Type[] { typeof(TKey) };
+        private static readonly Type[] ArgumentTypes_8ca377da40944cd49cb0b5af5e02d27c = new Type[] { typeof(TKey) };
 
         /// <inheritdoc />
         Task IDataCrudApi<T, TKey>.Delete(TKey key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_026922b66caf4828bb795aea04b7bfc2);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_8ca377da40944cd49cb0b5af5e02d27c);
             return (Task)func(Client, arguments);
         }
     }
@@ -1336,13 +1336,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_4e45039b9f914350b88bf7be534cbaf2 = new Type[] { ToNullable(typeof(System.Collections.Generic.List<string>)) };
+        private static readonly Type[] ArgumentTypes_0949d96ece124a6eaaaa458665ed30b0 = new Type[] { ToNullable(typeof(System.Collections.Generic.List<string>)) };
 
         /// <inheritdoc />
         Task IGenericNullableReferenceParameterService.Get(System.Collections.Generic.List<string>? reference)
         {
             var arguments = new object[] { reference };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_4e45039b9f914350b88bf7be534cbaf2);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_0949d96ece124a6eaaaa458665ed30b0);
             return (Task)func(Client, arguments);
         }
 
@@ -1373,13 +1373,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_e11b382c2b4441848d57c61da877b0c6 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_c380d9ee147f4d29ba6bea2b1a4fddf6 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string>? IGenericNullableReferenceService.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_e11b382c2b4441848d57c61da877b0c6);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_c380d9ee147f4d29ba6bea2b1a4fddf6);
             return (Task<string>?)func(Client, arguments);
         }
     }
@@ -1408,13 +1408,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_7dfa677b161d4a51957d18facb771516 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_3d10f32c17314037ba04fc3a5a516a7f = Array.Empty<Type>();
 
         /// <inheritdoc />
         ValueTask<int>? IGenericNullableValueService.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_7dfa677b161d4a51957d18facb771516);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_3d10f32c17314037ba04fc3a5a516a7f);
             return (ValueTask<int>?)func(Client, arguments);
         }
     }
@@ -1443,13 +1443,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_ff1fbe7dcb704c23892e8196e882c737 = new Type[] { ToNullable(typeof(System.Collections.Generic.List<string?>)) };
+        private static readonly Type[] ArgumentTypes_93ccb7daf7bc46de95461113e3108e59 = new Type[] { ToNullable(typeof(System.Collections.Generic.List<string?>)) };
 
         /// <inheritdoc />
         Task IGenericNullableWithNullableReferenceParameterService.Get(System.Collections.Generic.List<string?>? reference)
         {
             var arguments = new object[] { reference };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_ff1fbe7dcb704c23892e8196e882c737);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_93ccb7daf7bc46de95461113e3108e59);
             return (Task)func(Client, arguments);
         }
 
@@ -1480,13 +1480,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_5d32602120e84899b82e0b78343acc9e = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_fc4e89ccae654e72abf5f65ba144dee9 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string?>? IGenericNullableWithNullableReferenceService.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_5d32602120e84899b82e0b78343acc9e);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_fc4e89ccae654e72abf5f65ba144dee9);
             return (Task<string?>?)func(Client, arguments);
         }
     }
@@ -1515,13 +1515,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_f55308fe6638421899bd9101833b7be2 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_a309e68b914347ae9cbf0c0fe1cab671 = Array.Empty<Type>();
 
         /// <inheritdoc />
         ValueTask<int?>? IGenericNullableWithNullableValueService.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_f55308fe6638421899bd9101833b7be2);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_a309e68b914347ae9cbf0c0fe1cab671);
             return (ValueTask<int?>?)func(Client, arguments);
         }
     }
@@ -1550,13 +1550,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_39ec9c26b66d463ca6929efc807b2770 = new Type[] { typeof(System.Collections.Generic.List<string?>) };
+        private static readonly Type[] ArgumentTypes_a3fba2221f94466ca42c2b129f73c1e2 = new Type[] { typeof(System.Collections.Generic.List<string?>) };
 
         /// <inheritdoc />
         Task IGenericWithNullableReferenceParameterService.Get(System.Collections.Generic.List<string?> reference)
         {
             var arguments = new object[] { reference };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_39ec9c26b66d463ca6929efc807b2770);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_a3fba2221f94466ca42c2b129f73c1e2);
             return (Task)func(Client, arguments);
         }
     }
@@ -1585,13 +1585,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_0b482db2c26848ac8822ae8d5178cd42 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_d23e4cf7c0014168b584a174351aa6c4 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<int?> IGenericWithNullableValueService.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_0b482db2c26848ac8822ae8d5178cd42);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_d23e4cf7c0014168b584a174351aa6c4);
             return (Task<int?>)func(Client, arguments);
         }
     }
@@ -1620,13 +1620,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_82849c15effc40c79326d2dc3453befb = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_33979930fcd644b6a9be335caea543ca = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string?> IGenericWithResultService.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_82849c15effc40c79326d2dc3453befb);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_33979930fcd644b6a9be335caea543ca);
             return (Task<string?>)func(Client, arguments);
         }
     }
@@ -1661,133 +1661,133 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_eb9cc862592446e7bcaa47934d1e9063 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_8dfeb04a675648ccaf30bec57691abe0 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<User> IGitHubApi.GetUser(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUser", ArgumentTypes_eb9cc862592446e7bcaa47934d1e9063);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUser", ArgumentTypes_8dfeb04a675648ccaf30bec57691abe0);
             return (Task<User>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_e94a5a345f214b3fb5e1e6227563da27 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_1502f4ade371464b8e1ad25a1de26db3 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         IObservable<User> IGitHubApi.GetUserObservable(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserObservable", ArgumentTypes_e94a5a345f214b3fb5e1e6227563da27);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserObservable", ArgumentTypes_1502f4ade371464b8e1ad25a1de26db3);
             return (IObservable<User>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_fd06def76ab745408ee44e8a09c397a5 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_34029a0ae695450bb12357c3e339ce44 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         IObservable<User> IGitHubApi.GetUserCamelCase(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserCamelCase", ArgumentTypes_fd06def76ab745408ee44e8a09c397a5);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserCamelCase", ArgumentTypes_34029a0ae695450bb12357c3e339ce44);
             return (IObservable<User>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_8f2935c472834d26a9117011b7c92400 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_122d33066c704550bf2ef0cb49d92f96 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<List<User>> IGitHubApi.GetOrgMembers(string orgName)
         {
             var arguments = new object[] { orgName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetOrgMembers", ArgumentTypes_8f2935c472834d26a9117011b7c92400);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetOrgMembers", ArgumentTypes_122d33066c704550bf2ef0cb49d92f96);
             return (Task<List<User>>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_e4adb0464ccc4fdd9c87f5378ca8e880 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_613b781eee444927988db68fae8334aa = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<UserSearchResult> IGitHubApi.FindUsers(string q)
         {
             var arguments = new object[] { q };
-            var func = requestBuilder.BuildRestResultFuncForMethod("FindUsers", ArgumentTypes_e4adb0464ccc4fdd9c87f5378ca8e880);
+            var func = requestBuilder.BuildRestResultFuncForMethod("FindUsers", ArgumentTypes_613b781eee444927988db68fae8334aa);
             return (Task<UserSearchResult>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_fcec939287904012b5c1dd896e430faf = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_89a0bfb0fb2d4e86a24a9eeffbb2b220 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IGitHubApi.GetIndex()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndex", ArgumentTypes_fcec939287904012b5c1dd896e430faf);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndex", ArgumentTypes_89a0bfb0fb2d4e86a24a9eeffbb2b220);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_eb217e47884046db904ed2b7ea815780 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_fe22fbd5bf084b45a4d700b885287ba4 = Array.Empty<Type>();
 
         /// <inheritdoc />
         IObservable<string> IGitHubApi.GetIndexObservable()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndexObservable", ArgumentTypes_eb217e47884046db904ed2b7ea815780);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndexObservable", ArgumentTypes_fe22fbd5bf084b45a4d700b885287ba4);
             return (IObservable<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_42233be489214803996d3e71640a9a6f = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_6347decfef0c406a982e955a4cc00cda = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<User> IGitHubApi.NothingToSeeHere()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("NothingToSeeHere", ArgumentTypes_42233be489214803996d3e71640a9a6f);
+            var func = requestBuilder.BuildRestResultFuncForMethod("NothingToSeeHere", ArgumentTypes_6347decfef0c406a982e955a4cc00cda);
             return (Task<User>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_ea94f540b7ab4efa9582185e6e2b81bf = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_180575c6285e411c962cd05202ce93dc = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<ApiResponse<User>> IGitHubApi.NothingToSeeHereWithMetadata()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("NothingToSeeHereWithMetadata", ArgumentTypes_ea94f540b7ab4efa9582185e6e2b81bf);
+            var func = requestBuilder.BuildRestResultFuncForMethod("NothingToSeeHereWithMetadata", ArgumentTypes_180575c6285e411c962cd05202ce93dc);
             return (Task<ApiResponse<User>>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_adee9a3ccd70477eb43431b504c81878 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_12843af036a5449e80653892c0c5af66 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<ApiResponse<User>> IGitHubApi.GetUserWithMetadata(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserWithMetadata", ArgumentTypes_adee9a3ccd70477eb43431b504c81878);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserWithMetadata", ArgumentTypes_12843af036a5449e80653892c0c5af66);
             return (Task<ApiResponse<User>>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_dc6c91703ef84fc8aece0c4e4e6cef73 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_fe2c2bd81ee0402ba8ba62631bec7e76 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         IObservable<ApiResponse<User>> IGitHubApi.GetUserObservableWithMetadata(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserObservableWithMetadata", ArgumentTypes_dc6c91703ef84fc8aece0c4e4e6cef73);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserObservableWithMetadata", ArgumentTypes_fe2c2bd81ee0402ba8ba62631bec7e76);
             return (IObservable<ApiResponse<User>>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_c241f38681d84307a8b2753f77fd343e = new Type[] { typeof(User) };
+        private static readonly Type[] ArgumentTypes_3e50732ae63249e6bf9f1652c588f8f2 = new Type[] { typeof(User) };
 
         /// <inheritdoc />
         Task<User> IGitHubApi.CreateUser(User user)
         {
             var arguments = new object[] { user };
-            var func = requestBuilder.BuildRestResultFuncForMethod("CreateUser", ArgumentTypes_c241f38681d84307a8b2753f77fd343e);
+            var func = requestBuilder.BuildRestResultFuncForMethod("CreateUser", ArgumentTypes_3e50732ae63249e6bf9f1652c588f8f2);
             return (Task<User>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_93373ce4abb44ee5a55ca3aa36a66cf9 = new Type[] { typeof(User) };
+        private static readonly Type[] ArgumentTypes_da51f3d856c84d07b30326beda1468e6 = new Type[] { typeof(User) };
 
         /// <inheritdoc />
         Task<ApiResponse<User>> IGitHubApi.CreateUserWithMetadata(User user)
         {
             var arguments = new object[] { user };
-            var func = requestBuilder.BuildRestResultFuncForMethod("CreateUserWithMetadata", ArgumentTypes_93373ce4abb44ee5a55ca3aa36a66cf9);
+            var func = requestBuilder.BuildRestResultFuncForMethod("CreateUserWithMetadata", ArgumentTypes_da51f3d856c84d07b30326beda1468e6);
             return (Task<ApiResponse<User>>)func(Client, arguments);
         }
     }
@@ -1832,47 +1832,47 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_de0f94a241b0476191e081a72e56eecb = new Type[] { typeof(TParam), typeof(THeader) };
+        private static readonly Type[] ArgumentTypes_46113c251ba24b76b9ca435ef838b101 = new Type[] { typeof(TParam), typeof(THeader) };
 
         /// <inheritdoc />
         Task<TResponse> IHttpBinApi<TResponse, TParam, THeader>.Get(TParam param, THeader header)
         {
             var arguments = new object[] { param, header };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_de0f94a241b0476191e081a72e56eecb);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_46113c251ba24b76b9ca435ef838b101);
             return (Task<TResponse>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_e2d86090b08148c2876b20455bac3ffc = new Type[] { typeof(TParam) };
+        private static readonly Type[] ArgumentTypes_50c7a5ee88374bf0ba37bb07c778e56b = new Type[] { typeof(TParam) };
 
         /// <inheritdoc />
         Task<TResponse> IHttpBinApi<TResponse, TParam, THeader>.GetQuery(TParam param)
         {
             var arguments = new object[] { param };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetQuery", ArgumentTypes_e2d86090b08148c2876b20455bac3ffc);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetQuery", ArgumentTypes_50c7a5ee88374bf0ba37bb07c778e56b);
             return (Task<TResponse>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_6977c7b8804f4a36be922e0e52ea9a1b = new Type[] { typeof(TParam) };
+        private static readonly Type[] ArgumentTypes_876875bb2f674e2fbdd672c24918de6a = new Type[] { typeof(TParam) };
 
         /// <inheritdoc />
         Task<TResponse> IHttpBinApi<TResponse, TParam, THeader>.PostQuery(TParam param)
         {
             var arguments = new object[] { param };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostQuery", ArgumentTypes_6977c7b8804f4a36be922e0e52ea9a1b);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostQuery", ArgumentTypes_876875bb2f674e2fbdd672c24918de6a);
             return (Task<TResponse>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_87ca08e38b7c4d7bbacba1c46a2db798 = new Type[] { typeof(TParam) };
+        private static readonly Type[] ArgumentTypes_ce8eabdec62048aaacc8319710aa6074 = new Type[] { typeof(TParam) };
 
         /// <inheritdoc />
         Task<TResponse> IHttpBinApi<TResponse, TParam, THeader>.GetQueryWithIncludeParameterName(TParam param)
         {
             var arguments = new object[] { param };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetQueryWithIncludeParameterName", ArgumentTypes_87ca08e38b7c4d7bbacba1c46a2db798);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetQueryWithIncludeParameterName", ArgumentTypes_ce8eabdec62048aaacc8319710aa6074);
             return (Task<TResponse>)func(Client, arguments);
         }
 
-        private static class TypeHelper_1bda28ef13b642aeba28f98ba4d442c2<TValue>
+        private static class TypeHelper_2a2fa77fe73c4e7c9c4dbd4e10064d4e<TValue>
         {
             public static readonly Type[] ArgumentTypes = new Type[] { typeof(TParam) };
             public static readonly Type[] TypeParameters = new Type[] { typeof(TValue) };
@@ -1882,7 +1882,7 @@ namespace Refit.Tests
         Task<TValue> IHttpBinApi<TResponse, TParam, THeader>.GetQuery1<TValue>(TParam param)
         {
             var arguments = new object[] { param };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetQuery1", TypeHelper_1bda28ef13b642aeba28f98ba4d442c2<TValue>.ArgumentTypes, TypeHelper_1bda28ef13b642aeba28f98ba4d442c2<TValue>.TypeParameters);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetQuery1", TypeHelper_2a2fa77fe73c4e7c9c4dbd4e10064d4e<TValue>.ArgumentTypes, TypeHelper_2a2fa77fe73c4e7c9c4dbd4e10064d4e<TValue>.TypeParameters);
             return (Task<TValue>)func(Client, arguments);
         }
     }
@@ -1923,23 +1923,23 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_85adaa395d21419ab72fff0ab2f42b90 = new Type[] { typeof(HttpContent) };
+        private static readonly Type[] ArgumentTypes_b307caa8ec6449e9827e4f92693abfea = new Type[] { typeof(HttpContent) };
 
         /// <inheritdoc />
         Task<HttpContent> IHttpContentApi.PostFileUpload(HttpContent content)
         {
             var arguments = new object[] { content };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostFileUpload", ArgumentTypes_85adaa395d21419ab72fff0ab2f42b90);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostFileUpload", ArgumentTypes_b307caa8ec6449e9827e4f92693abfea);
             return (Task<HttpContent>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_42346890a15e40c08c4aa631497469f9 = new Type[] { typeof(HttpContent) };
+        private static readonly Type[] ArgumentTypes_20e74ad405df4b64a1af5047262ff253 = new Type[] { typeof(HttpContent) };
 
         /// <inheritdoc />
         Task<ApiResponse<HttpContent>> IHttpContentApi.PostFileUploadWithMetadata(HttpContent content)
         {
             var arguments = new object[] { content };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostFileUploadWithMetadata", ArgumentTypes_42346890a15e40c08c4aa631497469f9);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostFileUploadWithMetadata", ArgumentTypes_20e74ad405df4b64a1af5047262ff253);
             return (Task<ApiResponse<HttpContent>>)func(Client, arguments);
         }
     }
@@ -1981,13 +1981,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_d7089633ab9943e8a696c95a0853f860 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_586eeecca4104f39aa01c2422682b2f6 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<TestAliasObject> ResponseTests.IMyAliasService.GetTestObject()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetTestObject", ArgumentTypes_d7089633ab9943e8a696c95a0853f860);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetTestObject", ArgumentTypes_586eeecca4104f39aa01c2422682b2f6);
             return (Task<TestAliasObject>)func(Client, arguments);
         }
     }
@@ -2023,23 +2023,23 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_da89e5f7923a405b9f6e32ec2fa0fbf1 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_038549a6bdec42a29d779c6f9e0f91e3 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> AuthenticatedClientHandlerTests.IMyAuthenticatedService.GetUnauthenticated()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUnauthenticated", ArgumentTypes_da89e5f7923a405b9f6e32ec2fa0fbf1);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUnauthenticated", ArgumentTypes_038549a6bdec42a29d779c6f9e0f91e3);
             return (Task<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_b3a09c7902db4afdb99787c93eafab80 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_36f5b2072e304f22b0fad2e216a1f496 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> AuthenticatedClientHandlerTests.IMyAuthenticatedService.GetAuthenticated()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetAuthenticated", ArgumentTypes_b3a09c7902db4afdb99787c93eafab80);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetAuthenticated", ArgumentTypes_36f5b2072e304f22b0fad2e216a1f496);
             return (Task<string>)func(Client, arguments);
         }
     }
@@ -2070,13 +2070,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_26cc32f3e8b64f3f9f96504fd31ce86b = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_eed19731fbba49019c549a73a42ef80e = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<SomeType> INamespaceCollisionApi.SomeRequest()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", ArgumentTypes_26cc32f3e8b64f3f9f96504fd31ce86b);
+            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", ArgumentTypes_eed19731fbba49019c549a73a42ef80e);
             return (Task<SomeType>)func(Client, arguments);
         }
     }
@@ -2108,13 +2108,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_a046213fd7644c9d83305105058b955b = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_5c214ff0c5ee46df9fed14d7c789a0c0 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<SomeOtherType> INamespaceOverlapApi.SomeRequest()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", ArgumentTypes_a046213fd7644c9d83305105058b955b);
+            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", ArgumentTypes_5c214ff0c5ee46df9fed14d7c789a0c0);
             return (Task<SomeOtherType>)func(Client, arguments);
         }
     }
@@ -2149,83 +2149,83 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_6c3b119979c540e7a931091be4c2a225 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_cbeb1481f479428182322da32d93f595 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<User> TestNested.INestedGitHubApi.GetUser(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUser", ArgumentTypes_6c3b119979c540e7a931091be4c2a225);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUser", ArgumentTypes_cbeb1481f479428182322da32d93f595);
             return (Task<User>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_4e9579d84e334db48afc1b5af5d554d1 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_24bcd35e498948d48766129a8cb264a1 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         IObservable<User> TestNested.INestedGitHubApi.GetUserObservable(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserObservable", ArgumentTypes_4e9579d84e334db48afc1b5af5d554d1);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserObservable", ArgumentTypes_24bcd35e498948d48766129a8cb264a1);
             return (IObservable<User>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_69f6e36d53be4761bc826265cdb54410 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_605af9443fe74ab7ab12170ae304a881 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         IObservable<User> TestNested.INestedGitHubApi.GetUserCamelCase(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserCamelCase", ArgumentTypes_69f6e36d53be4761bc826265cdb54410);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserCamelCase", ArgumentTypes_605af9443fe74ab7ab12170ae304a881);
             return (IObservable<User>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_01ffe48e5fb0491cb856c34cf24b8d10 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_270b3c1c13934d38ada425fc441a8d87 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<List<User>> TestNested.INestedGitHubApi.GetOrgMembers(string orgName)
         {
             var arguments = new object[] { orgName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetOrgMembers", ArgumentTypes_01ffe48e5fb0491cb856c34cf24b8d10);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetOrgMembers", ArgumentTypes_270b3c1c13934d38ada425fc441a8d87);
             return (Task<List<User>>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_f39ee737cd4e470685b54e853ba71276 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_6aea8732f0af4ad29dd84918f17e04c7 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<UserSearchResult> TestNested.INestedGitHubApi.FindUsers(string q)
         {
             var arguments = new object[] { q };
-            var func = requestBuilder.BuildRestResultFuncForMethod("FindUsers", ArgumentTypes_f39ee737cd4e470685b54e853ba71276);
+            var func = requestBuilder.BuildRestResultFuncForMethod("FindUsers", ArgumentTypes_6aea8732f0af4ad29dd84918f17e04c7);
             return (Task<UserSearchResult>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_0504d60949ee433c9407005217f17deb = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_d30449b4bb2b4e508e2ddf161f0f0562 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<HttpResponseMessage> TestNested.INestedGitHubApi.GetIndex()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndex", ArgumentTypes_0504d60949ee433c9407005217f17deb);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndex", ArgumentTypes_d30449b4bb2b4e508e2ddf161f0f0562);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_bb400a0dba9c4f6fbefdcfb3336224fc = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_13ea9f9619984540bb551a37ecc660f8 = Array.Empty<Type>();
 
         /// <inheritdoc />
         IObservable<string> TestNested.INestedGitHubApi.GetIndexObservable()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndexObservable", ArgumentTypes_bb400a0dba9c4f6fbefdcfb3336224fc);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndexObservable", ArgumentTypes_13ea9f9619984540bb551a37ecc660f8);
             return (IObservable<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_cdc3c74137344ac9a106357be3936de5 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_7122a720bedb40bfae7b27bd78df1705 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task TestNested.INestedGitHubApi.NothingToSeeHere()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("NothingToSeeHere", ArgumentTypes_cdc3c74137344ac9a106357be3936de5);
+            var func = requestBuilder.BuildRestResultFuncForMethod("NothingToSeeHere", ArgumentTypes_7122a720bedb40bfae7b27bd78df1705);
             return (Task)func(Client, arguments);
         }
     }
@@ -2263,7 +2263,7 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static class TypeHelper_559abbdae8664e5bb4eeae3f2c30f8fa<T>
+        private static class TypeHelper_55c28e6979e14d5c8cf96a0bb18b030d<T>
         {
             public static readonly Type[] ArgumentTypes = new Type[] { typeof(T) };
             public static readonly Type[] TypeParameters = new Type[] { typeof(T) };
@@ -2273,11 +2273,11 @@ namespace Refit.Tests
         Task INonGenericInterfaceWithGenericMethod.PostMessage<T>(T message)
         {
             var arguments = new object[] { message };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostMessage", TypeHelper_559abbdae8664e5bb4eeae3f2c30f8fa<T>.ArgumentTypes, TypeHelper_559abbdae8664e5bb4eeae3f2c30f8fa<T>.TypeParameters);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostMessage", TypeHelper_55c28e6979e14d5c8cf96a0bb18b030d<T>.ArgumentTypes, TypeHelper_55c28e6979e14d5c8cf96a0bb18b030d<T>.TypeParameters);
             return (Task)func(Client, arguments);
         }
 
-        private static class TypeHelper_fd1380cb58644059b4e8eeadf6296253<T, U, V>
+        private static class TypeHelper_d44ef9a2e8d34f87af2c01e2de49252a<T, U, V>
         {
             public static readonly Type[] ArgumentTypes = new Type[] { typeof(T), typeof(U), typeof(V) };
             public static readonly Type[] TypeParameters = new Type[] { typeof(T), typeof(U), typeof(V) };
@@ -2287,7 +2287,7 @@ namespace Refit.Tests
         Task INonGenericInterfaceWithGenericMethod.PostMessage<T, U, V>(T message, U param1, V param2)
         {
             var arguments = new object[] { message, param1, param2 };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostMessage", TypeHelper_fd1380cb58644059b4e8eeadf6296253<T, U, V>.ArgumentTypes, TypeHelper_fd1380cb58644059b4e8eeadf6296253<T, U, V>.TypeParameters);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostMessage", TypeHelper_d44ef9a2e8d34f87af2c01e2de49252a<T, U, V>.ArgumentTypes, TypeHelper_d44ef9a2e8d34f87af2c01e2de49252a<T, U, V>.TypeParameters);
             return (Task)func(Client, arguments);
         }
     }
@@ -2328,13 +2328,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_2c8dbadcd9cb4726903f061136997397 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_21e377d281274587809cdfe9c63d361b = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<RootObject> INpmJs.GetCongruence()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetCongruence", ArgumentTypes_2c8dbadcd9cb4726903f061136997397);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetCongruence", ArgumentTypes_21e377d281274587809cdfe9c63d361b);
             return (Task<RootObject>)func(Client, arguments);
         }
     }
@@ -2363,13 +2363,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_15828926f9db4fad944adcc4d33f9465 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_c5452962550d4b99a87f7d036686a432 = Array.Empty<Type>();
 
         /// <inheritdoc />
         string? INullableReferenceService.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_15828926f9db4fad944adcc4d33f9465);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_c5452962550d4b99a87f7d036686a432);
             return (string?)func(Client, arguments);
         }
     }
@@ -2398,13 +2398,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_f21e362c036c4110a5264ee18b22970b = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_ac26a6c7eb5646d2bf7d2c5d6579cb04 = Array.Empty<Type>();
 
         /// <inheritdoc />
         int? INullableValueService.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_f21e362c036c4110a5264ee18b22970b);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_ac26a6c7eb5646d2bf7d2c5d6579cb04);
             return (int?)func(Client, arguments);
         }
     }
@@ -2434,13 +2434,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_52458e6a7ced4fc38e28d2a9304b74f2 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_390223737096447ea0d542882da3e1c5 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<SomeType> IReducedUsingInsideNamespaceApi.SomeRequest()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", ArgumentTypes_52458e6a7ced4fc38e28d2a9304b74f2);
+            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", ArgumentTypes_390223737096447ea0d542882da3e1c5);
             return (Task<SomeType>)func(Client, arguments);
         }
     }
@@ -2469,13 +2469,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_543e0483a07145bdaaa354aa59bbbb56 = new Type[] { ToNullable(typeof(string)), ToNullable(typeof(int)) };
+        private static readonly Type[] ArgumentTypes_986f8182b76d427f815bcbe232d1697e = new Type[] { ToNullable(typeof(string)), ToNullable(typeof(int)) };
 
         /// <inheritdoc />
         Task IReferenceAndValueParametersService.Get(string? reference, int? value)
         {
             var arguments = new object[] { reference, value };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_543e0483a07145bdaaa354aa59bbbb56);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_986f8182b76d427f815bcbe232d1697e);
             return (Task)func(Client, arguments);
         }
 
@@ -2518,13 +2518,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_fb20ec3d44b04ab08f5b61fac7021b1b = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_790de5eadf95440f833f62f580365d95 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IRefitInterfaceWithStaticMethod.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_fb20ec3d44b04ab08f5b61fac7021b1b);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_790de5eadf95440f833f62f580365d95);
             return (Task)func(Client, arguments);
         }
     }
@@ -2565,47 +2565,47 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_83f17c7db08c4b27aa617d95cc7018d3 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_14e4977f65934469b9e86daa9003e021 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IRequestBin.Post()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Post", ArgumentTypes_83f17c7db08c4b27aa617d95cc7018d3);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Post", ArgumentTypes_14e4977f65934469b9e86daa9003e021);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_c18bdc1b232f4bf49404c38522d170df = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_626e5504603c4ced8760cae679a8789c = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task IRequestBin.PostRawStringDefault(string str)
         {
             var arguments = new object[] { str };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostRawStringDefault", ArgumentTypes_c18bdc1b232f4bf49404c38522d170df);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostRawStringDefault", ArgumentTypes_626e5504603c4ced8760cae679a8789c);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_32f9d5b591854d1480f960c5044e185a = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_1ca19aa640c244f29424e2c14bd6939a = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task IRequestBin.PostRawStringJson(string str)
         {
             var arguments = new object[] { str };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostRawStringJson", ArgumentTypes_32f9d5b591854d1480f960c5044e185a);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostRawStringJson", ArgumentTypes_1ca19aa640c244f29424e2c14bd6939a);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_0c67833ae5cf4308842f74d6c043e9db = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_099c4b062bfb4a888a1a8626bc21b13f = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task IRequestBin.PostRawStringUrlEncoded(string str)
         {
             var arguments = new object[] { str };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostRawStringUrlEncoded", ArgumentTypes_0c67833ae5cf4308842f74d6c043e9db);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostRawStringUrlEncoded", ArgumentTypes_099c4b062bfb4a888a1a8626bc21b13f);
             return (Task)func(Client, arguments);
         }
 
-        private static class TypeHelper_950a5ed53666409684ca5862e037e5cf<T>
+        private static class TypeHelper_86efc3ef5d9240f1976efc10c7f50430<T>
         {
             public static readonly Type[] ArgumentTypes = new Type[] { typeof(T) };
             public static readonly Type[] TypeParameters = new Type[] { typeof(T) };
@@ -2615,7 +2615,7 @@ namespace Refit.Tests
         Task IRequestBin.PostGeneric<T>(T param)
         {
             var arguments = new object[] { param };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostGeneric", TypeHelper_950a5ed53666409684ca5862e037e5cf<T>.ArgumentTypes, TypeHelper_950a5ed53666409684ca5862e037e5cf<T>.TypeParameters);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostGeneric", TypeHelper_86efc3ef5d9240f1976efc10c7f50430<T>.ArgumentTypes, TypeHelper_86efc3ef5d9240f1976efc10c7f50430<T>.TypeParameters);
             return (Task)func(Client, arguments);
         }
     }
@@ -2656,133 +2656,133 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_198a3722931849acb2cf2c13cabc0063 = new Type[] { typeof(Stream) };
+        private static readonly Type[] ArgumentTypes_bbbdb47295f04c3aba244c81aa460b16 = new Type[] { typeof(Stream) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadStream(Stream stream)
         {
             var arguments = new object[] { stream };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStream", ArgumentTypes_198a3722931849acb2cf2c13cabc0063);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStream", ArgumentTypes_bbbdb47295f04c3aba244c81aa460b16);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_cb6a8dd327314d64bcf08ded5a8190ef = new Type[] { typeof(Stream) };
+        private static readonly Type[] ArgumentTypes_ce74f4016e164285b4b90d9fa66dc9f2 = new Type[] { typeof(Stream) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadStreamWithCustomBoundary(Stream stream)
         {
             var arguments = new object[] { stream };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStreamWithCustomBoundary", ArgumentTypes_cb6a8dd327314d64bcf08ded5a8190ef);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStreamWithCustomBoundary", ArgumentTypes_ce74f4016e164285b4b90d9fa66dc9f2);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_36ac597d361641a1bf3075dbca317c75 = new Type[] { typeof(StreamPart) };
+        private static readonly Type[] ArgumentTypes_5a7e99cf109c4f068dbad8d96e633d12 = new Type[] { typeof(StreamPart) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadStreamPart(StreamPart stream)
         {
             var arguments = new object[] { stream };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStreamPart", ArgumentTypes_36ac597d361641a1bf3075dbca317c75);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStreamPart", ArgumentTypes_5a7e99cf109c4f068dbad8d96e633d12);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_31e7c93c38844317ad3c2ed46888298e = new Type[] { typeof(ModelObject), typeof(StreamPart) };
+        private static readonly Type[] ArgumentTypes_3835fbf7968e4a938eb5963af13c0af8 = new Type[] { typeof(ModelObject), typeof(StreamPart) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadStreamPart(ModelObject someQueryParams, StreamPart stream)
         {
             var arguments = new object[] { someQueryParams, stream };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStreamPart", ArgumentTypes_31e7c93c38844317ad3c2ed46888298e);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStreamPart", ArgumentTypes_3835fbf7968e4a938eb5963af13c0af8);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_4433284065d74d86b0d136b52ab18ab1 = new Type[] { typeof(byte[]) };
+        private static readonly Type[] ArgumentTypes_698c270a8c784d22abdc3605110cb6c1 = new Type[] { typeof(byte[]) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadBytes(byte[] bytes)
         {
             var arguments = new object[] { bytes };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadBytes", ArgumentTypes_4433284065d74d86b0d136b52ab18ab1);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadBytes", ArgumentTypes_698c270a8c784d22abdc3605110cb6c1);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_e4c7af8b3d7741df9ceff2a9aeee9ed7 = new Type[] { typeof(ByteArrayPart) };
+        private static readonly Type[] ArgumentTypes_132b8e646ca841c0bb6a4849bc8a7f93 = new Type[] { typeof(ByteArrayPart) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadBytesPart(ByteArrayPart bytes)
         {
             var arguments = new object[] { bytes };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadBytesPart", ArgumentTypes_e4c7af8b3d7741df9ceff2a9aeee9ed7);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadBytesPart", ArgumentTypes_132b8e646ca841c0bb6a4849bc8a7f93);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_ecb54e62daf7407680e789606d7de9c6 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_05d8008013fe405ab2ba062c5d98ae50 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadString(string someString)
         {
             var arguments = new object[] { someString };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadString", ArgumentTypes_ecb54e62daf7407680e789606d7de9c6);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadString", ArgumentTypes_05d8008013fe405ab2ba062c5d98ae50);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_1020fd93b93e4b66b5c64c50ae2866e0 = new Type[] { typeof(IEnumerable<FileInfo>), typeof(FileInfo) };
+        private static readonly Type[] ArgumentTypes_95ef47447fc44727b54d6a73acf69ff1 = new Type[] { typeof(IEnumerable<FileInfo>), typeof(FileInfo) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadFileInfo(IEnumerable<FileInfo> fileInfos, FileInfo anotherFile)
         {
             var arguments = new object[] { fileInfos, anotherFile };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadFileInfo", ArgumentTypes_1020fd93b93e4b66b5c64c50ae2866e0);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadFileInfo", ArgumentTypes_95ef47447fc44727b54d6a73acf69ff1);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_bc11095ef2954dcabf474abe5c85927e = new Type[] { typeof(IEnumerable<FileInfoPart>), typeof(FileInfoPart) };
+        private static readonly Type[] ArgumentTypes_a0bb858a4a644dd292e3e57299c264ff = new Type[] { typeof(IEnumerable<FileInfoPart>), typeof(FileInfoPart) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadFileInfoPart(IEnumerable<FileInfoPart> fileInfos, FileInfoPart anotherFile)
         {
             var arguments = new object[] { fileInfos, anotherFile };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadFileInfoPart", ArgumentTypes_bc11095ef2954dcabf474abe5c85927e);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadFileInfoPart", ArgumentTypes_a0bb858a4a644dd292e3e57299c264ff);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_c62c3e7ee67c49c691798a1c32c8cc45 = new Type[] { typeof(ModelObject) };
+        private static readonly Type[] ArgumentTypes_ef8a147db6fe400fa7586bb04603f5fb = new Type[] { typeof(ModelObject) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadJsonObject(ModelObject theObject)
         {
             var arguments = new object[] { theObject };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadJsonObject", ArgumentTypes_c62c3e7ee67c49c691798a1c32c8cc45);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadJsonObject", ArgumentTypes_ef8a147db6fe400fa7586bb04603f5fb);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_bae83e2611034340be023f81f31db019 = new Type[] { typeof(IEnumerable<ModelObject>) };
+        private static readonly Type[] ArgumentTypes_05383aa6b8764e3dbc1250b4a83f4496 = new Type[] { typeof(IEnumerable<ModelObject>) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadJsonObjects(IEnumerable<ModelObject> theObjects)
         {
             var arguments = new object[] { theObjects };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadJsonObjects", ArgumentTypes_bae83e2611034340be023f81f31db019);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadJsonObjects", ArgumentTypes_05383aa6b8764e3dbc1250b4a83f4496);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_0a50561b213e43dcb0dcae4f550c34d2 = new Type[] { typeof(IEnumerable<ModelObject>), typeof(AnotherModel), typeof(FileInfo), typeof(AnEnum), typeof(string), typeof(int) };
+        private static readonly Type[] ArgumentTypes_3d149532f20548b7ae45c3ad8bab8dff = new Type[] { typeof(IEnumerable<ModelObject>), typeof(AnotherModel), typeof(FileInfo), typeof(AnEnum), typeof(string), typeof(int) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadMixedObjects(IEnumerable<ModelObject> theObjects, AnotherModel anotherModel, FileInfo aFile, AnEnum anEnum, string aString, int anInt)
         {
             var arguments = new object[] { theObjects, anotherModel, aFile, anEnum, aString, anInt };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadMixedObjects", ArgumentTypes_0a50561b213e43dcb0dcae4f550c34d2);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadMixedObjects", ArgumentTypes_3d149532f20548b7ae45c3ad8bab8dff);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_15ea0dfbf78e4edf9d29787d67eef7c1 = new Type[] { typeof(HttpContent) };
+        private static readonly Type[] ArgumentTypes_53dbac1cb0a2411bb79537718a1dcf8e = new Type[] { typeof(HttpContent) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadHttpContent(HttpContent content)
         {
             var arguments = new object[] { content };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadHttpContent", ArgumentTypes_15ea0dfbf78e4edf9d29787d67eef7c1);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadHttpContent", ArgumentTypes_53dbac1cb0a2411bb79537718a1dcf8e);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
     }
@@ -2814,23 +2814,23 @@ namespace AutoGeneratedIServiceWithoutNamespace
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_07243fab8f694b749a091808bb1d94cc = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_78f6f6420a4f4c25b0f99b5eb647f6a7 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IServiceWithoutNamespace.GetRoot()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetRoot", ArgumentTypes_07243fab8f694b749a091808bb1d94cc);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetRoot", ArgumentTypes_78f6f6420a4f4c25b0f99b5eb647f6a7);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_3eca43f166384cf688b48e44e3f2a678 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_581410930ee34e3c9ae77627db1f13d0 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IServiceWithoutNamespace.PostRoot()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostRoot", ArgumentTypes_3eca43f166384cf688b48e44e3f2a678);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostRoot", ArgumentTypes_581410930ee34e3c9ae77627db1f13d0);
             return (Task)func(Client, arguments);
         }
     }
@@ -2871,23 +2871,23 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_925534496a6f4a3ea13c5d5ddc4202be = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_9381e01b9f3d4faebd9d4e73eb3013f5 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<Stream> IStreamApi.GetRemoteFile(string filename)
         {
             var arguments = new object[] { filename };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetRemoteFile", ArgumentTypes_925534496a6f4a3ea13c5d5ddc4202be);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetRemoteFile", ArgumentTypes_9381e01b9f3d4faebd9d4e73eb3013f5);
             return (Task<Stream>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_87e39ab8352d4701be083ae3467653a9 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_10cf9049a3744e68b632b41920191073 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<ApiResponse<Stream>> IStreamApi.GetRemoteFileWithMetadata(string filename)
         {
             var arguments = new object[] { filename };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetRemoteFileWithMetadata", ArgumentTypes_87e39ab8352d4701be083ae3467653a9);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetRemoteFileWithMetadata", ArgumentTypes_10cf9049a3744e68b632b41920191073);
             return (Task<ApiResponse<Stream>>)func(Client, arguments);
         }
     }
@@ -2928,13 +2928,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_5d459eec59aa4f60aa245577d4317081 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_4188e6921fd54e70ad18c86f7816ff3b = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task ITrimTrailingForwardSlashApi.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_5d459eec59aa4f60aa245577d4317081);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_4188e6921fd54e70ad18c86f7816ff3b);
             return (Task)func(Client, arguments);
         }
     }
@@ -2964,13 +2964,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_d027ad0a33864409a3c95c1952e18797 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_4e9e0a710b61487991a59815ce459efd = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<SomeType> ITypeCollisionApiA.SomeARequest()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("SomeARequest", ArgumentTypes_d027ad0a33864409a3c95c1952e18797);
+            var func = requestBuilder.BuildRestResultFuncForMethod("SomeARequest", ArgumentTypes_4e9e0a710b61487991a59815ce459efd);
             return (Task<SomeType>)func(Client, arguments);
         }
     }
@@ -3000,13 +3000,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_07ad48c6a1344a16b782aee283c7226f = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_16488024e6674068a0fb51e56c1d6c1a = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<SomeType> ITypeCollisionApiB.SomeBRequest()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("SomeBRequest", ArgumentTypes_07ad48c6a1344a16b782aee283c7226f);
+            var func = requestBuilder.BuildRestResultFuncForMethod("SomeBRequest", ArgumentTypes_16488024e6674068a0fb51e56c1d6c1a);
             return (Task<SomeType>)func(Client, arguments);
         }
     }
@@ -3045,47 +3045,47 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_02910c89aa304f42b74de29b8733eaa6 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_da936458072d4e0d99c4448c53e55f62 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> IUseOverloadedGenericMethods<TResponse, TParam, THeader>.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_02910c89aa304f42b74de29b8733eaa6);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_da936458072d4e0d99c4448c53e55f62);
             return (Task<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_2a20ba4fbca14b7da65d2e3c50765c7b = new Type[] { typeof(TParam), typeof(THeader) };
+        private static readonly Type[] ArgumentTypes_ea0ba4f8d8cf4b00b0a4e0ff4ce1f984 = new Type[] { typeof(TParam), typeof(THeader) };
 
         /// <inheritdoc />
         Task<TResponse> IUseOverloadedGenericMethods<TResponse, TParam, THeader>.Get(TParam param, THeader header)
         {
             var arguments = new object[] { param, header };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_2a20ba4fbca14b7da65d2e3c50765c7b);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_ea0ba4f8d8cf4b00b0a4e0ff4ce1f984);
             return (Task<TResponse>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_e4a5f2d11b7c40cfb2db18f67b2996e6 = new Type[] { typeof(THeader), typeof(TParam) };
+        private static readonly Type[] ArgumentTypes_477438bfa3374fdba55ab97455c1cd4c = new Type[] { typeof(THeader), typeof(TParam) };
 
         /// <inheritdoc />
         Task<TResponse> IUseOverloadedGenericMethods<TResponse, TParam, THeader>.Get(THeader param, TParam header)
         {
             var arguments = new object[] { param, header };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_e4a5f2d11b7c40cfb2db18f67b2996e6);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_477438bfa3374fdba55ab97455c1cd4c);
             return (Task<TResponse>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_94d03ebf56b64650b83a738785fe6fe1 = new Type[] { typeof(int) };
+        private static readonly Type[] ArgumentTypes_f4ddcfb2f69746aabaab37a53d8d655d = new Type[] { typeof(int) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IUseOverloadedGenericMethods<TResponse, TParam, THeader>.Get(int httpstatuscode)
         {
             var arguments = new object[] { httpstatuscode };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_94d03ebf56b64650b83a738785fe6fe1);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_f4ddcfb2f69746aabaab37a53d8d655d);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static class TypeHelper_bbeff6f0a907426d92d8348422e3b67c<TValue>
+        private static class TypeHelper_aea96aba6ac94a70b1fc3dc7a133310a<TValue>
         {
             public static readonly Type[] ArgumentTypes = new Type[] { typeof(int) };
             public static readonly Type[] TypeParameters = new Type[] { typeof(TValue) };
@@ -3095,11 +3095,11 @@ namespace Refit.Tests
         Task<TValue> IUseOverloadedGenericMethods<TResponse, TParam, THeader>.Get<TValue>(int someVal)
         {
             var arguments = new object[] { someVal };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", TypeHelper_bbeff6f0a907426d92d8348422e3b67c<TValue>.ArgumentTypes, TypeHelper_bbeff6f0a907426d92d8348422e3b67c<TValue>.TypeParameters);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", TypeHelper_aea96aba6ac94a70b1fc3dc7a133310a<TValue>.ArgumentTypes, TypeHelper_aea96aba6ac94a70b1fc3dc7a133310a<TValue>.TypeParameters);
             return (Task<TValue>)func(Client, arguments);
         }
 
-        private static class TypeHelper_76b34f9783f446ccb7b5a55490bdd70e<TValue, TInput>
+        private static class TypeHelper_761c6c8c79b149cbb2279fc7384b89d8<TValue, TInput>
         {
             public static readonly Type[] ArgumentTypes = new Type[] { typeof(TInput) };
             public static readonly Type[] TypeParameters = new Type[] { typeof(TValue), typeof(TInput) };
@@ -3109,11 +3109,11 @@ namespace Refit.Tests
         Task<TValue> IUseOverloadedGenericMethods<TResponse, TParam, THeader>.Get<TValue, TInput>(TInput input)
         {
             var arguments = new object[] { input };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", TypeHelper_76b34f9783f446ccb7b5a55490bdd70e<TValue, TInput>.ArgumentTypes, TypeHelper_76b34f9783f446ccb7b5a55490bdd70e<TValue, TInput>.TypeParameters);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", TypeHelper_761c6c8c79b149cbb2279fc7384b89d8<TValue, TInput>.ArgumentTypes, TypeHelper_761c6c8c79b149cbb2279fc7384b89d8<TValue, TInput>.TypeParameters);
             return (Task<TValue>)func(Client, arguments);
         }
 
-        private static class TypeHelper_badc1e288da04f3cb48d9c01837a65a4<TInput1, TInput2>
+        private static class TypeHelper_fa8955a43e5c45b2b25bc38dd25a4ecf<TInput1, TInput2>
         {
             public static readonly Type[] ArgumentTypes = new Type[] { typeof(TInput1), typeof(TInput2) };
             public static readonly Type[] TypeParameters = new Type[] { typeof(TInput1), typeof(TInput2) };
@@ -3123,7 +3123,7 @@ namespace Refit.Tests
         Task IUseOverloadedGenericMethods<TResponse, TParam, THeader>.Get<TInput1, TInput2>(TInput1 input1, TInput2 input2)
         {
             var arguments = new object[] { input1, input2 };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", TypeHelper_badc1e288da04f3cb48d9c01837a65a4<TInput1, TInput2>.ArgumentTypes, TypeHelper_badc1e288da04f3cb48d9c01837a65a4<TInput1, TInput2>.TypeParameters);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", TypeHelper_fa8955a43e5c45b2b25bc38dd25a4ecf<TInput1, TInput2>.ArgumentTypes, TypeHelper_fa8955a43e5c45b2b25bc38dd25a4ecf<TInput1, TInput2>.TypeParameters);
             return (Task)func(Client, arguments);
         }
     }
@@ -3158,23 +3158,23 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_07d5933f8f394c0fbf4042bf70c83ea1 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_2e60e1ac49184a17ba2a1807715883d5 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> IUseOverloadedMethods.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_07d5933f8f394c0fbf4042bf70c83ea1);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_2e60e1ac49184a17ba2a1807715883d5);
             return (Task<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_d1644e57494b45d9ab59c1be7a3c26be = new Type[] { typeof(int) };
+        private static readonly Type[] ArgumentTypes_91f4870457594691b10ba80d7176022d = new Type[] { typeof(int) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IUseOverloadedMethods.Get(int httpstatuscode)
         {
             var arguments = new object[] { httpstatuscode };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_d1644e57494b45d9ab59c1be7a3c26be);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_91f4870457594691b10ba80d7176022d);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
     }
@@ -3215,13 +3215,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_4a656be62dad4069b51f11f32a77149d = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_081913b79f874bbb8fec4a49cce6465c = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IValidApi.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_4a656be62dad4069b51f11f32a77149d);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_081913b79f874bbb8fec4a49cce6465c);
             return (Task)func(Client, arguments);
         }
     }
@@ -3251,13 +3251,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_0b41c3542cf24168b500f12a8b236f89 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_647ae97a112c4c8ab3518c95c36674ae = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<SomeType> NamespaceWithGlobalAliasApi.SomeRequest()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", ArgumentTypes_0b41c3542cf24168b500f12a8b236f89);
+            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", ArgumentTypes_647ae97a112c4c8ab3518c95c36674ae);
             return (Task<SomeType>)func(Client, arguments);
         }
     }

--- a/Refit.Tests/RefitStubs.Net46.cs
+++ b/Refit.Tests/RefitStubs.Net46.cs
@@ -62,27 +62,27 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_83ba3bddcdd9498591042b9a4f8f34e3 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_d70d5717ca7f491084866f0055d1ae05 = new Type[] {  };
 
         /// <inheritdoc />
         Task IAmARefitInterfaceButNobodyUsesMe.RefitMethod()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("RefitMethod", ArgumentTypes_83ba3bddcdd9498591042b9a4f8f34e3);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("RefitMethod", ArgumentTypes_d70d5717ca7f491084866f0055d1ae05);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_a8781381f08c45f0acce03cbb3e6fc3c = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_14e16e76d1ec4135bde47566894297fc = new Type[] {  };
 
         /// <inheritdoc />
         Task IAmARefitInterfaceButNobodyUsesMe.AnotherRefitMethod()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("AnotherRefitMethod", ArgumentTypes_a8781381f08c45f0acce03cbb3e6fc3c);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("AnotherRefitMethod", ArgumentTypes_14e16e76d1ec4135bde47566894297fc);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_6cf8a1b44faf4dcab6e5cb730b95a5d5 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_fec539aaa04748f8ad6f040c99e0925b = new Type[] {  };
 
         /// <inheritdoc />
         Task IAmARefitInterfaceButNobodyUsesMe.NoConstantsAllowed()
@@ -90,23 +90,23 @@ namespace Refit.Tests
             throw new NotImplementedException("Either this method has no Refit HTTP method attribute or you've used something other than a string literal for the 'path' argument.");
         }
 
-        private static readonly Type[] ArgumentTypes_54c658601c4d481bae3c861bc15679ea = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_75d07de2fc0c4c6b9df9a74720216cee = new Type[] {  };
 
         /// <inheritdoc />
         Task IAmARefitInterfaceButNobodyUsesMe.SpacesShouldntBreakMe()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("SpacesShouldntBreakMe", ArgumentTypes_54c658601c4d481bae3c861bc15679ea);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("SpacesShouldntBreakMe", ArgumentTypes_75d07de2fc0c4c6b9df9a74720216cee);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_555c53653b54415495b35826a6518b73 = new Type[] { typeof(int), typeof(string), typeof(float) };
+        private static readonly Type[] ArgumentTypes_4ac7f9e0b1734bc2ba48cacfb9e99026 = new Type[] { typeof(int), typeof(string), typeof(float) };
 
         /// <inheritdoc />
         Task IAmARefitInterfaceButNobodyUsesMe.ReservedWordsForParameterNames(int @int, string @string, float @long)
         {
             var arguments = new object[] { @int, @string, @long };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReservedWordsForParameterNames", ArgumentTypes_555c53653b54415495b35826a6518b73);
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReservedWordsForParameterNames", ArgumentTypes_4ac7f9e0b1734bc2ba48cacfb9e99026);
             return (Task)func(Client, arguments);
         }
     }
@@ -147,17 +147,17 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_99caeed32c7346bca61b2890b41fb08d = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_6b3a345864c24115ad1863c5ffe10ef5 = new Type[] {  };
 
         /// <inheritdoc />
         Task IAmHalfRefit.Post()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Post", ArgumentTypes_99caeed32c7346bca61b2890b41fb08d);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Post", ArgumentTypes_6b3a345864c24115ad1863c5ffe10ef5);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_8ab0e4a9a65c4cf1b4f3662fc97652e8 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_6ad8f76cc7c247ec925aba587a3da56b = new Type[] {  };
 
         /// <inheritdoc />
         Task IAmHalfRefit.Get()
@@ -191,43 +191,43 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_cc7f6f63f1de4f89b8d8146af63d973b = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_3c2902981a404e9fb84b9b419a875763 = new Type[] {  };
 
         /// <inheritdoc />
         Task<string> IAmInterface.Pang()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Pang", ArgumentTypes_cc7f6f63f1de4f89b8d8146af63d973b);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Pang", ArgumentTypes_3c2902981a404e9fb84b9b419a875763);
             return (Task<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_073f543697d04a24a6b4efa4162fea55 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_2d10f515f5c449c890cadfe3fada62ed = new Type[] {  };
 
         /// <inheritdoc />
         Task<string> IAmInterfaceB.Pong()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Pong", ArgumentTypes_073f543697d04a24a6b4efa4162fea55);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Pong", ArgumentTypes_2d10f515f5c449c890cadfe3fada62ed);
             return (Task<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_7d65499a2d404824bbd952cfc48ef31a = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_9ae05949b1cf4bc18185d7f60f21bd9f = new Type[] {  };
 
         /// <inheritdoc />
         Task<string> IAmInterfaceD.Test()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Test", ArgumentTypes_7d65499a2d404824bbd952cfc48ef31a);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Test", ArgumentTypes_9ae05949b1cf4bc18185d7f60f21bd9f);
             return (Task<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_0bcf298e07f345d48b46966077b9cb53 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_8962537dcdf440e1a023b808372319ed = new Type[] {  };
 
         /// <inheritdoc />
         Task<string> IAmInterfaceA.Ping()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Ping", ArgumentTypes_0bcf298e07f345d48b46966077b9cb53);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Ping", ArgumentTypes_8962537dcdf440e1a023b808372319ed);
             return (Task<string>)func(Client, arguments);
         }
     }
@@ -257,13 +257,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_7497c638afff4a3c894aee80c9d12c09 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_97d622e8ed674977887245e577d232f6 = new Type[] {  };
 
         /// <inheritdoc />
         Task<string> IAmInterfaceA.Ping()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Ping", ArgumentTypes_7497c638afff4a3c894aee80c9d12c09);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Ping", ArgumentTypes_97d622e8ed674977887245e577d232f6);
             return (Task<string>)func(Client, arguments);
         }
     }
@@ -293,23 +293,23 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_fc591f1a688a40f8af143687399cd457 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_8a61dfae003640cbb8c5d935e997d7cf = new Type[] {  };
 
         /// <inheritdoc />
         Task<string> IAmInterfaceB.Pong()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Pong", ArgumentTypes_fc591f1a688a40f8af143687399cd457);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Pong", ArgumentTypes_8a61dfae003640cbb8c5d935e997d7cf);
             return (Task<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_3e2e337cd23f4f2ba995861c726d7ee8 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_e52ba749cf3b477b94cf43d601ef98f4 = new Type[] {  };
 
         /// <inheritdoc />
         Task<string> IAmInterfaceD.Test()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Test", ArgumentTypes_3e2e337cd23f4f2ba995861c726d7ee8);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Test", ArgumentTypes_e52ba749cf3b477b94cf43d601ef98f4);
             return (Task<string>)func(Client, arguments);
         }
     }
@@ -339,43 +339,43 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_368950e82d4f41fdaada942bf65aacd9 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_f0aca168db8843dea83596bb286d5b59 = new Type[] {  };
 
         /// <inheritdoc />
         Task<string> IAmInterfaceC.Pang()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Pang", ArgumentTypes_368950e82d4f41fdaada942bf65aacd9);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Pang", ArgumentTypes_f0aca168db8843dea83596bb286d5b59);
             return (Task<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_04104020f0e84675a7349921d4838a07 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_6ca67266e13940c39cf8c3367928cd90 = new Type[] {  };
 
         /// <inheritdoc />
         Task<string> IAmInterfaceB.Pong()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Pong", ArgumentTypes_04104020f0e84675a7349921d4838a07);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Pong", ArgumentTypes_6ca67266e13940c39cf8c3367928cd90);
             return (Task<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_f34a5f3809f348248afd45e96e75f2aa = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_0cc0d52d180a4553b68240d487ba6d5a = new Type[] {  };
 
         /// <inheritdoc />
         Task<string> IAmInterfaceD.Test()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Test", ArgumentTypes_f34a5f3809f348248afd45e96e75f2aa);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Test", ArgumentTypes_0cc0d52d180a4553b68240d487ba6d5a);
             return (Task<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_581797a447dc44c3ba148eb86b78e298 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_6438d1c4880e4d8f948b7b9876bd2593 = new Type[] {  };
 
         /// <inheritdoc />
         Task<string> IAmInterfaceA.Ping()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Ping", ArgumentTypes_581797a447dc44c3ba148eb86b78e298);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Ping", ArgumentTypes_6438d1c4880e4d8f948b7b9876bd2593);
             return (Task<string>)func(Client, arguments);
         }
     }
@@ -405,13 +405,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_1a99196dc62f4f6fa994b4de0786bc70 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_ea2364743e114dc4849b0a0a46969bb2 = new Type[] {  };
 
         /// <inheritdoc />
         Task<string> IAmInterfaceD.Test()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Test", ArgumentTypes_1a99196dc62f4f6fa994b4de0786bc70);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Test", ArgumentTypes_ea2364743e114dc4849b0a0a46969bb2);
             return (Task<string>)func(Client, arguments);
         }
     }
@@ -452,153 +452,153 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_d82084ee808e4632aedb7fcbe2aa5651 = new Type[] { typeof(PathBoundObject) };
+        private static readonly Type[] ArgumentTypes_40b9749177e54c0ca632d5f5fcc7cd36 = new Type[] { typeof(PathBoundObject) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetFooBars(PathBoundObject request)
         {
             var arguments = new object[] { request };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBars", ArgumentTypes_d82084ee808e4632aedb7fcbe2aa5651);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBars", ArgumentTypes_40b9749177e54c0ca632d5f5fcc7cd36);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_a0bb7060eae94ffdb5bfae4fc57dc78f = new Type[] { typeof(PathBoundObject) };
+        private static readonly Type[] ArgumentTypes_909623674b64460cabc4d71d124b1917 = new Type[] { typeof(PathBoundObject) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetFooBarsWithDifferentCasing(PathBoundObject requestParams)
         {
             var arguments = new object[] { requestParams };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBarsWithDifferentCasing", ArgumentTypes_a0bb7060eae94ffdb5bfae4fc57dc78f);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBarsWithDifferentCasing", ArgumentTypes_909623674b64460cabc4d71d124b1917);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_621299e359434bfaa57dde7a77a5f6a0 = new Type[] { typeof(string), typeof(PathBoundObject) };
+        private static readonly Type[] ArgumentTypes_1c9d839aa9cc4ced8b9f1d9c8d2a488c = new Type[] { typeof(string), typeof(PathBoundObject) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetBarsByFoo(string id, PathBoundObject request)
         {
             var arguments = new object[] { id, request };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetBarsByFoo", ArgumentTypes_621299e359434bfaa57dde7a77a5f6a0);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetBarsByFoo", ArgumentTypes_1c9d839aa9cc4ced8b9f1d9c8d2a488c);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_dc13f668316146828c8af4aea31545ee = new Type[] { typeof(PathBoundObject), typeof(string) };
+        private static readonly Type[] ArgumentTypes_21a88c1ee87f4756acc25db43141a274 = new Type[] { typeof(PathBoundObject), typeof(string) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetFooBars(PathBoundObject request, string someProperty)
         {
             var arguments = new object[] { request, someProperty };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBars", ArgumentTypes_dc13f668316146828c8af4aea31545ee);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBars", ArgumentTypes_21a88c1ee87f4756acc25db43141a274);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_38c22b0c6ac1414393310bf4d3ced164 = new Type[] { typeof(PathBoundObject) };
+        private static readonly Type[] ArgumentTypes_834eb53501374f54856a8a5cd82f088c = new Type[] { typeof(PathBoundObject) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetBarsByFoo(PathBoundObject request)
         {
             var arguments = new object[] { request };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetBarsByFoo", ArgumentTypes_38c22b0c6ac1414393310bf4d3ced164);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetBarsByFoo", ArgumentTypes_834eb53501374f54856a8a5cd82f088c);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_b5f62109b6124e56baebeb70c6d89955 = new Type[] { typeof(PathBoundObjectWithQueryFormat) };
+        private static readonly Type[] ArgumentTypes_bda177547c334271b27b99bccbbc626c = new Type[] { typeof(PathBoundObjectWithQueryFormat) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetBarsWithCustomQueryFormat(PathBoundObjectWithQueryFormat request)
         {
             var arguments = new object[] { request };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetBarsWithCustomQueryFormat", ArgumentTypes_b5f62109b6124e56baebeb70c6d89955);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetBarsWithCustomQueryFormat", ArgumentTypes_bda177547c334271b27b99bccbbc626c);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_e8af68fb098e4478999a4dcbd54544a1 = new Type[] { typeof(PathBoundDerivedObject) };
+        private static readonly Type[] ArgumentTypes_686b3298c60b4b32a514c67b3c89f41f = new Type[] { typeof(PathBoundDerivedObject) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetFooBarsDerived(PathBoundDerivedObject request)
         {
             var arguments = new object[] { request };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBarsDerived", ArgumentTypes_e8af68fb098e4478999a4dcbd54544a1);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBarsDerived", ArgumentTypes_686b3298c60b4b32a514c67b3c89f41f);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_17ac3b976a114118811521b0e6df4392 = new Type[] { typeof(PathBoundList) };
+        private static readonly Type[] ArgumentTypes_18e05c04f0044c9ca552e0bd595037ea = new Type[] { typeof(PathBoundList) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetFoos(PathBoundList request)
         {
             var arguments = new object[] { request };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetFoos", ArgumentTypes_17ac3b976a114118811521b0e6df4392);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetFoos", ArgumentTypes_18e05c04f0044c9ca552e0bd595037ea);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_caf6b9954a5c4fc7a0363e8355c55213 = new Type[] { typeof(List<int>) };
+        private static readonly Type[] ArgumentTypes_afa2312acb694a648ae29e7480154a84 = new Type[] { typeof(List<int>) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetFoos2(List<int> Values)
         {
             var arguments = new object[] { Values };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetFoos2", ArgumentTypes_caf6b9954a5c4fc7a0363e8355c55213);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetFoos2", ArgumentTypes_afa2312acb694a648ae29e7480154a84);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_f0284c703604497c8addac33ea883865 = new Type[] { typeof(PathBoundObject), typeof(object) };
+        private static readonly Type[] ArgumentTypes_c0799d78fdd04f1e9a0a3f60b0aae9a0 = new Type[] { typeof(PathBoundObject), typeof(object) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.PostFooBar(PathBoundObject request, object someObject)
         {
             var arguments = new object[] { request, someObject };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBar", ArgumentTypes_f0284c703604497c8addac33ea883865);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBar", ArgumentTypes_c0799d78fdd04f1e9a0a3f60b0aae9a0);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_bf9de5acb4664da9affb2da854cb9814 = new Type[] { typeof(PathBoundObjectWithQuery) };
+        private static readonly Type[] ArgumentTypes_d730cc53c68b4f89a53b2e4325a97921 = new Type[] { typeof(PathBoundObjectWithQuery) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetFooBars(PathBoundObjectWithQuery request)
         {
             var arguments = new object[] { request };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBars", ArgumentTypes_bf9de5acb4664da9affb2da854cb9814);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBars", ArgumentTypes_d730cc53c68b4f89a53b2e4325a97921);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_30b0ebdc104b4d13878f478e59db18b0 = new Type[] { typeof(PathBoundObject), typeof(ModelObject) };
+        private static readonly Type[] ArgumentTypes_03468b8d0d184ea1aa383316127ff658 = new Type[] { typeof(PathBoundObject), typeof(ModelObject) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IApiBindPathToObject.PostFooBar(PathBoundObject request, ModelObject someQueryParams)
         {
             var arguments = new object[] { request, someQueryParams };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBar", ArgumentTypes_30b0ebdc104b4d13878f478e59db18b0);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBar", ArgumentTypes_03468b8d0d184ea1aa383316127ff658);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_52bed48dbfe5444fa5c9a6d6c97ce393 = new Type[] { typeof(PathBoundObject), typeof(ModelObject), typeof(StreamPart) };
+        private static readonly Type[] ArgumentTypes_bcef5b8232844bb3a07df08fc4633cca = new Type[] { typeof(PathBoundObject), typeof(ModelObject), typeof(StreamPart) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IApiBindPathToObject.PostFooBarStreamPart(PathBoundObject request, ModelObject someQueryParams, StreamPart stream)
         {
             var arguments = new object[] { request, someQueryParams, stream };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBarStreamPart", ArgumentTypes_52bed48dbfe5444fa5c9a6d6c97ce393);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBarStreamPart", ArgumentTypes_bcef5b8232844bb3a07df08fc4633cca);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_a6bdb4b5cf164da7bd18d48cf71f1692 = new Type[] { typeof(PathBoundObject), typeof(StreamPart) };
+        private static readonly Type[] ArgumentTypes_cdf849fbe137417492c837f1ad346f58 = new Type[] { typeof(PathBoundObject), typeof(StreamPart) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IApiBindPathToObject.PostFooBarStreamPart(PathBoundObject request, StreamPart stream)
         {
             var arguments = new object[] { request, stream };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBarStreamPart", ArgumentTypes_a6bdb4b5cf164da7bd18d48cf71f1692);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBarStreamPart", ArgumentTypes_cdf849fbe137417492c837f1ad346f58);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_bab0280614e846aebec8e15044bafe2a = new Type[] { typeof(PathBoundObjectWithQuery), typeof(StreamPart) };
+        private static readonly Type[] ArgumentTypes_aeb0adb693a74a30bdec9a3559a97939 = new Type[] { typeof(PathBoundObjectWithQuery), typeof(StreamPart) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IApiBindPathToObject.PostFooBarStreamPart(PathBoundObjectWithQuery request, StreamPart stream)
         {
             var arguments = new object[] { request, stream };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBarStreamPart", ArgumentTypes_bab0280614e846aebec8e15044bafe2a);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBarStreamPart", ArgumentTypes_aeb0adb693a74a30bdec9a3559a97939);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
     }
@@ -639,13 +639,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_a08be4a8b6e14351a7dd354be8502d04 = new Type[] { typeof(decimal) };
+        private static readonly Type[] ArgumentTypes_14d7c1a44744458290dece9c4356b470 = new Type[] { typeof(decimal) };
 
         /// <inheritdoc />
         Task<string> IApiWithDecimal.GetWithDecimal(decimal value)
         {
             var arguments = new object[] { value };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetWithDecimal", ArgumentTypes_a08be4a8b6e14351a7dd354be8502d04);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetWithDecimal", ArgumentTypes_14d7c1a44744458290dece9c4356b470);
             return (Task<string>)func(Client, arguments);
         }
     }
@@ -686,33 +686,33 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_ef099a8790e346158ad36ec72488d09d = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_d1614c5cdc6946b49ee12304384c8369 = new Type[] {  };
 
         /// <inheritdoc />
         Task IBodylessApi.Post()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Post", ArgumentTypes_ef099a8790e346158ad36ec72488d09d);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Post", ArgumentTypes_d1614c5cdc6946b49ee12304384c8369);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_6bf7cf31fa9347a2898b86769079159c = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_9a16209422b74bf9bfec555d74312d3c = new Type[] {  };
 
         /// <inheritdoc />
         Task IBodylessApi.Get()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_6bf7cf31fa9347a2898b86769079159c);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_9a16209422b74bf9bfec555d74312d3c);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_8bb2bb21fef2447da5f28e9ac6438653 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_600682252fad4faba161f2c01d3bb467 = new Type[] {  };
 
         /// <inheritdoc />
         Task IBodylessApi.Head()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Head", ArgumentTypes_8bb2bb21fef2447da5f28e9ac6438653);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Head", ArgumentTypes_600682252fad4faba161f2c01d3bb467);
             return (Task)func(Client, arguments);
         }
     }
@@ -753,53 +753,53 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_abf7b391a3104791a915ea66be2dce9f = new Type[] { typeof(T) };
+        private static readonly Type[] ArgumentTypes_a794bd5c7a844df5bce6f832e70ebcfa = new Type[] { typeof(T) };
 
         /// <inheritdoc />
         Task<T> IBoringCrudApi<T, TKey>.Create(T paylod)
         {
             var arguments = new object[] { paylod };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_abf7b391a3104791a915ea66be2dce9f);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_a794bd5c7a844df5bce6f832e70ebcfa);
             return (Task<T>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_47928ca44645467aa4ee03cb247199b8 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_42a2a32cc04845d79f5b5960a4c3b049 = new Type[] {  };
 
         /// <inheritdoc />
         Task<List<T>> IBoringCrudApi<T, TKey>.ReadAll()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_47928ca44645467aa4ee03cb247199b8);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_42a2a32cc04845d79f5b5960a4c3b049);
             return (Task<List<T>>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_11dafea69f6247e19fc107e130ce21a5 = new Type[] { typeof(TKey) };
+        private static readonly Type[] ArgumentTypes_dee8f8a2a9ea4c1bb513b3abee930fce = new Type[] { typeof(TKey) };
 
         /// <inheritdoc />
         Task<T> IBoringCrudApi<T, TKey>.ReadOne(TKey key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_11dafea69f6247e19fc107e130ce21a5);
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_dee8f8a2a9ea4c1bb513b3abee930fce);
             return (Task<T>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_9701bbddfdfd4de1afed9f4c321d8da5 = new Type[] { typeof(TKey), typeof(T) };
+        private static readonly Type[] ArgumentTypes_601e33907d1a462dad924302c657a454 = new Type[] { typeof(TKey), typeof(T) };
 
         /// <inheritdoc />
         Task IBoringCrudApi<T, TKey>.Update(TKey key, T payload)
         {
             var arguments = new object[] { key, payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_9701bbddfdfd4de1afed9f4c321d8da5);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_601e33907d1a462dad924302c657a454);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_f9587170441840b8a7016420cc73f917 = new Type[] { typeof(TKey) };
+        private static readonly Type[] ArgumentTypes_3947ba2874ee4a34b8e4d133b703abf4 = new Type[] { typeof(TKey) };
 
         /// <inheritdoc />
         Task IBoringCrudApi<T, TKey>.Delete(TKey key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_f9587170441840b8a7016420cc73f917);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_3947ba2874ee4a34b8e4d133b703abf4);
             return (Task)func(Client, arguments);
         }
     }
@@ -840,13 +840,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_e8e104f1fe2849b7b5d4031b7809553b = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_b331bc563de94fe3bacbdbdb9db1058c = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<bool> IBrokenWebApi.PostAValue(string derp)
         {
             var arguments = new object[] { derp };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostAValue", ArgumentTypes_e8e104f1fe2849b7b5d4031b7809553b);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostAValue", ArgumentTypes_b331bc563de94fe3bacbdbdb9db1058c);
             return (Task<bool>)func(Client, arguments);
         }
     }
@@ -875,13 +875,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_6d3f119a4aec4cf5a11bf85c940897d9 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_edb953a4a96e42359e51163446a43c47 = new Type[] {  };
 
         /// <inheritdoc />
         CustomReferenceType? ICustomNullableReferenceService.Get()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_6d3f119a4aec4cf5a11bf85c940897d9);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_edb953a4a96e42359e51163446a43c47);
             return (CustomReferenceType?)func(Client, arguments);
         }
     }
@@ -910,13 +910,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_a4be7d7886714e72ad68b1ef16c8e062 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_7519a4f4881842c18ce684c005c7b7b0 = new Type[] {  };
 
         /// <inheritdoc />
         CustomValueType? ICustomNullableValueService.Get()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_a4be7d7886714e72ad68b1ef16c8e062);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_7519a4f4881842c18ce684c005c7b7b0);
             return (CustomValueType?)func(Client, arguments);
         }
     }
@@ -945,13 +945,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_1c1bc578e93a4d50adc08ea05cae067d = new Type[] { ToNullable(typeof(CustomReferenceType)), ToNullable(typeof(CustomValueType)) };
+        private static readonly Type[] ArgumentTypes_34f29288310148aba15121acdf1b5173 = new Type[] { ToNullable(typeof(CustomReferenceType)), ToNullable(typeof(CustomValueType)) };
 
         /// <inheritdoc />
         Task ICustomReferenceAndValueParametersService.Get(CustomReferenceType? reference, CustomValueType? value)
         {
             var arguments = new object[] { reference, value };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_1c1bc578e93a4d50adc08ea05cae067d);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_34f29288310148aba15121acdf1b5173);
             return (Task)func(Client, arguments);
         }
 
@@ -984,73 +984,73 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_7d5c0af5fae3474a931ac051a2e0921a = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_2dcff6edc69d4c7ea45e08330fb9e7d1 = new Type[] {  };
 
         /// <inheritdoc />
         Task IDataApiA.PingA()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PingA", ArgumentTypes_7d5c0af5fae3474a931ac051a2e0921a);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("PingA", ArgumentTypes_2dcff6edc69d4c7ea45e08330fb9e7d1);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_343e53168d8244108bc7395d52cb8014 = new Type[] { typeof(DataEntity) };
+        private static readonly Type[] ArgumentTypes_6a3c63f333cd471882abcba6a3402b7c = new Type[] { typeof(DataEntity) };
 
         /// <inheritdoc />
         Task<DataEntity> IDataCrudApi<DataEntity>.Copy(DataEntity payload)
         {
             var arguments = new object[] { payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Copy", ArgumentTypes_343e53168d8244108bc7395d52cb8014);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Copy", ArgumentTypes_6a3c63f333cd471882abcba6a3402b7c);
             return (Task<DataEntity>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_30b1609eb5564127b70bb74219f62ad5 = new Type[] { typeof(DataEntity) };
+        private static readonly Type[] ArgumentTypes_ddae7a9cd4f04f17ab27bee5bcdc552d = new Type[] { typeof(DataEntity) };
 
         /// <inheritdoc />
         Task<DataEntity> IDataCrudApi<DataEntity, long>.Create(DataEntity payload)
         {
             var arguments = new object[] { payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_30b1609eb5564127b70bb74219f62ad5);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_ddae7a9cd4f04f17ab27bee5bcdc552d);
             return (Task<DataEntity>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_45166a4875424f7c85ed171ec9e09244 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_99d36f321f75420cb9121410e198b66f = new Type[] {  };
 
         /// <inheritdoc />
         Task<List<DataEntity>> IDataCrudApi<DataEntity, long>.ReadAll()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_45166a4875424f7c85ed171ec9e09244);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_99d36f321f75420cb9121410e198b66f);
             return (Task<List<DataEntity>>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_4959a4c16d2c4930818be7064dc72929 = new Type[] { typeof(long) };
+        private static readonly Type[] ArgumentTypes_08ee977a5ef642e2ad2f9328378681aa = new Type[] { typeof(long) };
 
         /// <inheritdoc />
         Task<DataEntity> IDataCrudApi<DataEntity, long>.ReadOne(long key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_4959a4c16d2c4930818be7064dc72929);
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_08ee977a5ef642e2ad2f9328378681aa);
             return (Task<DataEntity>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_d678905a66f146daafdbf572bf9926e0 = new Type[] { typeof(long), typeof(DataEntity) };
+        private static readonly Type[] ArgumentTypes_e4b4a1f7311a49ea9e4d63df93e47a87 = new Type[] { typeof(long), typeof(DataEntity) };
 
         /// <inheritdoc />
         Task IDataCrudApi<DataEntity, long>.Update(long key, DataEntity payload)
         {
             var arguments = new object[] { key, payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_d678905a66f146daafdbf572bf9926e0);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_e4b4a1f7311a49ea9e4d63df93e47a87);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_27c3a88882aa41c5abe76eda1061f56e = new Type[] { typeof(long) };
+        private static readonly Type[] ArgumentTypes_e1119251405f45ee87f4ae5a7412685b = new Type[] { typeof(long) };
 
         /// <inheritdoc />
         Task IDataCrudApi<DataEntity, long>.Delete(long key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_27c3a88882aa41c5abe76eda1061f56e);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_e1119251405f45ee87f4ae5a7412685b);
             return (Task)func(Client, arguments);
         }
     }
@@ -1081,63 +1081,63 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_d521cbce8d9c407ea398a7a94e77f8ef = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_8f543ba691734b9887c15102e656ee6f = new Type[] {  };
 
         /// <inheritdoc />
         Task IDataApiB.PingB()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PingB", ArgumentTypes_d521cbce8d9c407ea398a7a94e77f8ef);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("PingB", ArgumentTypes_8f543ba691734b9887c15102e656ee6f);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_99873a955a29497e9732b1606bb5b671 = new Type[] { typeof(DataEntity) };
+        private static readonly Type[] ArgumentTypes_9ec6852eae804c9aa17a666c7f92d617 = new Type[] { typeof(DataEntity) };
 
         /// <inheritdoc />
         Task<DataEntity> IDataCrudApi<DataEntity, int>.Create(DataEntity payload)
         {
             var arguments = new object[] { payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_99873a955a29497e9732b1606bb5b671);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_9ec6852eae804c9aa17a666c7f92d617);
             return (Task<DataEntity>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_402fb50857d14d9987a4e09a81ac346d = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_2cd52c5d39854f5b8cbd0f0e29a5a9df = new Type[] {  };
 
         /// <inheritdoc />
         Task<List<DataEntity>> IDataCrudApi<DataEntity, int>.ReadAll()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_402fb50857d14d9987a4e09a81ac346d);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_2cd52c5d39854f5b8cbd0f0e29a5a9df);
             return (Task<List<DataEntity>>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_64a9eb0dedff40c1ab6edb3a196a1974 = new Type[] { typeof(int) };
+        private static readonly Type[] ArgumentTypes_77491932d1f74254bd2c452bdf54b308 = new Type[] { typeof(int) };
 
         /// <inheritdoc />
         Task<DataEntity> IDataCrudApi<DataEntity, int>.ReadOne(int key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_64a9eb0dedff40c1ab6edb3a196a1974);
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_77491932d1f74254bd2c452bdf54b308);
             return (Task<DataEntity>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_47174a46e1314d29975117db45d101e1 = new Type[] { typeof(int), typeof(DataEntity) };
+        private static readonly Type[] ArgumentTypes_ccb882c881ce4333a86cbf4ec339766c = new Type[] { typeof(int), typeof(DataEntity) };
 
         /// <inheritdoc />
         Task IDataCrudApi<DataEntity, int>.Update(int key, DataEntity payload)
         {
             var arguments = new object[] { key, payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_47174a46e1314d29975117db45d101e1);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_ccb882c881ce4333a86cbf4ec339766c);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_594d40ee267647e68885da682ba3cd7b = new Type[] { typeof(int) };
+        private static readonly Type[] ArgumentTypes_a8832482b50a4cb9a47814f55110dd1e = new Type[] { typeof(int) };
 
         /// <inheritdoc />
         Task IDataCrudApi<DataEntity, int>.Delete(int key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_594d40ee267647e68885da682ba3cd7b);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_a8832482b50a4cb9a47814f55110dd1e);
             return (Task)func(Client, arguments);
         }
     }
@@ -1171,63 +1171,63 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_1eea269d486a4dceba6fcf08dbe5df5e = new Type[] { typeof(T) };
+        private static readonly Type[] ArgumentTypes_4e760ce3568247d89d31a7552d1f8473 = new Type[] { typeof(T) };
 
         /// <inheritdoc />
         Task<T> IDataCrudApi<T>.Copy(T payload)
         {
             var arguments = new object[] { payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Copy", ArgumentTypes_1eea269d486a4dceba6fcf08dbe5df5e);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Copy", ArgumentTypes_4e760ce3568247d89d31a7552d1f8473);
             return (Task<T>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_37f940e1cc1a40c88e51f4f231fa6833 = new Type[] { typeof(T) };
+        private static readonly Type[] ArgumentTypes_14d88e8d5099420eab319d933908becb = new Type[] { typeof(T) };
 
         /// <inheritdoc />
         Task<T> IDataCrudApi<T, long>.Create(T payload)
         {
             var arguments = new object[] { payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_37f940e1cc1a40c88e51f4f231fa6833);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_14d88e8d5099420eab319d933908becb);
             return (Task<T>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_7f04796b527a4bc995d3bf3f0b5f08d3 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_0a1faaa18ee04e55a9cbe42ef7534683 = new Type[] {  };
 
         /// <inheritdoc />
         Task<List<T>> IDataCrudApi<T, long>.ReadAll()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_7f04796b527a4bc995d3bf3f0b5f08d3);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_0a1faaa18ee04e55a9cbe42ef7534683);
             return (Task<List<T>>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_7c52f39c7c7140f3a3b9d34edb51545f = new Type[] { typeof(long) };
+        private static readonly Type[] ArgumentTypes_b4834c016efe41839c3955f11a3e3f55 = new Type[] { typeof(long) };
 
         /// <inheritdoc />
         Task<T> IDataCrudApi<T, long>.ReadOne(long key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_7c52f39c7c7140f3a3b9d34edb51545f);
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_b4834c016efe41839c3955f11a3e3f55);
             return (Task<T>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_3afc97de14eb466d979e2ce7658c545f = new Type[] { typeof(long), typeof(T) };
+        private static readonly Type[] ArgumentTypes_40dfe37c2de54103834c33c35d82d5c8 = new Type[] { typeof(long), typeof(T) };
 
         /// <inheritdoc />
         Task IDataCrudApi<T, long>.Update(long key, T payload)
         {
             var arguments = new object[] { key, payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_3afc97de14eb466d979e2ce7658c545f);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_40dfe37c2de54103834c33c35d82d5c8);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_3518f113c0c946d7a2b0a93b6810c696 = new Type[] { typeof(long) };
+        private static readonly Type[] ArgumentTypes_d5e1dbeaba424e66a36b7317ad326c76 = new Type[] { typeof(long) };
 
         /// <inheritdoc />
         Task IDataCrudApi<T, long>.Delete(long key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_3518f113c0c946d7a2b0a93b6810c696);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_d5e1dbeaba424e66a36b7317ad326c76);
             return (Task)func(Client, arguments);
         }
     }
@@ -1261,53 +1261,53 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_2dd8932f23e94674b9cceeae76894962 = new Type[] { typeof(T) };
+        private static readonly Type[] ArgumentTypes_c4ba9c82081a4927be1491097050e339 = new Type[] { typeof(T) };
 
         /// <inheritdoc />
         Task<T> IDataCrudApi<T, TKey>.Create(T payload)
         {
             var arguments = new object[] { payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_2dd8932f23e94674b9cceeae76894962);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_c4ba9c82081a4927be1491097050e339);
             return (Task<T>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_5ff0e2178f414b799c966af528d795f5 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_fa6fba62a55140bdbe0f51bd466ec1d4 = new Type[] {  };
 
         /// <inheritdoc />
         Task<List<T>> IDataCrudApi<T, TKey>.ReadAll()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_5ff0e2178f414b799c966af528d795f5);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_fa6fba62a55140bdbe0f51bd466ec1d4);
             return (Task<List<T>>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_1a59a45c18b64c0596ded74cd7a24ace = new Type[] { typeof(TKey) };
+        private static readonly Type[] ArgumentTypes_33f78b1f4e85494e9c8811a13845ceda = new Type[] { typeof(TKey) };
 
         /// <inheritdoc />
         Task<T> IDataCrudApi<T, TKey>.ReadOne(TKey key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_1a59a45c18b64c0596ded74cd7a24ace);
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_33f78b1f4e85494e9c8811a13845ceda);
             return (Task<T>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_a31476e793b6496dac5bf496db2295e5 = new Type[] { typeof(TKey), typeof(T) };
+        private static readonly Type[] ArgumentTypes_83afcb5fcd414f9c86180b8b75acb5a9 = new Type[] { typeof(TKey), typeof(T) };
 
         /// <inheritdoc />
         Task IDataCrudApi<T, TKey>.Update(TKey key, T payload)
         {
             var arguments = new object[] { key, payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_a31476e793b6496dac5bf496db2295e5);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_83afcb5fcd414f9c86180b8b75acb5a9);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_da65613142d8419c867a4892a4548edc = new Type[] { typeof(TKey) };
+        private static readonly Type[] ArgumentTypes_d11c86793f6b4bc1a1d53f18e5c086b8 = new Type[] { typeof(TKey) };
 
         /// <inheritdoc />
         Task IDataCrudApi<T, TKey>.Delete(TKey key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_da65613142d8419c867a4892a4548edc);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_d11c86793f6b4bc1a1d53f18e5c086b8);
             return (Task)func(Client, arguments);
         }
     }
@@ -1336,13 +1336,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_91c724a303774144ab71158c5ece12cb = new Type[] { ToNullable(typeof(System.Collections.Generic.List<string>)) };
+        private static readonly Type[] ArgumentTypes_709afe232b4c48ad8710228b536caa17 = new Type[] { ToNullable(typeof(System.Collections.Generic.List<string>)) };
 
         /// <inheritdoc />
         Task IGenericNullableReferenceParameterService.Get(System.Collections.Generic.List<string>? reference)
         {
             var arguments = new object[] { reference };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_91c724a303774144ab71158c5ece12cb);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_709afe232b4c48ad8710228b536caa17);
             return (Task)func(Client, arguments);
         }
 
@@ -1373,13 +1373,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_3803f0c715de41b2b35f466e26eac0c1 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_dbf233a71c4b4c1fb950a07ac9bc4d5a = new Type[] {  };
 
         /// <inheritdoc />
         Task<string>? IGenericNullableReferenceService.Get()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_3803f0c715de41b2b35f466e26eac0c1);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_dbf233a71c4b4c1fb950a07ac9bc4d5a);
             return (Task<string>?)func(Client, arguments);
         }
     }
@@ -1408,13 +1408,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_6b7a6439a51249f8ac3e84009bc1e2bf = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_f78e2062ce1243e082c08c47342c1de8 = new Type[] {  };
 
         /// <inheritdoc />
         ValueTask<int>? IGenericNullableValueService.Get()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_6b7a6439a51249f8ac3e84009bc1e2bf);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_f78e2062ce1243e082c08c47342c1de8);
             return (ValueTask<int>?)func(Client, arguments);
         }
     }
@@ -1443,13 +1443,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_7edc88dc73034c4fbbe0ccdc9cdbffe7 = new Type[] { ToNullable(typeof(System.Collections.Generic.List<string?>)) };
+        private static readonly Type[] ArgumentTypes_68fe30c7aa4f4807b22fb54745d236f7 = new Type[] { ToNullable(typeof(System.Collections.Generic.List<string?>)) };
 
         /// <inheritdoc />
         Task IGenericNullableWithNullableReferenceParameterService.Get(System.Collections.Generic.List<string?>? reference)
         {
             var arguments = new object[] { reference };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_7edc88dc73034c4fbbe0ccdc9cdbffe7);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_68fe30c7aa4f4807b22fb54745d236f7);
             return (Task)func(Client, arguments);
         }
 
@@ -1480,13 +1480,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_c5ecfbdc7c7744029e0f8e0c707d4cb8 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_4d4731c7a0d44ca1b01cad852da9c8bf = new Type[] {  };
 
         /// <inheritdoc />
         Task<string?>? IGenericNullableWithNullableReferenceService.Get()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_c5ecfbdc7c7744029e0f8e0c707d4cb8);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_4d4731c7a0d44ca1b01cad852da9c8bf);
             return (Task<string?>?)func(Client, arguments);
         }
     }
@@ -1515,13 +1515,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_c418000d8ad649fc9a8c27b444aa92aa = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_26878fff821f48d3ae251734b6d837b0 = new Type[] {  };
 
         /// <inheritdoc />
         ValueTask<int?>? IGenericNullableWithNullableValueService.Get()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_c418000d8ad649fc9a8c27b444aa92aa);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_26878fff821f48d3ae251734b6d837b0);
             return (ValueTask<int?>?)func(Client, arguments);
         }
     }
@@ -1550,13 +1550,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_0f614393c6ea49e18c9c28e3dd3c2180 = new Type[] { typeof(System.Collections.Generic.List<string?>) };
+        private static readonly Type[] ArgumentTypes_688a3db092414606b7ed57d12f26804c = new Type[] { typeof(System.Collections.Generic.List<string?>) };
 
         /// <inheritdoc />
         Task IGenericWithNullableReferenceParameterService.Get(System.Collections.Generic.List<string?> reference)
         {
             var arguments = new object[] { reference };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_0f614393c6ea49e18c9c28e3dd3c2180);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_688a3db092414606b7ed57d12f26804c);
             return (Task)func(Client, arguments);
         }
     }
@@ -1585,13 +1585,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_607ae3a809a74c7e8c9009c1e1cd3c21 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_ee2363629bfc461496e77731d9dd21fc = new Type[] {  };
 
         /// <inheritdoc />
         Task<int?> IGenericWithNullableValueService.Get()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_607ae3a809a74c7e8c9009c1e1cd3c21);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_ee2363629bfc461496e77731d9dd21fc);
             return (Task<int?>)func(Client, arguments);
         }
     }
@@ -1620,13 +1620,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_4cec3e99456b4e6eb5fdd0fee3340519 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_c7dc7c8860f84f038f5efdee7e4c7303 = new Type[] {  };
 
         /// <inheritdoc />
         Task<string?> IGenericWithResultService.Get()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_4cec3e99456b4e6eb5fdd0fee3340519);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_c7dc7c8860f84f038f5efdee7e4c7303);
             return (Task<string?>)func(Client, arguments);
         }
     }
@@ -1661,133 +1661,133 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_825344cd83164381a710b05f132cd285 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_e5eea7ef21fe45dfada409f7474945bb = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<User> IGitHubApi.GetUser(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUser", ArgumentTypes_825344cd83164381a710b05f132cd285);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUser", ArgumentTypes_e5eea7ef21fe45dfada409f7474945bb);
             return (Task<User>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_a6ad0ccd63ae410caebec92bdfc469fa = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_3ad0fceaae92461db99c0855d00f7a92 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         IObservable<User> IGitHubApi.GetUserObservable(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserObservable", ArgumentTypes_a6ad0ccd63ae410caebec92bdfc469fa);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserObservable", ArgumentTypes_3ad0fceaae92461db99c0855d00f7a92);
             return (IObservable<User>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_0982d186f6f8463f9841376247ab81b4 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_3f042fa5a21143ea8b4ea399d5167abd = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         IObservable<User> IGitHubApi.GetUserCamelCase(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserCamelCase", ArgumentTypes_0982d186f6f8463f9841376247ab81b4);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserCamelCase", ArgumentTypes_3f042fa5a21143ea8b4ea399d5167abd);
             return (IObservable<User>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_176c28f24e834c5fb204b915b429b051 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_615a1760f8b14abc8726debf66362d68 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<List<User>> IGitHubApi.GetOrgMembers(string orgName)
         {
             var arguments = new object[] { orgName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetOrgMembers", ArgumentTypes_176c28f24e834c5fb204b915b429b051);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetOrgMembers", ArgumentTypes_615a1760f8b14abc8726debf66362d68);
             return (Task<List<User>>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_3e8a2a65a8934444b64df820a5e51301 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_caf7ad1d45d9444092c120383123d9c9 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<UserSearchResult> IGitHubApi.FindUsers(string q)
         {
             var arguments = new object[] { q };
-            var func = requestBuilder.BuildRestResultFuncForMethod("FindUsers", ArgumentTypes_3e8a2a65a8934444b64df820a5e51301);
+            var func = requestBuilder.BuildRestResultFuncForMethod("FindUsers", ArgumentTypes_caf7ad1d45d9444092c120383123d9c9);
             return (Task<UserSearchResult>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_c7334dae5eea4961a4ef24a94f922510 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_c4d4eb798ba24d139d3b6d585c83d224 = new Type[] {  };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IGitHubApi.GetIndex()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndex", ArgumentTypes_c7334dae5eea4961a4ef24a94f922510);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndex", ArgumentTypes_c4d4eb798ba24d139d3b6d585c83d224);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_27eb29e21a114838ac1362a6eac4b0d1 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_0e995ad512c6471e94598a3e03647f2e = new Type[] {  };
 
         /// <inheritdoc />
         IObservable<string> IGitHubApi.GetIndexObservable()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndexObservable", ArgumentTypes_27eb29e21a114838ac1362a6eac4b0d1);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndexObservable", ArgumentTypes_0e995ad512c6471e94598a3e03647f2e);
             return (IObservable<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_749bdd3f18a5417d8524d4509ac3b369 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_3c35fd35e26244c6af81e9f95a36d1e0 = new Type[] {  };
 
         /// <inheritdoc />
         Task<User> IGitHubApi.NothingToSeeHere()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("NothingToSeeHere", ArgumentTypes_749bdd3f18a5417d8524d4509ac3b369);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("NothingToSeeHere", ArgumentTypes_3c35fd35e26244c6af81e9f95a36d1e0);
             return (Task<User>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_8b73e68672d84d06b8881b930d41f9a8 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_a41df33786f94fbfb0e4aaa57803278d = new Type[] {  };
 
         /// <inheritdoc />
         Task<ApiResponse<User>> IGitHubApi.NothingToSeeHereWithMetadata()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("NothingToSeeHereWithMetadata", ArgumentTypes_8b73e68672d84d06b8881b930d41f9a8);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("NothingToSeeHereWithMetadata", ArgumentTypes_a41df33786f94fbfb0e4aaa57803278d);
             return (Task<ApiResponse<User>>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_da60ed58c3d045f3886c9d1ffe10518a = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_5875806a6b2a40568b1be16efcb0f173 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<ApiResponse<User>> IGitHubApi.GetUserWithMetadata(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserWithMetadata", ArgumentTypes_da60ed58c3d045f3886c9d1ffe10518a);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserWithMetadata", ArgumentTypes_5875806a6b2a40568b1be16efcb0f173);
             return (Task<ApiResponse<User>>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_944cb854ea8a4f7bb308f6d39eb0f171 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_7f9021a3cfee4b6bad29bb6a2c4c710b = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         IObservable<ApiResponse<User>> IGitHubApi.GetUserObservableWithMetadata(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserObservableWithMetadata", ArgumentTypes_944cb854ea8a4f7bb308f6d39eb0f171);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserObservableWithMetadata", ArgumentTypes_7f9021a3cfee4b6bad29bb6a2c4c710b);
             return (IObservable<ApiResponse<User>>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_db10a7fa440c47e4a6073b08e3005d2b = new Type[] { typeof(User) };
+        private static readonly Type[] ArgumentTypes_ce5ce359d67d4589ae07506f91540ec3 = new Type[] { typeof(User) };
 
         /// <inheritdoc />
         Task<User> IGitHubApi.CreateUser(User user)
         {
             var arguments = new object[] { user };
-            var func = requestBuilder.BuildRestResultFuncForMethod("CreateUser", ArgumentTypes_db10a7fa440c47e4a6073b08e3005d2b);
+            var func = requestBuilder.BuildRestResultFuncForMethod("CreateUser", ArgumentTypes_ce5ce359d67d4589ae07506f91540ec3);
             return (Task<User>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_654763b56bfb4b4284772da72f372e2b = new Type[] { typeof(User) };
+        private static readonly Type[] ArgumentTypes_42528656b4f64cbe9f8f0724723932d9 = new Type[] { typeof(User) };
 
         /// <inheritdoc />
         Task<ApiResponse<User>> IGitHubApi.CreateUserWithMetadata(User user)
         {
             var arguments = new object[] { user };
-            var func = requestBuilder.BuildRestResultFuncForMethod("CreateUserWithMetadata", ArgumentTypes_654763b56bfb4b4284772da72f372e2b);
+            var func = requestBuilder.BuildRestResultFuncForMethod("CreateUserWithMetadata", ArgumentTypes_42528656b4f64cbe9f8f0724723932d9);
             return (Task<ApiResponse<User>>)func(Client, arguments);
         }
     }
@@ -1832,47 +1832,47 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_ecebe7833dd44c0d96c11e51a43070b5 = new Type[] { typeof(TParam), typeof(THeader) };
+        private static readonly Type[] ArgumentTypes_069d049503fa4e70a750dedcc0edbb53 = new Type[] { typeof(TParam), typeof(THeader) };
 
         /// <inheritdoc />
         Task<TResponse> IHttpBinApi<TResponse, TParam, THeader>.Get(TParam param, THeader header)
         {
             var arguments = new object[] { param, header };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_ecebe7833dd44c0d96c11e51a43070b5);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_069d049503fa4e70a750dedcc0edbb53);
             return (Task<TResponse>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_2bec4fc6318e4d599242c196a243775f = new Type[] { typeof(TParam) };
+        private static readonly Type[] ArgumentTypes_0e3cc77c170242b3828afce89c534fa9 = new Type[] { typeof(TParam) };
 
         /// <inheritdoc />
         Task<TResponse> IHttpBinApi<TResponse, TParam, THeader>.GetQuery(TParam param)
         {
             var arguments = new object[] { param };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetQuery", ArgumentTypes_2bec4fc6318e4d599242c196a243775f);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetQuery", ArgumentTypes_0e3cc77c170242b3828afce89c534fa9);
             return (Task<TResponse>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_3fbd2156290e4091a751dcede3ecc9a8 = new Type[] { typeof(TParam) };
+        private static readonly Type[] ArgumentTypes_80616731a082431b9a4046005174be07 = new Type[] { typeof(TParam) };
 
         /// <inheritdoc />
         Task<TResponse> IHttpBinApi<TResponse, TParam, THeader>.PostQuery(TParam param)
         {
             var arguments = new object[] { param };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostQuery", ArgumentTypes_3fbd2156290e4091a751dcede3ecc9a8);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostQuery", ArgumentTypes_80616731a082431b9a4046005174be07);
             return (Task<TResponse>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_7d02a05c8f44435a9ec84d4733664772 = new Type[] { typeof(TParam) };
+        private static readonly Type[] ArgumentTypes_bced68b957664828ab16f41534187300 = new Type[] { typeof(TParam) };
 
         /// <inheritdoc />
         Task<TResponse> IHttpBinApi<TResponse, TParam, THeader>.GetQueryWithIncludeParameterName(TParam param)
         {
             var arguments = new object[] { param };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetQueryWithIncludeParameterName", ArgumentTypes_7d02a05c8f44435a9ec84d4733664772);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetQueryWithIncludeParameterName", ArgumentTypes_bced68b957664828ab16f41534187300);
             return (Task<TResponse>)func(Client, arguments);
         }
 
-        private static class TypeHelper_58cfbf92175c47d1abbe8cdb9ef4c08c<TValue>
+        private static class TypeHelper_55b57e7caf1d4d1899d882410c7296a0<TValue>
         {
             public static readonly Type[] ArgumentTypes = new Type[] { typeof(TParam) };
             public static readonly Type[] TypeParameters = new Type[] { typeof(TValue) };
@@ -1882,7 +1882,7 @@ namespace Refit.Tests
         Task<TValue> IHttpBinApi<TResponse, TParam, THeader>.GetQuery1<TValue>(TParam param)
         {
             var arguments = new object[] { param };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetQuery1", TypeHelper_58cfbf92175c47d1abbe8cdb9ef4c08c<TValue>.ArgumentTypes, TypeHelper_58cfbf92175c47d1abbe8cdb9ef4c08c<TValue>.TypeParameters);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetQuery1", TypeHelper_55b57e7caf1d4d1899d882410c7296a0<TValue>.ArgumentTypes, TypeHelper_55b57e7caf1d4d1899d882410c7296a0<TValue>.TypeParameters);
             return (Task<TValue>)func(Client, arguments);
         }
     }
@@ -1923,23 +1923,23 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_916233bede5448c287b2c3cbdb5bfbde = new Type[] { typeof(HttpContent) };
+        private static readonly Type[] ArgumentTypes_a3356fde48364f2e8c1cb533056a6c4c = new Type[] { typeof(HttpContent) };
 
         /// <inheritdoc />
         Task<HttpContent> IHttpContentApi.PostFileUpload(HttpContent content)
         {
             var arguments = new object[] { content };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostFileUpload", ArgumentTypes_916233bede5448c287b2c3cbdb5bfbde);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostFileUpload", ArgumentTypes_a3356fde48364f2e8c1cb533056a6c4c);
             return (Task<HttpContent>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_337c1407a71d495d88de5fcd8487bbd2 = new Type[] { typeof(HttpContent) };
+        private static readonly Type[] ArgumentTypes_19dfd8d5628a40c5900e08c127a31fd4 = new Type[] { typeof(HttpContent) };
 
         /// <inheritdoc />
         Task<ApiResponse<HttpContent>> IHttpContentApi.PostFileUploadWithMetadata(HttpContent content)
         {
             var arguments = new object[] { content };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostFileUploadWithMetadata", ArgumentTypes_337c1407a71d495d88de5fcd8487bbd2);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostFileUploadWithMetadata", ArgumentTypes_19dfd8d5628a40c5900e08c127a31fd4);
             return (Task<ApiResponse<HttpContent>>)func(Client, arguments);
         }
     }
@@ -1981,13 +1981,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_a3fa247f3e984a6ebc8ff5152208dfa3 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_a68920f592ec4d19b037655c4248d5b3 = new Type[] {  };
 
         /// <inheritdoc />
         Task<TestAliasObject> ResponseTests.IMyAliasService.GetTestObject()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetTestObject", ArgumentTypes_a3fa247f3e984a6ebc8ff5152208dfa3);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetTestObject", ArgumentTypes_a68920f592ec4d19b037655c4248d5b3);
             return (Task<TestAliasObject>)func(Client, arguments);
         }
     }
@@ -2023,23 +2023,23 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_0c64af5faa0441f2bc8e4a2a2c83361b = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_ca9424616d0d41d18d4f9732a621adba = new Type[] {  };
 
         /// <inheritdoc />
         Task<string> AuthenticatedClientHandlerTests.IMyAuthenticatedService.GetUnauthenticated()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUnauthenticated", ArgumentTypes_0c64af5faa0441f2bc8e4a2a2c83361b);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUnauthenticated", ArgumentTypes_ca9424616d0d41d18d4f9732a621adba);
             return (Task<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_3fe3a5722572445f91da95a9ec09d02f = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_3ab94cc9d0e14205a28bf3bad850701f = new Type[] {  };
 
         /// <inheritdoc />
         Task<string> AuthenticatedClientHandlerTests.IMyAuthenticatedService.GetAuthenticated()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetAuthenticated", ArgumentTypes_3fe3a5722572445f91da95a9ec09d02f);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetAuthenticated", ArgumentTypes_3ab94cc9d0e14205a28bf3bad850701f);
             return (Task<string>)func(Client, arguments);
         }
     }
@@ -2070,13 +2070,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_d6586b4240b5463bb75e1a334a6a1518 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_83d84be48dde491296b09a2ddc034b46 = new Type[] {  };
 
         /// <inheritdoc />
         Task<SomeType> INamespaceCollisionApi.SomeRequest()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", ArgumentTypes_d6586b4240b5463bb75e1a334a6a1518);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", ArgumentTypes_83d84be48dde491296b09a2ddc034b46);
             return (Task<SomeType>)func(Client, arguments);
         }
     }
@@ -2108,13 +2108,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_57c9155b70384c79a6c00be75a46b20d = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_754918f748fd446eb99b099f4e47185d = new Type[] {  };
 
         /// <inheritdoc />
         Task<SomeOtherType> INamespaceOverlapApi.SomeRequest()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", ArgumentTypes_57c9155b70384c79a6c00be75a46b20d);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", ArgumentTypes_754918f748fd446eb99b099f4e47185d);
             return (Task<SomeOtherType>)func(Client, arguments);
         }
     }
@@ -2149,83 +2149,83 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_6787694a254e497bb0fc8402d88ec5b0 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_2065b9c55d944391b3c49f77b8d95bef = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<User> TestNested.INestedGitHubApi.GetUser(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUser", ArgumentTypes_6787694a254e497bb0fc8402d88ec5b0);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUser", ArgumentTypes_2065b9c55d944391b3c49f77b8d95bef);
             return (Task<User>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_9349c66e870d4d4990c6838e127dd66d = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_e2bc5750675c41e19b17a06b933bfa69 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         IObservable<User> TestNested.INestedGitHubApi.GetUserObservable(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserObservable", ArgumentTypes_9349c66e870d4d4990c6838e127dd66d);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserObservable", ArgumentTypes_e2bc5750675c41e19b17a06b933bfa69);
             return (IObservable<User>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_eebf863635d7438d9f2cc187f9edfbf7 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_8a29b8ef353045db99e7b092bb137cb8 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         IObservable<User> TestNested.INestedGitHubApi.GetUserCamelCase(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserCamelCase", ArgumentTypes_eebf863635d7438d9f2cc187f9edfbf7);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserCamelCase", ArgumentTypes_8a29b8ef353045db99e7b092bb137cb8);
             return (IObservable<User>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_168d950ea0c84b26885467be85b61fab = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_96f3a7574f104285ad86e3aa4ac0270e = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<List<User>> TestNested.INestedGitHubApi.GetOrgMembers(string orgName)
         {
             var arguments = new object[] { orgName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetOrgMembers", ArgumentTypes_168d950ea0c84b26885467be85b61fab);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetOrgMembers", ArgumentTypes_96f3a7574f104285ad86e3aa4ac0270e);
             return (Task<List<User>>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_b970f988241d490495aab63b5b6b6f81 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_006aacd9073b4bf684ead6660cebefbf = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<UserSearchResult> TestNested.INestedGitHubApi.FindUsers(string q)
         {
             var arguments = new object[] { q };
-            var func = requestBuilder.BuildRestResultFuncForMethod("FindUsers", ArgumentTypes_b970f988241d490495aab63b5b6b6f81);
+            var func = requestBuilder.BuildRestResultFuncForMethod("FindUsers", ArgumentTypes_006aacd9073b4bf684ead6660cebefbf);
             return (Task<UserSearchResult>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_12b0613a1e674ac1a13bab221350fb9e = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_6e834f7f228443e29aa18e0627684ad8 = new Type[] {  };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> TestNested.INestedGitHubApi.GetIndex()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndex", ArgumentTypes_12b0613a1e674ac1a13bab221350fb9e);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndex", ArgumentTypes_6e834f7f228443e29aa18e0627684ad8);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_892b0da4f9c7450d85b1ac3efb7d268e = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_a59ea58a65de408281c93f0923bf7b7e = new Type[] {  };
 
         /// <inheritdoc />
         IObservable<string> TestNested.INestedGitHubApi.GetIndexObservable()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndexObservable", ArgumentTypes_892b0da4f9c7450d85b1ac3efb7d268e);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndexObservable", ArgumentTypes_a59ea58a65de408281c93f0923bf7b7e);
             return (IObservable<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_169d18dcad944458974aaa3f2113a1b6 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_079e9af2c4cd460c9c3df418c57d4982 = new Type[] {  };
 
         /// <inheritdoc />
         Task TestNested.INestedGitHubApi.NothingToSeeHere()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("NothingToSeeHere", ArgumentTypes_169d18dcad944458974aaa3f2113a1b6);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("NothingToSeeHere", ArgumentTypes_079e9af2c4cd460c9c3df418c57d4982);
             return (Task)func(Client, arguments);
         }
     }
@@ -2263,7 +2263,7 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static class TypeHelper_c12dfdbf764f4632bc0b02521e408c77<T>
+        private static class TypeHelper_ce3b8a623a484997b4ec407c4b8238d9<T>
         {
             public static readonly Type[] ArgumentTypes = new Type[] { typeof(T) };
             public static readonly Type[] TypeParameters = new Type[] { typeof(T) };
@@ -2273,11 +2273,11 @@ namespace Refit.Tests
         Task INonGenericInterfaceWithGenericMethod.PostMessage<T>(T message)
         {
             var arguments = new object[] { message };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostMessage", TypeHelper_c12dfdbf764f4632bc0b02521e408c77<T>.ArgumentTypes, TypeHelper_c12dfdbf764f4632bc0b02521e408c77<T>.TypeParameters);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostMessage", TypeHelper_ce3b8a623a484997b4ec407c4b8238d9<T>.ArgumentTypes, TypeHelper_ce3b8a623a484997b4ec407c4b8238d9<T>.TypeParameters);
             return (Task)func(Client, arguments);
         }
 
-        private static class TypeHelper_27934246c0974dce8f11d9ffff3dc4d2<T, U, V>
+        private static class TypeHelper_bcbaa7cc9d8a4ffa95c64f1fc7e508ee<T, U, V>
         {
             public static readonly Type[] ArgumentTypes = new Type[] { typeof(T), typeof(U), typeof(V) };
             public static readonly Type[] TypeParameters = new Type[] { typeof(T), typeof(U), typeof(V) };
@@ -2287,7 +2287,7 @@ namespace Refit.Tests
         Task INonGenericInterfaceWithGenericMethod.PostMessage<T, U, V>(T message, U param1, V param2)
         {
             var arguments = new object[] { message, param1, param2 };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostMessage", TypeHelper_27934246c0974dce8f11d9ffff3dc4d2<T, U, V>.ArgumentTypes, TypeHelper_27934246c0974dce8f11d9ffff3dc4d2<T, U, V>.TypeParameters);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostMessage", TypeHelper_bcbaa7cc9d8a4ffa95c64f1fc7e508ee<T, U, V>.ArgumentTypes, TypeHelper_bcbaa7cc9d8a4ffa95c64f1fc7e508ee<T, U, V>.TypeParameters);
             return (Task)func(Client, arguments);
         }
     }
@@ -2328,13 +2328,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_a1a8c9620a9e4348871dab2d3bbffb46 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_64aaa57de9c44b61b6a20c04dc9ab23f = new Type[] {  };
 
         /// <inheritdoc />
         Task<RootObject> INpmJs.GetCongruence()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetCongruence", ArgumentTypes_a1a8c9620a9e4348871dab2d3bbffb46);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetCongruence", ArgumentTypes_64aaa57de9c44b61b6a20c04dc9ab23f);
             return (Task<RootObject>)func(Client, arguments);
         }
     }
@@ -2363,13 +2363,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_e67e85252dd54696a64b61da843b861a = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_b1e81cc95f1b403fbd6306e2641f01d5 = new Type[] {  };
 
         /// <inheritdoc />
         string? INullableReferenceService.Get()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_e67e85252dd54696a64b61da843b861a);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_b1e81cc95f1b403fbd6306e2641f01d5);
             return (string?)func(Client, arguments);
         }
     }
@@ -2398,13 +2398,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_d734543f219b4468a3e27385f2882225 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_1c3a9104a4e44ddbbc4c60a2904ac6f2 = new Type[] {  };
 
         /// <inheritdoc />
         int? INullableValueService.Get()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_d734543f219b4468a3e27385f2882225);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_1c3a9104a4e44ddbbc4c60a2904ac6f2);
             return (int?)func(Client, arguments);
         }
     }
@@ -2434,13 +2434,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_71fa7deb0cd54d74918d11543b6687bc = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_b610b5d6f80448dbb6d34aa0f7eb5015 = new Type[] {  };
 
         /// <inheritdoc />
         Task<SomeType> IReducedUsingInsideNamespaceApi.SomeRequest()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", ArgumentTypes_71fa7deb0cd54d74918d11543b6687bc);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", ArgumentTypes_b610b5d6f80448dbb6d34aa0f7eb5015);
             return (Task<SomeType>)func(Client, arguments);
         }
     }
@@ -2469,13 +2469,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_405cdc425a40429f85710b845a796aa9 = new Type[] { ToNullable(typeof(string)), ToNullable(typeof(int)) };
+        private static readonly Type[] ArgumentTypes_a20a2c5c6c1d4d128cf3299b541bf22d = new Type[] { ToNullable(typeof(string)), ToNullable(typeof(int)) };
 
         /// <inheritdoc />
         Task IReferenceAndValueParametersService.Get(string? reference, int? value)
         {
             var arguments = new object[] { reference, value };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_405cdc425a40429f85710b845a796aa9);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_a20a2c5c6c1d4d128cf3299b541bf22d);
             return (Task)func(Client, arguments);
         }
 
@@ -2518,13 +2518,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_ad5d0c7deacd4242ba81c90c81cac767 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_413bb83c7188415884261263233b78c9 = new Type[] {  };
 
         /// <inheritdoc />
         Task IRefitInterfaceWithStaticMethod.Get()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_ad5d0c7deacd4242ba81c90c81cac767);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_413bb83c7188415884261263233b78c9);
             return (Task)func(Client, arguments);
         }
     }
@@ -2565,47 +2565,47 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_3f32dbbb00e44199a6379367fc3bf24a = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_a142419faae346529a8503aea89b5c48 = new Type[] {  };
 
         /// <inheritdoc />
         Task IRequestBin.Post()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Post", ArgumentTypes_3f32dbbb00e44199a6379367fc3bf24a);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Post", ArgumentTypes_a142419faae346529a8503aea89b5c48);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_20bc364aa548409f9a25fae9b11fcd34 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_54f6c9677f0e4e89a6b46b49c0b2f3ed = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task IRequestBin.PostRawStringDefault(string str)
         {
             var arguments = new object[] { str };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostRawStringDefault", ArgumentTypes_20bc364aa548409f9a25fae9b11fcd34);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostRawStringDefault", ArgumentTypes_54f6c9677f0e4e89a6b46b49c0b2f3ed);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_780a63f341274e4f96d551245c1a5269 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_c768a4ba55b54e0c9902144a4208c45c = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task IRequestBin.PostRawStringJson(string str)
         {
             var arguments = new object[] { str };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostRawStringJson", ArgumentTypes_780a63f341274e4f96d551245c1a5269);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostRawStringJson", ArgumentTypes_c768a4ba55b54e0c9902144a4208c45c);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_7c5225ba686a4e7dbb598eb731f0d2ab = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_47fb901149f2425c92da59faacf61e98 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task IRequestBin.PostRawStringUrlEncoded(string str)
         {
             var arguments = new object[] { str };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostRawStringUrlEncoded", ArgumentTypes_7c5225ba686a4e7dbb598eb731f0d2ab);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostRawStringUrlEncoded", ArgumentTypes_47fb901149f2425c92da59faacf61e98);
             return (Task)func(Client, arguments);
         }
 
-        private static class TypeHelper_b6c4f825f7c941b8b7b1a53b257b6498<T>
+        private static class TypeHelper_14ab8c74d5a0446aaa287f3f51c0f759<T>
         {
             public static readonly Type[] ArgumentTypes = new Type[] { typeof(T) };
             public static readonly Type[] TypeParameters = new Type[] { typeof(T) };
@@ -2615,7 +2615,7 @@ namespace Refit.Tests
         Task IRequestBin.PostGeneric<T>(T param)
         {
             var arguments = new object[] { param };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostGeneric", TypeHelper_b6c4f825f7c941b8b7b1a53b257b6498<T>.ArgumentTypes, TypeHelper_b6c4f825f7c941b8b7b1a53b257b6498<T>.TypeParameters);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostGeneric", TypeHelper_14ab8c74d5a0446aaa287f3f51c0f759<T>.ArgumentTypes, TypeHelper_14ab8c74d5a0446aaa287f3f51c0f759<T>.TypeParameters);
             return (Task)func(Client, arguments);
         }
     }
@@ -2656,133 +2656,133 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_022e0c52d10e49b3af23a6fc56123085 = new Type[] { typeof(Stream) };
+        private static readonly Type[] ArgumentTypes_463e5d9d9237439eae0de3a30afa9094 = new Type[] { typeof(Stream) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadStream(Stream stream)
         {
             var arguments = new object[] { stream };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStream", ArgumentTypes_022e0c52d10e49b3af23a6fc56123085);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStream", ArgumentTypes_463e5d9d9237439eae0de3a30afa9094);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_debe5c4f6d274399927c00dc8acde720 = new Type[] { typeof(Stream) };
+        private static readonly Type[] ArgumentTypes_791a032115864dab902b30a187ecc947 = new Type[] { typeof(Stream) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadStreamWithCustomBoundary(Stream stream)
         {
             var arguments = new object[] { stream };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStreamWithCustomBoundary", ArgumentTypes_debe5c4f6d274399927c00dc8acde720);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStreamWithCustomBoundary", ArgumentTypes_791a032115864dab902b30a187ecc947);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_81b1d3f22adb4daa919bb9e7067a57ce = new Type[] { typeof(StreamPart) };
+        private static readonly Type[] ArgumentTypes_e04dce59a36c4020bfaa7c67c17b750d = new Type[] { typeof(StreamPart) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadStreamPart(StreamPart stream)
         {
             var arguments = new object[] { stream };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStreamPart", ArgumentTypes_81b1d3f22adb4daa919bb9e7067a57ce);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStreamPart", ArgumentTypes_e04dce59a36c4020bfaa7c67c17b750d);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_cd2d6e95caa540d8b0385c96a6b9a946 = new Type[] { typeof(ModelObject), typeof(StreamPart) };
+        private static readonly Type[] ArgumentTypes_3ff4078ea0d6447ab55cf5d49e19229b = new Type[] { typeof(ModelObject), typeof(StreamPart) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadStreamPart(ModelObject someQueryParams, StreamPart stream)
         {
             var arguments = new object[] { someQueryParams, stream };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStreamPart", ArgumentTypes_cd2d6e95caa540d8b0385c96a6b9a946);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStreamPart", ArgumentTypes_3ff4078ea0d6447ab55cf5d49e19229b);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_f93d628e070048b4a839c9453343b5e9 = new Type[] { typeof(byte[]) };
+        private static readonly Type[] ArgumentTypes_370b19a5646a4d429f5d5374d39d5b37 = new Type[] { typeof(byte[]) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadBytes(byte[] bytes)
         {
             var arguments = new object[] { bytes };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadBytes", ArgumentTypes_f93d628e070048b4a839c9453343b5e9);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadBytes", ArgumentTypes_370b19a5646a4d429f5d5374d39d5b37);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_ba32fe9faf3c4535a9fd4fbd3ed85324 = new Type[] { typeof(ByteArrayPart) };
+        private static readonly Type[] ArgumentTypes_b50e00450b584f12b9cbc15ee29378f8 = new Type[] { typeof(ByteArrayPart) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadBytesPart(ByteArrayPart bytes)
         {
             var arguments = new object[] { bytes };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadBytesPart", ArgumentTypes_ba32fe9faf3c4535a9fd4fbd3ed85324);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadBytesPart", ArgumentTypes_b50e00450b584f12b9cbc15ee29378f8);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_ce2900d9ef5b4451a2d39e805bc738ab = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_d099aad6d0ca47a8886cb6d8cf4e8a56 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadString(string someString)
         {
             var arguments = new object[] { someString };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadString", ArgumentTypes_ce2900d9ef5b4451a2d39e805bc738ab);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadString", ArgumentTypes_d099aad6d0ca47a8886cb6d8cf4e8a56);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_7e6c500f4c114966bb186f60cbd4ac67 = new Type[] { typeof(IEnumerable<FileInfo>), typeof(FileInfo) };
+        private static readonly Type[] ArgumentTypes_612d0683d7d440ab9f566c0246f69336 = new Type[] { typeof(IEnumerable<FileInfo>), typeof(FileInfo) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadFileInfo(IEnumerable<FileInfo> fileInfos, FileInfo anotherFile)
         {
             var arguments = new object[] { fileInfos, anotherFile };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadFileInfo", ArgumentTypes_7e6c500f4c114966bb186f60cbd4ac67);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadFileInfo", ArgumentTypes_612d0683d7d440ab9f566c0246f69336);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_ac6f09f630d249e7a8f8754543e31e12 = new Type[] { typeof(IEnumerable<FileInfoPart>), typeof(FileInfoPart) };
+        private static readonly Type[] ArgumentTypes_2f349b2d92ba4e7f8374b18c56b3c3cc = new Type[] { typeof(IEnumerable<FileInfoPart>), typeof(FileInfoPart) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadFileInfoPart(IEnumerable<FileInfoPart> fileInfos, FileInfoPart anotherFile)
         {
             var arguments = new object[] { fileInfos, anotherFile };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadFileInfoPart", ArgumentTypes_ac6f09f630d249e7a8f8754543e31e12);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadFileInfoPart", ArgumentTypes_2f349b2d92ba4e7f8374b18c56b3c3cc);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_c8cbb75b99b9467faae9259be8059afa = new Type[] { typeof(ModelObject) };
+        private static readonly Type[] ArgumentTypes_4854aa6091444934bafab59ade42e37e = new Type[] { typeof(ModelObject) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadJsonObject(ModelObject theObject)
         {
             var arguments = new object[] { theObject };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadJsonObject", ArgumentTypes_c8cbb75b99b9467faae9259be8059afa);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadJsonObject", ArgumentTypes_4854aa6091444934bafab59ade42e37e);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_63c296818dfb460f85120318d1e5384c = new Type[] { typeof(IEnumerable<ModelObject>) };
+        private static readonly Type[] ArgumentTypes_00b03a8d76864f668fefece863fc0933 = new Type[] { typeof(IEnumerable<ModelObject>) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadJsonObjects(IEnumerable<ModelObject> theObjects)
         {
             var arguments = new object[] { theObjects };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadJsonObjects", ArgumentTypes_63c296818dfb460f85120318d1e5384c);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadJsonObjects", ArgumentTypes_00b03a8d76864f668fefece863fc0933);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_7c66b0c3fa44406dbbd9d9b0777c24ad = new Type[] { typeof(IEnumerable<ModelObject>), typeof(AnotherModel), typeof(FileInfo), typeof(AnEnum), typeof(string), typeof(int) };
+        private static readonly Type[] ArgumentTypes_75e6d6bc87604ac694e406ce1b1963e7 = new Type[] { typeof(IEnumerable<ModelObject>), typeof(AnotherModel), typeof(FileInfo), typeof(AnEnum), typeof(string), typeof(int) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadMixedObjects(IEnumerable<ModelObject> theObjects, AnotherModel anotherModel, FileInfo aFile, AnEnum anEnum, string aString, int anInt)
         {
             var arguments = new object[] { theObjects, anotherModel, aFile, anEnum, aString, anInt };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadMixedObjects", ArgumentTypes_7c66b0c3fa44406dbbd9d9b0777c24ad);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadMixedObjects", ArgumentTypes_75e6d6bc87604ac694e406ce1b1963e7);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_af0cb5e4253d4d9fbabf78d8819f1757 = new Type[] { typeof(HttpContent) };
+        private static readonly Type[] ArgumentTypes_17b21280cb5f42939ebf667b952152ed = new Type[] { typeof(HttpContent) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadHttpContent(HttpContent content)
         {
             var arguments = new object[] { content };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadHttpContent", ArgumentTypes_af0cb5e4253d4d9fbabf78d8819f1757);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadHttpContent", ArgumentTypes_17b21280cb5f42939ebf667b952152ed);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
     }
@@ -2814,23 +2814,23 @@ namespace AutoGeneratedIServiceWithoutNamespace
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_a5b1c9617d3448d6a297222a1f322444 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_a1e4c30bad5c4446a2d5ec0d5b73a7af = new Type[] {  };
 
         /// <inheritdoc />
         Task IServiceWithoutNamespace.GetRoot()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetRoot", ArgumentTypes_a5b1c9617d3448d6a297222a1f322444);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetRoot", ArgumentTypes_a1e4c30bad5c4446a2d5ec0d5b73a7af);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_c67c289b273049f5a87a4b07c1ccb3b5 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_9446035b69814f5aa9c1078d4a7e00b7 = new Type[] {  };
 
         /// <inheritdoc />
         Task IServiceWithoutNamespace.PostRoot()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostRoot", ArgumentTypes_c67c289b273049f5a87a4b07c1ccb3b5);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostRoot", ArgumentTypes_9446035b69814f5aa9c1078d4a7e00b7);
             return (Task)func(Client, arguments);
         }
     }
@@ -2871,23 +2871,23 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_715c065eccca40ebae0c314aff747e56 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_f87f6d356e5044d9a855b20aad8a7b52 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<Stream> IStreamApi.GetRemoteFile(string filename)
         {
             var arguments = new object[] { filename };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetRemoteFile", ArgumentTypes_715c065eccca40ebae0c314aff747e56);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetRemoteFile", ArgumentTypes_f87f6d356e5044d9a855b20aad8a7b52);
             return (Task<Stream>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_7a4fedfcb81d407b8b281d63b73ca901 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_648ed6dd44b040279cacacbe8e0def4d = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<ApiResponse<Stream>> IStreamApi.GetRemoteFileWithMetadata(string filename)
         {
             var arguments = new object[] { filename };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetRemoteFileWithMetadata", ArgumentTypes_7a4fedfcb81d407b8b281d63b73ca901);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetRemoteFileWithMetadata", ArgumentTypes_648ed6dd44b040279cacacbe8e0def4d);
             return (Task<ApiResponse<Stream>>)func(Client, arguments);
         }
     }
@@ -2928,13 +2928,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_b116cf541e2541578b2e064960fa92ba = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_0cbf100ccabd46ce9bd959126f10e31f = new Type[] {  };
 
         /// <inheritdoc />
         Task ITrimTrailingForwardSlashApi.Get()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_b116cf541e2541578b2e064960fa92ba);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_0cbf100ccabd46ce9bd959126f10e31f);
             return (Task)func(Client, arguments);
         }
     }
@@ -2964,13 +2964,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_e37a999a807c438eb98af353cd60ea3d = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_66dfb9313ce846e486c75b6f9e968ad6 = new Type[] {  };
 
         /// <inheritdoc />
         Task<SomeType> ITypeCollisionApiA.SomeARequest()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("SomeARequest", ArgumentTypes_e37a999a807c438eb98af353cd60ea3d);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("SomeARequest", ArgumentTypes_66dfb9313ce846e486c75b6f9e968ad6);
             return (Task<SomeType>)func(Client, arguments);
         }
     }
@@ -3000,13 +3000,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_8aa2159361be4a1189fd52e38f64a8f9 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_c4a880af605b449d8aa4b6e8fc59dd1f = new Type[] {  };
 
         /// <inheritdoc />
         Task<SomeType> ITypeCollisionApiB.SomeBRequest()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("SomeBRequest", ArgumentTypes_8aa2159361be4a1189fd52e38f64a8f9);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("SomeBRequest", ArgumentTypes_c4a880af605b449d8aa4b6e8fc59dd1f);
             return (Task<SomeType>)func(Client, arguments);
         }
     }
@@ -3045,47 +3045,47 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_1fc54f1d4f09409bac79946e82735947 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_85e801a243294fe4a44de3e2d6af36a4 = new Type[] {  };
 
         /// <inheritdoc />
         Task<string> IUseOverloadedGenericMethods<TResponse, TParam, THeader>.Get()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_1fc54f1d4f09409bac79946e82735947);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_85e801a243294fe4a44de3e2d6af36a4);
             return (Task<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_5d185f5fecb94fc383a8c03b79f4de49 = new Type[] { typeof(TParam), typeof(THeader) };
+        private static readonly Type[] ArgumentTypes_0d3da059a6ce4701ae226079a7fa9075 = new Type[] { typeof(TParam), typeof(THeader) };
 
         /// <inheritdoc />
         Task<TResponse> IUseOverloadedGenericMethods<TResponse, TParam, THeader>.Get(TParam param, THeader header)
         {
             var arguments = new object[] { param, header };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_5d185f5fecb94fc383a8c03b79f4de49);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_0d3da059a6ce4701ae226079a7fa9075);
             return (Task<TResponse>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_85eb479c09d44a928ecc44e88c098f8b = new Type[] { typeof(THeader), typeof(TParam) };
+        private static readonly Type[] ArgumentTypes_9a93db3bdc9046f9acbb4567bc58a313 = new Type[] { typeof(THeader), typeof(TParam) };
 
         /// <inheritdoc />
         Task<TResponse> IUseOverloadedGenericMethods<TResponse, TParam, THeader>.Get(THeader param, TParam header)
         {
             var arguments = new object[] { param, header };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_85eb479c09d44a928ecc44e88c098f8b);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_9a93db3bdc9046f9acbb4567bc58a313);
             return (Task<TResponse>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_c59f4caa124b4685b41113d3a2837299 = new Type[] { typeof(int) };
+        private static readonly Type[] ArgumentTypes_173b4eb5000643e0bf6a11a5c593895e = new Type[] { typeof(int) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IUseOverloadedGenericMethods<TResponse, TParam, THeader>.Get(int httpstatuscode)
         {
             var arguments = new object[] { httpstatuscode };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_c59f4caa124b4685b41113d3a2837299);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_173b4eb5000643e0bf6a11a5c593895e);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static class TypeHelper_0e9925d4bbf94c6c80e4667d829268f4<TValue>
+        private static class TypeHelper_39fd96fe461e48469cf855a0e9f0e058<TValue>
         {
             public static readonly Type[] ArgumentTypes = new Type[] { typeof(int) };
             public static readonly Type[] TypeParameters = new Type[] { typeof(TValue) };
@@ -3095,11 +3095,11 @@ namespace Refit.Tests
         Task<TValue> IUseOverloadedGenericMethods<TResponse, TParam, THeader>.Get<TValue>(int someVal)
         {
             var arguments = new object[] { someVal };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", TypeHelper_0e9925d4bbf94c6c80e4667d829268f4<TValue>.ArgumentTypes, TypeHelper_0e9925d4bbf94c6c80e4667d829268f4<TValue>.TypeParameters);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", TypeHelper_39fd96fe461e48469cf855a0e9f0e058<TValue>.ArgumentTypes, TypeHelper_39fd96fe461e48469cf855a0e9f0e058<TValue>.TypeParameters);
             return (Task<TValue>)func(Client, arguments);
         }
 
-        private static class TypeHelper_ef1437730af24bbf932827a41806c3bf<TValue, TInput>
+        private static class TypeHelper_13aa52549d7148979975c7e209ba87dc<TValue, TInput>
         {
             public static readonly Type[] ArgumentTypes = new Type[] { typeof(TInput) };
             public static readonly Type[] TypeParameters = new Type[] { typeof(TValue), typeof(TInput) };
@@ -3109,11 +3109,11 @@ namespace Refit.Tests
         Task<TValue> IUseOverloadedGenericMethods<TResponse, TParam, THeader>.Get<TValue, TInput>(TInput input)
         {
             var arguments = new object[] { input };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", TypeHelper_ef1437730af24bbf932827a41806c3bf<TValue, TInput>.ArgumentTypes, TypeHelper_ef1437730af24bbf932827a41806c3bf<TValue, TInput>.TypeParameters);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", TypeHelper_13aa52549d7148979975c7e209ba87dc<TValue, TInput>.ArgumentTypes, TypeHelper_13aa52549d7148979975c7e209ba87dc<TValue, TInput>.TypeParameters);
             return (Task<TValue>)func(Client, arguments);
         }
 
-        private static class TypeHelper_4a35c21d0bd34370ac49759c69b91cb6<TInput1, TInput2>
+        private static class TypeHelper_cd798b05db18477194646864f2c289fc<TInput1, TInput2>
         {
             public static readonly Type[] ArgumentTypes = new Type[] { typeof(TInput1), typeof(TInput2) };
             public static readonly Type[] TypeParameters = new Type[] { typeof(TInput1), typeof(TInput2) };
@@ -3123,7 +3123,7 @@ namespace Refit.Tests
         Task IUseOverloadedGenericMethods<TResponse, TParam, THeader>.Get<TInput1, TInput2>(TInput1 input1, TInput2 input2)
         {
             var arguments = new object[] { input1, input2 };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", TypeHelper_4a35c21d0bd34370ac49759c69b91cb6<TInput1, TInput2>.ArgumentTypes, TypeHelper_4a35c21d0bd34370ac49759c69b91cb6<TInput1, TInput2>.TypeParameters);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", TypeHelper_cd798b05db18477194646864f2c289fc<TInput1, TInput2>.ArgumentTypes, TypeHelper_cd798b05db18477194646864f2c289fc<TInput1, TInput2>.TypeParameters);
             return (Task)func(Client, arguments);
         }
     }
@@ -3158,23 +3158,23 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_098f13f83f014549a9f28abc4ea987bd = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_4d1a154ad99d4c66b6f56267eb3d660f = new Type[] {  };
 
         /// <inheritdoc />
         Task<string> IUseOverloadedMethods.Get()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_098f13f83f014549a9f28abc4ea987bd);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_4d1a154ad99d4c66b6f56267eb3d660f);
             return (Task<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_e17c788bddcc4478a61433ce8714057a = new Type[] { typeof(int) };
+        private static readonly Type[] ArgumentTypes_72c33f5a572a4b40b657da4de1b55c0e = new Type[] { typeof(int) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IUseOverloadedMethods.Get(int httpstatuscode)
         {
             var arguments = new object[] { httpstatuscode };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_e17c788bddcc4478a61433ce8714057a);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_72c33f5a572a4b40b657da4de1b55c0e);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
     }
@@ -3215,13 +3215,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_f7bae16e5c2841e2b3a695e2944e84fb = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_89418546f2a449358a8b103f3662275c = new Type[] {  };
 
         /// <inheritdoc />
         Task IValidApi.Get()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_f7bae16e5c2841e2b3a695e2944e84fb);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_89418546f2a449358a8b103f3662275c);
             return (Task)func(Client, arguments);
         }
     }
@@ -3251,13 +3251,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_fe61066f6f7c4a9291502841634b933e = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_008bd358370e4cbf8738261813bf2487 = new Type[] {  };
 
         /// <inheritdoc />
         Task<SomeType> NamespaceWithGlobalAliasApi.SomeRequest()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", ArgumentTypes_fe61066f6f7c4a9291502841634b933e);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", ArgumentTypes_008bd358370e4cbf8738261813bf2487);
             return (Task<SomeType>)func(Client, arguments);
         }
     }

--- a/Refit.Tests/RefitStubs.Net46.cs
+++ b/Refit.Tests/RefitStubs.Net46.cs
@@ -62,27 +62,27 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_d70d5717ca7f491084866f0055d1ae05 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_a48bc2b6f2be46ab971cb42e5cdcb30b = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IAmARefitInterfaceButNobodyUsesMe.RefitMethod()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("RefitMethod", ArgumentTypes_d70d5717ca7f491084866f0055d1ae05);
+            var func = requestBuilder.BuildRestResultFuncForMethod("RefitMethod", ArgumentTypes_a48bc2b6f2be46ab971cb42e5cdcb30b);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_14e16e76d1ec4135bde47566894297fc = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_af508c51c82b497c97e0c3d11206cd3d = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IAmARefitInterfaceButNobodyUsesMe.AnotherRefitMethod()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("AnotherRefitMethod", ArgumentTypes_14e16e76d1ec4135bde47566894297fc);
+            var func = requestBuilder.BuildRestResultFuncForMethod("AnotherRefitMethod", ArgumentTypes_af508c51c82b497c97e0c3d11206cd3d);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_fec539aaa04748f8ad6f040c99e0925b = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_ecc1c19be1fb4e5fab2677517343e6be = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IAmARefitInterfaceButNobodyUsesMe.NoConstantsAllowed()
@@ -90,23 +90,23 @@ namespace Refit.Tests
             throw new NotImplementedException("Either this method has no Refit HTTP method attribute or you've used something other than a string literal for the 'path' argument.");
         }
 
-        private static readonly Type[] ArgumentTypes_75d07de2fc0c4c6b9df9a74720216cee = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_d1e3a2494f414806aa55790955510242 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IAmARefitInterfaceButNobodyUsesMe.SpacesShouldntBreakMe()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("SpacesShouldntBreakMe", ArgumentTypes_75d07de2fc0c4c6b9df9a74720216cee);
+            var func = requestBuilder.BuildRestResultFuncForMethod("SpacesShouldntBreakMe", ArgumentTypes_d1e3a2494f414806aa55790955510242);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_4ac7f9e0b1734bc2ba48cacfb9e99026 = new Type[] { typeof(int), typeof(string), typeof(float) };
+        private static readonly Type[] ArgumentTypes_ff452461fe6b475e8d9679a3c43cbd05 = new Type[] { typeof(int), typeof(string), typeof(float) };
 
         /// <inheritdoc />
         Task IAmARefitInterfaceButNobodyUsesMe.ReservedWordsForParameterNames(int @int, string @string, float @long)
         {
             var arguments = new object[] { @int, @string, @long };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReservedWordsForParameterNames", ArgumentTypes_4ac7f9e0b1734bc2ba48cacfb9e99026);
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReservedWordsForParameterNames", ArgumentTypes_ff452461fe6b475e8d9679a3c43cbd05);
             return (Task)func(Client, arguments);
         }
     }
@@ -147,17 +147,17 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_6b3a345864c24115ad1863c5ffe10ef5 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_253a8552186f499ebd4944d3b293ce4a = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IAmHalfRefit.Post()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Post", ArgumentTypes_6b3a345864c24115ad1863c5ffe10ef5);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Post", ArgumentTypes_253a8552186f499ebd4944d3b293ce4a);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_6ad8f76cc7c247ec925aba587a3da56b = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_15ad005be3e4429c94ece17334e35954 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IAmHalfRefit.Get()
@@ -191,43 +191,43 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_3c2902981a404e9fb84b9b419a875763 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_26b79b10676a4718a1d22d6b4265f341 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> IAmInterface.Pang()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Pang", ArgumentTypes_3c2902981a404e9fb84b9b419a875763);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Pang", ArgumentTypes_26b79b10676a4718a1d22d6b4265f341);
             return (Task<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_2d10f515f5c449c890cadfe3fada62ed = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_ea7fd87b0904493bb73a5f26cadbe9ff = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> IAmInterfaceB.Pong()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Pong", ArgumentTypes_2d10f515f5c449c890cadfe3fada62ed);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Pong", ArgumentTypes_ea7fd87b0904493bb73a5f26cadbe9ff);
             return (Task<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_9ae05949b1cf4bc18185d7f60f21bd9f = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_6b8219c660d74f8a8a51932dfcc6d178 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> IAmInterfaceD.Test()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Test", ArgumentTypes_9ae05949b1cf4bc18185d7f60f21bd9f);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Test", ArgumentTypes_6b8219c660d74f8a8a51932dfcc6d178);
             return (Task<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_8962537dcdf440e1a023b808372319ed = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_6743d27257914fb381c1c8aa9b709ccc = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> IAmInterfaceA.Ping()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Ping", ArgumentTypes_8962537dcdf440e1a023b808372319ed);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Ping", ArgumentTypes_6743d27257914fb381c1c8aa9b709ccc);
             return (Task<string>)func(Client, arguments);
         }
     }
@@ -257,13 +257,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_97d622e8ed674977887245e577d232f6 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_731032c67ebd41e4a855b0306eada0cf = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> IAmInterfaceA.Ping()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Ping", ArgumentTypes_97d622e8ed674977887245e577d232f6);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Ping", ArgumentTypes_731032c67ebd41e4a855b0306eada0cf);
             return (Task<string>)func(Client, arguments);
         }
     }
@@ -293,23 +293,23 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_8a61dfae003640cbb8c5d935e997d7cf = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_27ecbf31ccc1487ead2be33be23b820f = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> IAmInterfaceB.Pong()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Pong", ArgumentTypes_8a61dfae003640cbb8c5d935e997d7cf);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Pong", ArgumentTypes_27ecbf31ccc1487ead2be33be23b820f);
             return (Task<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_e52ba749cf3b477b94cf43d601ef98f4 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_6a559b86d4d6469d953625b166a1c43b = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> IAmInterfaceD.Test()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Test", ArgumentTypes_e52ba749cf3b477b94cf43d601ef98f4);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Test", ArgumentTypes_6a559b86d4d6469d953625b166a1c43b);
             return (Task<string>)func(Client, arguments);
         }
     }
@@ -339,43 +339,43 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_f0aca168db8843dea83596bb286d5b59 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_372d2c0b672e4952b8073dd144cddccc = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> IAmInterfaceC.Pang()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Pang", ArgumentTypes_f0aca168db8843dea83596bb286d5b59);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Pang", ArgumentTypes_372d2c0b672e4952b8073dd144cddccc);
             return (Task<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_6ca67266e13940c39cf8c3367928cd90 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_88957aae34f6406288cc3a707794b4af = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> IAmInterfaceB.Pong()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Pong", ArgumentTypes_6ca67266e13940c39cf8c3367928cd90);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Pong", ArgumentTypes_88957aae34f6406288cc3a707794b4af);
             return (Task<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_0cc0d52d180a4553b68240d487ba6d5a = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_c6f018a7630e41eead454301e161e7a3 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> IAmInterfaceD.Test()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Test", ArgumentTypes_0cc0d52d180a4553b68240d487ba6d5a);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Test", ArgumentTypes_c6f018a7630e41eead454301e161e7a3);
             return (Task<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_6438d1c4880e4d8f948b7b9876bd2593 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_0d0382f9d6e749ec988e7e6e10d61e64 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> IAmInterfaceA.Ping()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Ping", ArgumentTypes_6438d1c4880e4d8f948b7b9876bd2593);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Ping", ArgumentTypes_0d0382f9d6e749ec988e7e6e10d61e64);
             return (Task<string>)func(Client, arguments);
         }
     }
@@ -405,13 +405,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_ea2364743e114dc4849b0a0a46969bb2 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_b9d9dcb9a51c4391bffd33b81e02d82c = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> IAmInterfaceD.Test()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Test", ArgumentTypes_ea2364743e114dc4849b0a0a46969bb2);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Test", ArgumentTypes_b9d9dcb9a51c4391bffd33b81e02d82c);
             return (Task<string>)func(Client, arguments);
         }
     }
@@ -452,153 +452,153 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_40b9749177e54c0ca632d5f5fcc7cd36 = new Type[] { typeof(PathBoundObject) };
+        private static readonly Type[] ArgumentTypes_2f182ae8f9a3496c960012d4d4ee6ba2 = new Type[] { typeof(PathBoundObject) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetFooBars(PathBoundObject request)
         {
             var arguments = new object[] { request };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBars", ArgumentTypes_40b9749177e54c0ca632d5f5fcc7cd36);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBars", ArgumentTypes_2f182ae8f9a3496c960012d4d4ee6ba2);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_909623674b64460cabc4d71d124b1917 = new Type[] { typeof(PathBoundObject) };
+        private static readonly Type[] ArgumentTypes_70f28ea9f4bb47958bd85e3c13de91e4 = new Type[] { typeof(PathBoundObject) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetFooBarsWithDifferentCasing(PathBoundObject requestParams)
         {
             var arguments = new object[] { requestParams };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBarsWithDifferentCasing", ArgumentTypes_909623674b64460cabc4d71d124b1917);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBarsWithDifferentCasing", ArgumentTypes_70f28ea9f4bb47958bd85e3c13de91e4);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_1c9d839aa9cc4ced8b9f1d9c8d2a488c = new Type[] { typeof(string), typeof(PathBoundObject) };
+        private static readonly Type[] ArgumentTypes_376b4d7cbe2a4a8f9e2f66121c2e349e = new Type[] { typeof(string), typeof(PathBoundObject) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetBarsByFoo(string id, PathBoundObject request)
         {
             var arguments = new object[] { id, request };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetBarsByFoo", ArgumentTypes_1c9d839aa9cc4ced8b9f1d9c8d2a488c);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetBarsByFoo", ArgumentTypes_376b4d7cbe2a4a8f9e2f66121c2e349e);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_21a88c1ee87f4756acc25db43141a274 = new Type[] { typeof(PathBoundObject), typeof(string) };
+        private static readonly Type[] ArgumentTypes_5e4cbced83af4fcea89dfdb1e4e6f255 = new Type[] { typeof(PathBoundObject), typeof(string) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetFooBars(PathBoundObject request, string someProperty)
         {
             var arguments = new object[] { request, someProperty };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBars", ArgumentTypes_21a88c1ee87f4756acc25db43141a274);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBars", ArgumentTypes_5e4cbced83af4fcea89dfdb1e4e6f255);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_834eb53501374f54856a8a5cd82f088c = new Type[] { typeof(PathBoundObject) };
+        private static readonly Type[] ArgumentTypes_f1edf614fee1483b8de881052edd50e9 = new Type[] { typeof(PathBoundObject) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetBarsByFoo(PathBoundObject request)
         {
             var arguments = new object[] { request };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetBarsByFoo", ArgumentTypes_834eb53501374f54856a8a5cd82f088c);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetBarsByFoo", ArgumentTypes_f1edf614fee1483b8de881052edd50e9);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_bda177547c334271b27b99bccbbc626c = new Type[] { typeof(PathBoundObjectWithQueryFormat) };
+        private static readonly Type[] ArgumentTypes_d56f182b10754740b3a2575394a67742 = new Type[] { typeof(PathBoundObjectWithQueryFormat) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetBarsWithCustomQueryFormat(PathBoundObjectWithQueryFormat request)
         {
             var arguments = new object[] { request };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetBarsWithCustomQueryFormat", ArgumentTypes_bda177547c334271b27b99bccbbc626c);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetBarsWithCustomQueryFormat", ArgumentTypes_d56f182b10754740b3a2575394a67742);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_686b3298c60b4b32a514c67b3c89f41f = new Type[] { typeof(PathBoundDerivedObject) };
+        private static readonly Type[] ArgumentTypes_a769470349f1438092c892b6b0db2c6a = new Type[] { typeof(PathBoundDerivedObject) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetFooBarsDerived(PathBoundDerivedObject request)
         {
             var arguments = new object[] { request };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBarsDerived", ArgumentTypes_686b3298c60b4b32a514c67b3c89f41f);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBarsDerived", ArgumentTypes_a769470349f1438092c892b6b0db2c6a);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_18e05c04f0044c9ca552e0bd595037ea = new Type[] { typeof(PathBoundList) };
+        private static readonly Type[] ArgumentTypes_aff1c21c921a4b798582c7145c33de42 = new Type[] { typeof(PathBoundList) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetFoos(PathBoundList request)
         {
             var arguments = new object[] { request };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetFoos", ArgumentTypes_18e05c04f0044c9ca552e0bd595037ea);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetFoos", ArgumentTypes_aff1c21c921a4b798582c7145c33de42);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_afa2312acb694a648ae29e7480154a84 = new Type[] { typeof(List<int>) };
+        private static readonly Type[] ArgumentTypes_29f3c556ba6d48d3b7bc674e275e58f2 = new Type[] { typeof(List<int>) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetFoos2(List<int> Values)
         {
             var arguments = new object[] { Values };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetFoos2", ArgumentTypes_afa2312acb694a648ae29e7480154a84);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetFoos2", ArgumentTypes_29f3c556ba6d48d3b7bc674e275e58f2);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_c0799d78fdd04f1e9a0a3f60b0aae9a0 = new Type[] { typeof(PathBoundObject), typeof(object) };
+        private static readonly Type[] ArgumentTypes_5448f950e324489d91466cae0c4b76ea = new Type[] { typeof(PathBoundObject), typeof(object) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.PostFooBar(PathBoundObject request, object someObject)
         {
             var arguments = new object[] { request, someObject };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBar", ArgumentTypes_c0799d78fdd04f1e9a0a3f60b0aae9a0);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBar", ArgumentTypes_5448f950e324489d91466cae0c4b76ea);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_d730cc53c68b4f89a53b2e4325a97921 = new Type[] { typeof(PathBoundObjectWithQuery) };
+        private static readonly Type[] ArgumentTypes_5b5c5ef67a424e0b9d37dd1f314cc2c0 = new Type[] { typeof(PathBoundObjectWithQuery) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetFooBars(PathBoundObjectWithQuery request)
         {
             var arguments = new object[] { request };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBars", ArgumentTypes_d730cc53c68b4f89a53b2e4325a97921);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBars", ArgumentTypes_5b5c5ef67a424e0b9d37dd1f314cc2c0);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_03468b8d0d184ea1aa383316127ff658 = new Type[] { typeof(PathBoundObject), typeof(ModelObject) };
+        private static readonly Type[] ArgumentTypes_a06b1cefaa4c4fda9f0c3158a974e20d = new Type[] { typeof(PathBoundObject), typeof(ModelObject) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IApiBindPathToObject.PostFooBar(PathBoundObject request, ModelObject someQueryParams)
         {
             var arguments = new object[] { request, someQueryParams };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBar", ArgumentTypes_03468b8d0d184ea1aa383316127ff658);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBar", ArgumentTypes_a06b1cefaa4c4fda9f0c3158a974e20d);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_bcef5b8232844bb3a07df08fc4633cca = new Type[] { typeof(PathBoundObject), typeof(ModelObject), typeof(StreamPart) };
+        private static readonly Type[] ArgumentTypes_b8fa2614d06e4ff2aeb882159ecad81c = new Type[] { typeof(PathBoundObject), typeof(ModelObject), typeof(StreamPart) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IApiBindPathToObject.PostFooBarStreamPart(PathBoundObject request, ModelObject someQueryParams, StreamPart stream)
         {
             var arguments = new object[] { request, someQueryParams, stream };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBarStreamPart", ArgumentTypes_bcef5b8232844bb3a07df08fc4633cca);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBarStreamPart", ArgumentTypes_b8fa2614d06e4ff2aeb882159ecad81c);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_cdf849fbe137417492c837f1ad346f58 = new Type[] { typeof(PathBoundObject), typeof(StreamPart) };
+        private static readonly Type[] ArgumentTypes_365ef833dac44adfa151c34c5b779f4d = new Type[] { typeof(PathBoundObject), typeof(StreamPart) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IApiBindPathToObject.PostFooBarStreamPart(PathBoundObject request, StreamPart stream)
         {
             var arguments = new object[] { request, stream };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBarStreamPart", ArgumentTypes_cdf849fbe137417492c837f1ad346f58);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBarStreamPart", ArgumentTypes_365ef833dac44adfa151c34c5b779f4d);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_aeb0adb693a74a30bdec9a3559a97939 = new Type[] { typeof(PathBoundObjectWithQuery), typeof(StreamPart) };
+        private static readonly Type[] ArgumentTypes_14036959e3994adda130822fe08de2c8 = new Type[] { typeof(PathBoundObjectWithQuery), typeof(StreamPart) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IApiBindPathToObject.PostFooBarStreamPart(PathBoundObjectWithQuery request, StreamPart stream)
         {
             var arguments = new object[] { request, stream };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBarStreamPart", ArgumentTypes_aeb0adb693a74a30bdec9a3559a97939);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBarStreamPart", ArgumentTypes_14036959e3994adda130822fe08de2c8);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
     }
@@ -639,13 +639,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_14d7c1a44744458290dece9c4356b470 = new Type[] { typeof(decimal) };
+        private static readonly Type[] ArgumentTypes_f2401111d63c4016af79e87a5168bb77 = new Type[] { typeof(decimal) };
 
         /// <inheritdoc />
         Task<string> IApiWithDecimal.GetWithDecimal(decimal value)
         {
             var arguments = new object[] { value };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetWithDecimal", ArgumentTypes_14d7c1a44744458290dece9c4356b470);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetWithDecimal", ArgumentTypes_f2401111d63c4016af79e87a5168bb77);
             return (Task<string>)func(Client, arguments);
         }
     }
@@ -686,33 +686,33 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_d1614c5cdc6946b49ee12304384c8369 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_d82e4c1202674bfb9e81331999c1ba1d = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IBodylessApi.Post()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Post", ArgumentTypes_d1614c5cdc6946b49ee12304384c8369);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Post", ArgumentTypes_d82e4c1202674bfb9e81331999c1ba1d);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_9a16209422b74bf9bfec555d74312d3c = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_fd8089bbab69431e9d28b70d38a9af6b = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IBodylessApi.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_9a16209422b74bf9bfec555d74312d3c);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_fd8089bbab69431e9d28b70d38a9af6b);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_600682252fad4faba161f2c01d3bb467 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_e1f8a071b55040d2bb87a60ee74f6ce6 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IBodylessApi.Head()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Head", ArgumentTypes_600682252fad4faba161f2c01d3bb467);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Head", ArgumentTypes_e1f8a071b55040d2bb87a60ee74f6ce6);
             return (Task)func(Client, arguments);
         }
     }
@@ -753,53 +753,53 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_a794bd5c7a844df5bce6f832e70ebcfa = new Type[] { typeof(T) };
+        private static readonly Type[] ArgumentTypes_0dbe008f1eef47fe91608889a8e1cbbd = new Type[] { typeof(T) };
 
         /// <inheritdoc />
         Task<T> IBoringCrudApi<T, TKey>.Create(T paylod)
         {
             var arguments = new object[] { paylod };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_a794bd5c7a844df5bce6f832e70ebcfa);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_0dbe008f1eef47fe91608889a8e1cbbd);
             return (Task<T>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_42a2a32cc04845d79f5b5960a4c3b049 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_e5bfb3a3cd7a42a08ea9eeabfacbf41c = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<List<T>> IBoringCrudApi<T, TKey>.ReadAll()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_42a2a32cc04845d79f5b5960a4c3b049);
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_e5bfb3a3cd7a42a08ea9eeabfacbf41c);
             return (Task<List<T>>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_dee8f8a2a9ea4c1bb513b3abee930fce = new Type[] { typeof(TKey) };
+        private static readonly Type[] ArgumentTypes_7e07c8d0fedf40c2ba3f9391f9d72281 = new Type[] { typeof(TKey) };
 
         /// <inheritdoc />
         Task<T> IBoringCrudApi<T, TKey>.ReadOne(TKey key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_dee8f8a2a9ea4c1bb513b3abee930fce);
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_7e07c8d0fedf40c2ba3f9391f9d72281);
             return (Task<T>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_601e33907d1a462dad924302c657a454 = new Type[] { typeof(TKey), typeof(T) };
+        private static readonly Type[] ArgumentTypes_69fd881ce4664fe6bf9e7f93db6a7010 = new Type[] { typeof(TKey), typeof(T) };
 
         /// <inheritdoc />
         Task IBoringCrudApi<T, TKey>.Update(TKey key, T payload)
         {
             var arguments = new object[] { key, payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_601e33907d1a462dad924302c657a454);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_69fd881ce4664fe6bf9e7f93db6a7010);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_3947ba2874ee4a34b8e4d133b703abf4 = new Type[] { typeof(TKey) };
+        private static readonly Type[] ArgumentTypes_8de5ef10fe0b442a8827a0ffc36b4ea0 = new Type[] { typeof(TKey) };
 
         /// <inheritdoc />
         Task IBoringCrudApi<T, TKey>.Delete(TKey key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_3947ba2874ee4a34b8e4d133b703abf4);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_8de5ef10fe0b442a8827a0ffc36b4ea0);
             return (Task)func(Client, arguments);
         }
     }
@@ -840,13 +840,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_b331bc563de94fe3bacbdbdb9db1058c = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_806b36fbd50d42e49c52cba474d5cdd9 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<bool> IBrokenWebApi.PostAValue(string derp)
         {
             var arguments = new object[] { derp };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostAValue", ArgumentTypes_b331bc563de94fe3bacbdbdb9db1058c);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostAValue", ArgumentTypes_806b36fbd50d42e49c52cba474d5cdd9);
             return (Task<bool>)func(Client, arguments);
         }
     }
@@ -875,13 +875,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_edb953a4a96e42359e51163446a43c47 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_ba89a9ca7434410aad38ab87e5615c8a = Array.Empty<Type>();
 
         /// <inheritdoc />
         CustomReferenceType? ICustomNullableReferenceService.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_edb953a4a96e42359e51163446a43c47);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_ba89a9ca7434410aad38ab87e5615c8a);
             return (CustomReferenceType?)func(Client, arguments);
         }
     }
@@ -910,13 +910,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_7519a4f4881842c18ce684c005c7b7b0 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_bed68500aa4a41469c7f2f83df276a30 = Array.Empty<Type>();
 
         /// <inheritdoc />
         CustomValueType? ICustomNullableValueService.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_7519a4f4881842c18ce684c005c7b7b0);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_bed68500aa4a41469c7f2f83df276a30);
             return (CustomValueType?)func(Client, arguments);
         }
     }
@@ -945,13 +945,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_34f29288310148aba15121acdf1b5173 = new Type[] { ToNullable(typeof(CustomReferenceType)), ToNullable(typeof(CustomValueType)) };
+        private static readonly Type[] ArgumentTypes_4b4ec04556314aeaa6ead2d624ba9ecb = new Type[] { ToNullable(typeof(CustomReferenceType)), ToNullable(typeof(CustomValueType)) };
 
         /// <inheritdoc />
         Task ICustomReferenceAndValueParametersService.Get(CustomReferenceType? reference, CustomValueType? value)
         {
             var arguments = new object[] { reference, value };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_34f29288310148aba15121acdf1b5173);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_4b4ec04556314aeaa6ead2d624ba9ecb);
             return (Task)func(Client, arguments);
         }
 
@@ -984,73 +984,73 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_2dcff6edc69d4c7ea45e08330fb9e7d1 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_93306ecc2dc64b2c9751dc3c227022d4 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IDataApiA.PingA()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("PingA", ArgumentTypes_2dcff6edc69d4c7ea45e08330fb9e7d1);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PingA", ArgumentTypes_93306ecc2dc64b2c9751dc3c227022d4);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_6a3c63f333cd471882abcba6a3402b7c = new Type[] { typeof(DataEntity) };
+        private static readonly Type[] ArgumentTypes_b8056e174c1a463f8aec91e08d30700b = new Type[] { typeof(DataEntity) };
 
         /// <inheritdoc />
         Task<DataEntity> IDataCrudApi<DataEntity>.Copy(DataEntity payload)
         {
             var arguments = new object[] { payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Copy", ArgumentTypes_6a3c63f333cd471882abcba6a3402b7c);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Copy", ArgumentTypes_b8056e174c1a463f8aec91e08d30700b);
             return (Task<DataEntity>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_ddae7a9cd4f04f17ab27bee5bcdc552d = new Type[] { typeof(DataEntity) };
+        private static readonly Type[] ArgumentTypes_e229e168b3d54e0f9d88812ae6b428f6 = new Type[] { typeof(DataEntity) };
 
         /// <inheritdoc />
         Task<DataEntity> IDataCrudApi<DataEntity, long>.Create(DataEntity payload)
         {
             var arguments = new object[] { payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_ddae7a9cd4f04f17ab27bee5bcdc552d);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_e229e168b3d54e0f9d88812ae6b428f6);
             return (Task<DataEntity>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_99d36f321f75420cb9121410e198b66f = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_f6f30f0cdd4842478bff919ac007ce01 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<List<DataEntity>> IDataCrudApi<DataEntity, long>.ReadAll()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_99d36f321f75420cb9121410e198b66f);
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_f6f30f0cdd4842478bff919ac007ce01);
             return (Task<List<DataEntity>>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_08ee977a5ef642e2ad2f9328378681aa = new Type[] { typeof(long) };
+        private static readonly Type[] ArgumentTypes_08d9d80a0f03466c9dd3e8c35531581e = new Type[] { typeof(long) };
 
         /// <inheritdoc />
         Task<DataEntity> IDataCrudApi<DataEntity, long>.ReadOne(long key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_08ee977a5ef642e2ad2f9328378681aa);
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_08d9d80a0f03466c9dd3e8c35531581e);
             return (Task<DataEntity>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_e4b4a1f7311a49ea9e4d63df93e47a87 = new Type[] { typeof(long), typeof(DataEntity) };
+        private static readonly Type[] ArgumentTypes_b2db3c73b5a94212b4b47b35229e1959 = new Type[] { typeof(long), typeof(DataEntity) };
 
         /// <inheritdoc />
         Task IDataCrudApi<DataEntity, long>.Update(long key, DataEntity payload)
         {
             var arguments = new object[] { key, payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_e4b4a1f7311a49ea9e4d63df93e47a87);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_b2db3c73b5a94212b4b47b35229e1959);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_e1119251405f45ee87f4ae5a7412685b = new Type[] { typeof(long) };
+        private static readonly Type[] ArgumentTypes_b39b4de3dfd247049fc457558882fe47 = new Type[] { typeof(long) };
 
         /// <inheritdoc />
         Task IDataCrudApi<DataEntity, long>.Delete(long key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_e1119251405f45ee87f4ae5a7412685b);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_b39b4de3dfd247049fc457558882fe47);
             return (Task)func(Client, arguments);
         }
     }
@@ -1081,63 +1081,63 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_8f543ba691734b9887c15102e656ee6f = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_846549be564c45e5beae993074d12e09 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IDataApiB.PingB()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("PingB", ArgumentTypes_8f543ba691734b9887c15102e656ee6f);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PingB", ArgumentTypes_846549be564c45e5beae993074d12e09);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_9ec6852eae804c9aa17a666c7f92d617 = new Type[] { typeof(DataEntity) };
+        private static readonly Type[] ArgumentTypes_9d0b0f1fe19442efb8b8763c8ba11ae8 = new Type[] { typeof(DataEntity) };
 
         /// <inheritdoc />
         Task<DataEntity> IDataCrudApi<DataEntity, int>.Create(DataEntity payload)
         {
             var arguments = new object[] { payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_9ec6852eae804c9aa17a666c7f92d617);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_9d0b0f1fe19442efb8b8763c8ba11ae8);
             return (Task<DataEntity>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_2cd52c5d39854f5b8cbd0f0e29a5a9df = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_7159f821444a47739a9bc138cbf42c6c = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<List<DataEntity>> IDataCrudApi<DataEntity, int>.ReadAll()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_2cd52c5d39854f5b8cbd0f0e29a5a9df);
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_7159f821444a47739a9bc138cbf42c6c);
             return (Task<List<DataEntity>>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_77491932d1f74254bd2c452bdf54b308 = new Type[] { typeof(int) };
+        private static readonly Type[] ArgumentTypes_b92ed93815aa452eb29b89a600a04dd4 = new Type[] { typeof(int) };
 
         /// <inheritdoc />
         Task<DataEntity> IDataCrudApi<DataEntity, int>.ReadOne(int key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_77491932d1f74254bd2c452bdf54b308);
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_b92ed93815aa452eb29b89a600a04dd4);
             return (Task<DataEntity>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_ccb882c881ce4333a86cbf4ec339766c = new Type[] { typeof(int), typeof(DataEntity) };
+        private static readonly Type[] ArgumentTypes_6c6a24e0970a4ee782934be15f900978 = new Type[] { typeof(int), typeof(DataEntity) };
 
         /// <inheritdoc />
         Task IDataCrudApi<DataEntity, int>.Update(int key, DataEntity payload)
         {
             var arguments = new object[] { key, payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_ccb882c881ce4333a86cbf4ec339766c);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_6c6a24e0970a4ee782934be15f900978);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_a8832482b50a4cb9a47814f55110dd1e = new Type[] { typeof(int) };
+        private static readonly Type[] ArgumentTypes_0b3b83da5a0d493eb911c9e668af0787 = new Type[] { typeof(int) };
 
         /// <inheritdoc />
         Task IDataCrudApi<DataEntity, int>.Delete(int key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_a8832482b50a4cb9a47814f55110dd1e);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_0b3b83da5a0d493eb911c9e668af0787);
             return (Task)func(Client, arguments);
         }
     }
@@ -1171,63 +1171,63 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_4e760ce3568247d89d31a7552d1f8473 = new Type[] { typeof(T) };
+        private static readonly Type[] ArgumentTypes_da6a19bb599748748b4872ba4496436d = new Type[] { typeof(T) };
 
         /// <inheritdoc />
         Task<T> IDataCrudApi<T>.Copy(T payload)
         {
             var arguments = new object[] { payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Copy", ArgumentTypes_4e760ce3568247d89d31a7552d1f8473);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Copy", ArgumentTypes_da6a19bb599748748b4872ba4496436d);
             return (Task<T>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_14d88e8d5099420eab319d933908becb = new Type[] { typeof(T) };
+        private static readonly Type[] ArgumentTypes_8d155d02a1b04e16b49052b75dffa65f = new Type[] { typeof(T) };
 
         /// <inheritdoc />
         Task<T> IDataCrudApi<T, long>.Create(T payload)
         {
             var arguments = new object[] { payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_14d88e8d5099420eab319d933908becb);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_8d155d02a1b04e16b49052b75dffa65f);
             return (Task<T>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_0a1faaa18ee04e55a9cbe42ef7534683 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_191b7aa802ac471490cfe925747a53dc = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<List<T>> IDataCrudApi<T, long>.ReadAll()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_0a1faaa18ee04e55a9cbe42ef7534683);
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_191b7aa802ac471490cfe925747a53dc);
             return (Task<List<T>>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_b4834c016efe41839c3955f11a3e3f55 = new Type[] { typeof(long) };
+        private static readonly Type[] ArgumentTypes_d708c41165e443169b73224d9ee83f28 = new Type[] { typeof(long) };
 
         /// <inheritdoc />
         Task<T> IDataCrudApi<T, long>.ReadOne(long key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_b4834c016efe41839c3955f11a3e3f55);
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_d708c41165e443169b73224d9ee83f28);
             return (Task<T>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_40dfe37c2de54103834c33c35d82d5c8 = new Type[] { typeof(long), typeof(T) };
+        private static readonly Type[] ArgumentTypes_a861038879ad48d580d3f3cbabd82918 = new Type[] { typeof(long), typeof(T) };
 
         /// <inheritdoc />
         Task IDataCrudApi<T, long>.Update(long key, T payload)
         {
             var arguments = new object[] { key, payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_40dfe37c2de54103834c33c35d82d5c8);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_a861038879ad48d580d3f3cbabd82918);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_d5e1dbeaba424e66a36b7317ad326c76 = new Type[] { typeof(long) };
+        private static readonly Type[] ArgumentTypes_d1bdd89197ce4e5daf7459f10f333e29 = new Type[] { typeof(long) };
 
         /// <inheritdoc />
         Task IDataCrudApi<T, long>.Delete(long key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_d5e1dbeaba424e66a36b7317ad326c76);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_d1bdd89197ce4e5daf7459f10f333e29);
             return (Task)func(Client, arguments);
         }
     }
@@ -1261,53 +1261,53 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_c4ba9c82081a4927be1491097050e339 = new Type[] { typeof(T) };
+        private static readonly Type[] ArgumentTypes_0b93f0bbee924c8db162e60147dd0734 = new Type[] { typeof(T) };
 
         /// <inheritdoc />
         Task<T> IDataCrudApi<T, TKey>.Create(T payload)
         {
             var arguments = new object[] { payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_c4ba9c82081a4927be1491097050e339);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_0b93f0bbee924c8db162e60147dd0734);
             return (Task<T>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_fa6fba62a55140bdbe0f51bd466ec1d4 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_09569e9fe23a4b16ad1668d742ae6686 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<List<T>> IDataCrudApi<T, TKey>.ReadAll()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_fa6fba62a55140bdbe0f51bd466ec1d4);
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_09569e9fe23a4b16ad1668d742ae6686);
             return (Task<List<T>>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_33f78b1f4e85494e9c8811a13845ceda = new Type[] { typeof(TKey) };
+        private static readonly Type[] ArgumentTypes_6983f40f12a24026aa83fead1cf70a57 = new Type[] { typeof(TKey) };
 
         /// <inheritdoc />
         Task<T> IDataCrudApi<T, TKey>.ReadOne(TKey key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_33f78b1f4e85494e9c8811a13845ceda);
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_6983f40f12a24026aa83fead1cf70a57);
             return (Task<T>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_83afcb5fcd414f9c86180b8b75acb5a9 = new Type[] { typeof(TKey), typeof(T) };
+        private static readonly Type[] ArgumentTypes_0efe952a63114f2d950a09e668f4fcad = new Type[] { typeof(TKey), typeof(T) };
 
         /// <inheritdoc />
         Task IDataCrudApi<T, TKey>.Update(TKey key, T payload)
         {
             var arguments = new object[] { key, payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_83afcb5fcd414f9c86180b8b75acb5a9);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_0efe952a63114f2d950a09e668f4fcad);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_d11c86793f6b4bc1a1d53f18e5c086b8 = new Type[] { typeof(TKey) };
+        private static readonly Type[] ArgumentTypes_026922b66caf4828bb795aea04b7bfc2 = new Type[] { typeof(TKey) };
 
         /// <inheritdoc />
         Task IDataCrudApi<T, TKey>.Delete(TKey key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_d11c86793f6b4bc1a1d53f18e5c086b8);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_026922b66caf4828bb795aea04b7bfc2);
             return (Task)func(Client, arguments);
         }
     }
@@ -1336,13 +1336,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_709afe232b4c48ad8710228b536caa17 = new Type[] { ToNullable(typeof(System.Collections.Generic.List<string>)) };
+        private static readonly Type[] ArgumentTypes_4e45039b9f914350b88bf7be534cbaf2 = new Type[] { ToNullable(typeof(System.Collections.Generic.List<string>)) };
 
         /// <inheritdoc />
         Task IGenericNullableReferenceParameterService.Get(System.Collections.Generic.List<string>? reference)
         {
             var arguments = new object[] { reference };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_709afe232b4c48ad8710228b536caa17);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_4e45039b9f914350b88bf7be534cbaf2);
             return (Task)func(Client, arguments);
         }
 
@@ -1373,13 +1373,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_dbf233a71c4b4c1fb950a07ac9bc4d5a = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_e11b382c2b4441848d57c61da877b0c6 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string>? IGenericNullableReferenceService.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_dbf233a71c4b4c1fb950a07ac9bc4d5a);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_e11b382c2b4441848d57c61da877b0c6);
             return (Task<string>?)func(Client, arguments);
         }
     }
@@ -1408,13 +1408,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_f78e2062ce1243e082c08c47342c1de8 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_7dfa677b161d4a51957d18facb771516 = Array.Empty<Type>();
 
         /// <inheritdoc />
         ValueTask<int>? IGenericNullableValueService.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_f78e2062ce1243e082c08c47342c1de8);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_7dfa677b161d4a51957d18facb771516);
             return (ValueTask<int>?)func(Client, arguments);
         }
     }
@@ -1443,13 +1443,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_68fe30c7aa4f4807b22fb54745d236f7 = new Type[] { ToNullable(typeof(System.Collections.Generic.List<string?>)) };
+        private static readonly Type[] ArgumentTypes_ff1fbe7dcb704c23892e8196e882c737 = new Type[] { ToNullable(typeof(System.Collections.Generic.List<string?>)) };
 
         /// <inheritdoc />
         Task IGenericNullableWithNullableReferenceParameterService.Get(System.Collections.Generic.List<string?>? reference)
         {
             var arguments = new object[] { reference };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_68fe30c7aa4f4807b22fb54745d236f7);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_ff1fbe7dcb704c23892e8196e882c737);
             return (Task)func(Client, arguments);
         }
 
@@ -1480,13 +1480,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_4d4731c7a0d44ca1b01cad852da9c8bf = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_5d32602120e84899b82e0b78343acc9e = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string?>? IGenericNullableWithNullableReferenceService.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_4d4731c7a0d44ca1b01cad852da9c8bf);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_5d32602120e84899b82e0b78343acc9e);
             return (Task<string?>?)func(Client, arguments);
         }
     }
@@ -1515,13 +1515,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_26878fff821f48d3ae251734b6d837b0 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_f55308fe6638421899bd9101833b7be2 = Array.Empty<Type>();
 
         /// <inheritdoc />
         ValueTask<int?>? IGenericNullableWithNullableValueService.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_26878fff821f48d3ae251734b6d837b0);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_f55308fe6638421899bd9101833b7be2);
             return (ValueTask<int?>?)func(Client, arguments);
         }
     }
@@ -1550,13 +1550,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_688a3db092414606b7ed57d12f26804c = new Type[] { typeof(System.Collections.Generic.List<string?>) };
+        private static readonly Type[] ArgumentTypes_39ec9c26b66d463ca6929efc807b2770 = new Type[] { typeof(System.Collections.Generic.List<string?>) };
 
         /// <inheritdoc />
         Task IGenericWithNullableReferenceParameterService.Get(System.Collections.Generic.List<string?> reference)
         {
             var arguments = new object[] { reference };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_688a3db092414606b7ed57d12f26804c);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_39ec9c26b66d463ca6929efc807b2770);
             return (Task)func(Client, arguments);
         }
     }
@@ -1585,13 +1585,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_ee2363629bfc461496e77731d9dd21fc = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_0b482db2c26848ac8822ae8d5178cd42 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<int?> IGenericWithNullableValueService.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_ee2363629bfc461496e77731d9dd21fc);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_0b482db2c26848ac8822ae8d5178cd42);
             return (Task<int?>)func(Client, arguments);
         }
     }
@@ -1620,13 +1620,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_c7dc7c8860f84f038f5efdee7e4c7303 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_82849c15effc40c79326d2dc3453befb = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string?> IGenericWithResultService.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_c7dc7c8860f84f038f5efdee7e4c7303);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_82849c15effc40c79326d2dc3453befb);
             return (Task<string?>)func(Client, arguments);
         }
     }
@@ -1661,133 +1661,133 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_e5eea7ef21fe45dfada409f7474945bb = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_eb9cc862592446e7bcaa47934d1e9063 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<User> IGitHubApi.GetUser(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUser", ArgumentTypes_e5eea7ef21fe45dfada409f7474945bb);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUser", ArgumentTypes_eb9cc862592446e7bcaa47934d1e9063);
             return (Task<User>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_3ad0fceaae92461db99c0855d00f7a92 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_e94a5a345f214b3fb5e1e6227563da27 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         IObservable<User> IGitHubApi.GetUserObservable(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserObservable", ArgumentTypes_3ad0fceaae92461db99c0855d00f7a92);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserObservable", ArgumentTypes_e94a5a345f214b3fb5e1e6227563da27);
             return (IObservable<User>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_3f042fa5a21143ea8b4ea399d5167abd = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_fd06def76ab745408ee44e8a09c397a5 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         IObservable<User> IGitHubApi.GetUserCamelCase(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserCamelCase", ArgumentTypes_3f042fa5a21143ea8b4ea399d5167abd);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserCamelCase", ArgumentTypes_fd06def76ab745408ee44e8a09c397a5);
             return (IObservable<User>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_615a1760f8b14abc8726debf66362d68 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_8f2935c472834d26a9117011b7c92400 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<List<User>> IGitHubApi.GetOrgMembers(string orgName)
         {
             var arguments = new object[] { orgName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetOrgMembers", ArgumentTypes_615a1760f8b14abc8726debf66362d68);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetOrgMembers", ArgumentTypes_8f2935c472834d26a9117011b7c92400);
             return (Task<List<User>>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_caf7ad1d45d9444092c120383123d9c9 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_e4adb0464ccc4fdd9c87f5378ca8e880 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<UserSearchResult> IGitHubApi.FindUsers(string q)
         {
             var arguments = new object[] { q };
-            var func = requestBuilder.BuildRestResultFuncForMethod("FindUsers", ArgumentTypes_caf7ad1d45d9444092c120383123d9c9);
+            var func = requestBuilder.BuildRestResultFuncForMethod("FindUsers", ArgumentTypes_e4adb0464ccc4fdd9c87f5378ca8e880);
             return (Task<UserSearchResult>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_c4d4eb798ba24d139d3b6d585c83d224 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_fcec939287904012b5c1dd896e430faf = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IGitHubApi.GetIndex()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndex", ArgumentTypes_c4d4eb798ba24d139d3b6d585c83d224);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndex", ArgumentTypes_fcec939287904012b5c1dd896e430faf);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_0e995ad512c6471e94598a3e03647f2e = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_eb217e47884046db904ed2b7ea815780 = Array.Empty<Type>();
 
         /// <inheritdoc />
         IObservable<string> IGitHubApi.GetIndexObservable()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndexObservable", ArgumentTypes_0e995ad512c6471e94598a3e03647f2e);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndexObservable", ArgumentTypes_eb217e47884046db904ed2b7ea815780);
             return (IObservable<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_3c35fd35e26244c6af81e9f95a36d1e0 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_42233be489214803996d3e71640a9a6f = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<User> IGitHubApi.NothingToSeeHere()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("NothingToSeeHere", ArgumentTypes_3c35fd35e26244c6af81e9f95a36d1e0);
+            var func = requestBuilder.BuildRestResultFuncForMethod("NothingToSeeHere", ArgumentTypes_42233be489214803996d3e71640a9a6f);
             return (Task<User>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_a41df33786f94fbfb0e4aaa57803278d = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_ea94f540b7ab4efa9582185e6e2b81bf = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<ApiResponse<User>> IGitHubApi.NothingToSeeHereWithMetadata()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("NothingToSeeHereWithMetadata", ArgumentTypes_a41df33786f94fbfb0e4aaa57803278d);
+            var func = requestBuilder.BuildRestResultFuncForMethod("NothingToSeeHereWithMetadata", ArgumentTypes_ea94f540b7ab4efa9582185e6e2b81bf);
             return (Task<ApiResponse<User>>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_5875806a6b2a40568b1be16efcb0f173 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_adee9a3ccd70477eb43431b504c81878 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<ApiResponse<User>> IGitHubApi.GetUserWithMetadata(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserWithMetadata", ArgumentTypes_5875806a6b2a40568b1be16efcb0f173);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserWithMetadata", ArgumentTypes_adee9a3ccd70477eb43431b504c81878);
             return (Task<ApiResponse<User>>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_7f9021a3cfee4b6bad29bb6a2c4c710b = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_dc6c91703ef84fc8aece0c4e4e6cef73 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         IObservable<ApiResponse<User>> IGitHubApi.GetUserObservableWithMetadata(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserObservableWithMetadata", ArgumentTypes_7f9021a3cfee4b6bad29bb6a2c4c710b);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserObservableWithMetadata", ArgumentTypes_dc6c91703ef84fc8aece0c4e4e6cef73);
             return (IObservable<ApiResponse<User>>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_ce5ce359d67d4589ae07506f91540ec3 = new Type[] { typeof(User) };
+        private static readonly Type[] ArgumentTypes_c241f38681d84307a8b2753f77fd343e = new Type[] { typeof(User) };
 
         /// <inheritdoc />
         Task<User> IGitHubApi.CreateUser(User user)
         {
             var arguments = new object[] { user };
-            var func = requestBuilder.BuildRestResultFuncForMethod("CreateUser", ArgumentTypes_ce5ce359d67d4589ae07506f91540ec3);
+            var func = requestBuilder.BuildRestResultFuncForMethod("CreateUser", ArgumentTypes_c241f38681d84307a8b2753f77fd343e);
             return (Task<User>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_42528656b4f64cbe9f8f0724723932d9 = new Type[] { typeof(User) };
+        private static readonly Type[] ArgumentTypes_93373ce4abb44ee5a55ca3aa36a66cf9 = new Type[] { typeof(User) };
 
         /// <inheritdoc />
         Task<ApiResponse<User>> IGitHubApi.CreateUserWithMetadata(User user)
         {
             var arguments = new object[] { user };
-            var func = requestBuilder.BuildRestResultFuncForMethod("CreateUserWithMetadata", ArgumentTypes_42528656b4f64cbe9f8f0724723932d9);
+            var func = requestBuilder.BuildRestResultFuncForMethod("CreateUserWithMetadata", ArgumentTypes_93373ce4abb44ee5a55ca3aa36a66cf9);
             return (Task<ApiResponse<User>>)func(Client, arguments);
         }
     }
@@ -1832,47 +1832,47 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_069d049503fa4e70a750dedcc0edbb53 = new Type[] { typeof(TParam), typeof(THeader) };
+        private static readonly Type[] ArgumentTypes_de0f94a241b0476191e081a72e56eecb = new Type[] { typeof(TParam), typeof(THeader) };
 
         /// <inheritdoc />
         Task<TResponse> IHttpBinApi<TResponse, TParam, THeader>.Get(TParam param, THeader header)
         {
             var arguments = new object[] { param, header };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_069d049503fa4e70a750dedcc0edbb53);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_de0f94a241b0476191e081a72e56eecb);
             return (Task<TResponse>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_0e3cc77c170242b3828afce89c534fa9 = new Type[] { typeof(TParam) };
+        private static readonly Type[] ArgumentTypes_e2d86090b08148c2876b20455bac3ffc = new Type[] { typeof(TParam) };
 
         /// <inheritdoc />
         Task<TResponse> IHttpBinApi<TResponse, TParam, THeader>.GetQuery(TParam param)
         {
             var arguments = new object[] { param };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetQuery", ArgumentTypes_0e3cc77c170242b3828afce89c534fa9);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetQuery", ArgumentTypes_e2d86090b08148c2876b20455bac3ffc);
             return (Task<TResponse>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_80616731a082431b9a4046005174be07 = new Type[] { typeof(TParam) };
+        private static readonly Type[] ArgumentTypes_6977c7b8804f4a36be922e0e52ea9a1b = new Type[] { typeof(TParam) };
 
         /// <inheritdoc />
         Task<TResponse> IHttpBinApi<TResponse, TParam, THeader>.PostQuery(TParam param)
         {
             var arguments = new object[] { param };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostQuery", ArgumentTypes_80616731a082431b9a4046005174be07);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostQuery", ArgumentTypes_6977c7b8804f4a36be922e0e52ea9a1b);
             return (Task<TResponse>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_bced68b957664828ab16f41534187300 = new Type[] { typeof(TParam) };
+        private static readonly Type[] ArgumentTypes_87ca08e38b7c4d7bbacba1c46a2db798 = new Type[] { typeof(TParam) };
 
         /// <inheritdoc />
         Task<TResponse> IHttpBinApi<TResponse, TParam, THeader>.GetQueryWithIncludeParameterName(TParam param)
         {
             var arguments = new object[] { param };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetQueryWithIncludeParameterName", ArgumentTypes_bced68b957664828ab16f41534187300);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetQueryWithIncludeParameterName", ArgumentTypes_87ca08e38b7c4d7bbacba1c46a2db798);
             return (Task<TResponse>)func(Client, arguments);
         }
 
-        private static class TypeHelper_55b57e7caf1d4d1899d882410c7296a0<TValue>
+        private static class TypeHelper_1bda28ef13b642aeba28f98ba4d442c2<TValue>
         {
             public static readonly Type[] ArgumentTypes = new Type[] { typeof(TParam) };
             public static readonly Type[] TypeParameters = new Type[] { typeof(TValue) };
@@ -1882,7 +1882,7 @@ namespace Refit.Tests
         Task<TValue> IHttpBinApi<TResponse, TParam, THeader>.GetQuery1<TValue>(TParam param)
         {
             var arguments = new object[] { param };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetQuery1", TypeHelper_55b57e7caf1d4d1899d882410c7296a0<TValue>.ArgumentTypes, TypeHelper_55b57e7caf1d4d1899d882410c7296a0<TValue>.TypeParameters);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetQuery1", TypeHelper_1bda28ef13b642aeba28f98ba4d442c2<TValue>.ArgumentTypes, TypeHelper_1bda28ef13b642aeba28f98ba4d442c2<TValue>.TypeParameters);
             return (Task<TValue>)func(Client, arguments);
         }
     }
@@ -1923,23 +1923,23 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_a3356fde48364f2e8c1cb533056a6c4c = new Type[] { typeof(HttpContent) };
+        private static readonly Type[] ArgumentTypes_85adaa395d21419ab72fff0ab2f42b90 = new Type[] { typeof(HttpContent) };
 
         /// <inheritdoc />
         Task<HttpContent> IHttpContentApi.PostFileUpload(HttpContent content)
         {
             var arguments = new object[] { content };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostFileUpload", ArgumentTypes_a3356fde48364f2e8c1cb533056a6c4c);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostFileUpload", ArgumentTypes_85adaa395d21419ab72fff0ab2f42b90);
             return (Task<HttpContent>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_19dfd8d5628a40c5900e08c127a31fd4 = new Type[] { typeof(HttpContent) };
+        private static readonly Type[] ArgumentTypes_42346890a15e40c08c4aa631497469f9 = new Type[] { typeof(HttpContent) };
 
         /// <inheritdoc />
         Task<ApiResponse<HttpContent>> IHttpContentApi.PostFileUploadWithMetadata(HttpContent content)
         {
             var arguments = new object[] { content };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostFileUploadWithMetadata", ArgumentTypes_19dfd8d5628a40c5900e08c127a31fd4);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostFileUploadWithMetadata", ArgumentTypes_42346890a15e40c08c4aa631497469f9);
             return (Task<ApiResponse<HttpContent>>)func(Client, arguments);
         }
     }
@@ -1981,13 +1981,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_a68920f592ec4d19b037655c4248d5b3 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_d7089633ab9943e8a696c95a0853f860 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<TestAliasObject> ResponseTests.IMyAliasService.GetTestObject()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetTestObject", ArgumentTypes_a68920f592ec4d19b037655c4248d5b3);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetTestObject", ArgumentTypes_d7089633ab9943e8a696c95a0853f860);
             return (Task<TestAliasObject>)func(Client, arguments);
         }
     }
@@ -2023,23 +2023,23 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_ca9424616d0d41d18d4f9732a621adba = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_da89e5f7923a405b9f6e32ec2fa0fbf1 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> AuthenticatedClientHandlerTests.IMyAuthenticatedService.GetUnauthenticated()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUnauthenticated", ArgumentTypes_ca9424616d0d41d18d4f9732a621adba);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUnauthenticated", ArgumentTypes_da89e5f7923a405b9f6e32ec2fa0fbf1);
             return (Task<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_3ab94cc9d0e14205a28bf3bad850701f = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_b3a09c7902db4afdb99787c93eafab80 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> AuthenticatedClientHandlerTests.IMyAuthenticatedService.GetAuthenticated()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetAuthenticated", ArgumentTypes_3ab94cc9d0e14205a28bf3bad850701f);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetAuthenticated", ArgumentTypes_b3a09c7902db4afdb99787c93eafab80);
             return (Task<string>)func(Client, arguments);
         }
     }
@@ -2070,13 +2070,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_83d84be48dde491296b09a2ddc034b46 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_26cc32f3e8b64f3f9f96504fd31ce86b = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<SomeType> INamespaceCollisionApi.SomeRequest()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", ArgumentTypes_83d84be48dde491296b09a2ddc034b46);
+            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", ArgumentTypes_26cc32f3e8b64f3f9f96504fd31ce86b);
             return (Task<SomeType>)func(Client, arguments);
         }
     }
@@ -2108,13 +2108,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_754918f748fd446eb99b099f4e47185d = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_a046213fd7644c9d83305105058b955b = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<SomeOtherType> INamespaceOverlapApi.SomeRequest()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", ArgumentTypes_754918f748fd446eb99b099f4e47185d);
+            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", ArgumentTypes_a046213fd7644c9d83305105058b955b);
             return (Task<SomeOtherType>)func(Client, arguments);
         }
     }
@@ -2149,83 +2149,83 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_2065b9c55d944391b3c49f77b8d95bef = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_6c3b119979c540e7a931091be4c2a225 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<User> TestNested.INestedGitHubApi.GetUser(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUser", ArgumentTypes_2065b9c55d944391b3c49f77b8d95bef);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUser", ArgumentTypes_6c3b119979c540e7a931091be4c2a225);
             return (Task<User>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_e2bc5750675c41e19b17a06b933bfa69 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_4e9579d84e334db48afc1b5af5d554d1 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         IObservable<User> TestNested.INestedGitHubApi.GetUserObservable(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserObservable", ArgumentTypes_e2bc5750675c41e19b17a06b933bfa69);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserObservable", ArgumentTypes_4e9579d84e334db48afc1b5af5d554d1);
             return (IObservable<User>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_8a29b8ef353045db99e7b092bb137cb8 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_69f6e36d53be4761bc826265cdb54410 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         IObservable<User> TestNested.INestedGitHubApi.GetUserCamelCase(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserCamelCase", ArgumentTypes_8a29b8ef353045db99e7b092bb137cb8);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserCamelCase", ArgumentTypes_69f6e36d53be4761bc826265cdb54410);
             return (IObservable<User>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_96f3a7574f104285ad86e3aa4ac0270e = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_01ffe48e5fb0491cb856c34cf24b8d10 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<List<User>> TestNested.INestedGitHubApi.GetOrgMembers(string orgName)
         {
             var arguments = new object[] { orgName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetOrgMembers", ArgumentTypes_96f3a7574f104285ad86e3aa4ac0270e);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetOrgMembers", ArgumentTypes_01ffe48e5fb0491cb856c34cf24b8d10);
             return (Task<List<User>>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_006aacd9073b4bf684ead6660cebefbf = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_f39ee737cd4e470685b54e853ba71276 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<UserSearchResult> TestNested.INestedGitHubApi.FindUsers(string q)
         {
             var arguments = new object[] { q };
-            var func = requestBuilder.BuildRestResultFuncForMethod("FindUsers", ArgumentTypes_006aacd9073b4bf684ead6660cebefbf);
+            var func = requestBuilder.BuildRestResultFuncForMethod("FindUsers", ArgumentTypes_f39ee737cd4e470685b54e853ba71276);
             return (Task<UserSearchResult>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_6e834f7f228443e29aa18e0627684ad8 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_0504d60949ee433c9407005217f17deb = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<HttpResponseMessage> TestNested.INestedGitHubApi.GetIndex()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndex", ArgumentTypes_6e834f7f228443e29aa18e0627684ad8);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndex", ArgumentTypes_0504d60949ee433c9407005217f17deb);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_a59ea58a65de408281c93f0923bf7b7e = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_bb400a0dba9c4f6fbefdcfb3336224fc = Array.Empty<Type>();
 
         /// <inheritdoc />
         IObservable<string> TestNested.INestedGitHubApi.GetIndexObservable()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndexObservable", ArgumentTypes_a59ea58a65de408281c93f0923bf7b7e);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndexObservable", ArgumentTypes_bb400a0dba9c4f6fbefdcfb3336224fc);
             return (IObservable<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_079e9af2c4cd460c9c3df418c57d4982 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_cdc3c74137344ac9a106357be3936de5 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task TestNested.INestedGitHubApi.NothingToSeeHere()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("NothingToSeeHere", ArgumentTypes_079e9af2c4cd460c9c3df418c57d4982);
+            var func = requestBuilder.BuildRestResultFuncForMethod("NothingToSeeHere", ArgumentTypes_cdc3c74137344ac9a106357be3936de5);
             return (Task)func(Client, arguments);
         }
     }
@@ -2263,7 +2263,7 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static class TypeHelper_ce3b8a623a484997b4ec407c4b8238d9<T>
+        private static class TypeHelper_559abbdae8664e5bb4eeae3f2c30f8fa<T>
         {
             public static readonly Type[] ArgumentTypes = new Type[] { typeof(T) };
             public static readonly Type[] TypeParameters = new Type[] { typeof(T) };
@@ -2273,11 +2273,11 @@ namespace Refit.Tests
         Task INonGenericInterfaceWithGenericMethod.PostMessage<T>(T message)
         {
             var arguments = new object[] { message };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostMessage", TypeHelper_ce3b8a623a484997b4ec407c4b8238d9<T>.ArgumentTypes, TypeHelper_ce3b8a623a484997b4ec407c4b8238d9<T>.TypeParameters);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostMessage", TypeHelper_559abbdae8664e5bb4eeae3f2c30f8fa<T>.ArgumentTypes, TypeHelper_559abbdae8664e5bb4eeae3f2c30f8fa<T>.TypeParameters);
             return (Task)func(Client, arguments);
         }
 
-        private static class TypeHelper_bcbaa7cc9d8a4ffa95c64f1fc7e508ee<T, U, V>
+        private static class TypeHelper_fd1380cb58644059b4e8eeadf6296253<T, U, V>
         {
             public static readonly Type[] ArgumentTypes = new Type[] { typeof(T), typeof(U), typeof(V) };
             public static readonly Type[] TypeParameters = new Type[] { typeof(T), typeof(U), typeof(V) };
@@ -2287,7 +2287,7 @@ namespace Refit.Tests
         Task INonGenericInterfaceWithGenericMethod.PostMessage<T, U, V>(T message, U param1, V param2)
         {
             var arguments = new object[] { message, param1, param2 };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostMessage", TypeHelper_bcbaa7cc9d8a4ffa95c64f1fc7e508ee<T, U, V>.ArgumentTypes, TypeHelper_bcbaa7cc9d8a4ffa95c64f1fc7e508ee<T, U, V>.TypeParameters);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostMessage", TypeHelper_fd1380cb58644059b4e8eeadf6296253<T, U, V>.ArgumentTypes, TypeHelper_fd1380cb58644059b4e8eeadf6296253<T, U, V>.TypeParameters);
             return (Task)func(Client, arguments);
         }
     }
@@ -2328,13 +2328,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_64aaa57de9c44b61b6a20c04dc9ab23f = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_2c8dbadcd9cb4726903f061136997397 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<RootObject> INpmJs.GetCongruence()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetCongruence", ArgumentTypes_64aaa57de9c44b61b6a20c04dc9ab23f);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetCongruence", ArgumentTypes_2c8dbadcd9cb4726903f061136997397);
             return (Task<RootObject>)func(Client, arguments);
         }
     }
@@ -2363,13 +2363,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_b1e81cc95f1b403fbd6306e2641f01d5 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_15828926f9db4fad944adcc4d33f9465 = Array.Empty<Type>();
 
         /// <inheritdoc />
         string? INullableReferenceService.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_b1e81cc95f1b403fbd6306e2641f01d5);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_15828926f9db4fad944adcc4d33f9465);
             return (string?)func(Client, arguments);
         }
     }
@@ -2398,13 +2398,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_1c3a9104a4e44ddbbc4c60a2904ac6f2 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_f21e362c036c4110a5264ee18b22970b = Array.Empty<Type>();
 
         /// <inheritdoc />
         int? INullableValueService.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_1c3a9104a4e44ddbbc4c60a2904ac6f2);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_f21e362c036c4110a5264ee18b22970b);
             return (int?)func(Client, arguments);
         }
     }
@@ -2434,13 +2434,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_b610b5d6f80448dbb6d34aa0f7eb5015 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_52458e6a7ced4fc38e28d2a9304b74f2 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<SomeType> IReducedUsingInsideNamespaceApi.SomeRequest()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", ArgumentTypes_b610b5d6f80448dbb6d34aa0f7eb5015);
+            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", ArgumentTypes_52458e6a7ced4fc38e28d2a9304b74f2);
             return (Task<SomeType>)func(Client, arguments);
         }
     }
@@ -2469,13 +2469,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_a20a2c5c6c1d4d128cf3299b541bf22d = new Type[] { ToNullable(typeof(string)), ToNullable(typeof(int)) };
+        private static readonly Type[] ArgumentTypes_543e0483a07145bdaaa354aa59bbbb56 = new Type[] { ToNullable(typeof(string)), ToNullable(typeof(int)) };
 
         /// <inheritdoc />
         Task IReferenceAndValueParametersService.Get(string? reference, int? value)
         {
             var arguments = new object[] { reference, value };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_a20a2c5c6c1d4d128cf3299b541bf22d);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_543e0483a07145bdaaa354aa59bbbb56);
             return (Task)func(Client, arguments);
         }
 
@@ -2518,13 +2518,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_413bb83c7188415884261263233b78c9 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_fb20ec3d44b04ab08f5b61fac7021b1b = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IRefitInterfaceWithStaticMethod.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_413bb83c7188415884261263233b78c9);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_fb20ec3d44b04ab08f5b61fac7021b1b);
             return (Task)func(Client, arguments);
         }
     }
@@ -2565,47 +2565,47 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_a142419faae346529a8503aea89b5c48 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_83f17c7db08c4b27aa617d95cc7018d3 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IRequestBin.Post()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Post", ArgumentTypes_a142419faae346529a8503aea89b5c48);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Post", ArgumentTypes_83f17c7db08c4b27aa617d95cc7018d3);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_54f6c9677f0e4e89a6b46b49c0b2f3ed = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_c18bdc1b232f4bf49404c38522d170df = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task IRequestBin.PostRawStringDefault(string str)
         {
             var arguments = new object[] { str };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostRawStringDefault", ArgumentTypes_54f6c9677f0e4e89a6b46b49c0b2f3ed);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostRawStringDefault", ArgumentTypes_c18bdc1b232f4bf49404c38522d170df);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_c768a4ba55b54e0c9902144a4208c45c = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_32f9d5b591854d1480f960c5044e185a = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task IRequestBin.PostRawStringJson(string str)
         {
             var arguments = new object[] { str };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostRawStringJson", ArgumentTypes_c768a4ba55b54e0c9902144a4208c45c);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostRawStringJson", ArgumentTypes_32f9d5b591854d1480f960c5044e185a);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_47fb901149f2425c92da59faacf61e98 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_0c67833ae5cf4308842f74d6c043e9db = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task IRequestBin.PostRawStringUrlEncoded(string str)
         {
             var arguments = new object[] { str };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostRawStringUrlEncoded", ArgumentTypes_47fb901149f2425c92da59faacf61e98);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostRawStringUrlEncoded", ArgumentTypes_0c67833ae5cf4308842f74d6c043e9db);
             return (Task)func(Client, arguments);
         }
 
-        private static class TypeHelper_14ab8c74d5a0446aaa287f3f51c0f759<T>
+        private static class TypeHelper_950a5ed53666409684ca5862e037e5cf<T>
         {
             public static readonly Type[] ArgumentTypes = new Type[] { typeof(T) };
             public static readonly Type[] TypeParameters = new Type[] { typeof(T) };
@@ -2615,7 +2615,7 @@ namespace Refit.Tests
         Task IRequestBin.PostGeneric<T>(T param)
         {
             var arguments = new object[] { param };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostGeneric", TypeHelper_14ab8c74d5a0446aaa287f3f51c0f759<T>.ArgumentTypes, TypeHelper_14ab8c74d5a0446aaa287f3f51c0f759<T>.TypeParameters);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostGeneric", TypeHelper_950a5ed53666409684ca5862e037e5cf<T>.ArgumentTypes, TypeHelper_950a5ed53666409684ca5862e037e5cf<T>.TypeParameters);
             return (Task)func(Client, arguments);
         }
     }
@@ -2656,133 +2656,133 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_463e5d9d9237439eae0de3a30afa9094 = new Type[] { typeof(Stream) };
+        private static readonly Type[] ArgumentTypes_198a3722931849acb2cf2c13cabc0063 = new Type[] { typeof(Stream) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadStream(Stream stream)
         {
             var arguments = new object[] { stream };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStream", ArgumentTypes_463e5d9d9237439eae0de3a30afa9094);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStream", ArgumentTypes_198a3722931849acb2cf2c13cabc0063);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_791a032115864dab902b30a187ecc947 = new Type[] { typeof(Stream) };
+        private static readonly Type[] ArgumentTypes_cb6a8dd327314d64bcf08ded5a8190ef = new Type[] { typeof(Stream) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadStreamWithCustomBoundary(Stream stream)
         {
             var arguments = new object[] { stream };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStreamWithCustomBoundary", ArgumentTypes_791a032115864dab902b30a187ecc947);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStreamWithCustomBoundary", ArgumentTypes_cb6a8dd327314d64bcf08ded5a8190ef);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_e04dce59a36c4020bfaa7c67c17b750d = new Type[] { typeof(StreamPart) };
+        private static readonly Type[] ArgumentTypes_36ac597d361641a1bf3075dbca317c75 = new Type[] { typeof(StreamPart) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadStreamPart(StreamPart stream)
         {
             var arguments = new object[] { stream };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStreamPart", ArgumentTypes_e04dce59a36c4020bfaa7c67c17b750d);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStreamPart", ArgumentTypes_36ac597d361641a1bf3075dbca317c75);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_3ff4078ea0d6447ab55cf5d49e19229b = new Type[] { typeof(ModelObject), typeof(StreamPart) };
+        private static readonly Type[] ArgumentTypes_31e7c93c38844317ad3c2ed46888298e = new Type[] { typeof(ModelObject), typeof(StreamPart) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadStreamPart(ModelObject someQueryParams, StreamPart stream)
         {
             var arguments = new object[] { someQueryParams, stream };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStreamPart", ArgumentTypes_3ff4078ea0d6447ab55cf5d49e19229b);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStreamPart", ArgumentTypes_31e7c93c38844317ad3c2ed46888298e);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_370b19a5646a4d429f5d5374d39d5b37 = new Type[] { typeof(byte[]) };
+        private static readonly Type[] ArgumentTypes_4433284065d74d86b0d136b52ab18ab1 = new Type[] { typeof(byte[]) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadBytes(byte[] bytes)
         {
             var arguments = new object[] { bytes };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadBytes", ArgumentTypes_370b19a5646a4d429f5d5374d39d5b37);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadBytes", ArgumentTypes_4433284065d74d86b0d136b52ab18ab1);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_b50e00450b584f12b9cbc15ee29378f8 = new Type[] { typeof(ByteArrayPart) };
+        private static readonly Type[] ArgumentTypes_e4c7af8b3d7741df9ceff2a9aeee9ed7 = new Type[] { typeof(ByteArrayPart) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadBytesPart(ByteArrayPart bytes)
         {
             var arguments = new object[] { bytes };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadBytesPart", ArgumentTypes_b50e00450b584f12b9cbc15ee29378f8);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadBytesPart", ArgumentTypes_e4c7af8b3d7741df9ceff2a9aeee9ed7);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_d099aad6d0ca47a8886cb6d8cf4e8a56 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_ecb54e62daf7407680e789606d7de9c6 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadString(string someString)
         {
             var arguments = new object[] { someString };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadString", ArgumentTypes_d099aad6d0ca47a8886cb6d8cf4e8a56);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadString", ArgumentTypes_ecb54e62daf7407680e789606d7de9c6);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_612d0683d7d440ab9f566c0246f69336 = new Type[] { typeof(IEnumerable<FileInfo>), typeof(FileInfo) };
+        private static readonly Type[] ArgumentTypes_1020fd93b93e4b66b5c64c50ae2866e0 = new Type[] { typeof(IEnumerable<FileInfo>), typeof(FileInfo) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadFileInfo(IEnumerable<FileInfo> fileInfos, FileInfo anotherFile)
         {
             var arguments = new object[] { fileInfos, anotherFile };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadFileInfo", ArgumentTypes_612d0683d7d440ab9f566c0246f69336);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadFileInfo", ArgumentTypes_1020fd93b93e4b66b5c64c50ae2866e0);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_2f349b2d92ba4e7f8374b18c56b3c3cc = new Type[] { typeof(IEnumerable<FileInfoPart>), typeof(FileInfoPart) };
+        private static readonly Type[] ArgumentTypes_bc11095ef2954dcabf474abe5c85927e = new Type[] { typeof(IEnumerable<FileInfoPart>), typeof(FileInfoPart) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadFileInfoPart(IEnumerable<FileInfoPart> fileInfos, FileInfoPart anotherFile)
         {
             var arguments = new object[] { fileInfos, anotherFile };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadFileInfoPart", ArgumentTypes_2f349b2d92ba4e7f8374b18c56b3c3cc);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadFileInfoPart", ArgumentTypes_bc11095ef2954dcabf474abe5c85927e);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_4854aa6091444934bafab59ade42e37e = new Type[] { typeof(ModelObject) };
+        private static readonly Type[] ArgumentTypes_c62c3e7ee67c49c691798a1c32c8cc45 = new Type[] { typeof(ModelObject) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadJsonObject(ModelObject theObject)
         {
             var arguments = new object[] { theObject };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadJsonObject", ArgumentTypes_4854aa6091444934bafab59ade42e37e);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadJsonObject", ArgumentTypes_c62c3e7ee67c49c691798a1c32c8cc45);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_00b03a8d76864f668fefece863fc0933 = new Type[] { typeof(IEnumerable<ModelObject>) };
+        private static readonly Type[] ArgumentTypes_bae83e2611034340be023f81f31db019 = new Type[] { typeof(IEnumerable<ModelObject>) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadJsonObjects(IEnumerable<ModelObject> theObjects)
         {
             var arguments = new object[] { theObjects };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadJsonObjects", ArgumentTypes_00b03a8d76864f668fefece863fc0933);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadJsonObjects", ArgumentTypes_bae83e2611034340be023f81f31db019);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_75e6d6bc87604ac694e406ce1b1963e7 = new Type[] { typeof(IEnumerable<ModelObject>), typeof(AnotherModel), typeof(FileInfo), typeof(AnEnum), typeof(string), typeof(int) };
+        private static readonly Type[] ArgumentTypes_0a50561b213e43dcb0dcae4f550c34d2 = new Type[] { typeof(IEnumerable<ModelObject>), typeof(AnotherModel), typeof(FileInfo), typeof(AnEnum), typeof(string), typeof(int) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadMixedObjects(IEnumerable<ModelObject> theObjects, AnotherModel anotherModel, FileInfo aFile, AnEnum anEnum, string aString, int anInt)
         {
             var arguments = new object[] { theObjects, anotherModel, aFile, anEnum, aString, anInt };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadMixedObjects", ArgumentTypes_75e6d6bc87604ac694e406ce1b1963e7);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadMixedObjects", ArgumentTypes_0a50561b213e43dcb0dcae4f550c34d2);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_17b21280cb5f42939ebf667b952152ed = new Type[] { typeof(HttpContent) };
+        private static readonly Type[] ArgumentTypes_15ea0dfbf78e4edf9d29787d67eef7c1 = new Type[] { typeof(HttpContent) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadHttpContent(HttpContent content)
         {
             var arguments = new object[] { content };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadHttpContent", ArgumentTypes_17b21280cb5f42939ebf667b952152ed);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadHttpContent", ArgumentTypes_15ea0dfbf78e4edf9d29787d67eef7c1);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
     }
@@ -2814,23 +2814,23 @@ namespace AutoGeneratedIServiceWithoutNamespace
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_a1e4c30bad5c4446a2d5ec0d5b73a7af = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_07243fab8f694b749a091808bb1d94cc = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IServiceWithoutNamespace.GetRoot()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetRoot", ArgumentTypes_a1e4c30bad5c4446a2d5ec0d5b73a7af);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetRoot", ArgumentTypes_07243fab8f694b749a091808bb1d94cc);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_9446035b69814f5aa9c1078d4a7e00b7 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_3eca43f166384cf688b48e44e3f2a678 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IServiceWithoutNamespace.PostRoot()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostRoot", ArgumentTypes_9446035b69814f5aa9c1078d4a7e00b7);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostRoot", ArgumentTypes_3eca43f166384cf688b48e44e3f2a678);
             return (Task)func(Client, arguments);
         }
     }
@@ -2871,23 +2871,23 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_f87f6d356e5044d9a855b20aad8a7b52 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_925534496a6f4a3ea13c5d5ddc4202be = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<Stream> IStreamApi.GetRemoteFile(string filename)
         {
             var arguments = new object[] { filename };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetRemoteFile", ArgumentTypes_f87f6d356e5044d9a855b20aad8a7b52);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetRemoteFile", ArgumentTypes_925534496a6f4a3ea13c5d5ddc4202be);
             return (Task<Stream>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_648ed6dd44b040279cacacbe8e0def4d = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_87e39ab8352d4701be083ae3467653a9 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<ApiResponse<Stream>> IStreamApi.GetRemoteFileWithMetadata(string filename)
         {
             var arguments = new object[] { filename };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetRemoteFileWithMetadata", ArgumentTypes_648ed6dd44b040279cacacbe8e0def4d);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetRemoteFileWithMetadata", ArgumentTypes_87e39ab8352d4701be083ae3467653a9);
             return (Task<ApiResponse<Stream>>)func(Client, arguments);
         }
     }
@@ -2928,13 +2928,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_0cbf100ccabd46ce9bd959126f10e31f = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_5d459eec59aa4f60aa245577d4317081 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task ITrimTrailingForwardSlashApi.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_0cbf100ccabd46ce9bd959126f10e31f);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_5d459eec59aa4f60aa245577d4317081);
             return (Task)func(Client, arguments);
         }
     }
@@ -2964,13 +2964,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_66dfb9313ce846e486c75b6f9e968ad6 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_d027ad0a33864409a3c95c1952e18797 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<SomeType> ITypeCollisionApiA.SomeARequest()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("SomeARequest", ArgumentTypes_66dfb9313ce846e486c75b6f9e968ad6);
+            var func = requestBuilder.BuildRestResultFuncForMethod("SomeARequest", ArgumentTypes_d027ad0a33864409a3c95c1952e18797);
             return (Task<SomeType>)func(Client, arguments);
         }
     }
@@ -3000,13 +3000,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_c4a880af605b449d8aa4b6e8fc59dd1f = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_07ad48c6a1344a16b782aee283c7226f = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<SomeType> ITypeCollisionApiB.SomeBRequest()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("SomeBRequest", ArgumentTypes_c4a880af605b449d8aa4b6e8fc59dd1f);
+            var func = requestBuilder.BuildRestResultFuncForMethod("SomeBRequest", ArgumentTypes_07ad48c6a1344a16b782aee283c7226f);
             return (Task<SomeType>)func(Client, arguments);
         }
     }
@@ -3045,47 +3045,47 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_85e801a243294fe4a44de3e2d6af36a4 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_02910c89aa304f42b74de29b8733eaa6 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> IUseOverloadedGenericMethods<TResponse, TParam, THeader>.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_85e801a243294fe4a44de3e2d6af36a4);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_02910c89aa304f42b74de29b8733eaa6);
             return (Task<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_0d3da059a6ce4701ae226079a7fa9075 = new Type[] { typeof(TParam), typeof(THeader) };
+        private static readonly Type[] ArgumentTypes_2a20ba4fbca14b7da65d2e3c50765c7b = new Type[] { typeof(TParam), typeof(THeader) };
 
         /// <inheritdoc />
         Task<TResponse> IUseOverloadedGenericMethods<TResponse, TParam, THeader>.Get(TParam param, THeader header)
         {
             var arguments = new object[] { param, header };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_0d3da059a6ce4701ae226079a7fa9075);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_2a20ba4fbca14b7da65d2e3c50765c7b);
             return (Task<TResponse>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_9a93db3bdc9046f9acbb4567bc58a313 = new Type[] { typeof(THeader), typeof(TParam) };
+        private static readonly Type[] ArgumentTypes_e4a5f2d11b7c40cfb2db18f67b2996e6 = new Type[] { typeof(THeader), typeof(TParam) };
 
         /// <inheritdoc />
         Task<TResponse> IUseOverloadedGenericMethods<TResponse, TParam, THeader>.Get(THeader param, TParam header)
         {
             var arguments = new object[] { param, header };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_9a93db3bdc9046f9acbb4567bc58a313);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_e4a5f2d11b7c40cfb2db18f67b2996e6);
             return (Task<TResponse>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_173b4eb5000643e0bf6a11a5c593895e = new Type[] { typeof(int) };
+        private static readonly Type[] ArgumentTypes_94d03ebf56b64650b83a738785fe6fe1 = new Type[] { typeof(int) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IUseOverloadedGenericMethods<TResponse, TParam, THeader>.Get(int httpstatuscode)
         {
             var arguments = new object[] { httpstatuscode };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_173b4eb5000643e0bf6a11a5c593895e);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_94d03ebf56b64650b83a738785fe6fe1);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static class TypeHelper_39fd96fe461e48469cf855a0e9f0e058<TValue>
+        private static class TypeHelper_bbeff6f0a907426d92d8348422e3b67c<TValue>
         {
             public static readonly Type[] ArgumentTypes = new Type[] { typeof(int) };
             public static readonly Type[] TypeParameters = new Type[] { typeof(TValue) };
@@ -3095,11 +3095,11 @@ namespace Refit.Tests
         Task<TValue> IUseOverloadedGenericMethods<TResponse, TParam, THeader>.Get<TValue>(int someVal)
         {
             var arguments = new object[] { someVal };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", TypeHelper_39fd96fe461e48469cf855a0e9f0e058<TValue>.ArgumentTypes, TypeHelper_39fd96fe461e48469cf855a0e9f0e058<TValue>.TypeParameters);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", TypeHelper_bbeff6f0a907426d92d8348422e3b67c<TValue>.ArgumentTypes, TypeHelper_bbeff6f0a907426d92d8348422e3b67c<TValue>.TypeParameters);
             return (Task<TValue>)func(Client, arguments);
         }
 
-        private static class TypeHelper_13aa52549d7148979975c7e209ba87dc<TValue, TInput>
+        private static class TypeHelper_76b34f9783f446ccb7b5a55490bdd70e<TValue, TInput>
         {
             public static readonly Type[] ArgumentTypes = new Type[] { typeof(TInput) };
             public static readonly Type[] TypeParameters = new Type[] { typeof(TValue), typeof(TInput) };
@@ -3109,11 +3109,11 @@ namespace Refit.Tests
         Task<TValue> IUseOverloadedGenericMethods<TResponse, TParam, THeader>.Get<TValue, TInput>(TInput input)
         {
             var arguments = new object[] { input };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", TypeHelper_13aa52549d7148979975c7e209ba87dc<TValue, TInput>.ArgumentTypes, TypeHelper_13aa52549d7148979975c7e209ba87dc<TValue, TInput>.TypeParameters);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", TypeHelper_76b34f9783f446ccb7b5a55490bdd70e<TValue, TInput>.ArgumentTypes, TypeHelper_76b34f9783f446ccb7b5a55490bdd70e<TValue, TInput>.TypeParameters);
             return (Task<TValue>)func(Client, arguments);
         }
 
-        private static class TypeHelper_cd798b05db18477194646864f2c289fc<TInput1, TInput2>
+        private static class TypeHelper_badc1e288da04f3cb48d9c01837a65a4<TInput1, TInput2>
         {
             public static readonly Type[] ArgumentTypes = new Type[] { typeof(TInput1), typeof(TInput2) };
             public static readonly Type[] TypeParameters = new Type[] { typeof(TInput1), typeof(TInput2) };
@@ -3123,7 +3123,7 @@ namespace Refit.Tests
         Task IUseOverloadedGenericMethods<TResponse, TParam, THeader>.Get<TInput1, TInput2>(TInput1 input1, TInput2 input2)
         {
             var arguments = new object[] { input1, input2 };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", TypeHelper_cd798b05db18477194646864f2c289fc<TInput1, TInput2>.ArgumentTypes, TypeHelper_cd798b05db18477194646864f2c289fc<TInput1, TInput2>.TypeParameters);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", TypeHelper_badc1e288da04f3cb48d9c01837a65a4<TInput1, TInput2>.ArgumentTypes, TypeHelper_badc1e288da04f3cb48d9c01837a65a4<TInput1, TInput2>.TypeParameters);
             return (Task)func(Client, arguments);
         }
     }
@@ -3158,23 +3158,23 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_4d1a154ad99d4c66b6f56267eb3d660f = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_07d5933f8f394c0fbf4042bf70c83ea1 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> IUseOverloadedMethods.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_4d1a154ad99d4c66b6f56267eb3d660f);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_07d5933f8f394c0fbf4042bf70c83ea1);
             return (Task<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_72c33f5a572a4b40b657da4de1b55c0e = new Type[] { typeof(int) };
+        private static readonly Type[] ArgumentTypes_d1644e57494b45d9ab59c1be7a3c26be = new Type[] { typeof(int) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IUseOverloadedMethods.Get(int httpstatuscode)
         {
             var arguments = new object[] { httpstatuscode };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_72c33f5a572a4b40b657da4de1b55c0e);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_d1644e57494b45d9ab59c1be7a3c26be);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
     }
@@ -3215,13 +3215,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_89418546f2a449358a8b103f3662275c = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_4a656be62dad4069b51f11f32a77149d = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IValidApi.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_89418546f2a449358a8b103f3662275c);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_4a656be62dad4069b51f11f32a77149d);
             return (Task)func(Client, arguments);
         }
     }
@@ -3251,13 +3251,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_008bd358370e4cbf8738261813bf2487 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_0b41c3542cf24168b500f12a8b236f89 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<SomeType> NamespaceWithGlobalAliasApi.SomeRequest()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", ArgumentTypes_008bd358370e4cbf8738261813bf2487);
+            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", ArgumentTypes_0b41c3542cf24168b500f12a8b236f89);
             return (Task<SomeType>)func(Client, arguments);
         }
     }

--- a/Refit.Tests/RefitStubs.NetCore2.cs
+++ b/Refit.Tests/RefitStubs.NetCore2.cs
@@ -62,21 +62,27 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_89f2a3206459448da85aba4bea423721 = new Type[] {  };
+
         /// <inheritdoc />
         Task IAmARefitInterfaceButNobodyUsesMe.RefitMethod()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("RefitMethod", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("RefitMethod", ArgumentTypes_89f2a3206459448da85aba4bea423721);
             return (Task)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_788383ee3e554cffb85b38f215395bcc = new Type[] {  };
 
         /// <inheritdoc />
         Task IAmARefitInterfaceButNobodyUsesMe.AnotherRefitMethod()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("AnotherRefitMethod", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("AnotherRefitMethod", ArgumentTypes_788383ee3e554cffb85b38f215395bcc);
             return (Task)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_9cc8908b765c49afa9ebb2d3c662fc5f = new Type[] {  };
 
         /// <inheritdoc />
         Task IAmARefitInterfaceButNobodyUsesMe.NoConstantsAllowed()
@@ -84,19 +90,23 @@ namespace Refit.Tests
             throw new NotImplementedException("Either this method has no Refit HTTP method attribute or you've used something other than a string literal for the 'path' argument.");
         }
 
+        private static readonly Type[] ArgumentTypes_885bd6840a12426ebafd1f905f51bb24 = new Type[] {  };
+
         /// <inheritdoc />
         Task IAmARefitInterfaceButNobodyUsesMe.SpacesShouldntBreakMe()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("SpacesShouldntBreakMe", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("SpacesShouldntBreakMe", ArgumentTypes_885bd6840a12426ebafd1f905f51bb24);
             return (Task)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_ea951264b389427189ff496aed051d7a = new Type[] { typeof(int), typeof(string), typeof(float) };
 
         /// <inheritdoc />
         Task IAmARefitInterfaceButNobodyUsesMe.ReservedWordsForParameterNames(int @int, string @string, float @long)
         {
             var arguments = new object[] { @int, @string, @long };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReservedWordsForParameterNames", new Type[] { typeof(int), typeof(string), typeof(float) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReservedWordsForParameterNames", ArgumentTypes_ea951264b389427189ff496aed051d7a);
             return (Task)func(Client, arguments);
         }
     }
@@ -137,13 +147,17 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_b5cfb1bb03044077beea116d8b5c094f = new Type[] {  };
+
         /// <inheritdoc />
         Task IAmHalfRefit.Post()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Post", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Post", ArgumentTypes_b5cfb1bb03044077beea116d8b5c094f);
             return (Task)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_2bb79711fafb4f54b81fbee9ffd0fa1d = new Type[] {  };
 
         /// <inheritdoc />
         Task IAmHalfRefit.Get()
@@ -177,35 +191,43 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_8381c32586b64925804d183986a40b7d = new Type[] {  };
+
         /// <inheritdoc />
         Task<string> IAmInterface.Pang()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Pang", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Pang", ArgumentTypes_8381c32586b64925804d183986a40b7d);
             return (Task<string>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_37dbfbca4bce41e1a1f578050682b819 = new Type[] {  };
 
         /// <inheritdoc />
         Task<string> IAmInterfaceB.Pong()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Pong", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Pong", ArgumentTypes_37dbfbca4bce41e1a1f578050682b819);
             return (Task<string>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_d28cbb6713e740c89f5bc2be5046bbf6 = new Type[] {  };
 
         /// <inheritdoc />
         Task<string> IAmInterfaceD.Test()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Test", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Test", ArgumentTypes_d28cbb6713e740c89f5bc2be5046bbf6);
             return (Task<string>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_0e11e87a86d64afcb7d05cd37e5eb723 = new Type[] {  };
 
         /// <inheritdoc />
         Task<string> IAmInterfaceA.Ping()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Ping", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Ping", ArgumentTypes_0e11e87a86d64afcb7d05cd37e5eb723);
             return (Task<string>)func(Client, arguments);
         }
     }
@@ -235,11 +257,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_2b64ef43de854e7d9f5471d657f2454f = new Type[] {  };
+
         /// <inheritdoc />
         Task<string> IAmInterfaceA.Ping()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Ping", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Ping", ArgumentTypes_2b64ef43de854e7d9f5471d657f2454f);
             return (Task<string>)func(Client, arguments);
         }
     }
@@ -269,19 +293,23 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_595c45e753484023bc301bd04f39217e = new Type[] {  };
+
         /// <inheritdoc />
         Task<string> IAmInterfaceB.Pong()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Pong", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Pong", ArgumentTypes_595c45e753484023bc301bd04f39217e);
             return (Task<string>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_2ee7022f8a214c2aa5db0460af54c29d = new Type[] {  };
 
         /// <inheritdoc />
         Task<string> IAmInterfaceD.Test()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Test", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Test", ArgumentTypes_2ee7022f8a214c2aa5db0460af54c29d);
             return (Task<string>)func(Client, arguments);
         }
     }
@@ -311,35 +339,43 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_f17a8294548447baa65a1e5e3371d58d = new Type[] {  };
+
         /// <inheritdoc />
         Task<string> IAmInterfaceC.Pang()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Pang", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Pang", ArgumentTypes_f17a8294548447baa65a1e5e3371d58d);
             return (Task<string>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_2810c21ea8e741d5a27153a89d5ecf41 = new Type[] {  };
 
         /// <inheritdoc />
         Task<string> IAmInterfaceB.Pong()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Pong", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Pong", ArgumentTypes_2810c21ea8e741d5a27153a89d5ecf41);
             return (Task<string>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_cd8f9ce45e5943728fa1b36a959bf31f = new Type[] {  };
 
         /// <inheritdoc />
         Task<string> IAmInterfaceD.Test()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Test", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Test", ArgumentTypes_cd8f9ce45e5943728fa1b36a959bf31f);
             return (Task<string>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_e9955255ce5d41ec912e56360aee47dc = new Type[] {  };
 
         /// <inheritdoc />
         Task<string> IAmInterfaceA.Ping()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Ping", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Ping", ArgumentTypes_e9955255ce5d41ec912e56360aee47dc);
             return (Task<string>)func(Client, arguments);
         }
     }
@@ -369,11 +405,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_f4b72f17d20e4d60ae34dc4a4c06af82 = new Type[] {  };
+
         /// <inheritdoc />
         Task<string> IAmInterfaceD.Test()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Test", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Test", ArgumentTypes_f4b72f17d20e4d60ae34dc4a4c06af82);
             return (Task<string>)func(Client, arguments);
         }
     }
@@ -414,123 +452,153 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_36e1574ef1db4b098362998fc2daef06 = new Type[] { typeof(PathBoundObject) };
+
         /// <inheritdoc />
         Task IApiBindPathToObject.GetFooBars(PathBoundObject request)
         {
             var arguments = new object[] { request };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBars", new Type[] { typeof(PathBoundObject) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBars", ArgumentTypes_36e1574ef1db4b098362998fc2daef06);
             return (Task)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_b845e97272564812b80725f0bf39274d = new Type[] { typeof(PathBoundObject) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetFooBarsWithDifferentCasing(PathBoundObject requestParams)
         {
             var arguments = new object[] { requestParams };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBarsWithDifferentCasing", new Type[] { typeof(PathBoundObject) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBarsWithDifferentCasing", ArgumentTypes_b845e97272564812b80725f0bf39274d);
             return (Task)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_7ed56772ed494bc1b7cdde5d38b4116e = new Type[] { typeof(string), typeof(PathBoundObject) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetBarsByFoo(string id, PathBoundObject request)
         {
             var arguments = new object[] { id, request };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetBarsByFoo", new Type[] { typeof(string), typeof(PathBoundObject) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetBarsByFoo", ArgumentTypes_7ed56772ed494bc1b7cdde5d38b4116e);
             return (Task)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_d1eb82e6376b47d19fda28df0d9abed0 = new Type[] { typeof(PathBoundObject), typeof(string) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetFooBars(PathBoundObject request, string someProperty)
         {
             var arguments = new object[] { request, someProperty };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBars", new Type[] { typeof(PathBoundObject), typeof(string) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBars", ArgumentTypes_d1eb82e6376b47d19fda28df0d9abed0);
             return (Task)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_31216cf02e644140a176ecba9764f73f = new Type[] { typeof(PathBoundObject) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetBarsByFoo(PathBoundObject request)
         {
             var arguments = new object[] { request };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetBarsByFoo", new Type[] { typeof(PathBoundObject) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetBarsByFoo", ArgumentTypes_31216cf02e644140a176ecba9764f73f);
             return (Task)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_dcdea29985044726aa7e062f858bc187 = new Type[] { typeof(PathBoundObjectWithQueryFormat) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetBarsWithCustomQueryFormat(PathBoundObjectWithQueryFormat request)
         {
             var arguments = new object[] { request };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetBarsWithCustomQueryFormat", new Type[] { typeof(PathBoundObjectWithQueryFormat) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetBarsWithCustomQueryFormat", ArgumentTypes_dcdea29985044726aa7e062f858bc187);
             return (Task)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_a3a856b8678641d1ae1afd3d6c372cc7 = new Type[] { typeof(PathBoundDerivedObject) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetFooBarsDerived(PathBoundDerivedObject request)
         {
             var arguments = new object[] { request };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBarsDerived", new Type[] { typeof(PathBoundDerivedObject) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBarsDerived", ArgumentTypes_a3a856b8678641d1ae1afd3d6c372cc7);
             return (Task)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_2c397f5b067e49518825d3fe057f7c1c = new Type[] { typeof(PathBoundList) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetFoos(PathBoundList request)
         {
             var arguments = new object[] { request };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetFoos", new Type[] { typeof(PathBoundList) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetFoos", ArgumentTypes_2c397f5b067e49518825d3fe057f7c1c);
             return (Task)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_cc80fa40b24546249ba4ba9a42edec50 = new Type[] { typeof(List<int>) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetFoos2(List<int> Values)
         {
             var arguments = new object[] { Values };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetFoos2", new Type[] { typeof(List<int>) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetFoos2", ArgumentTypes_cc80fa40b24546249ba4ba9a42edec50);
             return (Task)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_19cd90d8d554487d8b338f294f96ccbd = new Type[] { typeof(PathBoundObject), typeof(object) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.PostFooBar(PathBoundObject request, object someObject)
         {
             var arguments = new object[] { request, someObject };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBar", new Type[] { typeof(PathBoundObject), typeof(object) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBar", ArgumentTypes_19cd90d8d554487d8b338f294f96ccbd);
             return (Task)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_40409913b6c140b2bd3ff5cdf3e0facf = new Type[] { typeof(PathBoundObjectWithQuery) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetFooBars(PathBoundObjectWithQuery request)
         {
             var arguments = new object[] { request };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBars", new Type[] { typeof(PathBoundObjectWithQuery) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBars", ArgumentTypes_40409913b6c140b2bd3ff5cdf3e0facf);
             return (Task)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_ee12434b291242748df20b33a5246dbf = new Type[] { typeof(PathBoundObject), typeof(ModelObject) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IApiBindPathToObject.PostFooBar(PathBoundObject request, ModelObject someQueryParams)
         {
             var arguments = new object[] { request, someQueryParams };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBar", new Type[] { typeof(PathBoundObject), typeof(ModelObject) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBar", ArgumentTypes_ee12434b291242748df20b33a5246dbf);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_2ed0045336934ee2a8f1944448ebcbd5 = new Type[] { typeof(PathBoundObject), typeof(ModelObject), typeof(StreamPart) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IApiBindPathToObject.PostFooBarStreamPart(PathBoundObject request, ModelObject someQueryParams, StreamPart stream)
         {
             var arguments = new object[] { request, someQueryParams, stream };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBarStreamPart", new Type[] { typeof(PathBoundObject), typeof(ModelObject), typeof(StreamPart) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBarStreamPart", ArgumentTypes_2ed0045336934ee2a8f1944448ebcbd5);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_9900f8aa498044c7b8c1b88f70960167 = new Type[] { typeof(PathBoundObject), typeof(StreamPart) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IApiBindPathToObject.PostFooBarStreamPart(PathBoundObject request, StreamPart stream)
         {
             var arguments = new object[] { request, stream };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBarStreamPart", new Type[] { typeof(PathBoundObject), typeof(StreamPart) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBarStreamPart", ArgumentTypes_9900f8aa498044c7b8c1b88f70960167);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_126ae16464f24719b30dae255754e0f9 = new Type[] { typeof(PathBoundObjectWithQuery), typeof(StreamPart) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IApiBindPathToObject.PostFooBarStreamPart(PathBoundObjectWithQuery request, StreamPart stream)
         {
             var arguments = new object[] { request, stream };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBarStreamPart", new Type[] { typeof(PathBoundObjectWithQuery), typeof(StreamPart) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBarStreamPart", ArgumentTypes_126ae16464f24719b30dae255754e0f9);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
     }
@@ -571,11 +639,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_7d7fe42698874fce813c5fc59b77a505 = new Type[] { typeof(decimal) };
+
         /// <inheritdoc />
         Task<string> IApiWithDecimal.GetWithDecimal(decimal value)
         {
             var arguments = new object[] { value };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetWithDecimal", new Type[] { typeof(decimal) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetWithDecimal", ArgumentTypes_7d7fe42698874fce813c5fc59b77a505);
             return (Task<string>)func(Client, arguments);
         }
     }
@@ -616,27 +686,33 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_ecc99d6d921d4eb9890c644b7e43c341 = new Type[] {  };
+
         /// <inheritdoc />
         Task IBodylessApi.Post()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Post", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Post", ArgumentTypes_ecc99d6d921d4eb9890c644b7e43c341);
             return (Task)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_55539be98de645d18e9f4913a92ebe85 = new Type[] {  };
 
         /// <inheritdoc />
         Task IBodylessApi.Get()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_55539be98de645d18e9f4913a92ebe85);
             return (Task)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_13069be661c249878a0c2d62db2a0b7a = new Type[] {  };
 
         /// <inheritdoc />
         Task IBodylessApi.Head()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Head", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Head", ArgumentTypes_13069be661c249878a0c2d62db2a0b7a);
             return (Task)func(Client, arguments);
         }
     }
@@ -677,43 +753,53 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_06f772f4b47443e38ee8175c8c907ed9 = new Type[] { typeof(T) };
+
         /// <inheritdoc />
         Task<T> IBoringCrudApi<T, TKey>.Create(T paylod)
         {
             var arguments = new object[] { paylod };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Create", new Type[] { typeof(T) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_06f772f4b47443e38ee8175c8c907ed9);
             return (Task<T>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_24f5bc4e6dc14bd6ada8f665ad3616e8 = new Type[] {  };
 
         /// <inheritdoc />
         Task<List<T>> IBoringCrudApi<T, TKey>.ReadAll()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_24f5bc4e6dc14bd6ada8f665ad3616e8);
             return (Task<List<T>>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_f936f303a3b14ab0bca79f4edb999481 = new Type[] { typeof(TKey) };
 
         /// <inheritdoc />
         Task<T> IBoringCrudApi<T, TKey>.ReadOne(TKey key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", new Type[] { typeof(TKey) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_f936f303a3b14ab0bca79f4edb999481);
             return (Task<T>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_ddac488f7d1c48b6b5ccabf696696040 = new Type[] { typeof(TKey), typeof(T) };
 
         /// <inheritdoc />
         Task IBoringCrudApi<T, TKey>.Update(TKey key, T payload)
         {
             var arguments = new object[] { key, payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Update", new Type[] { typeof(TKey), typeof(T) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_ddac488f7d1c48b6b5ccabf696696040);
             return (Task)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_a736080d5d1f4803a6b005296f624daf = new Type[] { typeof(TKey) };
 
         /// <inheritdoc />
         Task IBoringCrudApi<T, TKey>.Delete(TKey key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", new Type[] { typeof(TKey) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_a736080d5d1f4803a6b005296f624daf);
             return (Task)func(Client, arguments);
         }
     }
@@ -754,11 +840,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_4fbff88eb7424ab8b70029ab6aa0ed3a = new Type[] { typeof(string) };
+
         /// <inheritdoc />
         Task<bool> IBrokenWebApi.PostAValue(string derp)
         {
             var arguments = new object[] { derp };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostAValue", new Type[] { typeof(string) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostAValue", ArgumentTypes_4fbff88eb7424ab8b70029ab6aa0ed3a);
             return (Task<bool>)func(Client, arguments);
         }
     }
@@ -787,11 +875,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_f48ae7399ea44c0ba5f64c03bbe87793 = new Type[] {  };
+
         /// <inheritdoc />
         CustomReferenceType? ICustomNullableReferenceService.Get()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_f48ae7399ea44c0ba5f64c03bbe87793);
             return (CustomReferenceType?)func(Client, arguments);
         }
     }
@@ -820,11 +910,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_c425a67888524daeaa92093ecd4a7f04 = new Type[] {  };
+
         /// <inheritdoc />
         CustomValueType? ICustomNullableValueService.Get()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_c425a67888524daeaa92093ecd4a7f04);
             return (CustomValueType?)func(Client, arguments);
         }
     }
@@ -853,11 +945,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_9542d255f7ed43f78497edd59078dd8f = new Type[] { ToNullable(typeof(CustomReferenceType)), ToNullable(typeof(CustomValueType)) };
+
         /// <inheritdoc />
         Task ICustomReferenceAndValueParametersService.Get(CustomReferenceType? reference, CustomValueType? value)
         {
             var arguments = new object[] { reference, value };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", new Type[] { ToNullable(typeof(CustomReferenceType)), ToNullable(typeof(CustomValueType)) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_9542d255f7ed43f78497edd59078dd8f);
             return (Task)func(Client, arguments);
         }
 
@@ -890,59 +984,73 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_8c958b912b9c42d0838a424ded3236eb = new Type[] {  };
+
         /// <inheritdoc />
         Task IDataApiA.PingA()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PingA", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("PingA", ArgumentTypes_8c958b912b9c42d0838a424ded3236eb);
             return (Task)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_936576d716284b5eb2c44673494f0a3c = new Type[] { typeof(DataEntity) };
 
         /// <inheritdoc />
         Task<DataEntity> IDataCrudApi<DataEntity>.Copy(DataEntity payload)
         {
             var arguments = new object[] { payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Copy", new Type[] { typeof(DataEntity) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Copy", ArgumentTypes_936576d716284b5eb2c44673494f0a3c);
             return (Task<DataEntity>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_8bc6f6b52ef94ba5a56b524877acabe7 = new Type[] { typeof(DataEntity) };
 
         /// <inheritdoc />
         Task<DataEntity> IDataCrudApi<DataEntity, long>.Create(DataEntity payload)
         {
             var arguments = new object[] { payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Create", new Type[] { typeof(DataEntity) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_8bc6f6b52ef94ba5a56b524877acabe7);
             return (Task<DataEntity>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_c04a4d593dfd4eb4a864f3cfdf674090 = new Type[] {  };
 
         /// <inheritdoc />
         Task<List<DataEntity>> IDataCrudApi<DataEntity, long>.ReadAll()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_c04a4d593dfd4eb4a864f3cfdf674090);
             return (Task<List<DataEntity>>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_16ae16cd81404731a5599b9526e8df93 = new Type[] { typeof(long) };
 
         /// <inheritdoc />
         Task<DataEntity> IDataCrudApi<DataEntity, long>.ReadOne(long key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", new Type[] { typeof(long) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_16ae16cd81404731a5599b9526e8df93);
             return (Task<DataEntity>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_640a2a59fb2a47498fa79075abdd7e2a = new Type[] { typeof(long), typeof(DataEntity) };
 
         /// <inheritdoc />
         Task IDataCrudApi<DataEntity, long>.Update(long key, DataEntity payload)
         {
             var arguments = new object[] { key, payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Update", new Type[] { typeof(long), typeof(DataEntity) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_640a2a59fb2a47498fa79075abdd7e2a);
             return (Task)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_e1336590050d4daab4e11dda17534cfd = new Type[] { typeof(long) };
 
         /// <inheritdoc />
         Task IDataCrudApi<DataEntity, long>.Delete(long key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", new Type[] { typeof(long) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_e1336590050d4daab4e11dda17534cfd);
             return (Task)func(Client, arguments);
         }
     }
@@ -973,51 +1081,63 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_189e6f2eed3d4b24a192785ff691a6f8 = new Type[] {  };
+
         /// <inheritdoc />
         Task IDataApiB.PingB()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PingB", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("PingB", ArgumentTypes_189e6f2eed3d4b24a192785ff691a6f8);
             return (Task)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_b0209bc21eb642c6be46cc543277e835 = new Type[] { typeof(DataEntity) };
 
         /// <inheritdoc />
         Task<DataEntity> IDataCrudApi<DataEntity, int>.Create(DataEntity payload)
         {
             var arguments = new object[] { payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Create", new Type[] { typeof(DataEntity) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_b0209bc21eb642c6be46cc543277e835);
             return (Task<DataEntity>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_2cbeabc1e6a5470ebc4e6e60722e174a = new Type[] {  };
 
         /// <inheritdoc />
         Task<List<DataEntity>> IDataCrudApi<DataEntity, int>.ReadAll()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_2cbeabc1e6a5470ebc4e6e60722e174a);
             return (Task<List<DataEntity>>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_c32da297ed1043da9af8bf0e8cb0455c = new Type[] { typeof(int) };
 
         /// <inheritdoc />
         Task<DataEntity> IDataCrudApi<DataEntity, int>.ReadOne(int key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", new Type[] { typeof(int) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_c32da297ed1043da9af8bf0e8cb0455c);
             return (Task<DataEntity>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_ab7664235f4e4c14aef8a24ec82f3a26 = new Type[] { typeof(int), typeof(DataEntity) };
 
         /// <inheritdoc />
         Task IDataCrudApi<DataEntity, int>.Update(int key, DataEntity payload)
         {
             var arguments = new object[] { key, payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Update", new Type[] { typeof(int), typeof(DataEntity) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_ab7664235f4e4c14aef8a24ec82f3a26);
             return (Task)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_ce25c0b32e3e4eef924a22882c8a0752 = new Type[] { typeof(int) };
 
         /// <inheritdoc />
         Task IDataCrudApi<DataEntity, int>.Delete(int key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", new Type[] { typeof(int) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_ce25c0b32e3e4eef924a22882c8a0752);
             return (Task)func(Client, arguments);
         }
     }
@@ -1051,51 +1171,63 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_6bc549767e6f4bca9b88adad85cef31e = new Type[] { typeof(T) };
+
         /// <inheritdoc />
         Task<T> IDataCrudApi<T>.Copy(T payload)
         {
             var arguments = new object[] { payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Copy", new Type[] { typeof(T) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Copy", ArgumentTypes_6bc549767e6f4bca9b88adad85cef31e);
             return (Task<T>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_98f1eb1d27a04deb92053063f0e092fe = new Type[] { typeof(T) };
 
         /// <inheritdoc />
         Task<T> IDataCrudApi<T, long>.Create(T payload)
         {
             var arguments = new object[] { payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Create", new Type[] { typeof(T) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_98f1eb1d27a04deb92053063f0e092fe);
             return (Task<T>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_6a001a9eb3fb4916a906ee365cfb928c = new Type[] {  };
 
         /// <inheritdoc />
         Task<List<T>> IDataCrudApi<T, long>.ReadAll()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_6a001a9eb3fb4916a906ee365cfb928c);
             return (Task<List<T>>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_df838d55651145fa8463c120ccc776da = new Type[] { typeof(long) };
 
         /// <inheritdoc />
         Task<T> IDataCrudApi<T, long>.ReadOne(long key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", new Type[] { typeof(long) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_df838d55651145fa8463c120ccc776da);
             return (Task<T>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_5d3cd2ee21e64eacbbf4be7221a7de66 = new Type[] { typeof(long), typeof(T) };
 
         /// <inheritdoc />
         Task IDataCrudApi<T, long>.Update(long key, T payload)
         {
             var arguments = new object[] { key, payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Update", new Type[] { typeof(long), typeof(T) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_5d3cd2ee21e64eacbbf4be7221a7de66);
             return (Task)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_abce846f762343a29c013776cfa3a695 = new Type[] { typeof(long) };
 
         /// <inheritdoc />
         Task IDataCrudApi<T, long>.Delete(long key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", new Type[] { typeof(long) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_abce846f762343a29c013776cfa3a695);
             return (Task)func(Client, arguments);
         }
     }
@@ -1129,43 +1261,53 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_9216c40587f94d1f835a263fd51267a0 = new Type[] { typeof(T) };
+
         /// <inheritdoc />
         Task<T> IDataCrudApi<T, TKey>.Create(T payload)
         {
             var arguments = new object[] { payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Create", new Type[] { typeof(T) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_9216c40587f94d1f835a263fd51267a0);
             return (Task<T>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_f6fbccd3f1dc4f5ebafb9ebed27d7eaf = new Type[] {  };
 
         /// <inheritdoc />
         Task<List<T>> IDataCrudApi<T, TKey>.ReadAll()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_f6fbccd3f1dc4f5ebafb9ebed27d7eaf);
             return (Task<List<T>>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_53c35b33c20f4848b554a8a34cbbf13d = new Type[] { typeof(TKey) };
 
         /// <inheritdoc />
         Task<T> IDataCrudApi<T, TKey>.ReadOne(TKey key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", new Type[] { typeof(TKey) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_53c35b33c20f4848b554a8a34cbbf13d);
             return (Task<T>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_2e2a9633c67245b5bf38415f36c55c7c = new Type[] { typeof(TKey), typeof(T) };
 
         /// <inheritdoc />
         Task IDataCrudApi<T, TKey>.Update(TKey key, T payload)
         {
             var arguments = new object[] { key, payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Update", new Type[] { typeof(TKey), typeof(T) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_2e2a9633c67245b5bf38415f36c55c7c);
             return (Task)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_0180f876b8054f0a98eb266f086aad4d = new Type[] { typeof(TKey) };
 
         /// <inheritdoc />
         Task IDataCrudApi<T, TKey>.Delete(TKey key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", new Type[] { typeof(TKey) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_0180f876b8054f0a98eb266f086aad4d);
             return (Task)func(Client, arguments);
         }
     }
@@ -1194,11 +1336,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_e0cef85e830644f9996c52f23d63a0a2 = new Type[] { ToNullable(typeof(System.Collections.Generic.List<string>)) };
+
         /// <inheritdoc />
         Task IGenericNullableReferenceParameterService.Get(System.Collections.Generic.List<string>? reference)
         {
             var arguments = new object[] { reference };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", new Type[] { ToNullable(typeof(System.Collections.Generic.List<string>)) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_e0cef85e830644f9996c52f23d63a0a2);
             return (Task)func(Client, arguments);
         }
 
@@ -1229,11 +1373,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_65726e7915f9477f8a2dc48fc6d013ab = new Type[] {  };
+
         /// <inheritdoc />
         Task<string>? IGenericNullableReferenceService.Get()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_65726e7915f9477f8a2dc48fc6d013ab);
             return (Task<string>?)func(Client, arguments);
         }
     }
@@ -1262,11 +1408,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_208b3d74280c472ea3360f18ee04e5ef = new Type[] {  };
+
         /// <inheritdoc />
         ValueTask<int>? IGenericNullableValueService.Get()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_208b3d74280c472ea3360f18ee04e5ef);
             return (ValueTask<int>?)func(Client, arguments);
         }
     }
@@ -1295,11 +1443,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_7cae2099dc444f78a434cd9d683fcf43 = new Type[] { ToNullable(typeof(System.Collections.Generic.List<string?>)) };
+
         /// <inheritdoc />
         Task IGenericNullableWithNullableReferenceParameterService.Get(System.Collections.Generic.List<string?>? reference)
         {
             var arguments = new object[] { reference };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", new Type[] { ToNullable(typeof(System.Collections.Generic.List<string?>)) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_7cae2099dc444f78a434cd9d683fcf43);
             return (Task)func(Client, arguments);
         }
 
@@ -1330,11 +1480,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_23df346cd79747f08e2daf8ebd4537a6 = new Type[] {  };
+
         /// <inheritdoc />
         Task<string?>? IGenericNullableWithNullableReferenceService.Get()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_23df346cd79747f08e2daf8ebd4537a6);
             return (Task<string?>?)func(Client, arguments);
         }
     }
@@ -1363,11 +1515,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_3f18b455174f43f1aa562b4ea27354fb = new Type[] {  };
+
         /// <inheritdoc />
         ValueTask<int?>? IGenericNullableWithNullableValueService.Get()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_3f18b455174f43f1aa562b4ea27354fb);
             return (ValueTask<int?>?)func(Client, arguments);
         }
     }
@@ -1396,11 +1550,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_cb4970f37e22408ba17e98692e2428d8 = new Type[] { typeof(System.Collections.Generic.List<string?>) };
+
         /// <inheritdoc />
         Task IGenericWithNullableReferenceParameterService.Get(System.Collections.Generic.List<string?> reference)
         {
             var arguments = new object[] { reference };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", new Type[] { typeof(System.Collections.Generic.List<string?>) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_cb4970f37e22408ba17e98692e2428d8);
             return (Task)func(Client, arguments);
         }
     }
@@ -1429,11 +1585,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_01d5977497ae44f5ba78ff47d5a068f5 = new Type[] {  };
+
         /// <inheritdoc />
         Task<int?> IGenericWithNullableValueService.Get()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_01d5977497ae44f5ba78ff47d5a068f5);
             return (Task<int?>)func(Client, arguments);
         }
     }
@@ -1462,11 +1620,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_6f2f746b389d45038e5aa14824712c95 = new Type[] {  };
+
         /// <inheritdoc />
         Task<string?> IGenericWithResultService.Get()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_6f2f746b389d45038e5aa14824712c95);
             return (Task<string?>)func(Client, arguments);
         }
     }
@@ -1501,107 +1661,133 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_b95f836d608d407695d74c33ac6d5bdd = new Type[] { typeof(string) };
+
         /// <inheritdoc />
         Task<User> IGitHubApi.GetUser(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUser", new Type[] { typeof(string) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUser", ArgumentTypes_b95f836d608d407695d74c33ac6d5bdd);
             return (Task<User>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_daa598a5ad9d4912b7064bce4e2dea1b = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         IObservable<User> IGitHubApi.GetUserObservable(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserObservable", new Type[] { typeof(string) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserObservable", ArgumentTypes_daa598a5ad9d4912b7064bce4e2dea1b);
             return (IObservable<User>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_cc7074f87041491c80552f6401686b18 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         IObservable<User> IGitHubApi.GetUserCamelCase(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserCamelCase", new Type[] { typeof(string) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserCamelCase", ArgumentTypes_cc7074f87041491c80552f6401686b18);
             return (IObservable<User>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_b840fde57630478f858e54ab664157c9 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<List<User>> IGitHubApi.GetOrgMembers(string orgName)
         {
             var arguments = new object[] { orgName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetOrgMembers", new Type[] { typeof(string) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetOrgMembers", ArgumentTypes_b840fde57630478f858e54ab664157c9);
             return (Task<List<User>>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_464d632e840f4bb7b2dfaa682b06958c = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<UserSearchResult> IGitHubApi.FindUsers(string q)
         {
             var arguments = new object[] { q };
-            var func = requestBuilder.BuildRestResultFuncForMethod("FindUsers", new Type[] { typeof(string) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("FindUsers", ArgumentTypes_464d632e840f4bb7b2dfaa682b06958c);
             return (Task<UserSearchResult>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_50aff6f3004041c6a636ac8c2506a096 = new Type[] {  };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IGitHubApi.GetIndex()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndex", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndex", ArgumentTypes_50aff6f3004041c6a636ac8c2506a096);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_d9af0075133e45eaa7025ae3f63560c1 = new Type[] {  };
 
         /// <inheritdoc />
         IObservable<string> IGitHubApi.GetIndexObservable()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndexObservable", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndexObservable", ArgumentTypes_d9af0075133e45eaa7025ae3f63560c1);
             return (IObservable<string>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_178960cf291b4fd8b9812afa9b7707ef = new Type[] {  };
 
         /// <inheritdoc />
         Task<User> IGitHubApi.NothingToSeeHere()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("NothingToSeeHere", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("NothingToSeeHere", ArgumentTypes_178960cf291b4fd8b9812afa9b7707ef);
             return (Task<User>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_1e1c0d77ec8e499da0a9f3396dc143f7 = new Type[] {  };
 
         /// <inheritdoc />
         Task<ApiResponse<User>> IGitHubApi.NothingToSeeHereWithMetadata()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("NothingToSeeHereWithMetadata", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("NothingToSeeHereWithMetadata", ArgumentTypes_1e1c0d77ec8e499da0a9f3396dc143f7);
             return (Task<ApiResponse<User>>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_55abac561507451ebdf216ec47685a4a = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<ApiResponse<User>> IGitHubApi.GetUserWithMetadata(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserWithMetadata", new Type[] { typeof(string) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserWithMetadata", ArgumentTypes_55abac561507451ebdf216ec47685a4a);
             return (Task<ApiResponse<User>>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_9d6e7f1e8adf493eae8951fa0d265cc0 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         IObservable<ApiResponse<User>> IGitHubApi.GetUserObservableWithMetadata(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserObservableWithMetadata", new Type[] { typeof(string) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserObservableWithMetadata", ArgumentTypes_9d6e7f1e8adf493eae8951fa0d265cc0);
             return (IObservable<ApiResponse<User>>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_b09ae606fe4e4347ac6df3fbdbe1bcbe = new Type[] { typeof(User) };
 
         /// <inheritdoc />
         Task<User> IGitHubApi.CreateUser(User user)
         {
             var arguments = new object[] { user };
-            var func = requestBuilder.BuildRestResultFuncForMethod("CreateUser", new Type[] { typeof(User) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("CreateUser", ArgumentTypes_b09ae606fe4e4347ac6df3fbdbe1bcbe);
             return (Task<User>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_59ba8f8ab7824074a8a3879ca8dbd399 = new Type[] { typeof(User) };
 
         /// <inheritdoc />
         Task<ApiResponse<User>> IGitHubApi.CreateUserWithMetadata(User user)
         {
             var arguments = new object[] { user };
-            var func = requestBuilder.BuildRestResultFuncForMethod("CreateUserWithMetadata", new Type[] { typeof(User) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("CreateUserWithMetadata", ArgumentTypes_59ba8f8ab7824074a8a3879ca8dbd399);
             return (Task<ApiResponse<User>>)func(Client, arguments);
         }
     }
@@ -1646,43 +1832,57 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_d7e7f8f4e9264e21ad13c7e3f8a7896c = new Type[] { typeof(TParam), typeof(THeader) };
+
         /// <inheritdoc />
         Task<TResponse> IHttpBinApi<TResponse, TParam, THeader>.Get(TParam param, THeader header)
         {
             var arguments = new object[] { param, header };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", new Type[] { typeof(TParam), typeof(THeader) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_d7e7f8f4e9264e21ad13c7e3f8a7896c);
             return (Task<TResponse>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_cd9a93d5b0f548aa91dbed655f96ffbd = new Type[] { typeof(TParam) };
 
         /// <inheritdoc />
         Task<TResponse> IHttpBinApi<TResponse, TParam, THeader>.GetQuery(TParam param)
         {
             var arguments = new object[] { param };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetQuery", new Type[] { typeof(TParam) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetQuery", ArgumentTypes_cd9a93d5b0f548aa91dbed655f96ffbd);
             return (Task<TResponse>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_70922752917b480d8cd0e6f5da68dd1b = new Type[] { typeof(TParam) };
 
         /// <inheritdoc />
         Task<TResponse> IHttpBinApi<TResponse, TParam, THeader>.PostQuery(TParam param)
         {
             var arguments = new object[] { param };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostQuery", new Type[] { typeof(TParam) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostQuery", ArgumentTypes_70922752917b480d8cd0e6f5da68dd1b);
             return (Task<TResponse>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_82ad60ed85414d418066f700977ce0cf = new Type[] { typeof(TParam) };
 
         /// <inheritdoc />
         Task<TResponse> IHttpBinApi<TResponse, TParam, THeader>.GetQueryWithIncludeParameterName(TParam param)
         {
             var arguments = new object[] { param };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetQueryWithIncludeParameterName", new Type[] { typeof(TParam) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetQueryWithIncludeParameterName", ArgumentTypes_82ad60ed85414d418066f700977ce0cf);
             return (Task<TResponse>)func(Client, arguments);
+        }
+
+        private static class TypeHelper_0ac9fdcc11424dde9c38248106a69894<TValue>
+        {
+            public static readonly Type[] ArgumentTypes = new Type[] { typeof(TParam) };
+            public static readonly Type[] TypeParameters = new Type[] { typeof(TValue) };
         }
 
         /// <inheritdoc />
         Task<TValue> IHttpBinApi<TResponse, TParam, THeader>.GetQuery1<TValue>(TParam param)
         {
             var arguments = new object[] { param };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetQuery1", new Type[] { typeof(TParam) }, new Type[] { typeof(TValue) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetQuery1", TypeHelper_0ac9fdcc11424dde9c38248106a69894<TValue>.ArgumentTypes, TypeHelper_0ac9fdcc11424dde9c38248106a69894<TValue>.TypeParameters);
             return (Task<TValue>)func(Client, arguments);
         }
     }
@@ -1723,19 +1923,23 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_b209bf0ddd334025b586f23ad0e0ec72 = new Type[] { typeof(HttpContent) };
+
         /// <inheritdoc />
         Task<HttpContent> IHttpContentApi.PostFileUpload(HttpContent content)
         {
             var arguments = new object[] { content };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostFileUpload", new Type[] { typeof(HttpContent) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostFileUpload", ArgumentTypes_b209bf0ddd334025b586f23ad0e0ec72);
             return (Task<HttpContent>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_d8bb383cb3074985b2262a77fae4c74f = new Type[] { typeof(HttpContent) };
 
         /// <inheritdoc />
         Task<ApiResponse<HttpContent>> IHttpContentApi.PostFileUploadWithMetadata(HttpContent content)
         {
             var arguments = new object[] { content };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostFileUploadWithMetadata", new Type[] { typeof(HttpContent) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostFileUploadWithMetadata", ArgumentTypes_d8bb383cb3074985b2262a77fae4c74f);
             return (Task<ApiResponse<HttpContent>>)func(Client, arguments);
         }
     }
@@ -1777,11 +1981,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_dd1ab6a96f8a4b6fa723c8112af45ef4 = new Type[] {  };
+
         /// <inheritdoc />
         Task<TestAliasObject> ResponseTests.IMyAliasService.GetTestObject()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetTestObject", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetTestObject", ArgumentTypes_dd1ab6a96f8a4b6fa723c8112af45ef4);
             return (Task<TestAliasObject>)func(Client, arguments);
         }
     }
@@ -1817,19 +2023,23 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_998257438a2e40a98858fefc86688e5c = new Type[] {  };
+
         /// <inheritdoc />
         Task<string> AuthenticatedClientHandlerTests.IMyAuthenticatedService.GetUnauthenticated()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUnauthenticated", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUnauthenticated", ArgumentTypes_998257438a2e40a98858fefc86688e5c);
             return (Task<string>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_94e6d83241134dd68225a3c79d34f7ab = new Type[] {  };
 
         /// <inheritdoc />
         Task<string> AuthenticatedClientHandlerTests.IMyAuthenticatedService.GetAuthenticated()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetAuthenticated", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetAuthenticated", ArgumentTypes_94e6d83241134dd68225a3c79d34f7ab);
             return (Task<string>)func(Client, arguments);
         }
     }
@@ -1860,11 +2070,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_d39408f77b764df089b25f5a7a419020 = new Type[] {  };
+
         /// <inheritdoc />
         Task<SomeType> INamespaceCollisionApi.SomeRequest()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", ArgumentTypes_d39408f77b764df089b25f5a7a419020);
             return (Task<SomeType>)func(Client, arguments);
         }
     }
@@ -1896,11 +2108,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_0edac52c77c54094951d4ca8ef8d8c29 = new Type[] {  };
+
         /// <inheritdoc />
         Task<SomeOtherType> INamespaceOverlapApi.SomeRequest()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", ArgumentTypes_0edac52c77c54094951d4ca8ef8d8c29);
             return (Task<SomeOtherType>)func(Client, arguments);
         }
     }
@@ -1935,67 +2149,83 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_4b98656ddefd462cb92fabba1f866162 = new Type[] { typeof(string) };
+
         /// <inheritdoc />
         Task<User> TestNested.INestedGitHubApi.GetUser(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUser", new Type[] { typeof(string) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUser", ArgumentTypes_4b98656ddefd462cb92fabba1f866162);
             return (Task<User>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_6edd73604f69438c81f067d591bf8865 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         IObservable<User> TestNested.INestedGitHubApi.GetUserObservable(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserObservable", new Type[] { typeof(string) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserObservable", ArgumentTypes_6edd73604f69438c81f067d591bf8865);
             return (IObservable<User>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_192deefdd4824932b8646de826f23cc8 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         IObservable<User> TestNested.INestedGitHubApi.GetUserCamelCase(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserCamelCase", new Type[] { typeof(string) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserCamelCase", ArgumentTypes_192deefdd4824932b8646de826f23cc8);
             return (IObservable<User>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_deb7fa5e47764b95876644502527bcd2 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<List<User>> TestNested.INestedGitHubApi.GetOrgMembers(string orgName)
         {
             var arguments = new object[] { orgName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetOrgMembers", new Type[] { typeof(string) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetOrgMembers", ArgumentTypes_deb7fa5e47764b95876644502527bcd2);
             return (Task<List<User>>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_4443c6eeab674504866d8808e59138b8 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<UserSearchResult> TestNested.INestedGitHubApi.FindUsers(string q)
         {
             var arguments = new object[] { q };
-            var func = requestBuilder.BuildRestResultFuncForMethod("FindUsers", new Type[] { typeof(string) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("FindUsers", ArgumentTypes_4443c6eeab674504866d8808e59138b8);
             return (Task<UserSearchResult>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_5b889676a34248b89ea9159f81c80b2a = new Type[] {  };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> TestNested.INestedGitHubApi.GetIndex()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndex", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndex", ArgumentTypes_5b889676a34248b89ea9159f81c80b2a);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_f7f4f274557d46a8905a330f8fe7c18f = new Type[] {  };
 
         /// <inheritdoc />
         IObservable<string> TestNested.INestedGitHubApi.GetIndexObservable()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndexObservable", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndexObservable", ArgumentTypes_f7f4f274557d46a8905a330f8fe7c18f);
             return (IObservable<string>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_087209133c8e4a2b82d9d0c6a8473906 = new Type[] {  };
 
         /// <inheritdoc />
         Task TestNested.INestedGitHubApi.NothingToSeeHere()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("NothingToSeeHere", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("NothingToSeeHere", ArgumentTypes_087209133c8e4a2b82d9d0c6a8473906);
             return (Task)func(Client, arguments);
         }
     }
@@ -2033,19 +2263,31 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static class TypeHelper_0efbbf3123bd4f24ac089aa1a50de3ce<T>
+        {
+            public static readonly Type[] ArgumentTypes = new Type[] { typeof(T) };
+            public static readonly Type[] TypeParameters = new Type[] { typeof(T) };
+        }
+
         /// <inheritdoc />
         Task INonGenericInterfaceWithGenericMethod.PostMessage<T>(T message)
         {
             var arguments = new object[] { message };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostMessage", new Type[] { typeof(T) }, new Type[] { typeof(T) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostMessage", TypeHelper_0efbbf3123bd4f24ac089aa1a50de3ce<T>.ArgumentTypes, TypeHelper_0efbbf3123bd4f24ac089aa1a50de3ce<T>.TypeParameters);
             return (Task)func(Client, arguments);
+        }
+
+        private static class TypeHelper_38bcb4e52db545909599e230fbf19ab6<T, U, V>
+        {
+            public static readonly Type[] ArgumentTypes = new Type[] { typeof(T), typeof(U), typeof(V) };
+            public static readonly Type[] TypeParameters = new Type[] { typeof(T), typeof(U), typeof(V) };
         }
 
         /// <inheritdoc />
         Task INonGenericInterfaceWithGenericMethod.PostMessage<T, U, V>(T message, U param1, V param2)
         {
             var arguments = new object[] { message, param1, param2 };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostMessage", new Type[] { typeof(T), typeof(U), typeof(V) }, new Type[] { typeof(T), typeof(U), typeof(V) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostMessage", TypeHelper_38bcb4e52db545909599e230fbf19ab6<T, U, V>.ArgumentTypes, TypeHelper_38bcb4e52db545909599e230fbf19ab6<T, U, V>.TypeParameters);
             return (Task)func(Client, arguments);
         }
     }
@@ -2086,11 +2328,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_debca49b25d04e04aae1d4f46ea51bd2 = new Type[] {  };
+
         /// <inheritdoc />
         Task<RootObject> INpmJs.GetCongruence()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetCongruence", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetCongruence", ArgumentTypes_debca49b25d04e04aae1d4f46ea51bd2);
             return (Task<RootObject>)func(Client, arguments);
         }
     }
@@ -2119,11 +2363,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_544ad08a41674c6692b3f0d7dbe433d4 = new Type[] {  };
+
         /// <inheritdoc />
         string? INullableReferenceService.Get()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_544ad08a41674c6692b3f0d7dbe433d4);
             return (string?)func(Client, arguments);
         }
     }
@@ -2152,11 +2398,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_f3ad97419661458f8ee72107a62ec6da = new Type[] {  };
+
         /// <inheritdoc />
         int? INullableValueService.Get()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_f3ad97419661458f8ee72107a62ec6da);
             return (int?)func(Client, arguments);
         }
     }
@@ -2186,11 +2434,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_cd3303368c9b498f8aed3fb8c7a73e6e = new Type[] {  };
+
         /// <inheritdoc />
         Task<SomeType> IReducedUsingInsideNamespaceApi.SomeRequest()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", ArgumentTypes_cd3303368c9b498f8aed3fb8c7a73e6e);
             return (Task<SomeType>)func(Client, arguments);
         }
     }
@@ -2219,11 +2469,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_af0cc83deaa64183b280b561efe8065a = new Type[] { ToNullable(typeof(string)), ToNullable(typeof(int)) };
+
         /// <inheritdoc />
         Task IReferenceAndValueParametersService.Get(string? reference, int? value)
         {
             var arguments = new object[] { reference, value };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", new Type[] { ToNullable(typeof(string)), ToNullable(typeof(int)) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_af0cc83deaa64183b280b561efe8065a);
             return (Task)func(Client, arguments);
         }
 
@@ -2266,11 +2518,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_2e857b524c484e3a930f1985d7f24104 = new Type[] {  };
+
         /// <inheritdoc />
         Task IRefitInterfaceWithStaticMethod.Get()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_2e857b524c484e3a930f1985d7f24104);
             return (Task)func(Client, arguments);
         }
     }
@@ -2311,43 +2565,57 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_530141991d3a44cbb5d862561640ee64 = new Type[] {  };
+
         /// <inheritdoc />
         Task IRequestBin.Post()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Post", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Post", ArgumentTypes_530141991d3a44cbb5d862561640ee64);
             return (Task)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_061df13e21b34b63b30331188bea7f25 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task IRequestBin.PostRawStringDefault(string str)
         {
             var arguments = new object[] { str };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostRawStringDefault", new Type[] { typeof(string) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostRawStringDefault", ArgumentTypes_061df13e21b34b63b30331188bea7f25);
             return (Task)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_ad94a04c8de54288bb80e72ae75c7742 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task IRequestBin.PostRawStringJson(string str)
         {
             var arguments = new object[] { str };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostRawStringJson", new Type[] { typeof(string) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostRawStringJson", ArgumentTypes_ad94a04c8de54288bb80e72ae75c7742);
             return (Task)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_34a9a1e975524e1c8237b0acafba0047 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task IRequestBin.PostRawStringUrlEncoded(string str)
         {
             var arguments = new object[] { str };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostRawStringUrlEncoded", new Type[] { typeof(string) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostRawStringUrlEncoded", ArgumentTypes_34a9a1e975524e1c8237b0acafba0047);
             return (Task)func(Client, arguments);
+        }
+
+        private static class TypeHelper_0006ecf1dfd3412dac0509149ce0c95f<T>
+        {
+            public static readonly Type[] ArgumentTypes = new Type[] { typeof(T) };
+            public static readonly Type[] TypeParameters = new Type[] { typeof(T) };
         }
 
         /// <inheritdoc />
         Task IRequestBin.PostGeneric<T>(T param)
         {
             var arguments = new object[] { param };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostGeneric", new Type[] { typeof(T) }, new Type[] { typeof(T) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostGeneric", TypeHelper_0006ecf1dfd3412dac0509149ce0c95f<T>.ArgumentTypes, TypeHelper_0006ecf1dfd3412dac0509149ce0c95f<T>.TypeParameters);
             return (Task)func(Client, arguments);
         }
     }
@@ -2388,107 +2656,133 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_52a7e959154447c595ed0d84d6f595c1 = new Type[] { typeof(Stream) };
+
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadStream(Stream stream)
         {
             var arguments = new object[] { stream };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStream", new Type[] { typeof(Stream) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStream", ArgumentTypes_52a7e959154447c595ed0d84d6f595c1);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_deef3643bb124865a4f0dd5c42035e47 = new Type[] { typeof(Stream) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadStreamWithCustomBoundary(Stream stream)
         {
             var arguments = new object[] { stream };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStreamWithCustomBoundary", new Type[] { typeof(Stream) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStreamWithCustomBoundary", ArgumentTypes_deef3643bb124865a4f0dd5c42035e47);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_32f7cfce69d74a15a0151fc9a882fef9 = new Type[] { typeof(StreamPart) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadStreamPart(StreamPart stream)
         {
             var arguments = new object[] { stream };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStreamPart", new Type[] { typeof(StreamPart) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStreamPart", ArgumentTypes_32f7cfce69d74a15a0151fc9a882fef9);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_6e114fdb34a643b8809f5e6538fe15db = new Type[] { typeof(ModelObject), typeof(StreamPart) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadStreamPart(ModelObject someQueryParams, StreamPart stream)
         {
             var arguments = new object[] { someQueryParams, stream };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStreamPart", new Type[] { typeof(ModelObject), typeof(StreamPart) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStreamPart", ArgumentTypes_6e114fdb34a643b8809f5e6538fe15db);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_095967ab42954b6f8d58accafc03ca31 = new Type[] { typeof(byte[]) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadBytes(byte[] bytes)
         {
             var arguments = new object[] { bytes };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadBytes", new Type[] { typeof(byte[]) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadBytes", ArgumentTypes_095967ab42954b6f8d58accafc03ca31);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_6452f4affe1f4115a11514084b671891 = new Type[] { typeof(ByteArrayPart) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadBytesPart(ByteArrayPart bytes)
         {
             var arguments = new object[] { bytes };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadBytesPart", new Type[] { typeof(ByteArrayPart) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadBytesPart", ArgumentTypes_6452f4affe1f4115a11514084b671891);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_5340467652404e228680d055011f9229 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadString(string someString)
         {
             var arguments = new object[] { someString };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadString", new Type[] { typeof(string) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadString", ArgumentTypes_5340467652404e228680d055011f9229);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_cecec1bb69ed40d18bc9f1b750c09810 = new Type[] { typeof(IEnumerable<FileInfo>), typeof(FileInfo) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadFileInfo(IEnumerable<FileInfo> fileInfos, FileInfo anotherFile)
         {
             var arguments = new object[] { fileInfos, anotherFile };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadFileInfo", new Type[] { typeof(IEnumerable<FileInfo>), typeof(FileInfo) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadFileInfo", ArgumentTypes_cecec1bb69ed40d18bc9f1b750c09810);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_4e112f2f2644498b9dc4f3237f47ec1b = new Type[] { typeof(IEnumerable<FileInfoPart>), typeof(FileInfoPart) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadFileInfoPart(IEnumerable<FileInfoPart> fileInfos, FileInfoPart anotherFile)
         {
             var arguments = new object[] { fileInfos, anotherFile };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadFileInfoPart", new Type[] { typeof(IEnumerable<FileInfoPart>), typeof(FileInfoPart) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadFileInfoPart", ArgumentTypes_4e112f2f2644498b9dc4f3237f47ec1b);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_97235970974b4460923df7165a0e4a63 = new Type[] { typeof(ModelObject) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadJsonObject(ModelObject theObject)
         {
             var arguments = new object[] { theObject };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadJsonObject", new Type[] { typeof(ModelObject) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadJsonObject", ArgumentTypes_97235970974b4460923df7165a0e4a63);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_b808705ebabc4a519b8f16fec414680d = new Type[] { typeof(IEnumerable<ModelObject>) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadJsonObjects(IEnumerable<ModelObject> theObjects)
         {
             var arguments = new object[] { theObjects };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadJsonObjects", new Type[] { typeof(IEnumerable<ModelObject>) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadJsonObjects", ArgumentTypes_b808705ebabc4a519b8f16fec414680d);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_d16650d4ea714ddaaf610b5ed392dce2 = new Type[] { typeof(IEnumerable<ModelObject>), typeof(AnotherModel), typeof(FileInfo), typeof(AnEnum), typeof(string), typeof(int) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadMixedObjects(IEnumerable<ModelObject> theObjects, AnotherModel anotherModel, FileInfo aFile, AnEnum anEnum, string aString, int anInt)
         {
             var arguments = new object[] { theObjects, anotherModel, aFile, anEnum, aString, anInt };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadMixedObjects", new Type[] { typeof(IEnumerable<ModelObject>), typeof(AnotherModel), typeof(FileInfo), typeof(AnEnum), typeof(string), typeof(int) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadMixedObjects", ArgumentTypes_d16650d4ea714ddaaf610b5ed392dce2);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_1ca8c106f1da4631bf6a5653f88e2076 = new Type[] { typeof(HttpContent) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadHttpContent(HttpContent content)
         {
             var arguments = new object[] { content };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadHttpContent", new Type[] { typeof(HttpContent) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadHttpContent", ArgumentTypes_1ca8c106f1da4631bf6a5653f88e2076);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
     }
@@ -2520,19 +2814,23 @@ namespace AutoGeneratedIServiceWithoutNamespace
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_026a5a4b658a4b1c9c6a03060b6e21ba = new Type[] {  };
+
         /// <inheritdoc />
         Task IServiceWithoutNamespace.GetRoot()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetRoot", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetRoot", ArgumentTypes_026a5a4b658a4b1c9c6a03060b6e21ba);
             return (Task)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_7e0849b7dea44db4abbe0fef46f86693 = new Type[] {  };
 
         /// <inheritdoc />
         Task IServiceWithoutNamespace.PostRoot()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostRoot", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostRoot", ArgumentTypes_7e0849b7dea44db4abbe0fef46f86693);
             return (Task)func(Client, arguments);
         }
     }
@@ -2573,19 +2871,23 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_891f9ecb070a42e3a4953be8a419670a = new Type[] { typeof(string) };
+
         /// <inheritdoc />
         Task<Stream> IStreamApi.GetRemoteFile(string filename)
         {
             var arguments = new object[] { filename };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetRemoteFile", new Type[] { typeof(string) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetRemoteFile", ArgumentTypes_891f9ecb070a42e3a4953be8a419670a);
             return (Task<Stream>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_ed5b6dcb680e4de4b633ca17938cfef8 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<ApiResponse<Stream>> IStreamApi.GetRemoteFileWithMetadata(string filename)
         {
             var arguments = new object[] { filename };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetRemoteFileWithMetadata", new Type[] { typeof(string) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetRemoteFileWithMetadata", ArgumentTypes_ed5b6dcb680e4de4b633ca17938cfef8);
             return (Task<ApiResponse<Stream>>)func(Client, arguments);
         }
     }
@@ -2626,11 +2928,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_d2fab4b8be1d4d7aad6f2fe2d53cd972 = new Type[] {  };
+
         /// <inheritdoc />
         Task ITrimTrailingForwardSlashApi.Get()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_d2fab4b8be1d4d7aad6f2fe2d53cd972);
             return (Task)func(Client, arguments);
         }
     }
@@ -2660,11 +2964,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_f109f15a42174957a376195b544a5dea = new Type[] {  };
+
         /// <inheritdoc />
         Task<SomeType> ITypeCollisionApiA.SomeARequest()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("SomeARequest", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("SomeARequest", ArgumentTypes_f109f15a42174957a376195b544a5dea);
             return (Task<SomeType>)func(Client, arguments);
         }
     }
@@ -2694,11 +3000,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_fa06f29465ce43d4b5648d692b6978e8 = new Type[] {  };
+
         /// <inheritdoc />
         Task<SomeType> ITypeCollisionApiB.SomeBRequest()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("SomeBRequest", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("SomeBRequest", ArgumentTypes_fa06f29465ce43d4b5648d692b6978e8);
             return (Task<SomeType>)func(Client, arguments);
         }
     }
@@ -2737,59 +3045,85 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_6e34eb34d7a14ddca0d95ee544dbad64 = new Type[] {  };
+
         /// <inheritdoc />
         Task<string> IUseOverloadedGenericMethods<TResponse, TParam, THeader>.Get()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_6e34eb34d7a14ddca0d95ee544dbad64);
             return (Task<string>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_0d4ca9afe142409294064e22ee7075f8 = new Type[] { typeof(TParam), typeof(THeader) };
 
         /// <inheritdoc />
         Task<TResponse> IUseOverloadedGenericMethods<TResponse, TParam, THeader>.Get(TParam param, THeader header)
         {
             var arguments = new object[] { param, header };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", new Type[] { typeof(TParam), typeof(THeader) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_0d4ca9afe142409294064e22ee7075f8);
             return (Task<TResponse>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_93c2ca4087b64654a2fcbc5146650f0a = new Type[] { typeof(THeader), typeof(TParam) };
 
         /// <inheritdoc />
         Task<TResponse> IUseOverloadedGenericMethods<TResponse, TParam, THeader>.Get(THeader param, TParam header)
         {
             var arguments = new object[] { param, header };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", new Type[] { typeof(THeader), typeof(TParam) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_93c2ca4087b64654a2fcbc5146650f0a);
             return (Task<TResponse>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_b98d312ed9324b8287c3efca3152022e = new Type[] { typeof(int) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IUseOverloadedGenericMethods<TResponse, TParam, THeader>.Get(int httpstatuscode)
         {
             var arguments = new object[] { httpstatuscode };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", new Type[] { typeof(int) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_b98d312ed9324b8287c3efca3152022e);
             return (Task<HttpResponseMessage>)func(Client, arguments);
+        }
+
+        private static class TypeHelper_b9d2572b7c074c5a85343acddc81c1f4<TValue>
+        {
+            public static readonly Type[] ArgumentTypes = new Type[] { typeof(int) };
+            public static readonly Type[] TypeParameters = new Type[] { typeof(TValue) };
         }
 
         /// <inheritdoc />
         Task<TValue> IUseOverloadedGenericMethods<TResponse, TParam, THeader>.Get<TValue>(int someVal)
         {
             var arguments = new object[] { someVal };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", new Type[] { typeof(int) }, new Type[] { typeof(TValue) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", TypeHelper_b9d2572b7c074c5a85343acddc81c1f4<TValue>.ArgumentTypes, TypeHelper_b9d2572b7c074c5a85343acddc81c1f4<TValue>.TypeParameters);
             return (Task<TValue>)func(Client, arguments);
+        }
+
+        private static class TypeHelper_355e5fca5d454ec59be859b11bb565f0<TValue, TInput>
+        {
+            public static readonly Type[] ArgumentTypes = new Type[] { typeof(TInput) };
+            public static readonly Type[] TypeParameters = new Type[] { typeof(TValue), typeof(TInput) };
         }
 
         /// <inheritdoc />
         Task<TValue> IUseOverloadedGenericMethods<TResponse, TParam, THeader>.Get<TValue, TInput>(TInput input)
         {
             var arguments = new object[] { input };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", new Type[] { typeof(TInput) }, new Type[] { typeof(TValue), typeof(TInput) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", TypeHelper_355e5fca5d454ec59be859b11bb565f0<TValue, TInput>.ArgumentTypes, TypeHelper_355e5fca5d454ec59be859b11bb565f0<TValue, TInput>.TypeParameters);
             return (Task<TValue>)func(Client, arguments);
+        }
+
+        private static class TypeHelper_c21182f8809c48c1babf4de1e4a4c58b<TInput1, TInput2>
+        {
+            public static readonly Type[] ArgumentTypes = new Type[] { typeof(TInput1), typeof(TInput2) };
+            public static readonly Type[] TypeParameters = new Type[] { typeof(TInput1), typeof(TInput2) };
         }
 
         /// <inheritdoc />
         Task IUseOverloadedGenericMethods<TResponse, TParam, THeader>.Get<TInput1, TInput2>(TInput1 input1, TInput2 input2)
         {
             var arguments = new object[] { input1, input2 };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", new Type[] { typeof(TInput1), typeof(TInput2) }, new Type[] { typeof(TInput1), typeof(TInput2) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", TypeHelper_c21182f8809c48c1babf4de1e4a4c58b<TInput1, TInput2>.ArgumentTypes, TypeHelper_c21182f8809c48c1babf4de1e4a4c58b<TInput1, TInput2>.TypeParameters);
             return (Task)func(Client, arguments);
         }
     }
@@ -2824,19 +3158,23 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_3b5e91efc4a24973a67f7a7e0f5c9422 = new Type[] {  };
+
         /// <inheritdoc />
         Task<string> IUseOverloadedMethods.Get()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_3b5e91efc4a24973a67f7a7e0f5c9422);
             return (Task<string>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_ea6ce69e0dad4bc8af419064c41f352f = new Type[] { typeof(int) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IUseOverloadedMethods.Get(int httpstatuscode)
         {
             var arguments = new object[] { httpstatuscode };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", new Type[] { typeof(int) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_ea6ce69e0dad4bc8af419064c41f352f);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
     }
@@ -2877,11 +3215,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_872b41bc397a42a6b8be3e462fe5683c = new Type[] {  };
+
         /// <inheritdoc />
         Task IValidApi.Get()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_872b41bc397a42a6b8be3e462fe5683c);
             return (Task)func(Client, arguments);
         }
     }
@@ -2911,11 +3251,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_8145f8ca1d6540f2809affbd906628c2 = new Type[] {  };
+
         /// <inheritdoc />
         Task<SomeType> NamespaceWithGlobalAliasApi.SomeRequest()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", ArgumentTypes_8145f8ca1d6540f2809affbd906628c2);
             return (Task<SomeType>)func(Client, arguments);
         }
     }

--- a/Refit.Tests/RefitStubs.NetCore2.cs
+++ b/Refit.Tests/RefitStubs.NetCore2.cs
@@ -62,27 +62,27 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_45cb4a617b084a82b71707366401ee01 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_135d72e6626846c1b8ea1593369280a6 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IAmARefitInterfaceButNobodyUsesMe.RefitMethod()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("RefitMethod", ArgumentTypes_45cb4a617b084a82b71707366401ee01);
+            var func = requestBuilder.BuildRestResultFuncForMethod("RefitMethod", ArgumentTypes_135d72e6626846c1b8ea1593369280a6);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_b5ae5f38734047f1a4f84fe4f6647598 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_aea0400f2a234dfdbeb825232226e0c6 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IAmARefitInterfaceButNobodyUsesMe.AnotherRefitMethod()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("AnotherRefitMethod", ArgumentTypes_b5ae5f38734047f1a4f84fe4f6647598);
+            var func = requestBuilder.BuildRestResultFuncForMethod("AnotherRefitMethod", ArgumentTypes_aea0400f2a234dfdbeb825232226e0c6);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_16a0e1dd57de4529b42fb8f976d43906 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_33f052c856424fdf87d3083d5152c243 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IAmARefitInterfaceButNobodyUsesMe.NoConstantsAllowed()
@@ -90,23 +90,23 @@ namespace Refit.Tests
             throw new NotImplementedException("Either this method has no Refit HTTP method attribute or you've used something other than a string literal for the 'path' argument.");
         }
 
-        private static readonly Type[] ArgumentTypes_4102d603330f4d5b8f8af8fd388e1fe0 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_8703f84ed90d4fe59a2ffcac42351830 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IAmARefitInterfaceButNobodyUsesMe.SpacesShouldntBreakMe()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("SpacesShouldntBreakMe", ArgumentTypes_4102d603330f4d5b8f8af8fd388e1fe0);
+            var func = requestBuilder.BuildRestResultFuncForMethod("SpacesShouldntBreakMe", ArgumentTypes_8703f84ed90d4fe59a2ffcac42351830);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_8297e5161cd94e9584ee2c9da0e71fab = new Type[] { typeof(int), typeof(string), typeof(float) };
+        private static readonly Type[] ArgumentTypes_e2448fda1ed140e3a21a94d5e65ab4db = new Type[] { typeof(int), typeof(string), typeof(float) };
 
         /// <inheritdoc />
         Task IAmARefitInterfaceButNobodyUsesMe.ReservedWordsForParameterNames(int @int, string @string, float @long)
         {
             var arguments = new object[] { @int, @string, @long };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReservedWordsForParameterNames", ArgumentTypes_8297e5161cd94e9584ee2c9da0e71fab);
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReservedWordsForParameterNames", ArgumentTypes_e2448fda1ed140e3a21a94d5e65ab4db);
             return (Task)func(Client, arguments);
         }
     }
@@ -147,17 +147,17 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_0ca6b1cb84cb4b1a8e1278b5e6d2bcd3 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_dfa86422f64646c28e18896032f90cf0 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IAmHalfRefit.Post()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Post", ArgumentTypes_0ca6b1cb84cb4b1a8e1278b5e6d2bcd3);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Post", ArgumentTypes_dfa86422f64646c28e18896032f90cf0);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_51152afba2ce4b99a9fef2418c020d24 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_411ffa2b3f1a4536ac47c82717893429 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IAmHalfRefit.Get()
@@ -191,43 +191,43 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_4d27c1f58eac472b88b6b256171cbfa5 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_3f5462909d594f1daef80884c7e45ea3 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> IAmInterface.Pang()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Pang", ArgumentTypes_4d27c1f58eac472b88b6b256171cbfa5);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Pang", ArgumentTypes_3f5462909d594f1daef80884c7e45ea3);
             return (Task<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_2d68bbcad6ea4c2f972a9e8274944fb0 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_2dc708c8d1d04cc5bf6a43b2c7d5f7b3 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> IAmInterfaceB.Pong()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Pong", ArgumentTypes_2d68bbcad6ea4c2f972a9e8274944fb0);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Pong", ArgumentTypes_2dc708c8d1d04cc5bf6a43b2c7d5f7b3);
             return (Task<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_a7c6edf4f46245d19212e6c41b6e2595 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_bce6ffe8b3bd43b7aef91fe7264ed519 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> IAmInterfaceD.Test()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Test", ArgumentTypes_a7c6edf4f46245d19212e6c41b6e2595);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Test", ArgumentTypes_bce6ffe8b3bd43b7aef91fe7264ed519);
             return (Task<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_a34353153dd34189b4534ee32ac69e04 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_02869cf6a6c348ad85a24e0e22fcc632 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> IAmInterfaceA.Ping()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Ping", ArgumentTypes_a34353153dd34189b4534ee32ac69e04);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Ping", ArgumentTypes_02869cf6a6c348ad85a24e0e22fcc632);
             return (Task<string>)func(Client, arguments);
         }
     }
@@ -257,13 +257,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_68f8287c03da4553a7370736879cb259 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_1d7d7006128d4d0596f5b1c4ebfaf5f1 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> IAmInterfaceA.Ping()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Ping", ArgumentTypes_68f8287c03da4553a7370736879cb259);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Ping", ArgumentTypes_1d7d7006128d4d0596f5b1c4ebfaf5f1);
             return (Task<string>)func(Client, arguments);
         }
     }
@@ -293,23 +293,23 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_e4c88e2f8003490191c615c43acf261a = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_bc2b18f8e59a4eafbae36e5858e77bb4 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> IAmInterfaceB.Pong()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Pong", ArgumentTypes_e4c88e2f8003490191c615c43acf261a);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Pong", ArgumentTypes_bc2b18f8e59a4eafbae36e5858e77bb4);
             return (Task<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_b1d0b42f746b46538f5246b1a3bc90bb = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_6888ed9c1c5d48ed98443f5836ded91a = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> IAmInterfaceD.Test()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Test", ArgumentTypes_b1d0b42f746b46538f5246b1a3bc90bb);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Test", ArgumentTypes_6888ed9c1c5d48ed98443f5836ded91a);
             return (Task<string>)func(Client, arguments);
         }
     }
@@ -339,43 +339,43 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_baac8fe585874ba7a45524388743f982 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_6f551442468b411f8c849d0e35e446dc = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> IAmInterfaceC.Pang()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Pang", ArgumentTypes_baac8fe585874ba7a45524388743f982);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Pang", ArgumentTypes_6f551442468b411f8c849d0e35e446dc);
             return (Task<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_77105199802c4fae98840027c7853730 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_cf53ed01fb2c49708c8139e0cf4ce755 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> IAmInterfaceB.Pong()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Pong", ArgumentTypes_77105199802c4fae98840027c7853730);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Pong", ArgumentTypes_cf53ed01fb2c49708c8139e0cf4ce755);
             return (Task<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_448940ffda5c4370a725580bdf0af406 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_8d2b7f7e16b049bbb89213453a2fbb8c = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> IAmInterfaceD.Test()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Test", ArgumentTypes_448940ffda5c4370a725580bdf0af406);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Test", ArgumentTypes_8d2b7f7e16b049bbb89213453a2fbb8c);
             return (Task<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_408c892ec23f4e86855668c044167156 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_1cc84fd779fc426c9a768f47798a63f9 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> IAmInterfaceA.Ping()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Ping", ArgumentTypes_408c892ec23f4e86855668c044167156);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Ping", ArgumentTypes_1cc84fd779fc426c9a768f47798a63f9);
             return (Task<string>)func(Client, arguments);
         }
     }
@@ -405,13 +405,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_f0f6eec72efc4ae3bf660bfb56b1ee3e = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_89e2f2d9fc544ff39ce23f02d00b106d = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> IAmInterfaceD.Test()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Test", ArgumentTypes_f0f6eec72efc4ae3bf660bfb56b1ee3e);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Test", ArgumentTypes_89e2f2d9fc544ff39ce23f02d00b106d);
             return (Task<string>)func(Client, arguments);
         }
     }
@@ -452,153 +452,153 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_556cf207c5d54380a6147522dc4c1c25 = new Type[] { typeof(PathBoundObject) };
+        private static readonly Type[] ArgumentTypes_72acc1d12e1843dcb46fd34a11a28968 = new Type[] { typeof(PathBoundObject) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetFooBars(PathBoundObject request)
         {
             var arguments = new object[] { request };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBars", ArgumentTypes_556cf207c5d54380a6147522dc4c1c25);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBars", ArgumentTypes_72acc1d12e1843dcb46fd34a11a28968);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_31291ac05c1349f9986b7ed76736ad91 = new Type[] { typeof(PathBoundObject) };
+        private static readonly Type[] ArgumentTypes_4636053dde53419a8e5e085f39be97ba = new Type[] { typeof(PathBoundObject) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetFooBarsWithDifferentCasing(PathBoundObject requestParams)
         {
             var arguments = new object[] { requestParams };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBarsWithDifferentCasing", ArgumentTypes_31291ac05c1349f9986b7ed76736ad91);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBarsWithDifferentCasing", ArgumentTypes_4636053dde53419a8e5e085f39be97ba);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_fb24b6da76714bd3820d664a6351b058 = new Type[] { typeof(string), typeof(PathBoundObject) };
+        private static readonly Type[] ArgumentTypes_86d38ecc0b6042f0b3f271747ab783c4 = new Type[] { typeof(string), typeof(PathBoundObject) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetBarsByFoo(string id, PathBoundObject request)
         {
             var arguments = new object[] { id, request };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetBarsByFoo", ArgumentTypes_fb24b6da76714bd3820d664a6351b058);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetBarsByFoo", ArgumentTypes_86d38ecc0b6042f0b3f271747ab783c4);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_94b1e075efd547979c507ab1db5b2412 = new Type[] { typeof(PathBoundObject), typeof(string) };
+        private static readonly Type[] ArgumentTypes_40c5542c69b04cdca106e9237a4b1bde = new Type[] { typeof(PathBoundObject), typeof(string) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetFooBars(PathBoundObject request, string someProperty)
         {
             var arguments = new object[] { request, someProperty };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBars", ArgumentTypes_94b1e075efd547979c507ab1db5b2412);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBars", ArgumentTypes_40c5542c69b04cdca106e9237a4b1bde);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_b5bec60af76a459487529e0b6567ec9e = new Type[] { typeof(PathBoundObject) };
+        private static readonly Type[] ArgumentTypes_5e550dcb9e7c4bb0b9cb9ff8e29ba075 = new Type[] { typeof(PathBoundObject) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetBarsByFoo(PathBoundObject request)
         {
             var arguments = new object[] { request };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetBarsByFoo", ArgumentTypes_b5bec60af76a459487529e0b6567ec9e);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetBarsByFoo", ArgumentTypes_5e550dcb9e7c4bb0b9cb9ff8e29ba075);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_96e2398121d64e93aad2554b1f0af6ad = new Type[] { typeof(PathBoundObjectWithQueryFormat) };
+        private static readonly Type[] ArgumentTypes_fba7efe36b81412db1916fd6a13630c2 = new Type[] { typeof(PathBoundObjectWithQueryFormat) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetBarsWithCustomQueryFormat(PathBoundObjectWithQueryFormat request)
         {
             var arguments = new object[] { request };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetBarsWithCustomQueryFormat", ArgumentTypes_96e2398121d64e93aad2554b1f0af6ad);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetBarsWithCustomQueryFormat", ArgumentTypes_fba7efe36b81412db1916fd6a13630c2);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_ce5fa2234ac54712988d6f6539de7aba = new Type[] { typeof(PathBoundDerivedObject) };
+        private static readonly Type[] ArgumentTypes_68ea9a5c90ca4e8f8f38f88ac88947cd = new Type[] { typeof(PathBoundDerivedObject) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetFooBarsDerived(PathBoundDerivedObject request)
         {
             var arguments = new object[] { request };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBarsDerived", ArgumentTypes_ce5fa2234ac54712988d6f6539de7aba);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBarsDerived", ArgumentTypes_68ea9a5c90ca4e8f8f38f88ac88947cd);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_13256c47e4864a50ad6de1bc6208d2ee = new Type[] { typeof(PathBoundList) };
+        private static readonly Type[] ArgumentTypes_1bd7f2f43d1a4945856181d447747ded = new Type[] { typeof(PathBoundList) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetFoos(PathBoundList request)
         {
             var arguments = new object[] { request };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetFoos", ArgumentTypes_13256c47e4864a50ad6de1bc6208d2ee);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetFoos", ArgumentTypes_1bd7f2f43d1a4945856181d447747ded);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_0a2c583849c1482e936d7a27934978a4 = new Type[] { typeof(List<int>) };
+        private static readonly Type[] ArgumentTypes_a9bba6fbf1274ef781d4bfc9a88471bf = new Type[] { typeof(List<int>) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetFoos2(List<int> Values)
         {
             var arguments = new object[] { Values };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetFoos2", ArgumentTypes_0a2c583849c1482e936d7a27934978a4);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetFoos2", ArgumentTypes_a9bba6fbf1274ef781d4bfc9a88471bf);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_2705c8909e2642bf8f1f213ea825b234 = new Type[] { typeof(PathBoundObject), typeof(object) };
+        private static readonly Type[] ArgumentTypes_abd03d9f309e45bd906bd7b74bed51a6 = new Type[] { typeof(PathBoundObject), typeof(object) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.PostFooBar(PathBoundObject request, object someObject)
         {
             var arguments = new object[] { request, someObject };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBar", ArgumentTypes_2705c8909e2642bf8f1f213ea825b234);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBar", ArgumentTypes_abd03d9f309e45bd906bd7b74bed51a6);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_31883515efd24c2dae5372a093147f44 = new Type[] { typeof(PathBoundObjectWithQuery) };
+        private static readonly Type[] ArgumentTypes_3a359766d1f346a0a26a6480a55b8e4f = new Type[] { typeof(PathBoundObjectWithQuery) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetFooBars(PathBoundObjectWithQuery request)
         {
             var arguments = new object[] { request };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBars", ArgumentTypes_31883515efd24c2dae5372a093147f44);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBars", ArgumentTypes_3a359766d1f346a0a26a6480a55b8e4f);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_eede4fed6e094f74b4bcbc76a2fb7842 = new Type[] { typeof(PathBoundObject), typeof(ModelObject) };
+        private static readonly Type[] ArgumentTypes_2dacb90f598f421db648d77ee1f7abe2 = new Type[] { typeof(PathBoundObject), typeof(ModelObject) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IApiBindPathToObject.PostFooBar(PathBoundObject request, ModelObject someQueryParams)
         {
             var arguments = new object[] { request, someQueryParams };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBar", ArgumentTypes_eede4fed6e094f74b4bcbc76a2fb7842);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBar", ArgumentTypes_2dacb90f598f421db648d77ee1f7abe2);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_cde56b7080c8483186531526e2488688 = new Type[] { typeof(PathBoundObject), typeof(ModelObject), typeof(StreamPart) };
+        private static readonly Type[] ArgumentTypes_b34eb5d06f004d9cb6926b51c4b7f203 = new Type[] { typeof(PathBoundObject), typeof(ModelObject), typeof(StreamPart) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IApiBindPathToObject.PostFooBarStreamPart(PathBoundObject request, ModelObject someQueryParams, StreamPart stream)
         {
             var arguments = new object[] { request, someQueryParams, stream };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBarStreamPart", ArgumentTypes_cde56b7080c8483186531526e2488688);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBarStreamPart", ArgumentTypes_b34eb5d06f004d9cb6926b51c4b7f203);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_7510e60fd7ea4ef4a9b03ed0f99c0054 = new Type[] { typeof(PathBoundObject), typeof(StreamPart) };
+        private static readonly Type[] ArgumentTypes_cb5dbb7678364395bb475ac3fdd391d8 = new Type[] { typeof(PathBoundObject), typeof(StreamPart) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IApiBindPathToObject.PostFooBarStreamPart(PathBoundObject request, StreamPart stream)
         {
             var arguments = new object[] { request, stream };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBarStreamPart", ArgumentTypes_7510e60fd7ea4ef4a9b03ed0f99c0054);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBarStreamPart", ArgumentTypes_cb5dbb7678364395bb475ac3fdd391d8);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_164d23e943c24a99bbff04e3c52c27ca = new Type[] { typeof(PathBoundObjectWithQuery), typeof(StreamPart) };
+        private static readonly Type[] ArgumentTypes_e29a6358c77743f5b89f6ac58cd29f3d = new Type[] { typeof(PathBoundObjectWithQuery), typeof(StreamPart) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IApiBindPathToObject.PostFooBarStreamPart(PathBoundObjectWithQuery request, StreamPart stream)
         {
             var arguments = new object[] { request, stream };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBarStreamPart", ArgumentTypes_164d23e943c24a99bbff04e3c52c27ca);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBarStreamPart", ArgumentTypes_e29a6358c77743f5b89f6ac58cd29f3d);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
     }
@@ -639,13 +639,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_041e5be978074e05a2fd3c848a238afc = new Type[] { typeof(decimal) };
+        private static readonly Type[] ArgumentTypes_ec077c4b30c746aabcba7f502dc0192d = new Type[] { typeof(decimal) };
 
         /// <inheritdoc />
         Task<string> IApiWithDecimal.GetWithDecimal(decimal value)
         {
             var arguments = new object[] { value };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetWithDecimal", ArgumentTypes_041e5be978074e05a2fd3c848a238afc);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetWithDecimal", ArgumentTypes_ec077c4b30c746aabcba7f502dc0192d);
             return (Task<string>)func(Client, arguments);
         }
     }
@@ -686,33 +686,33 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_82c7594aaa2c4d74930384eb5fc4826a = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_fe4c346bc2784570b0c0209e3ccb4456 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IBodylessApi.Post()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Post", ArgumentTypes_82c7594aaa2c4d74930384eb5fc4826a);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Post", ArgumentTypes_fe4c346bc2784570b0c0209e3ccb4456);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_e58b7c5f5b094dc0875228d559f89e8d = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_c786aaf352f4466caeb9ece3e8e0708c = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IBodylessApi.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_e58b7c5f5b094dc0875228d559f89e8d);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_c786aaf352f4466caeb9ece3e8e0708c);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_0c55686a72a24aec8ecd663ac2b92a85 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_3767a2c66e7c49b38ba98508e15d8104 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IBodylessApi.Head()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Head", ArgumentTypes_0c55686a72a24aec8ecd663ac2b92a85);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Head", ArgumentTypes_3767a2c66e7c49b38ba98508e15d8104);
             return (Task)func(Client, arguments);
         }
     }
@@ -753,53 +753,53 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_e2a27f42e40b4439a6d0cfdadd21ae1d = new Type[] { typeof(T) };
+        private static readonly Type[] ArgumentTypes_d71bbc2258ca4220b5ad9dee81a7559e = new Type[] { typeof(T) };
 
         /// <inheritdoc />
         Task<T> IBoringCrudApi<T, TKey>.Create(T paylod)
         {
             var arguments = new object[] { paylod };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_e2a27f42e40b4439a6d0cfdadd21ae1d);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_d71bbc2258ca4220b5ad9dee81a7559e);
             return (Task<T>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_31c48b202c304cb1ba2e201ec7535ab6 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_a584902d31c54fc0bf663d1263a6dcbd = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<List<T>> IBoringCrudApi<T, TKey>.ReadAll()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_31c48b202c304cb1ba2e201ec7535ab6);
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_a584902d31c54fc0bf663d1263a6dcbd);
             return (Task<List<T>>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_bc58a4c5e74041f5b77bbede464ec820 = new Type[] { typeof(TKey) };
+        private static readonly Type[] ArgumentTypes_1b407b941f944e2385031b13c8375ad8 = new Type[] { typeof(TKey) };
 
         /// <inheritdoc />
         Task<T> IBoringCrudApi<T, TKey>.ReadOne(TKey key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_bc58a4c5e74041f5b77bbede464ec820);
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_1b407b941f944e2385031b13c8375ad8);
             return (Task<T>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_c1190224fa074d9188d5b14821550935 = new Type[] { typeof(TKey), typeof(T) };
+        private static readonly Type[] ArgumentTypes_9f402308d9a14d6aae2b0b196a1be6bc = new Type[] { typeof(TKey), typeof(T) };
 
         /// <inheritdoc />
         Task IBoringCrudApi<T, TKey>.Update(TKey key, T payload)
         {
             var arguments = new object[] { key, payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_c1190224fa074d9188d5b14821550935);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_9f402308d9a14d6aae2b0b196a1be6bc);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_4afd99ef78954a5cba26df34ea37a527 = new Type[] { typeof(TKey) };
+        private static readonly Type[] ArgumentTypes_ed14f761ad434d0c9a7b9fcadcdadc14 = new Type[] { typeof(TKey) };
 
         /// <inheritdoc />
         Task IBoringCrudApi<T, TKey>.Delete(TKey key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_4afd99ef78954a5cba26df34ea37a527);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_ed14f761ad434d0c9a7b9fcadcdadc14);
             return (Task)func(Client, arguments);
         }
     }
@@ -840,13 +840,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_93f76309342741edbab331bd7762005d = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_daf0ae47632d41e8a33220b561324559 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<bool> IBrokenWebApi.PostAValue(string derp)
         {
             var arguments = new object[] { derp };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostAValue", ArgumentTypes_93f76309342741edbab331bd7762005d);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostAValue", ArgumentTypes_daf0ae47632d41e8a33220b561324559);
             return (Task<bool>)func(Client, arguments);
         }
     }
@@ -875,13 +875,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_41ff8f783e93482597031d0ece0930be = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_59d63d36db5b4f57bcb15d2b96b3c722 = Array.Empty<Type>();
 
         /// <inheritdoc />
         CustomReferenceType? ICustomNullableReferenceService.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_41ff8f783e93482597031d0ece0930be);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_59d63d36db5b4f57bcb15d2b96b3c722);
             return (CustomReferenceType?)func(Client, arguments);
         }
     }
@@ -910,13 +910,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_2bef6f4503434fa3b42e660dc8dab915 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_fce71d6929524d3fb64507300f168c19 = Array.Empty<Type>();
 
         /// <inheritdoc />
         CustomValueType? ICustomNullableValueService.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_2bef6f4503434fa3b42e660dc8dab915);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_fce71d6929524d3fb64507300f168c19);
             return (CustomValueType?)func(Client, arguments);
         }
     }
@@ -945,13 +945,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_1d36fa32b1044429be0809c60c1adb6d = new Type[] { ToNullable(typeof(CustomReferenceType)), ToNullable(typeof(CustomValueType)) };
+        private static readonly Type[] ArgumentTypes_c2b17a68ecdc44979c63d4ac21a29bac = new Type[] { ToNullable(typeof(CustomReferenceType)), ToNullable(typeof(CustomValueType)) };
 
         /// <inheritdoc />
         Task ICustomReferenceAndValueParametersService.Get(CustomReferenceType? reference, CustomValueType? value)
         {
             var arguments = new object[] { reference, value };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_1d36fa32b1044429be0809c60c1adb6d);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_c2b17a68ecdc44979c63d4ac21a29bac);
             return (Task)func(Client, arguments);
         }
 
@@ -984,73 +984,73 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_84e788d2ce964b42a8faeeb6584ca267 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_fae1e3f038c341bfbac3ce80a44b5c36 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IDataApiA.PingA()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("PingA", ArgumentTypes_84e788d2ce964b42a8faeeb6584ca267);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PingA", ArgumentTypes_fae1e3f038c341bfbac3ce80a44b5c36);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_b2d859cdfdd541efa38e06b41083853f = new Type[] { typeof(DataEntity) };
+        private static readonly Type[] ArgumentTypes_f2dac05c2bfa4393a1b33c10507d2a22 = new Type[] { typeof(DataEntity) };
 
         /// <inheritdoc />
         Task<DataEntity> IDataCrudApi<DataEntity>.Copy(DataEntity payload)
         {
             var arguments = new object[] { payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Copy", ArgumentTypes_b2d859cdfdd541efa38e06b41083853f);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Copy", ArgumentTypes_f2dac05c2bfa4393a1b33c10507d2a22);
             return (Task<DataEntity>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_10f5b865a7bf41a7ab16d53f2a56fbe7 = new Type[] { typeof(DataEntity) };
+        private static readonly Type[] ArgumentTypes_e0caab51ea1345e09c0bc663c21b148d = new Type[] { typeof(DataEntity) };
 
         /// <inheritdoc />
         Task<DataEntity> IDataCrudApi<DataEntity, long>.Create(DataEntity payload)
         {
             var arguments = new object[] { payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_10f5b865a7bf41a7ab16d53f2a56fbe7);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_e0caab51ea1345e09c0bc663c21b148d);
             return (Task<DataEntity>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_14ab4532d62f4feaafb5e7a938ddddc4 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_df4882ee87424a1fb8ff7636084f4b69 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<List<DataEntity>> IDataCrudApi<DataEntity, long>.ReadAll()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_14ab4532d62f4feaafb5e7a938ddddc4);
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_df4882ee87424a1fb8ff7636084f4b69);
             return (Task<List<DataEntity>>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_765dbd13bbad494daa73248429c4d3c1 = new Type[] { typeof(long) };
+        private static readonly Type[] ArgumentTypes_bb8ba1c377994af381a44c19967ea504 = new Type[] { typeof(long) };
 
         /// <inheritdoc />
         Task<DataEntity> IDataCrudApi<DataEntity, long>.ReadOne(long key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_765dbd13bbad494daa73248429c4d3c1);
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_bb8ba1c377994af381a44c19967ea504);
             return (Task<DataEntity>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_ac3487bbbffb4e368a38a9ea03af73c0 = new Type[] { typeof(long), typeof(DataEntity) };
+        private static readonly Type[] ArgumentTypes_94315b8772ac47c3b5c3480aba5e61c3 = new Type[] { typeof(long), typeof(DataEntity) };
 
         /// <inheritdoc />
         Task IDataCrudApi<DataEntity, long>.Update(long key, DataEntity payload)
         {
             var arguments = new object[] { key, payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_ac3487bbbffb4e368a38a9ea03af73c0);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_94315b8772ac47c3b5c3480aba5e61c3);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_98e9792e43aa4f7eb4dc21c9bbe1b029 = new Type[] { typeof(long) };
+        private static readonly Type[] ArgumentTypes_f3fc003032084fbf91a8d4aa3229c295 = new Type[] { typeof(long) };
 
         /// <inheritdoc />
         Task IDataCrudApi<DataEntity, long>.Delete(long key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_98e9792e43aa4f7eb4dc21c9bbe1b029);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_f3fc003032084fbf91a8d4aa3229c295);
             return (Task)func(Client, arguments);
         }
     }
@@ -1081,63 +1081,63 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_ead1c0a97e2a469db2d55de45f1178b2 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_ec4c96f151b04689a2c962272bc06b72 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IDataApiB.PingB()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("PingB", ArgumentTypes_ead1c0a97e2a469db2d55de45f1178b2);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PingB", ArgumentTypes_ec4c96f151b04689a2c962272bc06b72);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_4f75604f0ffe4d688e6600b726b686bc = new Type[] { typeof(DataEntity) };
+        private static readonly Type[] ArgumentTypes_a7d11f7be2614937b2b836694c76010d = new Type[] { typeof(DataEntity) };
 
         /// <inheritdoc />
         Task<DataEntity> IDataCrudApi<DataEntity, int>.Create(DataEntity payload)
         {
             var arguments = new object[] { payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_4f75604f0ffe4d688e6600b726b686bc);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_a7d11f7be2614937b2b836694c76010d);
             return (Task<DataEntity>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_cbbe59ca142241d79fe7a92e77dbd191 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_65a6b806b61b43b3898053e3726bc230 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<List<DataEntity>> IDataCrudApi<DataEntity, int>.ReadAll()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_cbbe59ca142241d79fe7a92e77dbd191);
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_65a6b806b61b43b3898053e3726bc230);
             return (Task<List<DataEntity>>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_dbf43e479efd417098f38f14de9dfe24 = new Type[] { typeof(int) };
+        private static readonly Type[] ArgumentTypes_d0bb0835f2e3497bbf012725c7d5430e = new Type[] { typeof(int) };
 
         /// <inheritdoc />
         Task<DataEntity> IDataCrudApi<DataEntity, int>.ReadOne(int key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_dbf43e479efd417098f38f14de9dfe24);
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_d0bb0835f2e3497bbf012725c7d5430e);
             return (Task<DataEntity>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_6445cd1527dc4c05b4d3325e209896f8 = new Type[] { typeof(int), typeof(DataEntity) };
+        private static readonly Type[] ArgumentTypes_9e3550e9d4104fd086c131ad32731aa2 = new Type[] { typeof(int), typeof(DataEntity) };
 
         /// <inheritdoc />
         Task IDataCrudApi<DataEntity, int>.Update(int key, DataEntity payload)
         {
             var arguments = new object[] { key, payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_6445cd1527dc4c05b4d3325e209896f8);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_9e3550e9d4104fd086c131ad32731aa2);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_432c6a9d1dba48028ca5324615362b9f = new Type[] { typeof(int) };
+        private static readonly Type[] ArgumentTypes_5264c3357d19488ab9e4290c25998759 = new Type[] { typeof(int) };
 
         /// <inheritdoc />
         Task IDataCrudApi<DataEntity, int>.Delete(int key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_432c6a9d1dba48028ca5324615362b9f);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_5264c3357d19488ab9e4290c25998759);
             return (Task)func(Client, arguments);
         }
     }
@@ -1171,63 +1171,63 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_f817a84585f340298f1452be539288a1 = new Type[] { typeof(T) };
+        private static readonly Type[] ArgumentTypes_0c21637322e74c4fa819635f74c6c1c2 = new Type[] { typeof(T) };
 
         /// <inheritdoc />
         Task<T> IDataCrudApi<T>.Copy(T payload)
         {
             var arguments = new object[] { payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Copy", ArgumentTypes_f817a84585f340298f1452be539288a1);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Copy", ArgumentTypes_0c21637322e74c4fa819635f74c6c1c2);
             return (Task<T>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_17fa467eee0543daaa0560387ff37c14 = new Type[] { typeof(T) };
+        private static readonly Type[] ArgumentTypes_8740dbd02f434105a1980cc51dd1baae = new Type[] { typeof(T) };
 
         /// <inheritdoc />
         Task<T> IDataCrudApi<T, long>.Create(T payload)
         {
             var arguments = new object[] { payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_17fa467eee0543daaa0560387ff37c14);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_8740dbd02f434105a1980cc51dd1baae);
             return (Task<T>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_c58f22f98b6a47e8a9744a1b46b02a8c = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_abaa922b3f2d437cba92d8d9f6635b1c = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<List<T>> IDataCrudApi<T, long>.ReadAll()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_c58f22f98b6a47e8a9744a1b46b02a8c);
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_abaa922b3f2d437cba92d8d9f6635b1c);
             return (Task<List<T>>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_6e0d2b1417c84d858bd78f03fcf22933 = new Type[] { typeof(long) };
+        private static readonly Type[] ArgumentTypes_c77a6f037a3645d3af9cc360d276d557 = new Type[] { typeof(long) };
 
         /// <inheritdoc />
         Task<T> IDataCrudApi<T, long>.ReadOne(long key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_6e0d2b1417c84d858bd78f03fcf22933);
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_c77a6f037a3645d3af9cc360d276d557);
             return (Task<T>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_290e96dd66fc486b80de83432e1cf8fb = new Type[] { typeof(long), typeof(T) };
+        private static readonly Type[] ArgumentTypes_70fb6b8e63844e94bd0b23c943b5373c = new Type[] { typeof(long), typeof(T) };
 
         /// <inheritdoc />
         Task IDataCrudApi<T, long>.Update(long key, T payload)
         {
             var arguments = new object[] { key, payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_290e96dd66fc486b80de83432e1cf8fb);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_70fb6b8e63844e94bd0b23c943b5373c);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_b11f3650607f4f1f84948f97873328dd = new Type[] { typeof(long) };
+        private static readonly Type[] ArgumentTypes_1c9eaf533083424c87f487e17a045937 = new Type[] { typeof(long) };
 
         /// <inheritdoc />
         Task IDataCrudApi<T, long>.Delete(long key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_b11f3650607f4f1f84948f97873328dd);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_1c9eaf533083424c87f487e17a045937);
             return (Task)func(Client, arguments);
         }
     }
@@ -1261,53 +1261,53 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_faf0b9cb18604e86a6832a1cd33d9684 = new Type[] { typeof(T) };
+        private static readonly Type[] ArgumentTypes_8ed005d2d95d49558b8d00185b32f23b = new Type[] { typeof(T) };
 
         /// <inheritdoc />
         Task<T> IDataCrudApi<T, TKey>.Create(T payload)
         {
             var arguments = new object[] { payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_faf0b9cb18604e86a6832a1cd33d9684);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_8ed005d2d95d49558b8d00185b32f23b);
             return (Task<T>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_c38842b49cb24a7a948d7152ff2a0e97 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_722dbfca7ea14e6db88e7aae1909d6ef = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<List<T>> IDataCrudApi<T, TKey>.ReadAll()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_c38842b49cb24a7a948d7152ff2a0e97);
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_722dbfca7ea14e6db88e7aae1909d6ef);
             return (Task<List<T>>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_3a36d6744e8049a2a5ffbf51886f34c3 = new Type[] { typeof(TKey) };
+        private static readonly Type[] ArgumentTypes_6b01ccb6941544b09f7c45016686cfed = new Type[] { typeof(TKey) };
 
         /// <inheritdoc />
         Task<T> IDataCrudApi<T, TKey>.ReadOne(TKey key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_3a36d6744e8049a2a5ffbf51886f34c3);
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_6b01ccb6941544b09f7c45016686cfed);
             return (Task<T>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_b0600da3b4224810b4825655593ec0e8 = new Type[] { typeof(TKey), typeof(T) };
+        private static readonly Type[] ArgumentTypes_6b5cb508af8848099360c26fdfe3b4a5 = new Type[] { typeof(TKey), typeof(T) };
 
         /// <inheritdoc />
         Task IDataCrudApi<T, TKey>.Update(TKey key, T payload)
         {
             var arguments = new object[] { key, payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_b0600da3b4224810b4825655593ec0e8);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_6b5cb508af8848099360c26fdfe3b4a5);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_73c3763fe5d64b6f8f41f4d3c404d67c = new Type[] { typeof(TKey) };
+        private static readonly Type[] ArgumentTypes_b84960faeb1e4231b63b41c38c888fcd = new Type[] { typeof(TKey) };
 
         /// <inheritdoc />
         Task IDataCrudApi<T, TKey>.Delete(TKey key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_73c3763fe5d64b6f8f41f4d3c404d67c);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_b84960faeb1e4231b63b41c38c888fcd);
             return (Task)func(Client, arguments);
         }
     }
@@ -1336,13 +1336,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_2a02aed38d2c45f399b5f79c227dcddb = new Type[] { ToNullable(typeof(System.Collections.Generic.List<string>)) };
+        private static readonly Type[] ArgumentTypes_4ef6f594e5c9404bb95454992e0227b5 = new Type[] { ToNullable(typeof(System.Collections.Generic.List<string>)) };
 
         /// <inheritdoc />
         Task IGenericNullableReferenceParameterService.Get(System.Collections.Generic.List<string>? reference)
         {
             var arguments = new object[] { reference };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_2a02aed38d2c45f399b5f79c227dcddb);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_4ef6f594e5c9404bb95454992e0227b5);
             return (Task)func(Client, arguments);
         }
 
@@ -1373,13 +1373,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_a3c883e0fd2c42328a18b21560bf00b8 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_59a49a16bc524e879f54a71380de06ed = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string>? IGenericNullableReferenceService.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_a3c883e0fd2c42328a18b21560bf00b8);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_59a49a16bc524e879f54a71380de06ed);
             return (Task<string>?)func(Client, arguments);
         }
     }
@@ -1408,13 +1408,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_35121835248e444f965aeaab7fe0cad2 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_f2d445665ba141a985f188710b990510 = Array.Empty<Type>();
 
         /// <inheritdoc />
         ValueTask<int>? IGenericNullableValueService.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_35121835248e444f965aeaab7fe0cad2);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_f2d445665ba141a985f188710b990510);
             return (ValueTask<int>?)func(Client, arguments);
         }
     }
@@ -1443,13 +1443,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_053f6b89eef74ef6babc3f0be5168781 = new Type[] { ToNullable(typeof(System.Collections.Generic.List<string?>)) };
+        private static readonly Type[] ArgumentTypes_fa80f14edd314f54b6fb850feeab4257 = new Type[] { ToNullable(typeof(System.Collections.Generic.List<string?>)) };
 
         /// <inheritdoc />
         Task IGenericNullableWithNullableReferenceParameterService.Get(System.Collections.Generic.List<string?>? reference)
         {
             var arguments = new object[] { reference };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_053f6b89eef74ef6babc3f0be5168781);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_fa80f14edd314f54b6fb850feeab4257);
             return (Task)func(Client, arguments);
         }
 
@@ -1480,13 +1480,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_c7df77d361bc4f219f2013f819c850d3 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_57e394798d934cd69d0e290853691794 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string?>? IGenericNullableWithNullableReferenceService.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_c7df77d361bc4f219f2013f819c850d3);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_57e394798d934cd69d0e290853691794);
             return (Task<string?>?)func(Client, arguments);
         }
     }
@@ -1515,13 +1515,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_23617700705b4a7b85c47698a2bb13b4 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_154d36646b494d38bd06e7a0fc1428a9 = Array.Empty<Type>();
 
         /// <inheritdoc />
         ValueTask<int?>? IGenericNullableWithNullableValueService.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_23617700705b4a7b85c47698a2bb13b4);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_154d36646b494d38bd06e7a0fc1428a9);
             return (ValueTask<int?>?)func(Client, arguments);
         }
     }
@@ -1550,13 +1550,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_6a55f214ead245829a5eb4b53c96edca = new Type[] { typeof(System.Collections.Generic.List<string?>) };
+        private static readonly Type[] ArgumentTypes_78c5749b7cf440f583d02de44dee3d9f = new Type[] { typeof(System.Collections.Generic.List<string?>) };
 
         /// <inheritdoc />
         Task IGenericWithNullableReferenceParameterService.Get(System.Collections.Generic.List<string?> reference)
         {
             var arguments = new object[] { reference };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_6a55f214ead245829a5eb4b53c96edca);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_78c5749b7cf440f583d02de44dee3d9f);
             return (Task)func(Client, arguments);
         }
     }
@@ -1585,13 +1585,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_1e75da778205494bab0f05930faadb88 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_2193774c8f7b4b4ea46b99e3487e3836 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<int?> IGenericWithNullableValueService.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_1e75da778205494bab0f05930faadb88);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_2193774c8f7b4b4ea46b99e3487e3836);
             return (Task<int?>)func(Client, arguments);
         }
     }
@@ -1620,13 +1620,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_dc1c8b54040f421a8b341b577c3dafd3 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_bdcc7d728a1a4c758109db5a5bb1d749 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string?> IGenericWithResultService.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_dc1c8b54040f421a8b341b577c3dafd3);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_bdcc7d728a1a4c758109db5a5bb1d749);
             return (Task<string?>)func(Client, arguments);
         }
     }
@@ -1661,133 +1661,133 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_2cb6203291764cada17d9f2936eb0987 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_3979f72be95f4c6cb7dbbe8c91300d21 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<User> IGitHubApi.GetUser(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUser", ArgumentTypes_2cb6203291764cada17d9f2936eb0987);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUser", ArgumentTypes_3979f72be95f4c6cb7dbbe8c91300d21);
             return (Task<User>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_aaa72a56f9ad4f6fba20447b2f31df13 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_dfaac992faab48e4a89fe2104ea93c47 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         IObservable<User> IGitHubApi.GetUserObservable(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserObservable", ArgumentTypes_aaa72a56f9ad4f6fba20447b2f31df13);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserObservable", ArgumentTypes_dfaac992faab48e4a89fe2104ea93c47);
             return (IObservable<User>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_6ab547879c6c413e9633e89c7ff4a7a8 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_f2cfaeb0423e4f358b44c5c1bb48a8c7 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         IObservable<User> IGitHubApi.GetUserCamelCase(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserCamelCase", ArgumentTypes_6ab547879c6c413e9633e89c7ff4a7a8);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserCamelCase", ArgumentTypes_f2cfaeb0423e4f358b44c5c1bb48a8c7);
             return (IObservable<User>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_9f3315e360fb41c993eb19c487855e4e = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_818b279b9c804d509c86c638e4eac26a = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<List<User>> IGitHubApi.GetOrgMembers(string orgName)
         {
             var arguments = new object[] { orgName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetOrgMembers", ArgumentTypes_9f3315e360fb41c993eb19c487855e4e);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetOrgMembers", ArgumentTypes_818b279b9c804d509c86c638e4eac26a);
             return (Task<List<User>>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_26fd0e3846ae4d258f390460347f38b6 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_ccc479bcc88441fd840b9461794e8891 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<UserSearchResult> IGitHubApi.FindUsers(string q)
         {
             var arguments = new object[] { q };
-            var func = requestBuilder.BuildRestResultFuncForMethod("FindUsers", ArgumentTypes_26fd0e3846ae4d258f390460347f38b6);
+            var func = requestBuilder.BuildRestResultFuncForMethod("FindUsers", ArgumentTypes_ccc479bcc88441fd840b9461794e8891);
             return (Task<UserSearchResult>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_3ca836d15a974d88b89e37a5050bc1e6 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_9dcb127f99574005a18d36964fbf7824 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IGitHubApi.GetIndex()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndex", ArgumentTypes_3ca836d15a974d88b89e37a5050bc1e6);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndex", ArgumentTypes_9dcb127f99574005a18d36964fbf7824);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_e4e653f5c45a44e587603fa4e18e3da8 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_9b7ea2aa985949efa9a03d4b2d47b66a = Array.Empty<Type>();
 
         /// <inheritdoc />
         IObservable<string> IGitHubApi.GetIndexObservable()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndexObservable", ArgumentTypes_e4e653f5c45a44e587603fa4e18e3da8);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndexObservable", ArgumentTypes_9b7ea2aa985949efa9a03d4b2d47b66a);
             return (IObservable<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_143c6c38995f46f98e893ad013f50063 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_eb4edacc4f284edbb0f2b00923766867 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<User> IGitHubApi.NothingToSeeHere()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("NothingToSeeHere", ArgumentTypes_143c6c38995f46f98e893ad013f50063);
+            var func = requestBuilder.BuildRestResultFuncForMethod("NothingToSeeHere", ArgumentTypes_eb4edacc4f284edbb0f2b00923766867);
             return (Task<User>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_4404f49f2e6247aba7d76ba04d3591cc = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_4000763e34804be994bf45f509bf8084 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<ApiResponse<User>> IGitHubApi.NothingToSeeHereWithMetadata()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("NothingToSeeHereWithMetadata", ArgumentTypes_4404f49f2e6247aba7d76ba04d3591cc);
+            var func = requestBuilder.BuildRestResultFuncForMethod("NothingToSeeHereWithMetadata", ArgumentTypes_4000763e34804be994bf45f509bf8084);
             return (Task<ApiResponse<User>>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_de1a1e1b66a449609d7497ba6a26e882 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_9b1e70ca1c3c49ee93b5ff0881edc738 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<ApiResponse<User>> IGitHubApi.GetUserWithMetadata(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserWithMetadata", ArgumentTypes_de1a1e1b66a449609d7497ba6a26e882);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserWithMetadata", ArgumentTypes_9b1e70ca1c3c49ee93b5ff0881edc738);
             return (Task<ApiResponse<User>>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_39eaefd7d2664899b35eb2ae8202fe99 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_a1bd719302ad426c94e18d7f966f5e11 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         IObservable<ApiResponse<User>> IGitHubApi.GetUserObservableWithMetadata(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserObservableWithMetadata", ArgumentTypes_39eaefd7d2664899b35eb2ae8202fe99);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserObservableWithMetadata", ArgumentTypes_a1bd719302ad426c94e18d7f966f5e11);
             return (IObservable<ApiResponse<User>>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_05e593e088494d678719992792ccd419 = new Type[] { typeof(User) };
+        private static readonly Type[] ArgumentTypes_ee46ae81a5c54aa29b2a6fc9fbab7721 = new Type[] { typeof(User) };
 
         /// <inheritdoc />
         Task<User> IGitHubApi.CreateUser(User user)
         {
             var arguments = new object[] { user };
-            var func = requestBuilder.BuildRestResultFuncForMethod("CreateUser", ArgumentTypes_05e593e088494d678719992792ccd419);
+            var func = requestBuilder.BuildRestResultFuncForMethod("CreateUser", ArgumentTypes_ee46ae81a5c54aa29b2a6fc9fbab7721);
             return (Task<User>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_ab1ed674897b4efdaef9eba920fd3ad9 = new Type[] { typeof(User) };
+        private static readonly Type[] ArgumentTypes_9ed5cb7a8dde4f3f8b5369c927b63573 = new Type[] { typeof(User) };
 
         /// <inheritdoc />
         Task<ApiResponse<User>> IGitHubApi.CreateUserWithMetadata(User user)
         {
             var arguments = new object[] { user };
-            var func = requestBuilder.BuildRestResultFuncForMethod("CreateUserWithMetadata", ArgumentTypes_ab1ed674897b4efdaef9eba920fd3ad9);
+            var func = requestBuilder.BuildRestResultFuncForMethod("CreateUserWithMetadata", ArgumentTypes_9ed5cb7a8dde4f3f8b5369c927b63573);
             return (Task<ApiResponse<User>>)func(Client, arguments);
         }
     }
@@ -1832,47 +1832,47 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_ec5e1cf1f7634dabac3761992c65037f = new Type[] { typeof(TParam), typeof(THeader) };
+        private static readonly Type[] ArgumentTypes_e68e6ee8646f4498b3b939866b34846b = new Type[] { typeof(TParam), typeof(THeader) };
 
         /// <inheritdoc />
         Task<TResponse> IHttpBinApi<TResponse, TParam, THeader>.Get(TParam param, THeader header)
         {
             var arguments = new object[] { param, header };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_ec5e1cf1f7634dabac3761992c65037f);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_e68e6ee8646f4498b3b939866b34846b);
             return (Task<TResponse>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_0f04a7d2c3f24df4943304840152d312 = new Type[] { typeof(TParam) };
+        private static readonly Type[] ArgumentTypes_ac91a689a09c4d459e5b80786ee9ccba = new Type[] { typeof(TParam) };
 
         /// <inheritdoc />
         Task<TResponse> IHttpBinApi<TResponse, TParam, THeader>.GetQuery(TParam param)
         {
             var arguments = new object[] { param };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetQuery", ArgumentTypes_0f04a7d2c3f24df4943304840152d312);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetQuery", ArgumentTypes_ac91a689a09c4d459e5b80786ee9ccba);
             return (Task<TResponse>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_01231ac66bb143048d2e53b21d266698 = new Type[] { typeof(TParam) };
+        private static readonly Type[] ArgumentTypes_a103e5730be043c78535004556e271d3 = new Type[] { typeof(TParam) };
 
         /// <inheritdoc />
         Task<TResponse> IHttpBinApi<TResponse, TParam, THeader>.PostQuery(TParam param)
         {
             var arguments = new object[] { param };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostQuery", ArgumentTypes_01231ac66bb143048d2e53b21d266698);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostQuery", ArgumentTypes_a103e5730be043c78535004556e271d3);
             return (Task<TResponse>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_ec8529bae3c9475ea8f6df7c1b6cd329 = new Type[] { typeof(TParam) };
+        private static readonly Type[] ArgumentTypes_c6c12bad723d4f459f1815b159c1e546 = new Type[] { typeof(TParam) };
 
         /// <inheritdoc />
         Task<TResponse> IHttpBinApi<TResponse, TParam, THeader>.GetQueryWithIncludeParameterName(TParam param)
         {
             var arguments = new object[] { param };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetQueryWithIncludeParameterName", ArgumentTypes_ec8529bae3c9475ea8f6df7c1b6cd329);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetQueryWithIncludeParameterName", ArgumentTypes_c6c12bad723d4f459f1815b159c1e546);
             return (Task<TResponse>)func(Client, arguments);
         }
 
-        private static class TypeHelper_3b927419d2e04667870dc9f95451dec8<TValue>
+        private static class TypeHelper_53b928e9c20f475b8ef3aa78d5aeee87<TValue>
         {
             public static readonly Type[] ArgumentTypes = new Type[] { typeof(TParam) };
             public static readonly Type[] TypeParameters = new Type[] { typeof(TValue) };
@@ -1882,7 +1882,7 @@ namespace Refit.Tests
         Task<TValue> IHttpBinApi<TResponse, TParam, THeader>.GetQuery1<TValue>(TParam param)
         {
             var arguments = new object[] { param };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetQuery1", TypeHelper_3b927419d2e04667870dc9f95451dec8<TValue>.ArgumentTypes, TypeHelper_3b927419d2e04667870dc9f95451dec8<TValue>.TypeParameters);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetQuery1", TypeHelper_53b928e9c20f475b8ef3aa78d5aeee87<TValue>.ArgumentTypes, TypeHelper_53b928e9c20f475b8ef3aa78d5aeee87<TValue>.TypeParameters);
             return (Task<TValue>)func(Client, arguments);
         }
     }
@@ -1923,23 +1923,23 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_5f3edfe8bb0a4ec3b6a73e03d754eee2 = new Type[] { typeof(HttpContent) };
+        private static readonly Type[] ArgumentTypes_d1ff8e06b7054df4b85b16a58855ec14 = new Type[] { typeof(HttpContent) };
 
         /// <inheritdoc />
         Task<HttpContent> IHttpContentApi.PostFileUpload(HttpContent content)
         {
             var arguments = new object[] { content };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostFileUpload", ArgumentTypes_5f3edfe8bb0a4ec3b6a73e03d754eee2);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostFileUpload", ArgumentTypes_d1ff8e06b7054df4b85b16a58855ec14);
             return (Task<HttpContent>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_2aa38514d7d34094b3808ffe2fa91fe3 = new Type[] { typeof(HttpContent) };
+        private static readonly Type[] ArgumentTypes_3f25d420c7ec4d09a1ae7eb271cb90ec = new Type[] { typeof(HttpContent) };
 
         /// <inheritdoc />
         Task<ApiResponse<HttpContent>> IHttpContentApi.PostFileUploadWithMetadata(HttpContent content)
         {
             var arguments = new object[] { content };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostFileUploadWithMetadata", ArgumentTypes_2aa38514d7d34094b3808ffe2fa91fe3);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostFileUploadWithMetadata", ArgumentTypes_3f25d420c7ec4d09a1ae7eb271cb90ec);
             return (Task<ApiResponse<HttpContent>>)func(Client, arguments);
         }
     }
@@ -1981,13 +1981,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_2609d659e3bd437a90188b0559b5eb1e = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_f794238af5e84808928c4597ceb6deae = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<TestAliasObject> ResponseTests.IMyAliasService.GetTestObject()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetTestObject", ArgumentTypes_2609d659e3bd437a90188b0559b5eb1e);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetTestObject", ArgumentTypes_f794238af5e84808928c4597ceb6deae);
             return (Task<TestAliasObject>)func(Client, arguments);
         }
     }
@@ -2023,23 +2023,23 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_2d5924ade7ff4f39bbdb949fc317a774 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_a0e8320ebd8d422fb3fcff61c148f1c8 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> AuthenticatedClientHandlerTests.IMyAuthenticatedService.GetUnauthenticated()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUnauthenticated", ArgumentTypes_2d5924ade7ff4f39bbdb949fc317a774);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUnauthenticated", ArgumentTypes_a0e8320ebd8d422fb3fcff61c148f1c8);
             return (Task<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_91fe256a9ee340228b6dfafab4e31eb5 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_24406a33878f44119cd9a68047678452 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> AuthenticatedClientHandlerTests.IMyAuthenticatedService.GetAuthenticated()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetAuthenticated", ArgumentTypes_91fe256a9ee340228b6dfafab4e31eb5);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetAuthenticated", ArgumentTypes_24406a33878f44119cd9a68047678452);
             return (Task<string>)func(Client, arguments);
         }
     }
@@ -2070,13 +2070,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_f35a382fa20c44169697e7f229e20a14 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_d1222ae1d1434ed1b031f218f40144ef = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<SomeType> INamespaceCollisionApi.SomeRequest()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", ArgumentTypes_f35a382fa20c44169697e7f229e20a14);
+            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", ArgumentTypes_d1222ae1d1434ed1b031f218f40144ef);
             return (Task<SomeType>)func(Client, arguments);
         }
     }
@@ -2108,13 +2108,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_8eb6df4c8c144524a0f2ac6183de052d = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_e3914a49c5364f0e89c955f9d7462760 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<SomeOtherType> INamespaceOverlapApi.SomeRequest()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", ArgumentTypes_8eb6df4c8c144524a0f2ac6183de052d);
+            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", ArgumentTypes_e3914a49c5364f0e89c955f9d7462760);
             return (Task<SomeOtherType>)func(Client, arguments);
         }
     }
@@ -2149,83 +2149,83 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_290d8c703d0c414a9c378854d2004022 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_cdd1e73d327a402da4a92ab34073ded9 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<User> TestNested.INestedGitHubApi.GetUser(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUser", ArgumentTypes_290d8c703d0c414a9c378854d2004022);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUser", ArgumentTypes_cdd1e73d327a402da4a92ab34073ded9);
             return (Task<User>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_f1a5a10ccaa34912baf4acf6c5b09c6d = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_7ff93b7357dd4fb9a70ff067c8c90921 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         IObservable<User> TestNested.INestedGitHubApi.GetUserObservable(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserObservable", ArgumentTypes_f1a5a10ccaa34912baf4acf6c5b09c6d);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserObservable", ArgumentTypes_7ff93b7357dd4fb9a70ff067c8c90921);
             return (IObservable<User>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_ee4a4f89edbb4442ab58b67dbc38b682 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_23f4398b6eac49e1a7eb585c4bb656b9 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         IObservable<User> TestNested.INestedGitHubApi.GetUserCamelCase(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserCamelCase", ArgumentTypes_ee4a4f89edbb4442ab58b67dbc38b682);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserCamelCase", ArgumentTypes_23f4398b6eac49e1a7eb585c4bb656b9);
             return (IObservable<User>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_adbaf47f6d7b464fa86e185831977dd5 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_221feeb87c0044c5bf801421f8eef3e4 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<List<User>> TestNested.INestedGitHubApi.GetOrgMembers(string orgName)
         {
             var arguments = new object[] { orgName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetOrgMembers", ArgumentTypes_adbaf47f6d7b464fa86e185831977dd5);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetOrgMembers", ArgumentTypes_221feeb87c0044c5bf801421f8eef3e4);
             return (Task<List<User>>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_e0ff1c2811ba410d99bfe5ac22c25e26 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_61b7111ba0c141a7ba9dc84ce9aedaf7 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<UserSearchResult> TestNested.INestedGitHubApi.FindUsers(string q)
         {
             var arguments = new object[] { q };
-            var func = requestBuilder.BuildRestResultFuncForMethod("FindUsers", ArgumentTypes_e0ff1c2811ba410d99bfe5ac22c25e26);
+            var func = requestBuilder.BuildRestResultFuncForMethod("FindUsers", ArgumentTypes_61b7111ba0c141a7ba9dc84ce9aedaf7);
             return (Task<UserSearchResult>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_5fa56402bd67427e8ce285460a926212 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_7024080b94e34a20b6fe674d8ec5918c = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<HttpResponseMessage> TestNested.INestedGitHubApi.GetIndex()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndex", ArgumentTypes_5fa56402bd67427e8ce285460a926212);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndex", ArgumentTypes_7024080b94e34a20b6fe674d8ec5918c);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_27313f99110b46e994e50c9643dd3a21 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_dec6e8c3627948298ba34d03668f096c = Array.Empty<Type>();
 
         /// <inheritdoc />
         IObservable<string> TestNested.INestedGitHubApi.GetIndexObservable()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndexObservable", ArgumentTypes_27313f99110b46e994e50c9643dd3a21);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndexObservable", ArgumentTypes_dec6e8c3627948298ba34d03668f096c);
             return (IObservable<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_01c44ff055ff436a878c23df9aa446e4 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_f89ab569c2d14c839cebf6bd1ae5adf9 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task TestNested.INestedGitHubApi.NothingToSeeHere()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("NothingToSeeHere", ArgumentTypes_01c44ff055ff436a878c23df9aa446e4);
+            var func = requestBuilder.BuildRestResultFuncForMethod("NothingToSeeHere", ArgumentTypes_f89ab569c2d14c839cebf6bd1ae5adf9);
             return (Task)func(Client, arguments);
         }
     }
@@ -2263,7 +2263,7 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static class TypeHelper_cc44cb02aefb46bdaba2b3e363f9f14a<T>
+        private static class TypeHelper_b122d2630c584b0db1daa65818d4ec03<T>
         {
             public static readonly Type[] ArgumentTypes = new Type[] { typeof(T) };
             public static readonly Type[] TypeParameters = new Type[] { typeof(T) };
@@ -2273,11 +2273,11 @@ namespace Refit.Tests
         Task INonGenericInterfaceWithGenericMethod.PostMessage<T>(T message)
         {
             var arguments = new object[] { message };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostMessage", TypeHelper_cc44cb02aefb46bdaba2b3e363f9f14a<T>.ArgumentTypes, TypeHelper_cc44cb02aefb46bdaba2b3e363f9f14a<T>.TypeParameters);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostMessage", TypeHelper_b122d2630c584b0db1daa65818d4ec03<T>.ArgumentTypes, TypeHelper_b122d2630c584b0db1daa65818d4ec03<T>.TypeParameters);
             return (Task)func(Client, arguments);
         }
 
-        private static class TypeHelper_2c635ff944134eca827ad0f89d58a2dc<T, U, V>
+        private static class TypeHelper_125e821cd52a4667a4e091e34affd24a<T, U, V>
         {
             public static readonly Type[] ArgumentTypes = new Type[] { typeof(T), typeof(U), typeof(V) };
             public static readonly Type[] TypeParameters = new Type[] { typeof(T), typeof(U), typeof(V) };
@@ -2287,7 +2287,7 @@ namespace Refit.Tests
         Task INonGenericInterfaceWithGenericMethod.PostMessage<T, U, V>(T message, U param1, V param2)
         {
             var arguments = new object[] { message, param1, param2 };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostMessage", TypeHelper_2c635ff944134eca827ad0f89d58a2dc<T, U, V>.ArgumentTypes, TypeHelper_2c635ff944134eca827ad0f89d58a2dc<T, U, V>.TypeParameters);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostMessage", TypeHelper_125e821cd52a4667a4e091e34affd24a<T, U, V>.ArgumentTypes, TypeHelper_125e821cd52a4667a4e091e34affd24a<T, U, V>.TypeParameters);
             return (Task)func(Client, arguments);
         }
     }
@@ -2328,13 +2328,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_de40d528bbb44dfda6b25a60c61317e9 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_d0dcde85f00b4efab3690368a5c4ef15 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<RootObject> INpmJs.GetCongruence()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetCongruence", ArgumentTypes_de40d528bbb44dfda6b25a60c61317e9);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetCongruence", ArgumentTypes_d0dcde85f00b4efab3690368a5c4ef15);
             return (Task<RootObject>)func(Client, arguments);
         }
     }
@@ -2363,13 +2363,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_eca5f3514570487dab2bd0e1c41eeecd = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_983e9e14c4d1475b929ad0226ca56b15 = Array.Empty<Type>();
 
         /// <inheritdoc />
         string? INullableReferenceService.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_eca5f3514570487dab2bd0e1c41eeecd);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_983e9e14c4d1475b929ad0226ca56b15);
             return (string?)func(Client, arguments);
         }
     }
@@ -2398,13 +2398,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_38481ff9a1aa4a9d99f13f2012826f08 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_ad137884c91440fa8ac86d0a51609fb2 = Array.Empty<Type>();
 
         /// <inheritdoc />
         int? INullableValueService.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_38481ff9a1aa4a9d99f13f2012826f08);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_ad137884c91440fa8ac86d0a51609fb2);
             return (int?)func(Client, arguments);
         }
     }
@@ -2434,13 +2434,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_e1026191ae0542459d5681530aef66af = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_49b23c552de84a5da20b5aac74b7fbcf = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<SomeType> IReducedUsingInsideNamespaceApi.SomeRequest()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", ArgumentTypes_e1026191ae0542459d5681530aef66af);
+            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", ArgumentTypes_49b23c552de84a5da20b5aac74b7fbcf);
             return (Task<SomeType>)func(Client, arguments);
         }
     }
@@ -2469,13 +2469,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_b854b536248445aa90ba6b7393eb5cb9 = new Type[] { ToNullable(typeof(string)), ToNullable(typeof(int)) };
+        private static readonly Type[] ArgumentTypes_c373547c267d48a49d5953ae3b76ffd7 = new Type[] { ToNullable(typeof(string)), ToNullable(typeof(int)) };
 
         /// <inheritdoc />
         Task IReferenceAndValueParametersService.Get(string? reference, int? value)
         {
             var arguments = new object[] { reference, value };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_b854b536248445aa90ba6b7393eb5cb9);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_c373547c267d48a49d5953ae3b76ffd7);
             return (Task)func(Client, arguments);
         }
 
@@ -2518,13 +2518,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_3ea0a901846549018dacce2e090c79f6 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_d78f8af4f275401c86d7a3fff605fb2b = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IRefitInterfaceWithStaticMethod.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_3ea0a901846549018dacce2e090c79f6);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_d78f8af4f275401c86d7a3fff605fb2b);
             return (Task)func(Client, arguments);
         }
     }
@@ -2565,47 +2565,47 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_ab39b9e0693d453c9846d548131807f3 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_5003748c9632429389223237183c144b = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IRequestBin.Post()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Post", ArgumentTypes_ab39b9e0693d453c9846d548131807f3);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Post", ArgumentTypes_5003748c9632429389223237183c144b);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_30a3ba0b20684a56847a21ee9a84294f = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_11f17546a26d4b4f88cb6c7547ec1f49 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task IRequestBin.PostRawStringDefault(string str)
         {
             var arguments = new object[] { str };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostRawStringDefault", ArgumentTypes_30a3ba0b20684a56847a21ee9a84294f);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostRawStringDefault", ArgumentTypes_11f17546a26d4b4f88cb6c7547ec1f49);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_6f5d4527917b40b8a7419c164e2b04bf = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_d5763aca3246491f92d6c41d477929c5 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task IRequestBin.PostRawStringJson(string str)
         {
             var arguments = new object[] { str };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostRawStringJson", ArgumentTypes_6f5d4527917b40b8a7419c164e2b04bf);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostRawStringJson", ArgumentTypes_d5763aca3246491f92d6c41d477929c5);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_7a72a289a3b4491f80c074bbafba16e4 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_6a70018e74f5400582ad42d88af3757b = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task IRequestBin.PostRawStringUrlEncoded(string str)
         {
             var arguments = new object[] { str };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostRawStringUrlEncoded", ArgumentTypes_7a72a289a3b4491f80c074bbafba16e4);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostRawStringUrlEncoded", ArgumentTypes_6a70018e74f5400582ad42d88af3757b);
             return (Task)func(Client, arguments);
         }
 
-        private static class TypeHelper_bafd5bc5e66e4a81a68d38d6bf9c1023<T>
+        private static class TypeHelper_be0bf1fca7e441499b33cf75bea048b7<T>
         {
             public static readonly Type[] ArgumentTypes = new Type[] { typeof(T) };
             public static readonly Type[] TypeParameters = new Type[] { typeof(T) };
@@ -2615,7 +2615,7 @@ namespace Refit.Tests
         Task IRequestBin.PostGeneric<T>(T param)
         {
             var arguments = new object[] { param };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostGeneric", TypeHelper_bafd5bc5e66e4a81a68d38d6bf9c1023<T>.ArgumentTypes, TypeHelper_bafd5bc5e66e4a81a68d38d6bf9c1023<T>.TypeParameters);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostGeneric", TypeHelper_be0bf1fca7e441499b33cf75bea048b7<T>.ArgumentTypes, TypeHelper_be0bf1fca7e441499b33cf75bea048b7<T>.TypeParameters);
             return (Task)func(Client, arguments);
         }
     }
@@ -2656,133 +2656,133 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_92793d040eb64afc99b08814cf8c6c32 = new Type[] { typeof(Stream) };
+        private static readonly Type[] ArgumentTypes_f9d79fa6a96a4118a2866d211fdd0a81 = new Type[] { typeof(Stream) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadStream(Stream stream)
         {
             var arguments = new object[] { stream };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStream", ArgumentTypes_92793d040eb64afc99b08814cf8c6c32);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStream", ArgumentTypes_f9d79fa6a96a4118a2866d211fdd0a81);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_9d691d17d8b54c088ddae81d2dfac6dd = new Type[] { typeof(Stream) };
+        private static readonly Type[] ArgumentTypes_5ac2112f6d64493996d4ae7d780bf688 = new Type[] { typeof(Stream) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadStreamWithCustomBoundary(Stream stream)
         {
             var arguments = new object[] { stream };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStreamWithCustomBoundary", ArgumentTypes_9d691d17d8b54c088ddae81d2dfac6dd);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStreamWithCustomBoundary", ArgumentTypes_5ac2112f6d64493996d4ae7d780bf688);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_9e1b93ce7a9747e8a4b04faf84b7b9e3 = new Type[] { typeof(StreamPart) };
+        private static readonly Type[] ArgumentTypes_c60f700ffb5b49c28691beaafa464cb6 = new Type[] { typeof(StreamPart) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadStreamPart(StreamPart stream)
         {
             var arguments = new object[] { stream };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStreamPart", ArgumentTypes_9e1b93ce7a9747e8a4b04faf84b7b9e3);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStreamPart", ArgumentTypes_c60f700ffb5b49c28691beaafa464cb6);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_cf71bb58e48d41a38af4746ffcfd1013 = new Type[] { typeof(ModelObject), typeof(StreamPart) };
+        private static readonly Type[] ArgumentTypes_247343f4dc604339a0cdb4caad97c7a2 = new Type[] { typeof(ModelObject), typeof(StreamPart) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadStreamPart(ModelObject someQueryParams, StreamPart stream)
         {
             var arguments = new object[] { someQueryParams, stream };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStreamPart", ArgumentTypes_cf71bb58e48d41a38af4746ffcfd1013);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStreamPart", ArgumentTypes_247343f4dc604339a0cdb4caad97c7a2);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_93436928ef3a4e93a9daafd41806d21a = new Type[] { typeof(byte[]) };
+        private static readonly Type[] ArgumentTypes_b64cc976fe2b49d1bae22fc6b884c206 = new Type[] { typeof(byte[]) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadBytes(byte[] bytes)
         {
             var arguments = new object[] { bytes };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadBytes", ArgumentTypes_93436928ef3a4e93a9daafd41806d21a);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadBytes", ArgumentTypes_b64cc976fe2b49d1bae22fc6b884c206);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_25ccac5fc1b44b46880ced61fa872793 = new Type[] { typeof(ByteArrayPart) };
+        private static readonly Type[] ArgumentTypes_26bccb489e414efc8d0de5ed533848b5 = new Type[] { typeof(ByteArrayPart) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadBytesPart(ByteArrayPart bytes)
         {
             var arguments = new object[] { bytes };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadBytesPart", ArgumentTypes_25ccac5fc1b44b46880ced61fa872793);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadBytesPart", ArgumentTypes_26bccb489e414efc8d0de5ed533848b5);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_4c483e4c52fe4d0a9e10500e6958e012 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_25763396a0f74832849b629a82fc919a = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadString(string someString)
         {
             var arguments = new object[] { someString };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadString", ArgumentTypes_4c483e4c52fe4d0a9e10500e6958e012);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadString", ArgumentTypes_25763396a0f74832849b629a82fc919a);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_528a488692a64a59acef12627ff3e70a = new Type[] { typeof(IEnumerable<FileInfo>), typeof(FileInfo) };
+        private static readonly Type[] ArgumentTypes_93a07ee851b148cc9b04e827ab7d0b67 = new Type[] { typeof(IEnumerable<FileInfo>), typeof(FileInfo) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadFileInfo(IEnumerable<FileInfo> fileInfos, FileInfo anotherFile)
         {
             var arguments = new object[] { fileInfos, anotherFile };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadFileInfo", ArgumentTypes_528a488692a64a59acef12627ff3e70a);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadFileInfo", ArgumentTypes_93a07ee851b148cc9b04e827ab7d0b67);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_8083d98ba0684bc8ac148ac4633ebc98 = new Type[] { typeof(IEnumerable<FileInfoPart>), typeof(FileInfoPart) };
+        private static readonly Type[] ArgumentTypes_320ccad705064889b7adde60a15db84d = new Type[] { typeof(IEnumerable<FileInfoPart>), typeof(FileInfoPart) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadFileInfoPart(IEnumerable<FileInfoPart> fileInfos, FileInfoPart anotherFile)
         {
             var arguments = new object[] { fileInfos, anotherFile };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadFileInfoPart", ArgumentTypes_8083d98ba0684bc8ac148ac4633ebc98);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadFileInfoPart", ArgumentTypes_320ccad705064889b7adde60a15db84d);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_dea109eab23544c990acc0a423f5b452 = new Type[] { typeof(ModelObject) };
+        private static readonly Type[] ArgumentTypes_670372c495e144e8bd3129dc50d756de = new Type[] { typeof(ModelObject) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadJsonObject(ModelObject theObject)
         {
             var arguments = new object[] { theObject };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadJsonObject", ArgumentTypes_dea109eab23544c990acc0a423f5b452);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadJsonObject", ArgumentTypes_670372c495e144e8bd3129dc50d756de);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_21a97a3182ec4f30b09847a257e2a50c = new Type[] { typeof(IEnumerable<ModelObject>) };
+        private static readonly Type[] ArgumentTypes_85d15c94d0044010a9a4e38f290605af = new Type[] { typeof(IEnumerable<ModelObject>) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadJsonObjects(IEnumerable<ModelObject> theObjects)
         {
             var arguments = new object[] { theObjects };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadJsonObjects", ArgumentTypes_21a97a3182ec4f30b09847a257e2a50c);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadJsonObjects", ArgumentTypes_85d15c94d0044010a9a4e38f290605af);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_61966fc1e02e4521b007879ac8eacaa1 = new Type[] { typeof(IEnumerable<ModelObject>), typeof(AnotherModel), typeof(FileInfo), typeof(AnEnum), typeof(string), typeof(int) };
+        private static readonly Type[] ArgumentTypes_2895c946a1fb4cce8a9e0ff3adf7c7d5 = new Type[] { typeof(IEnumerable<ModelObject>), typeof(AnotherModel), typeof(FileInfo), typeof(AnEnum), typeof(string), typeof(int) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadMixedObjects(IEnumerable<ModelObject> theObjects, AnotherModel anotherModel, FileInfo aFile, AnEnum anEnum, string aString, int anInt)
         {
             var arguments = new object[] { theObjects, anotherModel, aFile, anEnum, aString, anInt };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadMixedObjects", ArgumentTypes_61966fc1e02e4521b007879ac8eacaa1);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadMixedObjects", ArgumentTypes_2895c946a1fb4cce8a9e0ff3adf7c7d5);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_753a20dfa6cc4ba1b76da37a4b557368 = new Type[] { typeof(HttpContent) };
+        private static readonly Type[] ArgumentTypes_6107563cd891480eb598b6886a2be27f = new Type[] { typeof(HttpContent) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadHttpContent(HttpContent content)
         {
             var arguments = new object[] { content };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadHttpContent", ArgumentTypes_753a20dfa6cc4ba1b76da37a4b557368);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadHttpContent", ArgumentTypes_6107563cd891480eb598b6886a2be27f);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
     }
@@ -2814,23 +2814,23 @@ namespace AutoGeneratedIServiceWithoutNamespace
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_4f2db53a6b8f44ca88697958b94415c9 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_efe21013ca7c4f2d9589e7d815d5008f = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IServiceWithoutNamespace.GetRoot()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetRoot", ArgumentTypes_4f2db53a6b8f44ca88697958b94415c9);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetRoot", ArgumentTypes_efe21013ca7c4f2d9589e7d815d5008f);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_40bf5b3941b04a26bce6fdb4b8db310b = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_a1c2eb527a9b476e99bf7cef58bd0284 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IServiceWithoutNamespace.PostRoot()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostRoot", ArgumentTypes_40bf5b3941b04a26bce6fdb4b8db310b);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostRoot", ArgumentTypes_a1c2eb527a9b476e99bf7cef58bd0284);
             return (Task)func(Client, arguments);
         }
     }
@@ -2871,23 +2871,23 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_454352e006f84c2697b51eedee8873b7 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_a7ccb24255144897a4e5a57fbb83aed5 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<Stream> IStreamApi.GetRemoteFile(string filename)
         {
             var arguments = new object[] { filename };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetRemoteFile", ArgumentTypes_454352e006f84c2697b51eedee8873b7);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetRemoteFile", ArgumentTypes_a7ccb24255144897a4e5a57fbb83aed5);
             return (Task<Stream>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_fb6662beb1684c0988d7e8f4cbc1c2a2 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_ba28fe83680344c29e5a5edabfbed219 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<ApiResponse<Stream>> IStreamApi.GetRemoteFileWithMetadata(string filename)
         {
             var arguments = new object[] { filename };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetRemoteFileWithMetadata", ArgumentTypes_fb6662beb1684c0988d7e8f4cbc1c2a2);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetRemoteFileWithMetadata", ArgumentTypes_ba28fe83680344c29e5a5edabfbed219);
             return (Task<ApiResponse<Stream>>)func(Client, arguments);
         }
     }
@@ -2928,13 +2928,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_fdf80ec7baef4ad48e71a602f992d108 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_904e2a096bcd4250bff87a3fd4ae6dda = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task ITrimTrailingForwardSlashApi.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_fdf80ec7baef4ad48e71a602f992d108);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_904e2a096bcd4250bff87a3fd4ae6dda);
             return (Task)func(Client, arguments);
         }
     }
@@ -2964,13 +2964,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_f913063644914261aea5b3876590334b = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_ab82407757e74062b84dfe0bb2e17b4b = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<SomeType> ITypeCollisionApiA.SomeARequest()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("SomeARequest", ArgumentTypes_f913063644914261aea5b3876590334b);
+            var func = requestBuilder.BuildRestResultFuncForMethod("SomeARequest", ArgumentTypes_ab82407757e74062b84dfe0bb2e17b4b);
             return (Task<SomeType>)func(Client, arguments);
         }
     }
@@ -3000,13 +3000,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_48d9680fb6374837bcd9695dc82621bd = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_5508ee5a8d43415c97c12a9bd5f757f1 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<SomeType> ITypeCollisionApiB.SomeBRequest()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("SomeBRequest", ArgumentTypes_48d9680fb6374837bcd9695dc82621bd);
+            var func = requestBuilder.BuildRestResultFuncForMethod("SomeBRequest", ArgumentTypes_5508ee5a8d43415c97c12a9bd5f757f1);
             return (Task<SomeType>)func(Client, arguments);
         }
     }
@@ -3045,47 +3045,47 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_8b4de2910e6840f0b27b5c661cb4503d = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_5c595e6fd9554430b46b62e87a592e0d = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> IUseOverloadedGenericMethods<TResponse, TParam, THeader>.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_8b4de2910e6840f0b27b5c661cb4503d);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_5c595e6fd9554430b46b62e87a592e0d);
             return (Task<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_164053e3383e4c31811822c3fb5a9009 = new Type[] { typeof(TParam), typeof(THeader) };
+        private static readonly Type[] ArgumentTypes_47f73cd9259a46289871327a01ecb808 = new Type[] { typeof(TParam), typeof(THeader) };
 
         /// <inheritdoc />
         Task<TResponse> IUseOverloadedGenericMethods<TResponse, TParam, THeader>.Get(TParam param, THeader header)
         {
             var arguments = new object[] { param, header };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_164053e3383e4c31811822c3fb5a9009);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_47f73cd9259a46289871327a01ecb808);
             return (Task<TResponse>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_0e090ff90421432ba01be9312230a1b2 = new Type[] { typeof(THeader), typeof(TParam) };
+        private static readonly Type[] ArgumentTypes_9e707961e4c44f7eabfed7ebebc7f9b0 = new Type[] { typeof(THeader), typeof(TParam) };
 
         /// <inheritdoc />
         Task<TResponse> IUseOverloadedGenericMethods<TResponse, TParam, THeader>.Get(THeader param, TParam header)
         {
             var arguments = new object[] { param, header };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_0e090ff90421432ba01be9312230a1b2);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_9e707961e4c44f7eabfed7ebebc7f9b0);
             return (Task<TResponse>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_4e4c7ae5f1ba472db90ecdfabeacce93 = new Type[] { typeof(int) };
+        private static readonly Type[] ArgumentTypes_abbd64aa04bd41c8811d3f2e2bb86c6e = new Type[] { typeof(int) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IUseOverloadedGenericMethods<TResponse, TParam, THeader>.Get(int httpstatuscode)
         {
             var arguments = new object[] { httpstatuscode };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_4e4c7ae5f1ba472db90ecdfabeacce93);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_abbd64aa04bd41c8811d3f2e2bb86c6e);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static class TypeHelper_8636de4f5c4641ff9853ba48a3f8a084<TValue>
+        private static class TypeHelper_9f3442c913b1450897d0b3c62613d56c<TValue>
         {
             public static readonly Type[] ArgumentTypes = new Type[] { typeof(int) };
             public static readonly Type[] TypeParameters = new Type[] { typeof(TValue) };
@@ -3095,11 +3095,11 @@ namespace Refit.Tests
         Task<TValue> IUseOverloadedGenericMethods<TResponse, TParam, THeader>.Get<TValue>(int someVal)
         {
             var arguments = new object[] { someVal };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", TypeHelper_8636de4f5c4641ff9853ba48a3f8a084<TValue>.ArgumentTypes, TypeHelper_8636de4f5c4641ff9853ba48a3f8a084<TValue>.TypeParameters);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", TypeHelper_9f3442c913b1450897d0b3c62613d56c<TValue>.ArgumentTypes, TypeHelper_9f3442c913b1450897d0b3c62613d56c<TValue>.TypeParameters);
             return (Task<TValue>)func(Client, arguments);
         }
 
-        private static class TypeHelper_08b60cab0edb46f6a8fee5688112f696<TValue, TInput>
+        private static class TypeHelper_9f48466807f14603a0459121acb98056<TValue, TInput>
         {
             public static readonly Type[] ArgumentTypes = new Type[] { typeof(TInput) };
             public static readonly Type[] TypeParameters = new Type[] { typeof(TValue), typeof(TInput) };
@@ -3109,11 +3109,11 @@ namespace Refit.Tests
         Task<TValue> IUseOverloadedGenericMethods<TResponse, TParam, THeader>.Get<TValue, TInput>(TInput input)
         {
             var arguments = new object[] { input };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", TypeHelper_08b60cab0edb46f6a8fee5688112f696<TValue, TInput>.ArgumentTypes, TypeHelper_08b60cab0edb46f6a8fee5688112f696<TValue, TInput>.TypeParameters);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", TypeHelper_9f48466807f14603a0459121acb98056<TValue, TInput>.ArgumentTypes, TypeHelper_9f48466807f14603a0459121acb98056<TValue, TInput>.TypeParameters);
             return (Task<TValue>)func(Client, arguments);
         }
 
-        private static class TypeHelper_ed662afbcd3c4414a11386129c395550<TInput1, TInput2>
+        private static class TypeHelper_204fbadfc0fb43d59d2ebc0417c5bb0c<TInput1, TInput2>
         {
             public static readonly Type[] ArgumentTypes = new Type[] { typeof(TInput1), typeof(TInput2) };
             public static readonly Type[] TypeParameters = new Type[] { typeof(TInput1), typeof(TInput2) };
@@ -3123,7 +3123,7 @@ namespace Refit.Tests
         Task IUseOverloadedGenericMethods<TResponse, TParam, THeader>.Get<TInput1, TInput2>(TInput1 input1, TInput2 input2)
         {
             var arguments = new object[] { input1, input2 };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", TypeHelper_ed662afbcd3c4414a11386129c395550<TInput1, TInput2>.ArgumentTypes, TypeHelper_ed662afbcd3c4414a11386129c395550<TInput1, TInput2>.TypeParameters);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", TypeHelper_204fbadfc0fb43d59d2ebc0417c5bb0c<TInput1, TInput2>.ArgumentTypes, TypeHelper_204fbadfc0fb43d59d2ebc0417c5bb0c<TInput1, TInput2>.TypeParameters);
             return (Task)func(Client, arguments);
         }
     }
@@ -3158,23 +3158,23 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_b3f8f6f1c0d2406aad991851b892ee24 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_ff6a3505f049484d8f042a0b1412fcf6 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> IUseOverloadedMethods.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_b3f8f6f1c0d2406aad991851b892ee24);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_ff6a3505f049484d8f042a0b1412fcf6);
             return (Task<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_7f8aa790114f4991bc86c91ef0d08b29 = new Type[] { typeof(int) };
+        private static readonly Type[] ArgumentTypes_b6e87062504943bdbac11d23215162b8 = new Type[] { typeof(int) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IUseOverloadedMethods.Get(int httpstatuscode)
         {
             var arguments = new object[] { httpstatuscode };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_7f8aa790114f4991bc86c91ef0d08b29);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_b6e87062504943bdbac11d23215162b8);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
     }
@@ -3215,13 +3215,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_14bd736bd00245599e9e60aeb836dd7a = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_8170f4c0872245939db261d433b93cf7 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IValidApi.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_14bd736bd00245599e9e60aeb836dd7a);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_8170f4c0872245939db261d433b93cf7);
             return (Task)func(Client, arguments);
         }
     }
@@ -3251,13 +3251,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_cae0559fb0804ce294c7753e847a5387 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_b2a54c686afb4d19ac3134789cab1bb4 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<SomeType> NamespaceWithGlobalAliasApi.SomeRequest()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", ArgumentTypes_cae0559fb0804ce294c7753e847a5387);
+            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", ArgumentTypes_b2a54c686afb4d19ac3134789cab1bb4);
             return (Task<SomeType>)func(Client, arguments);
         }
     }

--- a/Refit.Tests/RefitStubs.NetCore2.cs
+++ b/Refit.Tests/RefitStubs.NetCore2.cs
@@ -62,27 +62,27 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_89f2a3206459448da85aba4bea423721 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_294c7beec3ae4c2ea2f551dd9f2ceac8 = new Type[] {  };
 
         /// <inheritdoc />
         Task IAmARefitInterfaceButNobodyUsesMe.RefitMethod()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("RefitMethod", ArgumentTypes_89f2a3206459448da85aba4bea423721);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("RefitMethod", ArgumentTypes_294c7beec3ae4c2ea2f551dd9f2ceac8);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_788383ee3e554cffb85b38f215395bcc = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_7e1d182ae429428bbb27c49383b8fbf9 = new Type[] {  };
 
         /// <inheritdoc />
         Task IAmARefitInterfaceButNobodyUsesMe.AnotherRefitMethod()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("AnotherRefitMethod", ArgumentTypes_788383ee3e554cffb85b38f215395bcc);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("AnotherRefitMethod", ArgumentTypes_7e1d182ae429428bbb27c49383b8fbf9);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_9cc8908b765c49afa9ebb2d3c662fc5f = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_5c1e302ec72d4423b80812ba9bc69632 = new Type[] {  };
 
         /// <inheritdoc />
         Task IAmARefitInterfaceButNobodyUsesMe.NoConstantsAllowed()
@@ -90,23 +90,23 @@ namespace Refit.Tests
             throw new NotImplementedException("Either this method has no Refit HTTP method attribute or you've used something other than a string literal for the 'path' argument.");
         }
 
-        private static readonly Type[] ArgumentTypes_885bd6840a12426ebafd1f905f51bb24 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_2cbc0427569d4f7884b2dfbee55fbce1 = new Type[] {  };
 
         /// <inheritdoc />
         Task IAmARefitInterfaceButNobodyUsesMe.SpacesShouldntBreakMe()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("SpacesShouldntBreakMe", ArgumentTypes_885bd6840a12426ebafd1f905f51bb24);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("SpacesShouldntBreakMe", ArgumentTypes_2cbc0427569d4f7884b2dfbee55fbce1);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_ea951264b389427189ff496aed051d7a = new Type[] { typeof(int), typeof(string), typeof(float) };
+        private static readonly Type[] ArgumentTypes_11bea462e8604f558a0c4795e0cfe583 = new Type[] { typeof(int), typeof(string), typeof(float) };
 
         /// <inheritdoc />
         Task IAmARefitInterfaceButNobodyUsesMe.ReservedWordsForParameterNames(int @int, string @string, float @long)
         {
             var arguments = new object[] { @int, @string, @long };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReservedWordsForParameterNames", ArgumentTypes_ea951264b389427189ff496aed051d7a);
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReservedWordsForParameterNames", ArgumentTypes_11bea462e8604f558a0c4795e0cfe583);
             return (Task)func(Client, arguments);
         }
     }
@@ -147,17 +147,17 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_b5cfb1bb03044077beea116d8b5c094f = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_246099c598864d098f368a9d2b141cd0 = new Type[] {  };
 
         /// <inheritdoc />
         Task IAmHalfRefit.Post()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Post", ArgumentTypes_b5cfb1bb03044077beea116d8b5c094f);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Post", ArgumentTypes_246099c598864d098f368a9d2b141cd0);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_2bb79711fafb4f54b81fbee9ffd0fa1d = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_9efebcb322ae46ee880c9274c91e713f = new Type[] {  };
 
         /// <inheritdoc />
         Task IAmHalfRefit.Get()
@@ -191,43 +191,43 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_8381c32586b64925804d183986a40b7d = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_ae79f7eb658e4498911be41f0e7b73c9 = new Type[] {  };
 
         /// <inheritdoc />
         Task<string> IAmInterface.Pang()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Pang", ArgumentTypes_8381c32586b64925804d183986a40b7d);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Pang", ArgumentTypes_ae79f7eb658e4498911be41f0e7b73c9);
             return (Task<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_37dbfbca4bce41e1a1f578050682b819 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_aea84e7985454fb7ac240c0623728900 = new Type[] {  };
 
         /// <inheritdoc />
         Task<string> IAmInterfaceB.Pong()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Pong", ArgumentTypes_37dbfbca4bce41e1a1f578050682b819);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Pong", ArgumentTypes_aea84e7985454fb7ac240c0623728900);
             return (Task<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_d28cbb6713e740c89f5bc2be5046bbf6 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_71aaacdbf10442ef8f8884066a2800ed = new Type[] {  };
 
         /// <inheritdoc />
         Task<string> IAmInterfaceD.Test()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Test", ArgumentTypes_d28cbb6713e740c89f5bc2be5046bbf6);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Test", ArgumentTypes_71aaacdbf10442ef8f8884066a2800ed);
             return (Task<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_0e11e87a86d64afcb7d05cd37e5eb723 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_e250d137cf2b41aebbdd66f580ecc4e2 = new Type[] {  };
 
         /// <inheritdoc />
         Task<string> IAmInterfaceA.Ping()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Ping", ArgumentTypes_0e11e87a86d64afcb7d05cd37e5eb723);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Ping", ArgumentTypes_e250d137cf2b41aebbdd66f580ecc4e2);
             return (Task<string>)func(Client, arguments);
         }
     }
@@ -257,13 +257,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_2b64ef43de854e7d9f5471d657f2454f = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_70c1dbcde7a144fab5e34770b582cd70 = new Type[] {  };
 
         /// <inheritdoc />
         Task<string> IAmInterfaceA.Ping()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Ping", ArgumentTypes_2b64ef43de854e7d9f5471d657f2454f);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Ping", ArgumentTypes_70c1dbcde7a144fab5e34770b582cd70);
             return (Task<string>)func(Client, arguments);
         }
     }
@@ -293,23 +293,23 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_595c45e753484023bc301bd04f39217e = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_972cf714ec0449debc8b850320e77796 = new Type[] {  };
 
         /// <inheritdoc />
         Task<string> IAmInterfaceB.Pong()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Pong", ArgumentTypes_595c45e753484023bc301bd04f39217e);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Pong", ArgumentTypes_972cf714ec0449debc8b850320e77796);
             return (Task<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_2ee7022f8a214c2aa5db0460af54c29d = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_1985886340014917ac67199a5532f642 = new Type[] {  };
 
         /// <inheritdoc />
         Task<string> IAmInterfaceD.Test()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Test", ArgumentTypes_2ee7022f8a214c2aa5db0460af54c29d);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Test", ArgumentTypes_1985886340014917ac67199a5532f642);
             return (Task<string>)func(Client, arguments);
         }
     }
@@ -339,43 +339,43 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_f17a8294548447baa65a1e5e3371d58d = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_56608d8e192b4d68a2a1cd4cd922d351 = new Type[] {  };
 
         /// <inheritdoc />
         Task<string> IAmInterfaceC.Pang()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Pang", ArgumentTypes_f17a8294548447baa65a1e5e3371d58d);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Pang", ArgumentTypes_56608d8e192b4d68a2a1cd4cd922d351);
             return (Task<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_2810c21ea8e741d5a27153a89d5ecf41 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_27e1d521019046148a0027ad81074cc1 = new Type[] {  };
 
         /// <inheritdoc />
         Task<string> IAmInterfaceB.Pong()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Pong", ArgumentTypes_2810c21ea8e741d5a27153a89d5ecf41);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Pong", ArgumentTypes_27e1d521019046148a0027ad81074cc1);
             return (Task<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_cd8f9ce45e5943728fa1b36a959bf31f = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_7bba69f3179d4f6f994eaa1f56e8ab4c = new Type[] {  };
 
         /// <inheritdoc />
         Task<string> IAmInterfaceD.Test()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Test", ArgumentTypes_cd8f9ce45e5943728fa1b36a959bf31f);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Test", ArgumentTypes_7bba69f3179d4f6f994eaa1f56e8ab4c);
             return (Task<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_e9955255ce5d41ec912e56360aee47dc = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_1d960319b7e842d8ba1d3c3af98c79d4 = new Type[] {  };
 
         /// <inheritdoc />
         Task<string> IAmInterfaceA.Ping()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Ping", ArgumentTypes_e9955255ce5d41ec912e56360aee47dc);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Ping", ArgumentTypes_1d960319b7e842d8ba1d3c3af98c79d4);
             return (Task<string>)func(Client, arguments);
         }
     }
@@ -405,13 +405,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_f4b72f17d20e4d60ae34dc4a4c06af82 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_028b918e4db94eb1b81abdfe1c3c53cc = new Type[] {  };
 
         /// <inheritdoc />
         Task<string> IAmInterfaceD.Test()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Test", ArgumentTypes_f4b72f17d20e4d60ae34dc4a4c06af82);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Test", ArgumentTypes_028b918e4db94eb1b81abdfe1c3c53cc);
             return (Task<string>)func(Client, arguments);
         }
     }
@@ -452,153 +452,153 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_36e1574ef1db4b098362998fc2daef06 = new Type[] { typeof(PathBoundObject) };
+        private static readonly Type[] ArgumentTypes_97e3e61e76e440789d5093e7b93da5f9 = new Type[] { typeof(PathBoundObject) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetFooBars(PathBoundObject request)
         {
             var arguments = new object[] { request };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBars", ArgumentTypes_36e1574ef1db4b098362998fc2daef06);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBars", ArgumentTypes_97e3e61e76e440789d5093e7b93da5f9);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_b845e97272564812b80725f0bf39274d = new Type[] { typeof(PathBoundObject) };
+        private static readonly Type[] ArgumentTypes_a59bde75544042239980fd5468640db6 = new Type[] { typeof(PathBoundObject) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetFooBarsWithDifferentCasing(PathBoundObject requestParams)
         {
             var arguments = new object[] { requestParams };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBarsWithDifferentCasing", ArgumentTypes_b845e97272564812b80725f0bf39274d);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBarsWithDifferentCasing", ArgumentTypes_a59bde75544042239980fd5468640db6);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_7ed56772ed494bc1b7cdde5d38b4116e = new Type[] { typeof(string), typeof(PathBoundObject) };
+        private static readonly Type[] ArgumentTypes_6d949a2336e0440e8e28c34fa7701f27 = new Type[] { typeof(string), typeof(PathBoundObject) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetBarsByFoo(string id, PathBoundObject request)
         {
             var arguments = new object[] { id, request };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetBarsByFoo", ArgumentTypes_7ed56772ed494bc1b7cdde5d38b4116e);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetBarsByFoo", ArgumentTypes_6d949a2336e0440e8e28c34fa7701f27);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_d1eb82e6376b47d19fda28df0d9abed0 = new Type[] { typeof(PathBoundObject), typeof(string) };
+        private static readonly Type[] ArgumentTypes_d6ab9111652e4b5bb21ea0c484b812ff = new Type[] { typeof(PathBoundObject), typeof(string) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetFooBars(PathBoundObject request, string someProperty)
         {
             var arguments = new object[] { request, someProperty };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBars", ArgumentTypes_d1eb82e6376b47d19fda28df0d9abed0);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBars", ArgumentTypes_d6ab9111652e4b5bb21ea0c484b812ff);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_31216cf02e644140a176ecba9764f73f = new Type[] { typeof(PathBoundObject) };
+        private static readonly Type[] ArgumentTypes_40697492eb7d42909346b14cda09b5b7 = new Type[] { typeof(PathBoundObject) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetBarsByFoo(PathBoundObject request)
         {
             var arguments = new object[] { request };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetBarsByFoo", ArgumentTypes_31216cf02e644140a176ecba9764f73f);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetBarsByFoo", ArgumentTypes_40697492eb7d42909346b14cda09b5b7);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_dcdea29985044726aa7e062f858bc187 = new Type[] { typeof(PathBoundObjectWithQueryFormat) };
+        private static readonly Type[] ArgumentTypes_a7964ea160c446c5b209ae6fcadebc44 = new Type[] { typeof(PathBoundObjectWithQueryFormat) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetBarsWithCustomQueryFormat(PathBoundObjectWithQueryFormat request)
         {
             var arguments = new object[] { request };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetBarsWithCustomQueryFormat", ArgumentTypes_dcdea29985044726aa7e062f858bc187);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetBarsWithCustomQueryFormat", ArgumentTypes_a7964ea160c446c5b209ae6fcadebc44);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_a3a856b8678641d1ae1afd3d6c372cc7 = new Type[] { typeof(PathBoundDerivedObject) };
+        private static readonly Type[] ArgumentTypes_6174d733cdff4b81b3bf4713e20e26d4 = new Type[] { typeof(PathBoundDerivedObject) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetFooBarsDerived(PathBoundDerivedObject request)
         {
             var arguments = new object[] { request };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBarsDerived", ArgumentTypes_a3a856b8678641d1ae1afd3d6c372cc7);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBarsDerived", ArgumentTypes_6174d733cdff4b81b3bf4713e20e26d4);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_2c397f5b067e49518825d3fe057f7c1c = new Type[] { typeof(PathBoundList) };
+        private static readonly Type[] ArgumentTypes_ecd201eeb1804392a65f1fdfa85885fa = new Type[] { typeof(PathBoundList) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetFoos(PathBoundList request)
         {
             var arguments = new object[] { request };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetFoos", ArgumentTypes_2c397f5b067e49518825d3fe057f7c1c);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetFoos", ArgumentTypes_ecd201eeb1804392a65f1fdfa85885fa);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_cc80fa40b24546249ba4ba9a42edec50 = new Type[] { typeof(List<int>) };
+        private static readonly Type[] ArgumentTypes_6e24e1b6674b453d9fde5f5f8d82977a = new Type[] { typeof(List<int>) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetFoos2(List<int> Values)
         {
             var arguments = new object[] { Values };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetFoos2", ArgumentTypes_cc80fa40b24546249ba4ba9a42edec50);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetFoos2", ArgumentTypes_6e24e1b6674b453d9fde5f5f8d82977a);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_19cd90d8d554487d8b338f294f96ccbd = new Type[] { typeof(PathBoundObject), typeof(object) };
+        private static readonly Type[] ArgumentTypes_9e9447f11d4242478c5c7328f30d54d1 = new Type[] { typeof(PathBoundObject), typeof(object) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.PostFooBar(PathBoundObject request, object someObject)
         {
             var arguments = new object[] { request, someObject };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBar", ArgumentTypes_19cd90d8d554487d8b338f294f96ccbd);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBar", ArgumentTypes_9e9447f11d4242478c5c7328f30d54d1);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_40409913b6c140b2bd3ff5cdf3e0facf = new Type[] { typeof(PathBoundObjectWithQuery) };
+        private static readonly Type[] ArgumentTypes_156f9a29068f4c0db65436448e567391 = new Type[] { typeof(PathBoundObjectWithQuery) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetFooBars(PathBoundObjectWithQuery request)
         {
             var arguments = new object[] { request };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBars", ArgumentTypes_40409913b6c140b2bd3ff5cdf3e0facf);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBars", ArgumentTypes_156f9a29068f4c0db65436448e567391);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_ee12434b291242748df20b33a5246dbf = new Type[] { typeof(PathBoundObject), typeof(ModelObject) };
+        private static readonly Type[] ArgumentTypes_02ed75d988bc4d929900f5a25383cb60 = new Type[] { typeof(PathBoundObject), typeof(ModelObject) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IApiBindPathToObject.PostFooBar(PathBoundObject request, ModelObject someQueryParams)
         {
             var arguments = new object[] { request, someQueryParams };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBar", ArgumentTypes_ee12434b291242748df20b33a5246dbf);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBar", ArgumentTypes_02ed75d988bc4d929900f5a25383cb60);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_2ed0045336934ee2a8f1944448ebcbd5 = new Type[] { typeof(PathBoundObject), typeof(ModelObject), typeof(StreamPart) };
+        private static readonly Type[] ArgumentTypes_101184cad9734b12a877ba24f0f938df = new Type[] { typeof(PathBoundObject), typeof(ModelObject), typeof(StreamPart) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IApiBindPathToObject.PostFooBarStreamPart(PathBoundObject request, ModelObject someQueryParams, StreamPart stream)
         {
             var arguments = new object[] { request, someQueryParams, stream };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBarStreamPart", ArgumentTypes_2ed0045336934ee2a8f1944448ebcbd5);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBarStreamPart", ArgumentTypes_101184cad9734b12a877ba24f0f938df);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_9900f8aa498044c7b8c1b88f70960167 = new Type[] { typeof(PathBoundObject), typeof(StreamPart) };
+        private static readonly Type[] ArgumentTypes_5244145622d7493ab2938a8c3ce22bbf = new Type[] { typeof(PathBoundObject), typeof(StreamPart) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IApiBindPathToObject.PostFooBarStreamPart(PathBoundObject request, StreamPart stream)
         {
             var arguments = new object[] { request, stream };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBarStreamPart", ArgumentTypes_9900f8aa498044c7b8c1b88f70960167);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBarStreamPart", ArgumentTypes_5244145622d7493ab2938a8c3ce22bbf);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_126ae16464f24719b30dae255754e0f9 = new Type[] { typeof(PathBoundObjectWithQuery), typeof(StreamPart) };
+        private static readonly Type[] ArgumentTypes_f5923ecb0afa4c36a6d77564c22a4542 = new Type[] { typeof(PathBoundObjectWithQuery), typeof(StreamPart) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IApiBindPathToObject.PostFooBarStreamPart(PathBoundObjectWithQuery request, StreamPart stream)
         {
             var arguments = new object[] { request, stream };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBarStreamPart", ArgumentTypes_126ae16464f24719b30dae255754e0f9);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBarStreamPart", ArgumentTypes_f5923ecb0afa4c36a6d77564c22a4542);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
     }
@@ -639,13 +639,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_7d7fe42698874fce813c5fc59b77a505 = new Type[] { typeof(decimal) };
+        private static readonly Type[] ArgumentTypes_60e898143f604e54ac71cda9adb0393b = new Type[] { typeof(decimal) };
 
         /// <inheritdoc />
         Task<string> IApiWithDecimal.GetWithDecimal(decimal value)
         {
             var arguments = new object[] { value };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetWithDecimal", ArgumentTypes_7d7fe42698874fce813c5fc59b77a505);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetWithDecimal", ArgumentTypes_60e898143f604e54ac71cda9adb0393b);
             return (Task<string>)func(Client, arguments);
         }
     }
@@ -686,33 +686,33 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_ecc99d6d921d4eb9890c644b7e43c341 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_1e65017d5981469b89f423f3dcafb423 = new Type[] {  };
 
         /// <inheritdoc />
         Task IBodylessApi.Post()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Post", ArgumentTypes_ecc99d6d921d4eb9890c644b7e43c341);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Post", ArgumentTypes_1e65017d5981469b89f423f3dcafb423);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_55539be98de645d18e9f4913a92ebe85 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_6ee706b775304db4ab55902380c8be2f = new Type[] {  };
 
         /// <inheritdoc />
         Task IBodylessApi.Get()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_55539be98de645d18e9f4913a92ebe85);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_6ee706b775304db4ab55902380c8be2f);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_13069be661c249878a0c2d62db2a0b7a = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_c3feb021fae14f5c8c1dc2238d8a0ecc = new Type[] {  };
 
         /// <inheritdoc />
         Task IBodylessApi.Head()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Head", ArgumentTypes_13069be661c249878a0c2d62db2a0b7a);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Head", ArgumentTypes_c3feb021fae14f5c8c1dc2238d8a0ecc);
             return (Task)func(Client, arguments);
         }
     }
@@ -753,53 +753,53 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_06f772f4b47443e38ee8175c8c907ed9 = new Type[] { typeof(T) };
+        private static readonly Type[] ArgumentTypes_c4eebfa0b051453390f293a0c42c4c99 = new Type[] { typeof(T) };
 
         /// <inheritdoc />
         Task<T> IBoringCrudApi<T, TKey>.Create(T paylod)
         {
             var arguments = new object[] { paylod };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_06f772f4b47443e38ee8175c8c907ed9);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_c4eebfa0b051453390f293a0c42c4c99);
             return (Task<T>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_24f5bc4e6dc14bd6ada8f665ad3616e8 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_62b55579eb314eb788ddd5eabb8abd2b = new Type[] {  };
 
         /// <inheritdoc />
         Task<List<T>> IBoringCrudApi<T, TKey>.ReadAll()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_24f5bc4e6dc14bd6ada8f665ad3616e8);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_62b55579eb314eb788ddd5eabb8abd2b);
             return (Task<List<T>>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_f936f303a3b14ab0bca79f4edb999481 = new Type[] { typeof(TKey) };
+        private static readonly Type[] ArgumentTypes_3fc10bc9079148b28e2c684ab769f3e1 = new Type[] { typeof(TKey) };
 
         /// <inheritdoc />
         Task<T> IBoringCrudApi<T, TKey>.ReadOne(TKey key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_f936f303a3b14ab0bca79f4edb999481);
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_3fc10bc9079148b28e2c684ab769f3e1);
             return (Task<T>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_ddac488f7d1c48b6b5ccabf696696040 = new Type[] { typeof(TKey), typeof(T) };
+        private static readonly Type[] ArgumentTypes_130fa10a15f948d3a4ec536b8159648c = new Type[] { typeof(TKey), typeof(T) };
 
         /// <inheritdoc />
         Task IBoringCrudApi<T, TKey>.Update(TKey key, T payload)
         {
             var arguments = new object[] { key, payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_ddac488f7d1c48b6b5ccabf696696040);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_130fa10a15f948d3a4ec536b8159648c);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_a736080d5d1f4803a6b005296f624daf = new Type[] { typeof(TKey) };
+        private static readonly Type[] ArgumentTypes_8f6b7e81e39d482aadace7f60f2623ec = new Type[] { typeof(TKey) };
 
         /// <inheritdoc />
         Task IBoringCrudApi<T, TKey>.Delete(TKey key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_a736080d5d1f4803a6b005296f624daf);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_8f6b7e81e39d482aadace7f60f2623ec);
             return (Task)func(Client, arguments);
         }
     }
@@ -840,13 +840,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_4fbff88eb7424ab8b70029ab6aa0ed3a = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_30826e9a64d04fe782fd04dd4b744d99 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<bool> IBrokenWebApi.PostAValue(string derp)
         {
             var arguments = new object[] { derp };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostAValue", ArgumentTypes_4fbff88eb7424ab8b70029ab6aa0ed3a);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostAValue", ArgumentTypes_30826e9a64d04fe782fd04dd4b744d99);
             return (Task<bool>)func(Client, arguments);
         }
     }
@@ -875,13 +875,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_f48ae7399ea44c0ba5f64c03bbe87793 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_15f4ba1fb58d40179652b64d4d45bd19 = new Type[] {  };
 
         /// <inheritdoc />
         CustomReferenceType? ICustomNullableReferenceService.Get()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_f48ae7399ea44c0ba5f64c03bbe87793);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_15f4ba1fb58d40179652b64d4d45bd19);
             return (CustomReferenceType?)func(Client, arguments);
         }
     }
@@ -910,13 +910,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_c425a67888524daeaa92093ecd4a7f04 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_d935b340a475426085eaa39e5022625c = new Type[] {  };
 
         /// <inheritdoc />
         CustomValueType? ICustomNullableValueService.Get()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_c425a67888524daeaa92093ecd4a7f04);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_d935b340a475426085eaa39e5022625c);
             return (CustomValueType?)func(Client, arguments);
         }
     }
@@ -945,13 +945,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_9542d255f7ed43f78497edd59078dd8f = new Type[] { ToNullable(typeof(CustomReferenceType)), ToNullable(typeof(CustomValueType)) };
+        private static readonly Type[] ArgumentTypes_eaa7c011160d49e884007030aa4831ec = new Type[] { ToNullable(typeof(CustomReferenceType)), ToNullable(typeof(CustomValueType)) };
 
         /// <inheritdoc />
         Task ICustomReferenceAndValueParametersService.Get(CustomReferenceType? reference, CustomValueType? value)
         {
             var arguments = new object[] { reference, value };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_9542d255f7ed43f78497edd59078dd8f);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_eaa7c011160d49e884007030aa4831ec);
             return (Task)func(Client, arguments);
         }
 
@@ -984,73 +984,73 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_8c958b912b9c42d0838a424ded3236eb = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_7443f859105a4b72807cb5e485df66f6 = new Type[] {  };
 
         /// <inheritdoc />
         Task IDataApiA.PingA()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PingA", ArgumentTypes_8c958b912b9c42d0838a424ded3236eb);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("PingA", ArgumentTypes_7443f859105a4b72807cb5e485df66f6);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_936576d716284b5eb2c44673494f0a3c = new Type[] { typeof(DataEntity) };
+        private static readonly Type[] ArgumentTypes_6906dea5934e4628b01800510d4069a9 = new Type[] { typeof(DataEntity) };
 
         /// <inheritdoc />
         Task<DataEntity> IDataCrudApi<DataEntity>.Copy(DataEntity payload)
         {
             var arguments = new object[] { payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Copy", ArgumentTypes_936576d716284b5eb2c44673494f0a3c);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Copy", ArgumentTypes_6906dea5934e4628b01800510d4069a9);
             return (Task<DataEntity>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_8bc6f6b52ef94ba5a56b524877acabe7 = new Type[] { typeof(DataEntity) };
+        private static readonly Type[] ArgumentTypes_21d82fc69d7242009ac9f77ec785cd81 = new Type[] { typeof(DataEntity) };
 
         /// <inheritdoc />
         Task<DataEntity> IDataCrudApi<DataEntity, long>.Create(DataEntity payload)
         {
             var arguments = new object[] { payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_8bc6f6b52ef94ba5a56b524877acabe7);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_21d82fc69d7242009ac9f77ec785cd81);
             return (Task<DataEntity>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_c04a4d593dfd4eb4a864f3cfdf674090 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_9b2563d045404470a02ba7528869fa48 = new Type[] {  };
 
         /// <inheritdoc />
         Task<List<DataEntity>> IDataCrudApi<DataEntity, long>.ReadAll()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_c04a4d593dfd4eb4a864f3cfdf674090);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_9b2563d045404470a02ba7528869fa48);
             return (Task<List<DataEntity>>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_16ae16cd81404731a5599b9526e8df93 = new Type[] { typeof(long) };
+        private static readonly Type[] ArgumentTypes_2ec03741cea74983a94786367f0ab5ac = new Type[] { typeof(long) };
 
         /// <inheritdoc />
         Task<DataEntity> IDataCrudApi<DataEntity, long>.ReadOne(long key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_16ae16cd81404731a5599b9526e8df93);
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_2ec03741cea74983a94786367f0ab5ac);
             return (Task<DataEntity>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_640a2a59fb2a47498fa79075abdd7e2a = new Type[] { typeof(long), typeof(DataEntity) };
+        private static readonly Type[] ArgumentTypes_bc885e8308b74d418decd5d9cd9e49ce = new Type[] { typeof(long), typeof(DataEntity) };
 
         /// <inheritdoc />
         Task IDataCrudApi<DataEntity, long>.Update(long key, DataEntity payload)
         {
             var arguments = new object[] { key, payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_640a2a59fb2a47498fa79075abdd7e2a);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_bc885e8308b74d418decd5d9cd9e49ce);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_e1336590050d4daab4e11dda17534cfd = new Type[] { typeof(long) };
+        private static readonly Type[] ArgumentTypes_f0c5a7d602d74469a2822f04d50902ef = new Type[] { typeof(long) };
 
         /// <inheritdoc />
         Task IDataCrudApi<DataEntity, long>.Delete(long key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_e1336590050d4daab4e11dda17534cfd);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_f0c5a7d602d74469a2822f04d50902ef);
             return (Task)func(Client, arguments);
         }
     }
@@ -1081,63 +1081,63 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_189e6f2eed3d4b24a192785ff691a6f8 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_7dcab60e55bf4898bed92507f27c44ec = new Type[] {  };
 
         /// <inheritdoc />
         Task IDataApiB.PingB()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PingB", ArgumentTypes_189e6f2eed3d4b24a192785ff691a6f8);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("PingB", ArgumentTypes_7dcab60e55bf4898bed92507f27c44ec);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_b0209bc21eb642c6be46cc543277e835 = new Type[] { typeof(DataEntity) };
+        private static readonly Type[] ArgumentTypes_7fb0696d08b9421da6cf4de1d411f102 = new Type[] { typeof(DataEntity) };
 
         /// <inheritdoc />
         Task<DataEntity> IDataCrudApi<DataEntity, int>.Create(DataEntity payload)
         {
             var arguments = new object[] { payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_b0209bc21eb642c6be46cc543277e835);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_7fb0696d08b9421da6cf4de1d411f102);
             return (Task<DataEntity>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_2cbeabc1e6a5470ebc4e6e60722e174a = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_a655abb96e744b18ab67b5bb6494e341 = new Type[] {  };
 
         /// <inheritdoc />
         Task<List<DataEntity>> IDataCrudApi<DataEntity, int>.ReadAll()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_2cbeabc1e6a5470ebc4e6e60722e174a);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_a655abb96e744b18ab67b5bb6494e341);
             return (Task<List<DataEntity>>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_c32da297ed1043da9af8bf0e8cb0455c = new Type[] { typeof(int) };
+        private static readonly Type[] ArgumentTypes_b8a2eb86f0e54af48d4a7907ee0ff1b8 = new Type[] { typeof(int) };
 
         /// <inheritdoc />
         Task<DataEntity> IDataCrudApi<DataEntity, int>.ReadOne(int key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_c32da297ed1043da9af8bf0e8cb0455c);
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_b8a2eb86f0e54af48d4a7907ee0ff1b8);
             return (Task<DataEntity>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_ab7664235f4e4c14aef8a24ec82f3a26 = new Type[] { typeof(int), typeof(DataEntity) };
+        private static readonly Type[] ArgumentTypes_87135550a591433585ec5c4484f11a92 = new Type[] { typeof(int), typeof(DataEntity) };
 
         /// <inheritdoc />
         Task IDataCrudApi<DataEntity, int>.Update(int key, DataEntity payload)
         {
             var arguments = new object[] { key, payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_ab7664235f4e4c14aef8a24ec82f3a26);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_87135550a591433585ec5c4484f11a92);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_ce25c0b32e3e4eef924a22882c8a0752 = new Type[] { typeof(int) };
+        private static readonly Type[] ArgumentTypes_63ca47c245b4423a95610ac4a9e274de = new Type[] { typeof(int) };
 
         /// <inheritdoc />
         Task IDataCrudApi<DataEntity, int>.Delete(int key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_ce25c0b32e3e4eef924a22882c8a0752);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_63ca47c245b4423a95610ac4a9e274de);
             return (Task)func(Client, arguments);
         }
     }
@@ -1171,63 +1171,63 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_6bc549767e6f4bca9b88adad85cef31e = new Type[] { typeof(T) };
+        private static readonly Type[] ArgumentTypes_a074e69f312342d5afe0c4201c9b7da4 = new Type[] { typeof(T) };
 
         /// <inheritdoc />
         Task<T> IDataCrudApi<T>.Copy(T payload)
         {
             var arguments = new object[] { payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Copy", ArgumentTypes_6bc549767e6f4bca9b88adad85cef31e);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Copy", ArgumentTypes_a074e69f312342d5afe0c4201c9b7da4);
             return (Task<T>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_98f1eb1d27a04deb92053063f0e092fe = new Type[] { typeof(T) };
+        private static readonly Type[] ArgumentTypes_8972e5c9755e46c9bfe7c9b77fbd58b8 = new Type[] { typeof(T) };
 
         /// <inheritdoc />
         Task<T> IDataCrudApi<T, long>.Create(T payload)
         {
             var arguments = new object[] { payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_98f1eb1d27a04deb92053063f0e092fe);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_8972e5c9755e46c9bfe7c9b77fbd58b8);
             return (Task<T>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_6a001a9eb3fb4916a906ee365cfb928c = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_a99e7462a6ae49bcb13210aaab647eb1 = new Type[] {  };
 
         /// <inheritdoc />
         Task<List<T>> IDataCrudApi<T, long>.ReadAll()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_6a001a9eb3fb4916a906ee365cfb928c);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_a99e7462a6ae49bcb13210aaab647eb1);
             return (Task<List<T>>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_df838d55651145fa8463c120ccc776da = new Type[] { typeof(long) };
+        private static readonly Type[] ArgumentTypes_959adb09159f4f2386615f7649a86e1d = new Type[] { typeof(long) };
 
         /// <inheritdoc />
         Task<T> IDataCrudApi<T, long>.ReadOne(long key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_df838d55651145fa8463c120ccc776da);
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_959adb09159f4f2386615f7649a86e1d);
             return (Task<T>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_5d3cd2ee21e64eacbbf4be7221a7de66 = new Type[] { typeof(long), typeof(T) };
+        private static readonly Type[] ArgumentTypes_9e00a26393504a5ea5a202d42d8ff954 = new Type[] { typeof(long), typeof(T) };
 
         /// <inheritdoc />
         Task IDataCrudApi<T, long>.Update(long key, T payload)
         {
             var arguments = new object[] { key, payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_5d3cd2ee21e64eacbbf4be7221a7de66);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_9e00a26393504a5ea5a202d42d8ff954);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_abce846f762343a29c013776cfa3a695 = new Type[] { typeof(long) };
+        private static readonly Type[] ArgumentTypes_dea250aa28bb44c293e80ed8a7d7537d = new Type[] { typeof(long) };
 
         /// <inheritdoc />
         Task IDataCrudApi<T, long>.Delete(long key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_abce846f762343a29c013776cfa3a695);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_dea250aa28bb44c293e80ed8a7d7537d);
             return (Task)func(Client, arguments);
         }
     }
@@ -1261,53 +1261,53 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_9216c40587f94d1f835a263fd51267a0 = new Type[] { typeof(T) };
+        private static readonly Type[] ArgumentTypes_33e0f5bbee2841b9b1597d04fa8daff6 = new Type[] { typeof(T) };
 
         /// <inheritdoc />
         Task<T> IDataCrudApi<T, TKey>.Create(T payload)
         {
             var arguments = new object[] { payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_9216c40587f94d1f835a263fd51267a0);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_33e0f5bbee2841b9b1597d04fa8daff6);
             return (Task<T>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_f6fbccd3f1dc4f5ebafb9ebed27d7eaf = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_28737e6e0eda453a908b51f986d1471e = new Type[] {  };
 
         /// <inheritdoc />
         Task<List<T>> IDataCrudApi<T, TKey>.ReadAll()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_f6fbccd3f1dc4f5ebafb9ebed27d7eaf);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_28737e6e0eda453a908b51f986d1471e);
             return (Task<List<T>>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_53c35b33c20f4848b554a8a34cbbf13d = new Type[] { typeof(TKey) };
+        private static readonly Type[] ArgumentTypes_8aa88d642a604f55ada6225fecf2e635 = new Type[] { typeof(TKey) };
 
         /// <inheritdoc />
         Task<T> IDataCrudApi<T, TKey>.ReadOne(TKey key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_53c35b33c20f4848b554a8a34cbbf13d);
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_8aa88d642a604f55ada6225fecf2e635);
             return (Task<T>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_2e2a9633c67245b5bf38415f36c55c7c = new Type[] { typeof(TKey), typeof(T) };
+        private static readonly Type[] ArgumentTypes_a0965b05779d4f9b925fe6bf38027b28 = new Type[] { typeof(TKey), typeof(T) };
 
         /// <inheritdoc />
         Task IDataCrudApi<T, TKey>.Update(TKey key, T payload)
         {
             var arguments = new object[] { key, payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_2e2a9633c67245b5bf38415f36c55c7c);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_a0965b05779d4f9b925fe6bf38027b28);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_0180f876b8054f0a98eb266f086aad4d = new Type[] { typeof(TKey) };
+        private static readonly Type[] ArgumentTypes_f60b29bcec6c48f6803a5e4a6b0bbb83 = new Type[] { typeof(TKey) };
 
         /// <inheritdoc />
         Task IDataCrudApi<T, TKey>.Delete(TKey key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_0180f876b8054f0a98eb266f086aad4d);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_f60b29bcec6c48f6803a5e4a6b0bbb83);
             return (Task)func(Client, arguments);
         }
     }
@@ -1336,13 +1336,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_e0cef85e830644f9996c52f23d63a0a2 = new Type[] { ToNullable(typeof(System.Collections.Generic.List<string>)) };
+        private static readonly Type[] ArgumentTypes_2159071202184c619f7c1faaec73123b = new Type[] { ToNullable(typeof(System.Collections.Generic.List<string>)) };
 
         /// <inheritdoc />
         Task IGenericNullableReferenceParameterService.Get(System.Collections.Generic.List<string>? reference)
         {
             var arguments = new object[] { reference };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_e0cef85e830644f9996c52f23d63a0a2);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_2159071202184c619f7c1faaec73123b);
             return (Task)func(Client, arguments);
         }
 
@@ -1373,13 +1373,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_65726e7915f9477f8a2dc48fc6d013ab = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_2b16524e85974ec5aab4b08e4b8a51dd = new Type[] {  };
 
         /// <inheritdoc />
         Task<string>? IGenericNullableReferenceService.Get()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_65726e7915f9477f8a2dc48fc6d013ab);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_2b16524e85974ec5aab4b08e4b8a51dd);
             return (Task<string>?)func(Client, arguments);
         }
     }
@@ -1408,13 +1408,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_208b3d74280c472ea3360f18ee04e5ef = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_cb0a80401eb440b38347af2c736ac446 = new Type[] {  };
 
         /// <inheritdoc />
         ValueTask<int>? IGenericNullableValueService.Get()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_208b3d74280c472ea3360f18ee04e5ef);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_cb0a80401eb440b38347af2c736ac446);
             return (ValueTask<int>?)func(Client, arguments);
         }
     }
@@ -1443,13 +1443,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_7cae2099dc444f78a434cd9d683fcf43 = new Type[] { ToNullable(typeof(System.Collections.Generic.List<string?>)) };
+        private static readonly Type[] ArgumentTypes_7f604d9e0f5a4ab98b37f5b9d02487fa = new Type[] { ToNullable(typeof(System.Collections.Generic.List<string?>)) };
 
         /// <inheritdoc />
         Task IGenericNullableWithNullableReferenceParameterService.Get(System.Collections.Generic.List<string?>? reference)
         {
             var arguments = new object[] { reference };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_7cae2099dc444f78a434cd9d683fcf43);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_7f604d9e0f5a4ab98b37f5b9d02487fa);
             return (Task)func(Client, arguments);
         }
 
@@ -1480,13 +1480,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_23df346cd79747f08e2daf8ebd4537a6 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_c98509685b8b4224a81837db1de99ce1 = new Type[] {  };
 
         /// <inheritdoc />
         Task<string?>? IGenericNullableWithNullableReferenceService.Get()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_23df346cd79747f08e2daf8ebd4537a6);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_c98509685b8b4224a81837db1de99ce1);
             return (Task<string?>?)func(Client, arguments);
         }
     }
@@ -1515,13 +1515,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_3f18b455174f43f1aa562b4ea27354fb = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_97a9579518504bc9bd68fccfe472e907 = new Type[] {  };
 
         /// <inheritdoc />
         ValueTask<int?>? IGenericNullableWithNullableValueService.Get()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_3f18b455174f43f1aa562b4ea27354fb);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_97a9579518504bc9bd68fccfe472e907);
             return (ValueTask<int?>?)func(Client, arguments);
         }
     }
@@ -1550,13 +1550,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_cb4970f37e22408ba17e98692e2428d8 = new Type[] { typeof(System.Collections.Generic.List<string?>) };
+        private static readonly Type[] ArgumentTypes_b1cd681449dc4f2aabb76eaad58d741c = new Type[] { typeof(System.Collections.Generic.List<string?>) };
 
         /// <inheritdoc />
         Task IGenericWithNullableReferenceParameterService.Get(System.Collections.Generic.List<string?> reference)
         {
             var arguments = new object[] { reference };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_cb4970f37e22408ba17e98692e2428d8);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_b1cd681449dc4f2aabb76eaad58d741c);
             return (Task)func(Client, arguments);
         }
     }
@@ -1585,13 +1585,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_01d5977497ae44f5ba78ff47d5a068f5 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_9c1e41b9f2ce49dc80d0d8edd473aab3 = new Type[] {  };
 
         /// <inheritdoc />
         Task<int?> IGenericWithNullableValueService.Get()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_01d5977497ae44f5ba78ff47d5a068f5);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_9c1e41b9f2ce49dc80d0d8edd473aab3);
             return (Task<int?>)func(Client, arguments);
         }
     }
@@ -1620,13 +1620,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_6f2f746b389d45038e5aa14824712c95 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_0f5e2def14944a298b4aad7a29549d46 = new Type[] {  };
 
         /// <inheritdoc />
         Task<string?> IGenericWithResultService.Get()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_6f2f746b389d45038e5aa14824712c95);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_0f5e2def14944a298b4aad7a29549d46);
             return (Task<string?>)func(Client, arguments);
         }
     }
@@ -1661,133 +1661,133 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_b95f836d608d407695d74c33ac6d5bdd = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_23e53669c26447f18ed714a3cbd26ea7 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<User> IGitHubApi.GetUser(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUser", ArgumentTypes_b95f836d608d407695d74c33ac6d5bdd);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUser", ArgumentTypes_23e53669c26447f18ed714a3cbd26ea7);
             return (Task<User>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_daa598a5ad9d4912b7064bce4e2dea1b = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_98d8c00512894d0c89d9f8e3e89f6874 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         IObservable<User> IGitHubApi.GetUserObservable(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserObservable", ArgumentTypes_daa598a5ad9d4912b7064bce4e2dea1b);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserObservable", ArgumentTypes_98d8c00512894d0c89d9f8e3e89f6874);
             return (IObservable<User>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_cc7074f87041491c80552f6401686b18 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_af1e060037bb41b2a5960c9aacd017a3 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         IObservable<User> IGitHubApi.GetUserCamelCase(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserCamelCase", ArgumentTypes_cc7074f87041491c80552f6401686b18);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserCamelCase", ArgumentTypes_af1e060037bb41b2a5960c9aacd017a3);
             return (IObservable<User>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_b840fde57630478f858e54ab664157c9 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_4aab89d36342433caef51d05ed1b37af = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<List<User>> IGitHubApi.GetOrgMembers(string orgName)
         {
             var arguments = new object[] { orgName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetOrgMembers", ArgumentTypes_b840fde57630478f858e54ab664157c9);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetOrgMembers", ArgumentTypes_4aab89d36342433caef51d05ed1b37af);
             return (Task<List<User>>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_464d632e840f4bb7b2dfaa682b06958c = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_5e81b1cfa13341489ff88d3529722bff = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<UserSearchResult> IGitHubApi.FindUsers(string q)
         {
             var arguments = new object[] { q };
-            var func = requestBuilder.BuildRestResultFuncForMethod("FindUsers", ArgumentTypes_464d632e840f4bb7b2dfaa682b06958c);
+            var func = requestBuilder.BuildRestResultFuncForMethod("FindUsers", ArgumentTypes_5e81b1cfa13341489ff88d3529722bff);
             return (Task<UserSearchResult>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_50aff6f3004041c6a636ac8c2506a096 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_466ba850f8ce45a4b06e4743937694a7 = new Type[] {  };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IGitHubApi.GetIndex()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndex", ArgumentTypes_50aff6f3004041c6a636ac8c2506a096);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndex", ArgumentTypes_466ba850f8ce45a4b06e4743937694a7);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_d9af0075133e45eaa7025ae3f63560c1 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_8eea8a9bf8ba4ae1aed3d26ce2f4b5c3 = new Type[] {  };
 
         /// <inheritdoc />
         IObservable<string> IGitHubApi.GetIndexObservable()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndexObservable", ArgumentTypes_d9af0075133e45eaa7025ae3f63560c1);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndexObservable", ArgumentTypes_8eea8a9bf8ba4ae1aed3d26ce2f4b5c3);
             return (IObservable<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_178960cf291b4fd8b9812afa9b7707ef = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_2c852723b8664796ac762a077e2f54ae = new Type[] {  };
 
         /// <inheritdoc />
         Task<User> IGitHubApi.NothingToSeeHere()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("NothingToSeeHere", ArgumentTypes_178960cf291b4fd8b9812afa9b7707ef);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("NothingToSeeHere", ArgumentTypes_2c852723b8664796ac762a077e2f54ae);
             return (Task<User>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_1e1c0d77ec8e499da0a9f3396dc143f7 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_042421f12c2c49a89cd83af9a6c54298 = new Type[] {  };
 
         /// <inheritdoc />
         Task<ApiResponse<User>> IGitHubApi.NothingToSeeHereWithMetadata()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("NothingToSeeHereWithMetadata", ArgumentTypes_1e1c0d77ec8e499da0a9f3396dc143f7);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("NothingToSeeHereWithMetadata", ArgumentTypes_042421f12c2c49a89cd83af9a6c54298);
             return (Task<ApiResponse<User>>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_55abac561507451ebdf216ec47685a4a = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_bc66e008ada24a34b0e313358a4a5f83 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<ApiResponse<User>> IGitHubApi.GetUserWithMetadata(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserWithMetadata", ArgumentTypes_55abac561507451ebdf216ec47685a4a);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserWithMetadata", ArgumentTypes_bc66e008ada24a34b0e313358a4a5f83);
             return (Task<ApiResponse<User>>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_9d6e7f1e8adf493eae8951fa0d265cc0 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_fc144a3fad4f4d69bc9a42c133be4428 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         IObservable<ApiResponse<User>> IGitHubApi.GetUserObservableWithMetadata(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserObservableWithMetadata", ArgumentTypes_9d6e7f1e8adf493eae8951fa0d265cc0);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserObservableWithMetadata", ArgumentTypes_fc144a3fad4f4d69bc9a42c133be4428);
             return (IObservable<ApiResponse<User>>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_b09ae606fe4e4347ac6df3fbdbe1bcbe = new Type[] { typeof(User) };
+        private static readonly Type[] ArgumentTypes_73a5041b17c44f7dac77e5b9716299a7 = new Type[] { typeof(User) };
 
         /// <inheritdoc />
         Task<User> IGitHubApi.CreateUser(User user)
         {
             var arguments = new object[] { user };
-            var func = requestBuilder.BuildRestResultFuncForMethod("CreateUser", ArgumentTypes_b09ae606fe4e4347ac6df3fbdbe1bcbe);
+            var func = requestBuilder.BuildRestResultFuncForMethod("CreateUser", ArgumentTypes_73a5041b17c44f7dac77e5b9716299a7);
             return (Task<User>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_59ba8f8ab7824074a8a3879ca8dbd399 = new Type[] { typeof(User) };
+        private static readonly Type[] ArgumentTypes_300c5e3ad8c94bf98349348b84a983c1 = new Type[] { typeof(User) };
 
         /// <inheritdoc />
         Task<ApiResponse<User>> IGitHubApi.CreateUserWithMetadata(User user)
         {
             var arguments = new object[] { user };
-            var func = requestBuilder.BuildRestResultFuncForMethod("CreateUserWithMetadata", ArgumentTypes_59ba8f8ab7824074a8a3879ca8dbd399);
+            var func = requestBuilder.BuildRestResultFuncForMethod("CreateUserWithMetadata", ArgumentTypes_300c5e3ad8c94bf98349348b84a983c1);
             return (Task<ApiResponse<User>>)func(Client, arguments);
         }
     }
@@ -1832,47 +1832,47 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_d7e7f8f4e9264e21ad13c7e3f8a7896c = new Type[] { typeof(TParam), typeof(THeader) };
+        private static readonly Type[] ArgumentTypes_8ff83789e9d84c97981e15bd53567fd2 = new Type[] { typeof(TParam), typeof(THeader) };
 
         /// <inheritdoc />
         Task<TResponse> IHttpBinApi<TResponse, TParam, THeader>.Get(TParam param, THeader header)
         {
             var arguments = new object[] { param, header };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_d7e7f8f4e9264e21ad13c7e3f8a7896c);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_8ff83789e9d84c97981e15bd53567fd2);
             return (Task<TResponse>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_cd9a93d5b0f548aa91dbed655f96ffbd = new Type[] { typeof(TParam) };
+        private static readonly Type[] ArgumentTypes_975cbc248ee24861a11e409a0027c77a = new Type[] { typeof(TParam) };
 
         /// <inheritdoc />
         Task<TResponse> IHttpBinApi<TResponse, TParam, THeader>.GetQuery(TParam param)
         {
             var arguments = new object[] { param };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetQuery", ArgumentTypes_cd9a93d5b0f548aa91dbed655f96ffbd);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetQuery", ArgumentTypes_975cbc248ee24861a11e409a0027c77a);
             return (Task<TResponse>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_70922752917b480d8cd0e6f5da68dd1b = new Type[] { typeof(TParam) };
+        private static readonly Type[] ArgumentTypes_1724bcfa7adb42e683bf72fc20584224 = new Type[] { typeof(TParam) };
 
         /// <inheritdoc />
         Task<TResponse> IHttpBinApi<TResponse, TParam, THeader>.PostQuery(TParam param)
         {
             var arguments = new object[] { param };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostQuery", ArgumentTypes_70922752917b480d8cd0e6f5da68dd1b);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostQuery", ArgumentTypes_1724bcfa7adb42e683bf72fc20584224);
             return (Task<TResponse>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_82ad60ed85414d418066f700977ce0cf = new Type[] { typeof(TParam) };
+        private static readonly Type[] ArgumentTypes_31a6a8cd9e19465baf47faecf71c6367 = new Type[] { typeof(TParam) };
 
         /// <inheritdoc />
         Task<TResponse> IHttpBinApi<TResponse, TParam, THeader>.GetQueryWithIncludeParameterName(TParam param)
         {
             var arguments = new object[] { param };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetQueryWithIncludeParameterName", ArgumentTypes_82ad60ed85414d418066f700977ce0cf);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetQueryWithIncludeParameterName", ArgumentTypes_31a6a8cd9e19465baf47faecf71c6367);
             return (Task<TResponse>)func(Client, arguments);
         }
 
-        private static class TypeHelper_0ac9fdcc11424dde9c38248106a69894<TValue>
+        private static class TypeHelper_32d63acc5d264362bec259a1ec2910bd<TValue>
         {
             public static readonly Type[] ArgumentTypes = new Type[] { typeof(TParam) };
             public static readonly Type[] TypeParameters = new Type[] { typeof(TValue) };
@@ -1882,7 +1882,7 @@ namespace Refit.Tests
         Task<TValue> IHttpBinApi<TResponse, TParam, THeader>.GetQuery1<TValue>(TParam param)
         {
             var arguments = new object[] { param };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetQuery1", TypeHelper_0ac9fdcc11424dde9c38248106a69894<TValue>.ArgumentTypes, TypeHelper_0ac9fdcc11424dde9c38248106a69894<TValue>.TypeParameters);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetQuery1", TypeHelper_32d63acc5d264362bec259a1ec2910bd<TValue>.ArgumentTypes, TypeHelper_32d63acc5d264362bec259a1ec2910bd<TValue>.TypeParameters);
             return (Task<TValue>)func(Client, arguments);
         }
     }
@@ -1923,23 +1923,23 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_b209bf0ddd334025b586f23ad0e0ec72 = new Type[] { typeof(HttpContent) };
+        private static readonly Type[] ArgumentTypes_e0bd494deec548fd826780052b71ec4e = new Type[] { typeof(HttpContent) };
 
         /// <inheritdoc />
         Task<HttpContent> IHttpContentApi.PostFileUpload(HttpContent content)
         {
             var arguments = new object[] { content };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostFileUpload", ArgumentTypes_b209bf0ddd334025b586f23ad0e0ec72);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostFileUpload", ArgumentTypes_e0bd494deec548fd826780052b71ec4e);
             return (Task<HttpContent>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_d8bb383cb3074985b2262a77fae4c74f = new Type[] { typeof(HttpContent) };
+        private static readonly Type[] ArgumentTypes_dfe62030c6004c71bb527a5f3ab94d12 = new Type[] { typeof(HttpContent) };
 
         /// <inheritdoc />
         Task<ApiResponse<HttpContent>> IHttpContentApi.PostFileUploadWithMetadata(HttpContent content)
         {
             var arguments = new object[] { content };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostFileUploadWithMetadata", ArgumentTypes_d8bb383cb3074985b2262a77fae4c74f);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostFileUploadWithMetadata", ArgumentTypes_dfe62030c6004c71bb527a5f3ab94d12);
             return (Task<ApiResponse<HttpContent>>)func(Client, arguments);
         }
     }
@@ -1981,13 +1981,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_dd1ab6a96f8a4b6fa723c8112af45ef4 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_fde75d58e4204ddba3a08ce7bfe1e7d8 = new Type[] {  };
 
         /// <inheritdoc />
         Task<TestAliasObject> ResponseTests.IMyAliasService.GetTestObject()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetTestObject", ArgumentTypes_dd1ab6a96f8a4b6fa723c8112af45ef4);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetTestObject", ArgumentTypes_fde75d58e4204ddba3a08ce7bfe1e7d8);
             return (Task<TestAliasObject>)func(Client, arguments);
         }
     }
@@ -2023,23 +2023,23 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_998257438a2e40a98858fefc86688e5c = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_d1ccada55ce14192ae7895a00eae6abd = new Type[] {  };
 
         /// <inheritdoc />
         Task<string> AuthenticatedClientHandlerTests.IMyAuthenticatedService.GetUnauthenticated()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUnauthenticated", ArgumentTypes_998257438a2e40a98858fefc86688e5c);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUnauthenticated", ArgumentTypes_d1ccada55ce14192ae7895a00eae6abd);
             return (Task<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_94e6d83241134dd68225a3c79d34f7ab = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_d3f9801ff70541efa492ec0c1ac31789 = new Type[] {  };
 
         /// <inheritdoc />
         Task<string> AuthenticatedClientHandlerTests.IMyAuthenticatedService.GetAuthenticated()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetAuthenticated", ArgumentTypes_94e6d83241134dd68225a3c79d34f7ab);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetAuthenticated", ArgumentTypes_d3f9801ff70541efa492ec0c1ac31789);
             return (Task<string>)func(Client, arguments);
         }
     }
@@ -2070,13 +2070,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_d39408f77b764df089b25f5a7a419020 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_f4d218575e0c473db28da1edc3f5d821 = new Type[] {  };
 
         /// <inheritdoc />
         Task<SomeType> INamespaceCollisionApi.SomeRequest()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", ArgumentTypes_d39408f77b764df089b25f5a7a419020);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", ArgumentTypes_f4d218575e0c473db28da1edc3f5d821);
             return (Task<SomeType>)func(Client, arguments);
         }
     }
@@ -2108,13 +2108,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_0edac52c77c54094951d4ca8ef8d8c29 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_fd6d8723e35a4375b5d6cc199e345f58 = new Type[] {  };
 
         /// <inheritdoc />
         Task<SomeOtherType> INamespaceOverlapApi.SomeRequest()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", ArgumentTypes_0edac52c77c54094951d4ca8ef8d8c29);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", ArgumentTypes_fd6d8723e35a4375b5d6cc199e345f58);
             return (Task<SomeOtherType>)func(Client, arguments);
         }
     }
@@ -2149,83 +2149,83 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_4b98656ddefd462cb92fabba1f866162 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_1aa9e1a664964925bfdb507256b1e93d = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<User> TestNested.INestedGitHubApi.GetUser(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUser", ArgumentTypes_4b98656ddefd462cb92fabba1f866162);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUser", ArgumentTypes_1aa9e1a664964925bfdb507256b1e93d);
             return (Task<User>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_6edd73604f69438c81f067d591bf8865 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_934e98aabf654fb8a54fb09784ccc583 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         IObservable<User> TestNested.INestedGitHubApi.GetUserObservable(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserObservable", ArgumentTypes_6edd73604f69438c81f067d591bf8865);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserObservable", ArgumentTypes_934e98aabf654fb8a54fb09784ccc583);
             return (IObservable<User>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_192deefdd4824932b8646de826f23cc8 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_989d53fbefe94189b7a96c5abc3d5d6b = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         IObservable<User> TestNested.INestedGitHubApi.GetUserCamelCase(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserCamelCase", ArgumentTypes_192deefdd4824932b8646de826f23cc8);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserCamelCase", ArgumentTypes_989d53fbefe94189b7a96c5abc3d5d6b);
             return (IObservable<User>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_deb7fa5e47764b95876644502527bcd2 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_39929cbbb0fa46a0ab21e60c6390966f = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<List<User>> TestNested.INestedGitHubApi.GetOrgMembers(string orgName)
         {
             var arguments = new object[] { orgName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetOrgMembers", ArgumentTypes_deb7fa5e47764b95876644502527bcd2);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetOrgMembers", ArgumentTypes_39929cbbb0fa46a0ab21e60c6390966f);
             return (Task<List<User>>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_4443c6eeab674504866d8808e59138b8 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_a5ea3ef1d02e45e48da8d8ddf5515d84 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<UserSearchResult> TestNested.INestedGitHubApi.FindUsers(string q)
         {
             var arguments = new object[] { q };
-            var func = requestBuilder.BuildRestResultFuncForMethod("FindUsers", ArgumentTypes_4443c6eeab674504866d8808e59138b8);
+            var func = requestBuilder.BuildRestResultFuncForMethod("FindUsers", ArgumentTypes_a5ea3ef1d02e45e48da8d8ddf5515d84);
             return (Task<UserSearchResult>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_5b889676a34248b89ea9159f81c80b2a = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_654bcf15105f40ca89fa453333abd530 = new Type[] {  };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> TestNested.INestedGitHubApi.GetIndex()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndex", ArgumentTypes_5b889676a34248b89ea9159f81c80b2a);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndex", ArgumentTypes_654bcf15105f40ca89fa453333abd530);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_f7f4f274557d46a8905a330f8fe7c18f = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_9e2bf872a17442de8da56891287387a4 = new Type[] {  };
 
         /// <inheritdoc />
         IObservable<string> TestNested.INestedGitHubApi.GetIndexObservable()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndexObservable", ArgumentTypes_f7f4f274557d46a8905a330f8fe7c18f);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndexObservable", ArgumentTypes_9e2bf872a17442de8da56891287387a4);
             return (IObservable<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_087209133c8e4a2b82d9d0c6a8473906 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_eaf258c5aece4d16a8aa15d76132f74a = new Type[] {  };
 
         /// <inheritdoc />
         Task TestNested.INestedGitHubApi.NothingToSeeHere()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("NothingToSeeHere", ArgumentTypes_087209133c8e4a2b82d9d0c6a8473906);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("NothingToSeeHere", ArgumentTypes_eaf258c5aece4d16a8aa15d76132f74a);
             return (Task)func(Client, arguments);
         }
     }
@@ -2263,7 +2263,7 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static class TypeHelper_0efbbf3123bd4f24ac089aa1a50de3ce<T>
+        private static class TypeHelper_b5a47e4eeca84837bffd25d3bdc03246<T>
         {
             public static readonly Type[] ArgumentTypes = new Type[] { typeof(T) };
             public static readonly Type[] TypeParameters = new Type[] { typeof(T) };
@@ -2273,11 +2273,11 @@ namespace Refit.Tests
         Task INonGenericInterfaceWithGenericMethod.PostMessage<T>(T message)
         {
             var arguments = new object[] { message };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostMessage", TypeHelper_0efbbf3123bd4f24ac089aa1a50de3ce<T>.ArgumentTypes, TypeHelper_0efbbf3123bd4f24ac089aa1a50de3ce<T>.TypeParameters);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostMessage", TypeHelper_b5a47e4eeca84837bffd25d3bdc03246<T>.ArgumentTypes, TypeHelper_b5a47e4eeca84837bffd25d3bdc03246<T>.TypeParameters);
             return (Task)func(Client, arguments);
         }
 
-        private static class TypeHelper_38bcb4e52db545909599e230fbf19ab6<T, U, V>
+        private static class TypeHelper_49dffda4257642a8a6776c46de4ae559<T, U, V>
         {
             public static readonly Type[] ArgumentTypes = new Type[] { typeof(T), typeof(U), typeof(V) };
             public static readonly Type[] TypeParameters = new Type[] { typeof(T), typeof(U), typeof(V) };
@@ -2287,7 +2287,7 @@ namespace Refit.Tests
         Task INonGenericInterfaceWithGenericMethod.PostMessage<T, U, V>(T message, U param1, V param2)
         {
             var arguments = new object[] { message, param1, param2 };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostMessage", TypeHelper_38bcb4e52db545909599e230fbf19ab6<T, U, V>.ArgumentTypes, TypeHelper_38bcb4e52db545909599e230fbf19ab6<T, U, V>.TypeParameters);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostMessage", TypeHelper_49dffda4257642a8a6776c46de4ae559<T, U, V>.ArgumentTypes, TypeHelper_49dffda4257642a8a6776c46de4ae559<T, U, V>.TypeParameters);
             return (Task)func(Client, arguments);
         }
     }
@@ -2328,13 +2328,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_debca49b25d04e04aae1d4f46ea51bd2 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_56dfebaefcdb47fba923abfd59d5f52a = new Type[] {  };
 
         /// <inheritdoc />
         Task<RootObject> INpmJs.GetCongruence()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetCongruence", ArgumentTypes_debca49b25d04e04aae1d4f46ea51bd2);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetCongruence", ArgumentTypes_56dfebaefcdb47fba923abfd59d5f52a);
             return (Task<RootObject>)func(Client, arguments);
         }
     }
@@ -2363,13 +2363,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_544ad08a41674c6692b3f0d7dbe433d4 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_1cb3ee5c77114f4ea08663ccf509dc30 = new Type[] {  };
 
         /// <inheritdoc />
         string? INullableReferenceService.Get()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_544ad08a41674c6692b3f0d7dbe433d4);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_1cb3ee5c77114f4ea08663ccf509dc30);
             return (string?)func(Client, arguments);
         }
     }
@@ -2398,13 +2398,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_f3ad97419661458f8ee72107a62ec6da = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_650c6af1b28c46e188b58894f6704f12 = new Type[] {  };
 
         /// <inheritdoc />
         int? INullableValueService.Get()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_f3ad97419661458f8ee72107a62ec6da);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_650c6af1b28c46e188b58894f6704f12);
             return (int?)func(Client, arguments);
         }
     }
@@ -2434,13 +2434,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_cd3303368c9b498f8aed3fb8c7a73e6e = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_cd62d3f3d196464a8592542f094b7329 = new Type[] {  };
 
         /// <inheritdoc />
         Task<SomeType> IReducedUsingInsideNamespaceApi.SomeRequest()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", ArgumentTypes_cd3303368c9b498f8aed3fb8c7a73e6e);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", ArgumentTypes_cd62d3f3d196464a8592542f094b7329);
             return (Task<SomeType>)func(Client, arguments);
         }
     }
@@ -2469,13 +2469,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_af0cc83deaa64183b280b561efe8065a = new Type[] { ToNullable(typeof(string)), ToNullable(typeof(int)) };
+        private static readonly Type[] ArgumentTypes_7f7ee8bf304e4de2a8862981e3ab9f48 = new Type[] { ToNullable(typeof(string)), ToNullable(typeof(int)) };
 
         /// <inheritdoc />
         Task IReferenceAndValueParametersService.Get(string? reference, int? value)
         {
             var arguments = new object[] { reference, value };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_af0cc83deaa64183b280b561efe8065a);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_7f7ee8bf304e4de2a8862981e3ab9f48);
             return (Task)func(Client, arguments);
         }
 
@@ -2518,13 +2518,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_2e857b524c484e3a930f1985d7f24104 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_0ba8586508b24ec59a6906d46a2c3b48 = new Type[] {  };
 
         /// <inheritdoc />
         Task IRefitInterfaceWithStaticMethod.Get()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_2e857b524c484e3a930f1985d7f24104);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_0ba8586508b24ec59a6906d46a2c3b48);
             return (Task)func(Client, arguments);
         }
     }
@@ -2565,47 +2565,47 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_530141991d3a44cbb5d862561640ee64 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_b87b0a5485bc445b9df0033f245b6567 = new Type[] {  };
 
         /// <inheritdoc />
         Task IRequestBin.Post()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Post", ArgumentTypes_530141991d3a44cbb5d862561640ee64);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Post", ArgumentTypes_b87b0a5485bc445b9df0033f245b6567);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_061df13e21b34b63b30331188bea7f25 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_11a1cb839e35442ba3f9a1b150916c32 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task IRequestBin.PostRawStringDefault(string str)
         {
             var arguments = new object[] { str };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostRawStringDefault", ArgumentTypes_061df13e21b34b63b30331188bea7f25);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostRawStringDefault", ArgumentTypes_11a1cb839e35442ba3f9a1b150916c32);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_ad94a04c8de54288bb80e72ae75c7742 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_dd7da2dba1a5425e97470899507e5c11 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task IRequestBin.PostRawStringJson(string str)
         {
             var arguments = new object[] { str };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostRawStringJson", ArgumentTypes_ad94a04c8de54288bb80e72ae75c7742);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostRawStringJson", ArgumentTypes_dd7da2dba1a5425e97470899507e5c11);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_34a9a1e975524e1c8237b0acafba0047 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_324ef6691f064a8eb5e6a4b0bb0fb94b = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task IRequestBin.PostRawStringUrlEncoded(string str)
         {
             var arguments = new object[] { str };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostRawStringUrlEncoded", ArgumentTypes_34a9a1e975524e1c8237b0acafba0047);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostRawStringUrlEncoded", ArgumentTypes_324ef6691f064a8eb5e6a4b0bb0fb94b);
             return (Task)func(Client, arguments);
         }
 
-        private static class TypeHelper_0006ecf1dfd3412dac0509149ce0c95f<T>
+        private static class TypeHelper_2141e5a6a02e4cf5839bc0680b10d8bf<T>
         {
             public static readonly Type[] ArgumentTypes = new Type[] { typeof(T) };
             public static readonly Type[] TypeParameters = new Type[] { typeof(T) };
@@ -2615,7 +2615,7 @@ namespace Refit.Tests
         Task IRequestBin.PostGeneric<T>(T param)
         {
             var arguments = new object[] { param };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostGeneric", TypeHelper_0006ecf1dfd3412dac0509149ce0c95f<T>.ArgumentTypes, TypeHelper_0006ecf1dfd3412dac0509149ce0c95f<T>.TypeParameters);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostGeneric", TypeHelper_2141e5a6a02e4cf5839bc0680b10d8bf<T>.ArgumentTypes, TypeHelper_2141e5a6a02e4cf5839bc0680b10d8bf<T>.TypeParameters);
             return (Task)func(Client, arguments);
         }
     }
@@ -2656,133 +2656,133 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_52a7e959154447c595ed0d84d6f595c1 = new Type[] { typeof(Stream) };
+        private static readonly Type[] ArgumentTypes_88f3792289c243ecb97a877fb738cff7 = new Type[] { typeof(Stream) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadStream(Stream stream)
         {
             var arguments = new object[] { stream };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStream", ArgumentTypes_52a7e959154447c595ed0d84d6f595c1);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStream", ArgumentTypes_88f3792289c243ecb97a877fb738cff7);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_deef3643bb124865a4f0dd5c42035e47 = new Type[] { typeof(Stream) };
+        private static readonly Type[] ArgumentTypes_45ff912751d64992aaa609889048a177 = new Type[] { typeof(Stream) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadStreamWithCustomBoundary(Stream stream)
         {
             var arguments = new object[] { stream };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStreamWithCustomBoundary", ArgumentTypes_deef3643bb124865a4f0dd5c42035e47);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStreamWithCustomBoundary", ArgumentTypes_45ff912751d64992aaa609889048a177);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_32f7cfce69d74a15a0151fc9a882fef9 = new Type[] { typeof(StreamPart) };
+        private static readonly Type[] ArgumentTypes_093b9c0127ef45839492246b5fbe4893 = new Type[] { typeof(StreamPart) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadStreamPart(StreamPart stream)
         {
             var arguments = new object[] { stream };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStreamPart", ArgumentTypes_32f7cfce69d74a15a0151fc9a882fef9);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStreamPart", ArgumentTypes_093b9c0127ef45839492246b5fbe4893);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_6e114fdb34a643b8809f5e6538fe15db = new Type[] { typeof(ModelObject), typeof(StreamPart) };
+        private static readonly Type[] ArgumentTypes_63cef04ab489449d9276e88c089c60b0 = new Type[] { typeof(ModelObject), typeof(StreamPart) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadStreamPart(ModelObject someQueryParams, StreamPart stream)
         {
             var arguments = new object[] { someQueryParams, stream };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStreamPart", ArgumentTypes_6e114fdb34a643b8809f5e6538fe15db);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStreamPart", ArgumentTypes_63cef04ab489449d9276e88c089c60b0);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_095967ab42954b6f8d58accafc03ca31 = new Type[] { typeof(byte[]) };
+        private static readonly Type[] ArgumentTypes_a510e7e908a249e78f972d86f5bea4ba = new Type[] { typeof(byte[]) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadBytes(byte[] bytes)
         {
             var arguments = new object[] { bytes };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadBytes", ArgumentTypes_095967ab42954b6f8d58accafc03ca31);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadBytes", ArgumentTypes_a510e7e908a249e78f972d86f5bea4ba);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_6452f4affe1f4115a11514084b671891 = new Type[] { typeof(ByteArrayPart) };
+        private static readonly Type[] ArgumentTypes_5350e490399a4b3987f20ec366630fee = new Type[] { typeof(ByteArrayPart) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadBytesPart(ByteArrayPart bytes)
         {
             var arguments = new object[] { bytes };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadBytesPart", ArgumentTypes_6452f4affe1f4115a11514084b671891);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadBytesPart", ArgumentTypes_5350e490399a4b3987f20ec366630fee);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_5340467652404e228680d055011f9229 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_205eb88081a2422f817bf24482155579 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadString(string someString)
         {
             var arguments = new object[] { someString };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadString", ArgumentTypes_5340467652404e228680d055011f9229);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadString", ArgumentTypes_205eb88081a2422f817bf24482155579);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_cecec1bb69ed40d18bc9f1b750c09810 = new Type[] { typeof(IEnumerable<FileInfo>), typeof(FileInfo) };
+        private static readonly Type[] ArgumentTypes_6d4a02ff94b44fa89a1269febe1fbf0a = new Type[] { typeof(IEnumerable<FileInfo>), typeof(FileInfo) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadFileInfo(IEnumerable<FileInfo> fileInfos, FileInfo anotherFile)
         {
             var arguments = new object[] { fileInfos, anotherFile };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadFileInfo", ArgumentTypes_cecec1bb69ed40d18bc9f1b750c09810);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadFileInfo", ArgumentTypes_6d4a02ff94b44fa89a1269febe1fbf0a);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_4e112f2f2644498b9dc4f3237f47ec1b = new Type[] { typeof(IEnumerable<FileInfoPart>), typeof(FileInfoPart) };
+        private static readonly Type[] ArgumentTypes_8859056121734edc9c99aa562505231f = new Type[] { typeof(IEnumerable<FileInfoPart>), typeof(FileInfoPart) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadFileInfoPart(IEnumerable<FileInfoPart> fileInfos, FileInfoPart anotherFile)
         {
             var arguments = new object[] { fileInfos, anotherFile };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadFileInfoPart", ArgumentTypes_4e112f2f2644498b9dc4f3237f47ec1b);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadFileInfoPart", ArgumentTypes_8859056121734edc9c99aa562505231f);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_97235970974b4460923df7165a0e4a63 = new Type[] { typeof(ModelObject) };
+        private static readonly Type[] ArgumentTypes_c5c283f30d7147a686bdbb42873042df = new Type[] { typeof(ModelObject) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadJsonObject(ModelObject theObject)
         {
             var arguments = new object[] { theObject };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadJsonObject", ArgumentTypes_97235970974b4460923df7165a0e4a63);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadJsonObject", ArgumentTypes_c5c283f30d7147a686bdbb42873042df);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_b808705ebabc4a519b8f16fec414680d = new Type[] { typeof(IEnumerable<ModelObject>) };
+        private static readonly Type[] ArgumentTypes_287c7ab35dc84dddb7f7cc5656e16394 = new Type[] { typeof(IEnumerable<ModelObject>) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadJsonObjects(IEnumerable<ModelObject> theObjects)
         {
             var arguments = new object[] { theObjects };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadJsonObjects", ArgumentTypes_b808705ebabc4a519b8f16fec414680d);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadJsonObjects", ArgumentTypes_287c7ab35dc84dddb7f7cc5656e16394);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_d16650d4ea714ddaaf610b5ed392dce2 = new Type[] { typeof(IEnumerable<ModelObject>), typeof(AnotherModel), typeof(FileInfo), typeof(AnEnum), typeof(string), typeof(int) };
+        private static readonly Type[] ArgumentTypes_e06638eb1f2d4226a27f66f226084289 = new Type[] { typeof(IEnumerable<ModelObject>), typeof(AnotherModel), typeof(FileInfo), typeof(AnEnum), typeof(string), typeof(int) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadMixedObjects(IEnumerable<ModelObject> theObjects, AnotherModel anotherModel, FileInfo aFile, AnEnum anEnum, string aString, int anInt)
         {
             var arguments = new object[] { theObjects, anotherModel, aFile, anEnum, aString, anInt };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadMixedObjects", ArgumentTypes_d16650d4ea714ddaaf610b5ed392dce2);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadMixedObjects", ArgumentTypes_e06638eb1f2d4226a27f66f226084289);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_1ca8c106f1da4631bf6a5653f88e2076 = new Type[] { typeof(HttpContent) };
+        private static readonly Type[] ArgumentTypes_ca6132b180dc4cdbb67609eb8d37a18a = new Type[] { typeof(HttpContent) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadHttpContent(HttpContent content)
         {
             var arguments = new object[] { content };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadHttpContent", ArgumentTypes_1ca8c106f1da4631bf6a5653f88e2076);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadHttpContent", ArgumentTypes_ca6132b180dc4cdbb67609eb8d37a18a);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
     }
@@ -2814,23 +2814,23 @@ namespace AutoGeneratedIServiceWithoutNamespace
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_026a5a4b658a4b1c9c6a03060b6e21ba = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_e776cab422f34342a86d28d182293e8b = new Type[] {  };
 
         /// <inheritdoc />
         Task IServiceWithoutNamespace.GetRoot()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetRoot", ArgumentTypes_026a5a4b658a4b1c9c6a03060b6e21ba);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetRoot", ArgumentTypes_e776cab422f34342a86d28d182293e8b);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_7e0849b7dea44db4abbe0fef46f86693 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_721c873c7a864c1f88e198ab8ec3b24d = new Type[] {  };
 
         /// <inheritdoc />
         Task IServiceWithoutNamespace.PostRoot()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostRoot", ArgumentTypes_7e0849b7dea44db4abbe0fef46f86693);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostRoot", ArgumentTypes_721c873c7a864c1f88e198ab8ec3b24d);
             return (Task)func(Client, arguments);
         }
     }
@@ -2871,23 +2871,23 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_891f9ecb070a42e3a4953be8a419670a = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_924436df0bb149298ef71acee4e3a3f4 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<Stream> IStreamApi.GetRemoteFile(string filename)
         {
             var arguments = new object[] { filename };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetRemoteFile", ArgumentTypes_891f9ecb070a42e3a4953be8a419670a);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetRemoteFile", ArgumentTypes_924436df0bb149298ef71acee4e3a3f4);
             return (Task<Stream>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_ed5b6dcb680e4de4b633ca17938cfef8 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_6ae54bf7e5ec4a61b87e0a0ee61ff662 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<ApiResponse<Stream>> IStreamApi.GetRemoteFileWithMetadata(string filename)
         {
             var arguments = new object[] { filename };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetRemoteFileWithMetadata", ArgumentTypes_ed5b6dcb680e4de4b633ca17938cfef8);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetRemoteFileWithMetadata", ArgumentTypes_6ae54bf7e5ec4a61b87e0a0ee61ff662);
             return (Task<ApiResponse<Stream>>)func(Client, arguments);
         }
     }
@@ -2928,13 +2928,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_d2fab4b8be1d4d7aad6f2fe2d53cd972 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_7a3f93a2e3674b30b73d9c2a05f4ad9f = new Type[] {  };
 
         /// <inheritdoc />
         Task ITrimTrailingForwardSlashApi.Get()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_d2fab4b8be1d4d7aad6f2fe2d53cd972);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_7a3f93a2e3674b30b73d9c2a05f4ad9f);
             return (Task)func(Client, arguments);
         }
     }
@@ -2964,13 +2964,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_f109f15a42174957a376195b544a5dea = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_435ba311aa2f403faecf2bd64c22bc50 = new Type[] {  };
 
         /// <inheritdoc />
         Task<SomeType> ITypeCollisionApiA.SomeARequest()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("SomeARequest", ArgumentTypes_f109f15a42174957a376195b544a5dea);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("SomeARequest", ArgumentTypes_435ba311aa2f403faecf2bd64c22bc50);
             return (Task<SomeType>)func(Client, arguments);
         }
     }
@@ -3000,13 +3000,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_fa06f29465ce43d4b5648d692b6978e8 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_c05a98bdd827409aab48a634ea5c15f9 = new Type[] {  };
 
         /// <inheritdoc />
         Task<SomeType> ITypeCollisionApiB.SomeBRequest()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("SomeBRequest", ArgumentTypes_fa06f29465ce43d4b5648d692b6978e8);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("SomeBRequest", ArgumentTypes_c05a98bdd827409aab48a634ea5c15f9);
             return (Task<SomeType>)func(Client, arguments);
         }
     }
@@ -3045,47 +3045,47 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_6e34eb34d7a14ddca0d95ee544dbad64 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_22c7e3b6a764407498875eb0254488ca = new Type[] {  };
 
         /// <inheritdoc />
         Task<string> IUseOverloadedGenericMethods<TResponse, TParam, THeader>.Get()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_6e34eb34d7a14ddca0d95ee544dbad64);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_22c7e3b6a764407498875eb0254488ca);
             return (Task<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_0d4ca9afe142409294064e22ee7075f8 = new Type[] { typeof(TParam), typeof(THeader) };
+        private static readonly Type[] ArgumentTypes_5ca05f21c5464503869c9766eb5919f9 = new Type[] { typeof(TParam), typeof(THeader) };
 
         /// <inheritdoc />
         Task<TResponse> IUseOverloadedGenericMethods<TResponse, TParam, THeader>.Get(TParam param, THeader header)
         {
             var arguments = new object[] { param, header };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_0d4ca9afe142409294064e22ee7075f8);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_5ca05f21c5464503869c9766eb5919f9);
             return (Task<TResponse>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_93c2ca4087b64654a2fcbc5146650f0a = new Type[] { typeof(THeader), typeof(TParam) };
+        private static readonly Type[] ArgumentTypes_c59678da0be04ebfbb12e4092ccfd3da = new Type[] { typeof(THeader), typeof(TParam) };
 
         /// <inheritdoc />
         Task<TResponse> IUseOverloadedGenericMethods<TResponse, TParam, THeader>.Get(THeader param, TParam header)
         {
             var arguments = new object[] { param, header };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_93c2ca4087b64654a2fcbc5146650f0a);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_c59678da0be04ebfbb12e4092ccfd3da);
             return (Task<TResponse>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_b98d312ed9324b8287c3efca3152022e = new Type[] { typeof(int) };
+        private static readonly Type[] ArgumentTypes_e0b091b222ae48dfb45015b6f2bd2b3a = new Type[] { typeof(int) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IUseOverloadedGenericMethods<TResponse, TParam, THeader>.Get(int httpstatuscode)
         {
             var arguments = new object[] { httpstatuscode };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_b98d312ed9324b8287c3efca3152022e);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_e0b091b222ae48dfb45015b6f2bd2b3a);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static class TypeHelper_b9d2572b7c074c5a85343acddc81c1f4<TValue>
+        private static class TypeHelper_c924631c1ae54481b40a9f6bb5204c66<TValue>
         {
             public static readonly Type[] ArgumentTypes = new Type[] { typeof(int) };
             public static readonly Type[] TypeParameters = new Type[] { typeof(TValue) };
@@ -3095,11 +3095,11 @@ namespace Refit.Tests
         Task<TValue> IUseOverloadedGenericMethods<TResponse, TParam, THeader>.Get<TValue>(int someVal)
         {
             var arguments = new object[] { someVal };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", TypeHelper_b9d2572b7c074c5a85343acddc81c1f4<TValue>.ArgumentTypes, TypeHelper_b9d2572b7c074c5a85343acddc81c1f4<TValue>.TypeParameters);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", TypeHelper_c924631c1ae54481b40a9f6bb5204c66<TValue>.ArgumentTypes, TypeHelper_c924631c1ae54481b40a9f6bb5204c66<TValue>.TypeParameters);
             return (Task<TValue>)func(Client, arguments);
         }
 
-        private static class TypeHelper_355e5fca5d454ec59be859b11bb565f0<TValue, TInput>
+        private static class TypeHelper_476335ac19a94bb0997e7a24c1644168<TValue, TInput>
         {
             public static readonly Type[] ArgumentTypes = new Type[] { typeof(TInput) };
             public static readonly Type[] TypeParameters = new Type[] { typeof(TValue), typeof(TInput) };
@@ -3109,11 +3109,11 @@ namespace Refit.Tests
         Task<TValue> IUseOverloadedGenericMethods<TResponse, TParam, THeader>.Get<TValue, TInput>(TInput input)
         {
             var arguments = new object[] { input };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", TypeHelper_355e5fca5d454ec59be859b11bb565f0<TValue, TInput>.ArgumentTypes, TypeHelper_355e5fca5d454ec59be859b11bb565f0<TValue, TInput>.TypeParameters);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", TypeHelper_476335ac19a94bb0997e7a24c1644168<TValue, TInput>.ArgumentTypes, TypeHelper_476335ac19a94bb0997e7a24c1644168<TValue, TInput>.TypeParameters);
             return (Task<TValue>)func(Client, arguments);
         }
 
-        private static class TypeHelper_c21182f8809c48c1babf4de1e4a4c58b<TInput1, TInput2>
+        private static class TypeHelper_e03b91f334714b879db4aab11e07612d<TInput1, TInput2>
         {
             public static readonly Type[] ArgumentTypes = new Type[] { typeof(TInput1), typeof(TInput2) };
             public static readonly Type[] TypeParameters = new Type[] { typeof(TInput1), typeof(TInput2) };
@@ -3123,7 +3123,7 @@ namespace Refit.Tests
         Task IUseOverloadedGenericMethods<TResponse, TParam, THeader>.Get<TInput1, TInput2>(TInput1 input1, TInput2 input2)
         {
             var arguments = new object[] { input1, input2 };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", TypeHelper_c21182f8809c48c1babf4de1e4a4c58b<TInput1, TInput2>.ArgumentTypes, TypeHelper_c21182f8809c48c1babf4de1e4a4c58b<TInput1, TInput2>.TypeParameters);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", TypeHelper_e03b91f334714b879db4aab11e07612d<TInput1, TInput2>.ArgumentTypes, TypeHelper_e03b91f334714b879db4aab11e07612d<TInput1, TInput2>.TypeParameters);
             return (Task)func(Client, arguments);
         }
     }
@@ -3158,23 +3158,23 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_3b5e91efc4a24973a67f7a7e0f5c9422 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_60dc6b71a25144929593d89ba5ff2264 = new Type[] {  };
 
         /// <inheritdoc />
         Task<string> IUseOverloadedMethods.Get()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_3b5e91efc4a24973a67f7a7e0f5c9422);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_60dc6b71a25144929593d89ba5ff2264);
             return (Task<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_ea6ce69e0dad4bc8af419064c41f352f = new Type[] { typeof(int) };
+        private static readonly Type[] ArgumentTypes_07028f211ed74e48b1c062f574b4aa79 = new Type[] { typeof(int) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IUseOverloadedMethods.Get(int httpstatuscode)
         {
             var arguments = new object[] { httpstatuscode };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_ea6ce69e0dad4bc8af419064c41f352f);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_07028f211ed74e48b1c062f574b4aa79);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
     }
@@ -3215,13 +3215,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_872b41bc397a42a6b8be3e462fe5683c = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_10c8310e2d33499aab173cbb1f92fa45 = new Type[] {  };
 
         /// <inheritdoc />
         Task IValidApi.Get()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_872b41bc397a42a6b8be3e462fe5683c);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_10c8310e2d33499aab173cbb1f92fa45);
             return (Task)func(Client, arguments);
         }
     }
@@ -3251,13 +3251,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_8145f8ca1d6540f2809affbd906628c2 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_8a31d25c22b34166bc3105f3abaf6b58 = new Type[] {  };
 
         /// <inheritdoc />
         Task<SomeType> NamespaceWithGlobalAliasApi.SomeRequest()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", ArgumentTypes_8145f8ca1d6540f2809affbd906628c2);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", ArgumentTypes_8a31d25c22b34166bc3105f3abaf6b58);
             return (Task<SomeType>)func(Client, arguments);
         }
     }

--- a/Refit.Tests/RefitStubs.NetCore2.cs
+++ b/Refit.Tests/RefitStubs.NetCore2.cs
@@ -62,27 +62,27 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_294c7beec3ae4c2ea2f551dd9f2ceac8 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_45cb4a617b084a82b71707366401ee01 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IAmARefitInterfaceButNobodyUsesMe.RefitMethod()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("RefitMethod", ArgumentTypes_294c7beec3ae4c2ea2f551dd9f2ceac8);
+            var func = requestBuilder.BuildRestResultFuncForMethod("RefitMethod", ArgumentTypes_45cb4a617b084a82b71707366401ee01);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_7e1d182ae429428bbb27c49383b8fbf9 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_b5ae5f38734047f1a4f84fe4f6647598 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IAmARefitInterfaceButNobodyUsesMe.AnotherRefitMethod()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("AnotherRefitMethod", ArgumentTypes_7e1d182ae429428bbb27c49383b8fbf9);
+            var func = requestBuilder.BuildRestResultFuncForMethod("AnotherRefitMethod", ArgumentTypes_b5ae5f38734047f1a4f84fe4f6647598);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_5c1e302ec72d4423b80812ba9bc69632 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_16a0e1dd57de4529b42fb8f976d43906 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IAmARefitInterfaceButNobodyUsesMe.NoConstantsAllowed()
@@ -90,23 +90,23 @@ namespace Refit.Tests
             throw new NotImplementedException("Either this method has no Refit HTTP method attribute or you've used something other than a string literal for the 'path' argument.");
         }
 
-        private static readonly Type[] ArgumentTypes_2cbc0427569d4f7884b2dfbee55fbce1 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_4102d603330f4d5b8f8af8fd388e1fe0 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IAmARefitInterfaceButNobodyUsesMe.SpacesShouldntBreakMe()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("SpacesShouldntBreakMe", ArgumentTypes_2cbc0427569d4f7884b2dfbee55fbce1);
+            var func = requestBuilder.BuildRestResultFuncForMethod("SpacesShouldntBreakMe", ArgumentTypes_4102d603330f4d5b8f8af8fd388e1fe0);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_11bea462e8604f558a0c4795e0cfe583 = new Type[] { typeof(int), typeof(string), typeof(float) };
+        private static readonly Type[] ArgumentTypes_8297e5161cd94e9584ee2c9da0e71fab = new Type[] { typeof(int), typeof(string), typeof(float) };
 
         /// <inheritdoc />
         Task IAmARefitInterfaceButNobodyUsesMe.ReservedWordsForParameterNames(int @int, string @string, float @long)
         {
             var arguments = new object[] { @int, @string, @long };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReservedWordsForParameterNames", ArgumentTypes_11bea462e8604f558a0c4795e0cfe583);
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReservedWordsForParameterNames", ArgumentTypes_8297e5161cd94e9584ee2c9da0e71fab);
             return (Task)func(Client, arguments);
         }
     }
@@ -147,17 +147,17 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_246099c598864d098f368a9d2b141cd0 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_0ca6b1cb84cb4b1a8e1278b5e6d2bcd3 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IAmHalfRefit.Post()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Post", ArgumentTypes_246099c598864d098f368a9d2b141cd0);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Post", ArgumentTypes_0ca6b1cb84cb4b1a8e1278b5e6d2bcd3);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_9efebcb322ae46ee880c9274c91e713f = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_51152afba2ce4b99a9fef2418c020d24 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IAmHalfRefit.Get()
@@ -191,43 +191,43 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_ae79f7eb658e4498911be41f0e7b73c9 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_4d27c1f58eac472b88b6b256171cbfa5 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> IAmInterface.Pang()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Pang", ArgumentTypes_ae79f7eb658e4498911be41f0e7b73c9);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Pang", ArgumentTypes_4d27c1f58eac472b88b6b256171cbfa5);
             return (Task<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_aea84e7985454fb7ac240c0623728900 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_2d68bbcad6ea4c2f972a9e8274944fb0 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> IAmInterfaceB.Pong()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Pong", ArgumentTypes_aea84e7985454fb7ac240c0623728900);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Pong", ArgumentTypes_2d68bbcad6ea4c2f972a9e8274944fb0);
             return (Task<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_71aaacdbf10442ef8f8884066a2800ed = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_a7c6edf4f46245d19212e6c41b6e2595 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> IAmInterfaceD.Test()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Test", ArgumentTypes_71aaacdbf10442ef8f8884066a2800ed);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Test", ArgumentTypes_a7c6edf4f46245d19212e6c41b6e2595);
             return (Task<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_e250d137cf2b41aebbdd66f580ecc4e2 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_a34353153dd34189b4534ee32ac69e04 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> IAmInterfaceA.Ping()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Ping", ArgumentTypes_e250d137cf2b41aebbdd66f580ecc4e2);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Ping", ArgumentTypes_a34353153dd34189b4534ee32ac69e04);
             return (Task<string>)func(Client, arguments);
         }
     }
@@ -257,13 +257,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_70c1dbcde7a144fab5e34770b582cd70 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_68f8287c03da4553a7370736879cb259 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> IAmInterfaceA.Ping()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Ping", ArgumentTypes_70c1dbcde7a144fab5e34770b582cd70);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Ping", ArgumentTypes_68f8287c03da4553a7370736879cb259);
             return (Task<string>)func(Client, arguments);
         }
     }
@@ -293,23 +293,23 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_972cf714ec0449debc8b850320e77796 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_e4c88e2f8003490191c615c43acf261a = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> IAmInterfaceB.Pong()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Pong", ArgumentTypes_972cf714ec0449debc8b850320e77796);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Pong", ArgumentTypes_e4c88e2f8003490191c615c43acf261a);
             return (Task<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_1985886340014917ac67199a5532f642 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_b1d0b42f746b46538f5246b1a3bc90bb = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> IAmInterfaceD.Test()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Test", ArgumentTypes_1985886340014917ac67199a5532f642);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Test", ArgumentTypes_b1d0b42f746b46538f5246b1a3bc90bb);
             return (Task<string>)func(Client, arguments);
         }
     }
@@ -339,43 +339,43 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_56608d8e192b4d68a2a1cd4cd922d351 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_baac8fe585874ba7a45524388743f982 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> IAmInterfaceC.Pang()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Pang", ArgumentTypes_56608d8e192b4d68a2a1cd4cd922d351);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Pang", ArgumentTypes_baac8fe585874ba7a45524388743f982);
             return (Task<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_27e1d521019046148a0027ad81074cc1 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_77105199802c4fae98840027c7853730 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> IAmInterfaceB.Pong()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Pong", ArgumentTypes_27e1d521019046148a0027ad81074cc1);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Pong", ArgumentTypes_77105199802c4fae98840027c7853730);
             return (Task<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_7bba69f3179d4f6f994eaa1f56e8ab4c = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_448940ffda5c4370a725580bdf0af406 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> IAmInterfaceD.Test()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Test", ArgumentTypes_7bba69f3179d4f6f994eaa1f56e8ab4c);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Test", ArgumentTypes_448940ffda5c4370a725580bdf0af406);
             return (Task<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_1d960319b7e842d8ba1d3c3af98c79d4 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_408c892ec23f4e86855668c044167156 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> IAmInterfaceA.Ping()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Ping", ArgumentTypes_1d960319b7e842d8ba1d3c3af98c79d4);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Ping", ArgumentTypes_408c892ec23f4e86855668c044167156);
             return (Task<string>)func(Client, arguments);
         }
     }
@@ -405,13 +405,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_028b918e4db94eb1b81abdfe1c3c53cc = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_f0f6eec72efc4ae3bf660bfb56b1ee3e = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> IAmInterfaceD.Test()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Test", ArgumentTypes_028b918e4db94eb1b81abdfe1c3c53cc);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Test", ArgumentTypes_f0f6eec72efc4ae3bf660bfb56b1ee3e);
             return (Task<string>)func(Client, arguments);
         }
     }
@@ -452,153 +452,153 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_97e3e61e76e440789d5093e7b93da5f9 = new Type[] { typeof(PathBoundObject) };
+        private static readonly Type[] ArgumentTypes_556cf207c5d54380a6147522dc4c1c25 = new Type[] { typeof(PathBoundObject) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetFooBars(PathBoundObject request)
         {
             var arguments = new object[] { request };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBars", ArgumentTypes_97e3e61e76e440789d5093e7b93da5f9);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBars", ArgumentTypes_556cf207c5d54380a6147522dc4c1c25);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_a59bde75544042239980fd5468640db6 = new Type[] { typeof(PathBoundObject) };
+        private static readonly Type[] ArgumentTypes_31291ac05c1349f9986b7ed76736ad91 = new Type[] { typeof(PathBoundObject) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetFooBarsWithDifferentCasing(PathBoundObject requestParams)
         {
             var arguments = new object[] { requestParams };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBarsWithDifferentCasing", ArgumentTypes_a59bde75544042239980fd5468640db6);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBarsWithDifferentCasing", ArgumentTypes_31291ac05c1349f9986b7ed76736ad91);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_6d949a2336e0440e8e28c34fa7701f27 = new Type[] { typeof(string), typeof(PathBoundObject) };
+        private static readonly Type[] ArgumentTypes_fb24b6da76714bd3820d664a6351b058 = new Type[] { typeof(string), typeof(PathBoundObject) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetBarsByFoo(string id, PathBoundObject request)
         {
             var arguments = new object[] { id, request };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetBarsByFoo", ArgumentTypes_6d949a2336e0440e8e28c34fa7701f27);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetBarsByFoo", ArgumentTypes_fb24b6da76714bd3820d664a6351b058);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_d6ab9111652e4b5bb21ea0c484b812ff = new Type[] { typeof(PathBoundObject), typeof(string) };
+        private static readonly Type[] ArgumentTypes_94b1e075efd547979c507ab1db5b2412 = new Type[] { typeof(PathBoundObject), typeof(string) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetFooBars(PathBoundObject request, string someProperty)
         {
             var arguments = new object[] { request, someProperty };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBars", ArgumentTypes_d6ab9111652e4b5bb21ea0c484b812ff);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBars", ArgumentTypes_94b1e075efd547979c507ab1db5b2412);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_40697492eb7d42909346b14cda09b5b7 = new Type[] { typeof(PathBoundObject) };
+        private static readonly Type[] ArgumentTypes_b5bec60af76a459487529e0b6567ec9e = new Type[] { typeof(PathBoundObject) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetBarsByFoo(PathBoundObject request)
         {
             var arguments = new object[] { request };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetBarsByFoo", ArgumentTypes_40697492eb7d42909346b14cda09b5b7);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetBarsByFoo", ArgumentTypes_b5bec60af76a459487529e0b6567ec9e);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_a7964ea160c446c5b209ae6fcadebc44 = new Type[] { typeof(PathBoundObjectWithQueryFormat) };
+        private static readonly Type[] ArgumentTypes_96e2398121d64e93aad2554b1f0af6ad = new Type[] { typeof(PathBoundObjectWithQueryFormat) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetBarsWithCustomQueryFormat(PathBoundObjectWithQueryFormat request)
         {
             var arguments = new object[] { request };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetBarsWithCustomQueryFormat", ArgumentTypes_a7964ea160c446c5b209ae6fcadebc44);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetBarsWithCustomQueryFormat", ArgumentTypes_96e2398121d64e93aad2554b1f0af6ad);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_6174d733cdff4b81b3bf4713e20e26d4 = new Type[] { typeof(PathBoundDerivedObject) };
+        private static readonly Type[] ArgumentTypes_ce5fa2234ac54712988d6f6539de7aba = new Type[] { typeof(PathBoundDerivedObject) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetFooBarsDerived(PathBoundDerivedObject request)
         {
             var arguments = new object[] { request };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBarsDerived", ArgumentTypes_6174d733cdff4b81b3bf4713e20e26d4);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBarsDerived", ArgumentTypes_ce5fa2234ac54712988d6f6539de7aba);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_ecd201eeb1804392a65f1fdfa85885fa = new Type[] { typeof(PathBoundList) };
+        private static readonly Type[] ArgumentTypes_13256c47e4864a50ad6de1bc6208d2ee = new Type[] { typeof(PathBoundList) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetFoos(PathBoundList request)
         {
             var arguments = new object[] { request };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetFoos", ArgumentTypes_ecd201eeb1804392a65f1fdfa85885fa);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetFoos", ArgumentTypes_13256c47e4864a50ad6de1bc6208d2ee);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_6e24e1b6674b453d9fde5f5f8d82977a = new Type[] { typeof(List<int>) };
+        private static readonly Type[] ArgumentTypes_0a2c583849c1482e936d7a27934978a4 = new Type[] { typeof(List<int>) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetFoos2(List<int> Values)
         {
             var arguments = new object[] { Values };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetFoos2", ArgumentTypes_6e24e1b6674b453d9fde5f5f8d82977a);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetFoos2", ArgumentTypes_0a2c583849c1482e936d7a27934978a4);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_9e9447f11d4242478c5c7328f30d54d1 = new Type[] { typeof(PathBoundObject), typeof(object) };
+        private static readonly Type[] ArgumentTypes_2705c8909e2642bf8f1f213ea825b234 = new Type[] { typeof(PathBoundObject), typeof(object) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.PostFooBar(PathBoundObject request, object someObject)
         {
             var arguments = new object[] { request, someObject };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBar", ArgumentTypes_9e9447f11d4242478c5c7328f30d54d1);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBar", ArgumentTypes_2705c8909e2642bf8f1f213ea825b234);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_156f9a29068f4c0db65436448e567391 = new Type[] { typeof(PathBoundObjectWithQuery) };
+        private static readonly Type[] ArgumentTypes_31883515efd24c2dae5372a093147f44 = new Type[] { typeof(PathBoundObjectWithQuery) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetFooBars(PathBoundObjectWithQuery request)
         {
             var arguments = new object[] { request };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBars", ArgumentTypes_156f9a29068f4c0db65436448e567391);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBars", ArgumentTypes_31883515efd24c2dae5372a093147f44);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_02ed75d988bc4d929900f5a25383cb60 = new Type[] { typeof(PathBoundObject), typeof(ModelObject) };
+        private static readonly Type[] ArgumentTypes_eede4fed6e094f74b4bcbc76a2fb7842 = new Type[] { typeof(PathBoundObject), typeof(ModelObject) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IApiBindPathToObject.PostFooBar(PathBoundObject request, ModelObject someQueryParams)
         {
             var arguments = new object[] { request, someQueryParams };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBar", ArgumentTypes_02ed75d988bc4d929900f5a25383cb60);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBar", ArgumentTypes_eede4fed6e094f74b4bcbc76a2fb7842);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_101184cad9734b12a877ba24f0f938df = new Type[] { typeof(PathBoundObject), typeof(ModelObject), typeof(StreamPart) };
+        private static readonly Type[] ArgumentTypes_cde56b7080c8483186531526e2488688 = new Type[] { typeof(PathBoundObject), typeof(ModelObject), typeof(StreamPart) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IApiBindPathToObject.PostFooBarStreamPart(PathBoundObject request, ModelObject someQueryParams, StreamPart stream)
         {
             var arguments = new object[] { request, someQueryParams, stream };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBarStreamPart", ArgumentTypes_101184cad9734b12a877ba24f0f938df);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBarStreamPart", ArgumentTypes_cde56b7080c8483186531526e2488688);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_5244145622d7493ab2938a8c3ce22bbf = new Type[] { typeof(PathBoundObject), typeof(StreamPart) };
+        private static readonly Type[] ArgumentTypes_7510e60fd7ea4ef4a9b03ed0f99c0054 = new Type[] { typeof(PathBoundObject), typeof(StreamPart) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IApiBindPathToObject.PostFooBarStreamPart(PathBoundObject request, StreamPart stream)
         {
             var arguments = new object[] { request, stream };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBarStreamPart", ArgumentTypes_5244145622d7493ab2938a8c3ce22bbf);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBarStreamPart", ArgumentTypes_7510e60fd7ea4ef4a9b03ed0f99c0054);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_f5923ecb0afa4c36a6d77564c22a4542 = new Type[] { typeof(PathBoundObjectWithQuery), typeof(StreamPart) };
+        private static readonly Type[] ArgumentTypes_164d23e943c24a99bbff04e3c52c27ca = new Type[] { typeof(PathBoundObjectWithQuery), typeof(StreamPart) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IApiBindPathToObject.PostFooBarStreamPart(PathBoundObjectWithQuery request, StreamPart stream)
         {
             var arguments = new object[] { request, stream };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBarStreamPart", ArgumentTypes_f5923ecb0afa4c36a6d77564c22a4542);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBarStreamPart", ArgumentTypes_164d23e943c24a99bbff04e3c52c27ca);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
     }
@@ -639,13 +639,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_60e898143f604e54ac71cda9adb0393b = new Type[] { typeof(decimal) };
+        private static readonly Type[] ArgumentTypes_041e5be978074e05a2fd3c848a238afc = new Type[] { typeof(decimal) };
 
         /// <inheritdoc />
         Task<string> IApiWithDecimal.GetWithDecimal(decimal value)
         {
             var arguments = new object[] { value };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetWithDecimal", ArgumentTypes_60e898143f604e54ac71cda9adb0393b);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetWithDecimal", ArgumentTypes_041e5be978074e05a2fd3c848a238afc);
             return (Task<string>)func(Client, arguments);
         }
     }
@@ -686,33 +686,33 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_1e65017d5981469b89f423f3dcafb423 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_82c7594aaa2c4d74930384eb5fc4826a = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IBodylessApi.Post()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Post", ArgumentTypes_1e65017d5981469b89f423f3dcafb423);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Post", ArgumentTypes_82c7594aaa2c4d74930384eb5fc4826a);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_6ee706b775304db4ab55902380c8be2f = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_e58b7c5f5b094dc0875228d559f89e8d = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IBodylessApi.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_6ee706b775304db4ab55902380c8be2f);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_e58b7c5f5b094dc0875228d559f89e8d);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_c3feb021fae14f5c8c1dc2238d8a0ecc = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_0c55686a72a24aec8ecd663ac2b92a85 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IBodylessApi.Head()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Head", ArgumentTypes_c3feb021fae14f5c8c1dc2238d8a0ecc);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Head", ArgumentTypes_0c55686a72a24aec8ecd663ac2b92a85);
             return (Task)func(Client, arguments);
         }
     }
@@ -753,53 +753,53 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_c4eebfa0b051453390f293a0c42c4c99 = new Type[] { typeof(T) };
+        private static readonly Type[] ArgumentTypes_e2a27f42e40b4439a6d0cfdadd21ae1d = new Type[] { typeof(T) };
 
         /// <inheritdoc />
         Task<T> IBoringCrudApi<T, TKey>.Create(T paylod)
         {
             var arguments = new object[] { paylod };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_c4eebfa0b051453390f293a0c42c4c99);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_e2a27f42e40b4439a6d0cfdadd21ae1d);
             return (Task<T>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_62b55579eb314eb788ddd5eabb8abd2b = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_31c48b202c304cb1ba2e201ec7535ab6 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<List<T>> IBoringCrudApi<T, TKey>.ReadAll()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_62b55579eb314eb788ddd5eabb8abd2b);
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_31c48b202c304cb1ba2e201ec7535ab6);
             return (Task<List<T>>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_3fc10bc9079148b28e2c684ab769f3e1 = new Type[] { typeof(TKey) };
+        private static readonly Type[] ArgumentTypes_bc58a4c5e74041f5b77bbede464ec820 = new Type[] { typeof(TKey) };
 
         /// <inheritdoc />
         Task<T> IBoringCrudApi<T, TKey>.ReadOne(TKey key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_3fc10bc9079148b28e2c684ab769f3e1);
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_bc58a4c5e74041f5b77bbede464ec820);
             return (Task<T>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_130fa10a15f948d3a4ec536b8159648c = new Type[] { typeof(TKey), typeof(T) };
+        private static readonly Type[] ArgumentTypes_c1190224fa074d9188d5b14821550935 = new Type[] { typeof(TKey), typeof(T) };
 
         /// <inheritdoc />
         Task IBoringCrudApi<T, TKey>.Update(TKey key, T payload)
         {
             var arguments = new object[] { key, payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_130fa10a15f948d3a4ec536b8159648c);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_c1190224fa074d9188d5b14821550935);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_8f6b7e81e39d482aadace7f60f2623ec = new Type[] { typeof(TKey) };
+        private static readonly Type[] ArgumentTypes_4afd99ef78954a5cba26df34ea37a527 = new Type[] { typeof(TKey) };
 
         /// <inheritdoc />
         Task IBoringCrudApi<T, TKey>.Delete(TKey key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_8f6b7e81e39d482aadace7f60f2623ec);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_4afd99ef78954a5cba26df34ea37a527);
             return (Task)func(Client, arguments);
         }
     }
@@ -840,13 +840,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_30826e9a64d04fe782fd04dd4b744d99 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_93f76309342741edbab331bd7762005d = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<bool> IBrokenWebApi.PostAValue(string derp)
         {
             var arguments = new object[] { derp };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostAValue", ArgumentTypes_30826e9a64d04fe782fd04dd4b744d99);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostAValue", ArgumentTypes_93f76309342741edbab331bd7762005d);
             return (Task<bool>)func(Client, arguments);
         }
     }
@@ -875,13 +875,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_15f4ba1fb58d40179652b64d4d45bd19 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_41ff8f783e93482597031d0ece0930be = Array.Empty<Type>();
 
         /// <inheritdoc />
         CustomReferenceType? ICustomNullableReferenceService.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_15f4ba1fb58d40179652b64d4d45bd19);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_41ff8f783e93482597031d0ece0930be);
             return (CustomReferenceType?)func(Client, arguments);
         }
     }
@@ -910,13 +910,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_d935b340a475426085eaa39e5022625c = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_2bef6f4503434fa3b42e660dc8dab915 = Array.Empty<Type>();
 
         /// <inheritdoc />
         CustomValueType? ICustomNullableValueService.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_d935b340a475426085eaa39e5022625c);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_2bef6f4503434fa3b42e660dc8dab915);
             return (CustomValueType?)func(Client, arguments);
         }
     }
@@ -945,13 +945,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_eaa7c011160d49e884007030aa4831ec = new Type[] { ToNullable(typeof(CustomReferenceType)), ToNullable(typeof(CustomValueType)) };
+        private static readonly Type[] ArgumentTypes_1d36fa32b1044429be0809c60c1adb6d = new Type[] { ToNullable(typeof(CustomReferenceType)), ToNullable(typeof(CustomValueType)) };
 
         /// <inheritdoc />
         Task ICustomReferenceAndValueParametersService.Get(CustomReferenceType? reference, CustomValueType? value)
         {
             var arguments = new object[] { reference, value };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_eaa7c011160d49e884007030aa4831ec);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_1d36fa32b1044429be0809c60c1adb6d);
             return (Task)func(Client, arguments);
         }
 
@@ -984,73 +984,73 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_7443f859105a4b72807cb5e485df66f6 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_84e788d2ce964b42a8faeeb6584ca267 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IDataApiA.PingA()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("PingA", ArgumentTypes_7443f859105a4b72807cb5e485df66f6);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PingA", ArgumentTypes_84e788d2ce964b42a8faeeb6584ca267);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_6906dea5934e4628b01800510d4069a9 = new Type[] { typeof(DataEntity) };
+        private static readonly Type[] ArgumentTypes_b2d859cdfdd541efa38e06b41083853f = new Type[] { typeof(DataEntity) };
 
         /// <inheritdoc />
         Task<DataEntity> IDataCrudApi<DataEntity>.Copy(DataEntity payload)
         {
             var arguments = new object[] { payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Copy", ArgumentTypes_6906dea5934e4628b01800510d4069a9);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Copy", ArgumentTypes_b2d859cdfdd541efa38e06b41083853f);
             return (Task<DataEntity>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_21d82fc69d7242009ac9f77ec785cd81 = new Type[] { typeof(DataEntity) };
+        private static readonly Type[] ArgumentTypes_10f5b865a7bf41a7ab16d53f2a56fbe7 = new Type[] { typeof(DataEntity) };
 
         /// <inheritdoc />
         Task<DataEntity> IDataCrudApi<DataEntity, long>.Create(DataEntity payload)
         {
             var arguments = new object[] { payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_21d82fc69d7242009ac9f77ec785cd81);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_10f5b865a7bf41a7ab16d53f2a56fbe7);
             return (Task<DataEntity>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_9b2563d045404470a02ba7528869fa48 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_14ab4532d62f4feaafb5e7a938ddddc4 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<List<DataEntity>> IDataCrudApi<DataEntity, long>.ReadAll()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_9b2563d045404470a02ba7528869fa48);
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_14ab4532d62f4feaafb5e7a938ddddc4);
             return (Task<List<DataEntity>>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_2ec03741cea74983a94786367f0ab5ac = new Type[] { typeof(long) };
+        private static readonly Type[] ArgumentTypes_765dbd13bbad494daa73248429c4d3c1 = new Type[] { typeof(long) };
 
         /// <inheritdoc />
         Task<DataEntity> IDataCrudApi<DataEntity, long>.ReadOne(long key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_2ec03741cea74983a94786367f0ab5ac);
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_765dbd13bbad494daa73248429c4d3c1);
             return (Task<DataEntity>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_bc885e8308b74d418decd5d9cd9e49ce = new Type[] { typeof(long), typeof(DataEntity) };
+        private static readonly Type[] ArgumentTypes_ac3487bbbffb4e368a38a9ea03af73c0 = new Type[] { typeof(long), typeof(DataEntity) };
 
         /// <inheritdoc />
         Task IDataCrudApi<DataEntity, long>.Update(long key, DataEntity payload)
         {
             var arguments = new object[] { key, payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_bc885e8308b74d418decd5d9cd9e49ce);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_ac3487bbbffb4e368a38a9ea03af73c0);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_f0c5a7d602d74469a2822f04d50902ef = new Type[] { typeof(long) };
+        private static readonly Type[] ArgumentTypes_98e9792e43aa4f7eb4dc21c9bbe1b029 = new Type[] { typeof(long) };
 
         /// <inheritdoc />
         Task IDataCrudApi<DataEntity, long>.Delete(long key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_f0c5a7d602d74469a2822f04d50902ef);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_98e9792e43aa4f7eb4dc21c9bbe1b029);
             return (Task)func(Client, arguments);
         }
     }
@@ -1081,63 +1081,63 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_7dcab60e55bf4898bed92507f27c44ec = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_ead1c0a97e2a469db2d55de45f1178b2 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IDataApiB.PingB()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("PingB", ArgumentTypes_7dcab60e55bf4898bed92507f27c44ec);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PingB", ArgumentTypes_ead1c0a97e2a469db2d55de45f1178b2);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_7fb0696d08b9421da6cf4de1d411f102 = new Type[] { typeof(DataEntity) };
+        private static readonly Type[] ArgumentTypes_4f75604f0ffe4d688e6600b726b686bc = new Type[] { typeof(DataEntity) };
 
         /// <inheritdoc />
         Task<DataEntity> IDataCrudApi<DataEntity, int>.Create(DataEntity payload)
         {
             var arguments = new object[] { payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_7fb0696d08b9421da6cf4de1d411f102);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_4f75604f0ffe4d688e6600b726b686bc);
             return (Task<DataEntity>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_a655abb96e744b18ab67b5bb6494e341 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_cbbe59ca142241d79fe7a92e77dbd191 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<List<DataEntity>> IDataCrudApi<DataEntity, int>.ReadAll()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_a655abb96e744b18ab67b5bb6494e341);
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_cbbe59ca142241d79fe7a92e77dbd191);
             return (Task<List<DataEntity>>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_b8a2eb86f0e54af48d4a7907ee0ff1b8 = new Type[] { typeof(int) };
+        private static readonly Type[] ArgumentTypes_dbf43e479efd417098f38f14de9dfe24 = new Type[] { typeof(int) };
 
         /// <inheritdoc />
         Task<DataEntity> IDataCrudApi<DataEntity, int>.ReadOne(int key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_b8a2eb86f0e54af48d4a7907ee0ff1b8);
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_dbf43e479efd417098f38f14de9dfe24);
             return (Task<DataEntity>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_87135550a591433585ec5c4484f11a92 = new Type[] { typeof(int), typeof(DataEntity) };
+        private static readonly Type[] ArgumentTypes_6445cd1527dc4c05b4d3325e209896f8 = new Type[] { typeof(int), typeof(DataEntity) };
 
         /// <inheritdoc />
         Task IDataCrudApi<DataEntity, int>.Update(int key, DataEntity payload)
         {
             var arguments = new object[] { key, payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_87135550a591433585ec5c4484f11a92);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_6445cd1527dc4c05b4d3325e209896f8);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_63ca47c245b4423a95610ac4a9e274de = new Type[] { typeof(int) };
+        private static readonly Type[] ArgumentTypes_432c6a9d1dba48028ca5324615362b9f = new Type[] { typeof(int) };
 
         /// <inheritdoc />
         Task IDataCrudApi<DataEntity, int>.Delete(int key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_63ca47c245b4423a95610ac4a9e274de);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_432c6a9d1dba48028ca5324615362b9f);
             return (Task)func(Client, arguments);
         }
     }
@@ -1171,63 +1171,63 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_a074e69f312342d5afe0c4201c9b7da4 = new Type[] { typeof(T) };
+        private static readonly Type[] ArgumentTypes_f817a84585f340298f1452be539288a1 = new Type[] { typeof(T) };
 
         /// <inheritdoc />
         Task<T> IDataCrudApi<T>.Copy(T payload)
         {
             var arguments = new object[] { payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Copy", ArgumentTypes_a074e69f312342d5afe0c4201c9b7da4);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Copy", ArgumentTypes_f817a84585f340298f1452be539288a1);
             return (Task<T>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_8972e5c9755e46c9bfe7c9b77fbd58b8 = new Type[] { typeof(T) };
+        private static readonly Type[] ArgumentTypes_17fa467eee0543daaa0560387ff37c14 = new Type[] { typeof(T) };
 
         /// <inheritdoc />
         Task<T> IDataCrudApi<T, long>.Create(T payload)
         {
             var arguments = new object[] { payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_8972e5c9755e46c9bfe7c9b77fbd58b8);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_17fa467eee0543daaa0560387ff37c14);
             return (Task<T>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_a99e7462a6ae49bcb13210aaab647eb1 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_c58f22f98b6a47e8a9744a1b46b02a8c = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<List<T>> IDataCrudApi<T, long>.ReadAll()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_a99e7462a6ae49bcb13210aaab647eb1);
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_c58f22f98b6a47e8a9744a1b46b02a8c);
             return (Task<List<T>>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_959adb09159f4f2386615f7649a86e1d = new Type[] { typeof(long) };
+        private static readonly Type[] ArgumentTypes_6e0d2b1417c84d858bd78f03fcf22933 = new Type[] { typeof(long) };
 
         /// <inheritdoc />
         Task<T> IDataCrudApi<T, long>.ReadOne(long key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_959adb09159f4f2386615f7649a86e1d);
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_6e0d2b1417c84d858bd78f03fcf22933);
             return (Task<T>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_9e00a26393504a5ea5a202d42d8ff954 = new Type[] { typeof(long), typeof(T) };
+        private static readonly Type[] ArgumentTypes_290e96dd66fc486b80de83432e1cf8fb = new Type[] { typeof(long), typeof(T) };
 
         /// <inheritdoc />
         Task IDataCrudApi<T, long>.Update(long key, T payload)
         {
             var arguments = new object[] { key, payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_9e00a26393504a5ea5a202d42d8ff954);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_290e96dd66fc486b80de83432e1cf8fb);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_dea250aa28bb44c293e80ed8a7d7537d = new Type[] { typeof(long) };
+        private static readonly Type[] ArgumentTypes_b11f3650607f4f1f84948f97873328dd = new Type[] { typeof(long) };
 
         /// <inheritdoc />
         Task IDataCrudApi<T, long>.Delete(long key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_dea250aa28bb44c293e80ed8a7d7537d);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_b11f3650607f4f1f84948f97873328dd);
             return (Task)func(Client, arguments);
         }
     }
@@ -1261,53 +1261,53 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_33e0f5bbee2841b9b1597d04fa8daff6 = new Type[] { typeof(T) };
+        private static readonly Type[] ArgumentTypes_faf0b9cb18604e86a6832a1cd33d9684 = new Type[] { typeof(T) };
 
         /// <inheritdoc />
         Task<T> IDataCrudApi<T, TKey>.Create(T payload)
         {
             var arguments = new object[] { payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_33e0f5bbee2841b9b1597d04fa8daff6);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_faf0b9cb18604e86a6832a1cd33d9684);
             return (Task<T>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_28737e6e0eda453a908b51f986d1471e = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_c38842b49cb24a7a948d7152ff2a0e97 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<List<T>> IDataCrudApi<T, TKey>.ReadAll()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_28737e6e0eda453a908b51f986d1471e);
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_c38842b49cb24a7a948d7152ff2a0e97);
             return (Task<List<T>>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_8aa88d642a604f55ada6225fecf2e635 = new Type[] { typeof(TKey) };
+        private static readonly Type[] ArgumentTypes_3a36d6744e8049a2a5ffbf51886f34c3 = new Type[] { typeof(TKey) };
 
         /// <inheritdoc />
         Task<T> IDataCrudApi<T, TKey>.ReadOne(TKey key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_8aa88d642a604f55ada6225fecf2e635);
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_3a36d6744e8049a2a5ffbf51886f34c3);
             return (Task<T>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_a0965b05779d4f9b925fe6bf38027b28 = new Type[] { typeof(TKey), typeof(T) };
+        private static readonly Type[] ArgumentTypes_b0600da3b4224810b4825655593ec0e8 = new Type[] { typeof(TKey), typeof(T) };
 
         /// <inheritdoc />
         Task IDataCrudApi<T, TKey>.Update(TKey key, T payload)
         {
             var arguments = new object[] { key, payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_a0965b05779d4f9b925fe6bf38027b28);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_b0600da3b4224810b4825655593ec0e8);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_f60b29bcec6c48f6803a5e4a6b0bbb83 = new Type[] { typeof(TKey) };
+        private static readonly Type[] ArgumentTypes_73c3763fe5d64b6f8f41f4d3c404d67c = new Type[] { typeof(TKey) };
 
         /// <inheritdoc />
         Task IDataCrudApi<T, TKey>.Delete(TKey key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_f60b29bcec6c48f6803a5e4a6b0bbb83);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_73c3763fe5d64b6f8f41f4d3c404d67c);
             return (Task)func(Client, arguments);
         }
     }
@@ -1336,13 +1336,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_2159071202184c619f7c1faaec73123b = new Type[] { ToNullable(typeof(System.Collections.Generic.List<string>)) };
+        private static readonly Type[] ArgumentTypes_2a02aed38d2c45f399b5f79c227dcddb = new Type[] { ToNullable(typeof(System.Collections.Generic.List<string>)) };
 
         /// <inheritdoc />
         Task IGenericNullableReferenceParameterService.Get(System.Collections.Generic.List<string>? reference)
         {
             var arguments = new object[] { reference };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_2159071202184c619f7c1faaec73123b);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_2a02aed38d2c45f399b5f79c227dcddb);
             return (Task)func(Client, arguments);
         }
 
@@ -1373,13 +1373,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_2b16524e85974ec5aab4b08e4b8a51dd = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_a3c883e0fd2c42328a18b21560bf00b8 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string>? IGenericNullableReferenceService.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_2b16524e85974ec5aab4b08e4b8a51dd);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_a3c883e0fd2c42328a18b21560bf00b8);
             return (Task<string>?)func(Client, arguments);
         }
     }
@@ -1408,13 +1408,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_cb0a80401eb440b38347af2c736ac446 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_35121835248e444f965aeaab7fe0cad2 = Array.Empty<Type>();
 
         /// <inheritdoc />
         ValueTask<int>? IGenericNullableValueService.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_cb0a80401eb440b38347af2c736ac446);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_35121835248e444f965aeaab7fe0cad2);
             return (ValueTask<int>?)func(Client, arguments);
         }
     }
@@ -1443,13 +1443,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_7f604d9e0f5a4ab98b37f5b9d02487fa = new Type[] { ToNullable(typeof(System.Collections.Generic.List<string?>)) };
+        private static readonly Type[] ArgumentTypes_053f6b89eef74ef6babc3f0be5168781 = new Type[] { ToNullable(typeof(System.Collections.Generic.List<string?>)) };
 
         /// <inheritdoc />
         Task IGenericNullableWithNullableReferenceParameterService.Get(System.Collections.Generic.List<string?>? reference)
         {
             var arguments = new object[] { reference };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_7f604d9e0f5a4ab98b37f5b9d02487fa);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_053f6b89eef74ef6babc3f0be5168781);
             return (Task)func(Client, arguments);
         }
 
@@ -1480,13 +1480,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_c98509685b8b4224a81837db1de99ce1 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_c7df77d361bc4f219f2013f819c850d3 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string?>? IGenericNullableWithNullableReferenceService.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_c98509685b8b4224a81837db1de99ce1);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_c7df77d361bc4f219f2013f819c850d3);
             return (Task<string?>?)func(Client, arguments);
         }
     }
@@ -1515,13 +1515,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_97a9579518504bc9bd68fccfe472e907 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_23617700705b4a7b85c47698a2bb13b4 = Array.Empty<Type>();
 
         /// <inheritdoc />
         ValueTask<int?>? IGenericNullableWithNullableValueService.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_97a9579518504bc9bd68fccfe472e907);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_23617700705b4a7b85c47698a2bb13b4);
             return (ValueTask<int?>?)func(Client, arguments);
         }
     }
@@ -1550,13 +1550,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_b1cd681449dc4f2aabb76eaad58d741c = new Type[] { typeof(System.Collections.Generic.List<string?>) };
+        private static readonly Type[] ArgumentTypes_6a55f214ead245829a5eb4b53c96edca = new Type[] { typeof(System.Collections.Generic.List<string?>) };
 
         /// <inheritdoc />
         Task IGenericWithNullableReferenceParameterService.Get(System.Collections.Generic.List<string?> reference)
         {
             var arguments = new object[] { reference };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_b1cd681449dc4f2aabb76eaad58d741c);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_6a55f214ead245829a5eb4b53c96edca);
             return (Task)func(Client, arguments);
         }
     }
@@ -1585,13 +1585,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_9c1e41b9f2ce49dc80d0d8edd473aab3 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_1e75da778205494bab0f05930faadb88 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<int?> IGenericWithNullableValueService.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_9c1e41b9f2ce49dc80d0d8edd473aab3);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_1e75da778205494bab0f05930faadb88);
             return (Task<int?>)func(Client, arguments);
         }
     }
@@ -1620,13 +1620,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_0f5e2def14944a298b4aad7a29549d46 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_dc1c8b54040f421a8b341b577c3dafd3 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string?> IGenericWithResultService.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_0f5e2def14944a298b4aad7a29549d46);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_dc1c8b54040f421a8b341b577c3dafd3);
             return (Task<string?>)func(Client, arguments);
         }
     }
@@ -1661,133 +1661,133 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_23e53669c26447f18ed714a3cbd26ea7 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_2cb6203291764cada17d9f2936eb0987 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<User> IGitHubApi.GetUser(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUser", ArgumentTypes_23e53669c26447f18ed714a3cbd26ea7);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUser", ArgumentTypes_2cb6203291764cada17d9f2936eb0987);
             return (Task<User>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_98d8c00512894d0c89d9f8e3e89f6874 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_aaa72a56f9ad4f6fba20447b2f31df13 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         IObservable<User> IGitHubApi.GetUserObservable(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserObservable", ArgumentTypes_98d8c00512894d0c89d9f8e3e89f6874);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserObservable", ArgumentTypes_aaa72a56f9ad4f6fba20447b2f31df13);
             return (IObservable<User>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_af1e060037bb41b2a5960c9aacd017a3 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_6ab547879c6c413e9633e89c7ff4a7a8 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         IObservable<User> IGitHubApi.GetUserCamelCase(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserCamelCase", ArgumentTypes_af1e060037bb41b2a5960c9aacd017a3);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserCamelCase", ArgumentTypes_6ab547879c6c413e9633e89c7ff4a7a8);
             return (IObservable<User>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_4aab89d36342433caef51d05ed1b37af = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_9f3315e360fb41c993eb19c487855e4e = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<List<User>> IGitHubApi.GetOrgMembers(string orgName)
         {
             var arguments = new object[] { orgName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetOrgMembers", ArgumentTypes_4aab89d36342433caef51d05ed1b37af);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetOrgMembers", ArgumentTypes_9f3315e360fb41c993eb19c487855e4e);
             return (Task<List<User>>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_5e81b1cfa13341489ff88d3529722bff = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_26fd0e3846ae4d258f390460347f38b6 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<UserSearchResult> IGitHubApi.FindUsers(string q)
         {
             var arguments = new object[] { q };
-            var func = requestBuilder.BuildRestResultFuncForMethod("FindUsers", ArgumentTypes_5e81b1cfa13341489ff88d3529722bff);
+            var func = requestBuilder.BuildRestResultFuncForMethod("FindUsers", ArgumentTypes_26fd0e3846ae4d258f390460347f38b6);
             return (Task<UserSearchResult>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_466ba850f8ce45a4b06e4743937694a7 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_3ca836d15a974d88b89e37a5050bc1e6 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IGitHubApi.GetIndex()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndex", ArgumentTypes_466ba850f8ce45a4b06e4743937694a7);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndex", ArgumentTypes_3ca836d15a974d88b89e37a5050bc1e6);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_8eea8a9bf8ba4ae1aed3d26ce2f4b5c3 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_e4e653f5c45a44e587603fa4e18e3da8 = Array.Empty<Type>();
 
         /// <inheritdoc />
         IObservable<string> IGitHubApi.GetIndexObservable()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndexObservable", ArgumentTypes_8eea8a9bf8ba4ae1aed3d26ce2f4b5c3);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndexObservable", ArgumentTypes_e4e653f5c45a44e587603fa4e18e3da8);
             return (IObservable<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_2c852723b8664796ac762a077e2f54ae = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_143c6c38995f46f98e893ad013f50063 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<User> IGitHubApi.NothingToSeeHere()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("NothingToSeeHere", ArgumentTypes_2c852723b8664796ac762a077e2f54ae);
+            var func = requestBuilder.BuildRestResultFuncForMethod("NothingToSeeHere", ArgumentTypes_143c6c38995f46f98e893ad013f50063);
             return (Task<User>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_042421f12c2c49a89cd83af9a6c54298 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_4404f49f2e6247aba7d76ba04d3591cc = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<ApiResponse<User>> IGitHubApi.NothingToSeeHereWithMetadata()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("NothingToSeeHereWithMetadata", ArgumentTypes_042421f12c2c49a89cd83af9a6c54298);
+            var func = requestBuilder.BuildRestResultFuncForMethod("NothingToSeeHereWithMetadata", ArgumentTypes_4404f49f2e6247aba7d76ba04d3591cc);
             return (Task<ApiResponse<User>>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_bc66e008ada24a34b0e313358a4a5f83 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_de1a1e1b66a449609d7497ba6a26e882 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<ApiResponse<User>> IGitHubApi.GetUserWithMetadata(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserWithMetadata", ArgumentTypes_bc66e008ada24a34b0e313358a4a5f83);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserWithMetadata", ArgumentTypes_de1a1e1b66a449609d7497ba6a26e882);
             return (Task<ApiResponse<User>>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_fc144a3fad4f4d69bc9a42c133be4428 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_39eaefd7d2664899b35eb2ae8202fe99 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         IObservable<ApiResponse<User>> IGitHubApi.GetUserObservableWithMetadata(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserObservableWithMetadata", ArgumentTypes_fc144a3fad4f4d69bc9a42c133be4428);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserObservableWithMetadata", ArgumentTypes_39eaefd7d2664899b35eb2ae8202fe99);
             return (IObservable<ApiResponse<User>>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_73a5041b17c44f7dac77e5b9716299a7 = new Type[] { typeof(User) };
+        private static readonly Type[] ArgumentTypes_05e593e088494d678719992792ccd419 = new Type[] { typeof(User) };
 
         /// <inheritdoc />
         Task<User> IGitHubApi.CreateUser(User user)
         {
             var arguments = new object[] { user };
-            var func = requestBuilder.BuildRestResultFuncForMethod("CreateUser", ArgumentTypes_73a5041b17c44f7dac77e5b9716299a7);
+            var func = requestBuilder.BuildRestResultFuncForMethod("CreateUser", ArgumentTypes_05e593e088494d678719992792ccd419);
             return (Task<User>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_300c5e3ad8c94bf98349348b84a983c1 = new Type[] { typeof(User) };
+        private static readonly Type[] ArgumentTypes_ab1ed674897b4efdaef9eba920fd3ad9 = new Type[] { typeof(User) };
 
         /// <inheritdoc />
         Task<ApiResponse<User>> IGitHubApi.CreateUserWithMetadata(User user)
         {
             var arguments = new object[] { user };
-            var func = requestBuilder.BuildRestResultFuncForMethod("CreateUserWithMetadata", ArgumentTypes_300c5e3ad8c94bf98349348b84a983c1);
+            var func = requestBuilder.BuildRestResultFuncForMethod("CreateUserWithMetadata", ArgumentTypes_ab1ed674897b4efdaef9eba920fd3ad9);
             return (Task<ApiResponse<User>>)func(Client, arguments);
         }
     }
@@ -1832,47 +1832,47 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_8ff83789e9d84c97981e15bd53567fd2 = new Type[] { typeof(TParam), typeof(THeader) };
+        private static readonly Type[] ArgumentTypes_ec5e1cf1f7634dabac3761992c65037f = new Type[] { typeof(TParam), typeof(THeader) };
 
         /// <inheritdoc />
         Task<TResponse> IHttpBinApi<TResponse, TParam, THeader>.Get(TParam param, THeader header)
         {
             var arguments = new object[] { param, header };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_8ff83789e9d84c97981e15bd53567fd2);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_ec5e1cf1f7634dabac3761992c65037f);
             return (Task<TResponse>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_975cbc248ee24861a11e409a0027c77a = new Type[] { typeof(TParam) };
+        private static readonly Type[] ArgumentTypes_0f04a7d2c3f24df4943304840152d312 = new Type[] { typeof(TParam) };
 
         /// <inheritdoc />
         Task<TResponse> IHttpBinApi<TResponse, TParam, THeader>.GetQuery(TParam param)
         {
             var arguments = new object[] { param };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetQuery", ArgumentTypes_975cbc248ee24861a11e409a0027c77a);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetQuery", ArgumentTypes_0f04a7d2c3f24df4943304840152d312);
             return (Task<TResponse>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_1724bcfa7adb42e683bf72fc20584224 = new Type[] { typeof(TParam) };
+        private static readonly Type[] ArgumentTypes_01231ac66bb143048d2e53b21d266698 = new Type[] { typeof(TParam) };
 
         /// <inheritdoc />
         Task<TResponse> IHttpBinApi<TResponse, TParam, THeader>.PostQuery(TParam param)
         {
             var arguments = new object[] { param };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostQuery", ArgumentTypes_1724bcfa7adb42e683bf72fc20584224);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostQuery", ArgumentTypes_01231ac66bb143048d2e53b21d266698);
             return (Task<TResponse>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_31a6a8cd9e19465baf47faecf71c6367 = new Type[] { typeof(TParam) };
+        private static readonly Type[] ArgumentTypes_ec8529bae3c9475ea8f6df7c1b6cd329 = new Type[] { typeof(TParam) };
 
         /// <inheritdoc />
         Task<TResponse> IHttpBinApi<TResponse, TParam, THeader>.GetQueryWithIncludeParameterName(TParam param)
         {
             var arguments = new object[] { param };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetQueryWithIncludeParameterName", ArgumentTypes_31a6a8cd9e19465baf47faecf71c6367);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetQueryWithIncludeParameterName", ArgumentTypes_ec8529bae3c9475ea8f6df7c1b6cd329);
             return (Task<TResponse>)func(Client, arguments);
         }
 
-        private static class TypeHelper_32d63acc5d264362bec259a1ec2910bd<TValue>
+        private static class TypeHelper_3b927419d2e04667870dc9f95451dec8<TValue>
         {
             public static readonly Type[] ArgumentTypes = new Type[] { typeof(TParam) };
             public static readonly Type[] TypeParameters = new Type[] { typeof(TValue) };
@@ -1882,7 +1882,7 @@ namespace Refit.Tests
         Task<TValue> IHttpBinApi<TResponse, TParam, THeader>.GetQuery1<TValue>(TParam param)
         {
             var arguments = new object[] { param };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetQuery1", TypeHelper_32d63acc5d264362bec259a1ec2910bd<TValue>.ArgumentTypes, TypeHelper_32d63acc5d264362bec259a1ec2910bd<TValue>.TypeParameters);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetQuery1", TypeHelper_3b927419d2e04667870dc9f95451dec8<TValue>.ArgumentTypes, TypeHelper_3b927419d2e04667870dc9f95451dec8<TValue>.TypeParameters);
             return (Task<TValue>)func(Client, arguments);
         }
     }
@@ -1923,23 +1923,23 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_e0bd494deec548fd826780052b71ec4e = new Type[] { typeof(HttpContent) };
+        private static readonly Type[] ArgumentTypes_5f3edfe8bb0a4ec3b6a73e03d754eee2 = new Type[] { typeof(HttpContent) };
 
         /// <inheritdoc />
         Task<HttpContent> IHttpContentApi.PostFileUpload(HttpContent content)
         {
             var arguments = new object[] { content };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostFileUpload", ArgumentTypes_e0bd494deec548fd826780052b71ec4e);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostFileUpload", ArgumentTypes_5f3edfe8bb0a4ec3b6a73e03d754eee2);
             return (Task<HttpContent>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_dfe62030c6004c71bb527a5f3ab94d12 = new Type[] { typeof(HttpContent) };
+        private static readonly Type[] ArgumentTypes_2aa38514d7d34094b3808ffe2fa91fe3 = new Type[] { typeof(HttpContent) };
 
         /// <inheritdoc />
         Task<ApiResponse<HttpContent>> IHttpContentApi.PostFileUploadWithMetadata(HttpContent content)
         {
             var arguments = new object[] { content };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostFileUploadWithMetadata", ArgumentTypes_dfe62030c6004c71bb527a5f3ab94d12);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostFileUploadWithMetadata", ArgumentTypes_2aa38514d7d34094b3808ffe2fa91fe3);
             return (Task<ApiResponse<HttpContent>>)func(Client, arguments);
         }
     }
@@ -1981,13 +1981,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_fde75d58e4204ddba3a08ce7bfe1e7d8 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_2609d659e3bd437a90188b0559b5eb1e = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<TestAliasObject> ResponseTests.IMyAliasService.GetTestObject()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetTestObject", ArgumentTypes_fde75d58e4204ddba3a08ce7bfe1e7d8);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetTestObject", ArgumentTypes_2609d659e3bd437a90188b0559b5eb1e);
             return (Task<TestAliasObject>)func(Client, arguments);
         }
     }
@@ -2023,23 +2023,23 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_d1ccada55ce14192ae7895a00eae6abd = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_2d5924ade7ff4f39bbdb949fc317a774 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> AuthenticatedClientHandlerTests.IMyAuthenticatedService.GetUnauthenticated()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUnauthenticated", ArgumentTypes_d1ccada55ce14192ae7895a00eae6abd);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUnauthenticated", ArgumentTypes_2d5924ade7ff4f39bbdb949fc317a774);
             return (Task<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_d3f9801ff70541efa492ec0c1ac31789 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_91fe256a9ee340228b6dfafab4e31eb5 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> AuthenticatedClientHandlerTests.IMyAuthenticatedService.GetAuthenticated()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetAuthenticated", ArgumentTypes_d3f9801ff70541efa492ec0c1ac31789);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetAuthenticated", ArgumentTypes_91fe256a9ee340228b6dfafab4e31eb5);
             return (Task<string>)func(Client, arguments);
         }
     }
@@ -2070,13 +2070,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_f4d218575e0c473db28da1edc3f5d821 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_f35a382fa20c44169697e7f229e20a14 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<SomeType> INamespaceCollisionApi.SomeRequest()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", ArgumentTypes_f4d218575e0c473db28da1edc3f5d821);
+            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", ArgumentTypes_f35a382fa20c44169697e7f229e20a14);
             return (Task<SomeType>)func(Client, arguments);
         }
     }
@@ -2108,13 +2108,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_fd6d8723e35a4375b5d6cc199e345f58 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_8eb6df4c8c144524a0f2ac6183de052d = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<SomeOtherType> INamespaceOverlapApi.SomeRequest()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", ArgumentTypes_fd6d8723e35a4375b5d6cc199e345f58);
+            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", ArgumentTypes_8eb6df4c8c144524a0f2ac6183de052d);
             return (Task<SomeOtherType>)func(Client, arguments);
         }
     }
@@ -2149,83 +2149,83 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_1aa9e1a664964925bfdb507256b1e93d = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_290d8c703d0c414a9c378854d2004022 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<User> TestNested.INestedGitHubApi.GetUser(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUser", ArgumentTypes_1aa9e1a664964925bfdb507256b1e93d);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUser", ArgumentTypes_290d8c703d0c414a9c378854d2004022);
             return (Task<User>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_934e98aabf654fb8a54fb09784ccc583 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_f1a5a10ccaa34912baf4acf6c5b09c6d = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         IObservable<User> TestNested.INestedGitHubApi.GetUserObservable(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserObservable", ArgumentTypes_934e98aabf654fb8a54fb09784ccc583);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserObservable", ArgumentTypes_f1a5a10ccaa34912baf4acf6c5b09c6d);
             return (IObservable<User>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_989d53fbefe94189b7a96c5abc3d5d6b = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_ee4a4f89edbb4442ab58b67dbc38b682 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         IObservable<User> TestNested.INestedGitHubApi.GetUserCamelCase(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserCamelCase", ArgumentTypes_989d53fbefe94189b7a96c5abc3d5d6b);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserCamelCase", ArgumentTypes_ee4a4f89edbb4442ab58b67dbc38b682);
             return (IObservable<User>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_39929cbbb0fa46a0ab21e60c6390966f = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_adbaf47f6d7b464fa86e185831977dd5 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<List<User>> TestNested.INestedGitHubApi.GetOrgMembers(string orgName)
         {
             var arguments = new object[] { orgName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetOrgMembers", ArgumentTypes_39929cbbb0fa46a0ab21e60c6390966f);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetOrgMembers", ArgumentTypes_adbaf47f6d7b464fa86e185831977dd5);
             return (Task<List<User>>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_a5ea3ef1d02e45e48da8d8ddf5515d84 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_e0ff1c2811ba410d99bfe5ac22c25e26 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<UserSearchResult> TestNested.INestedGitHubApi.FindUsers(string q)
         {
             var arguments = new object[] { q };
-            var func = requestBuilder.BuildRestResultFuncForMethod("FindUsers", ArgumentTypes_a5ea3ef1d02e45e48da8d8ddf5515d84);
+            var func = requestBuilder.BuildRestResultFuncForMethod("FindUsers", ArgumentTypes_e0ff1c2811ba410d99bfe5ac22c25e26);
             return (Task<UserSearchResult>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_654bcf15105f40ca89fa453333abd530 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_5fa56402bd67427e8ce285460a926212 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<HttpResponseMessage> TestNested.INestedGitHubApi.GetIndex()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndex", ArgumentTypes_654bcf15105f40ca89fa453333abd530);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndex", ArgumentTypes_5fa56402bd67427e8ce285460a926212);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_9e2bf872a17442de8da56891287387a4 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_27313f99110b46e994e50c9643dd3a21 = Array.Empty<Type>();
 
         /// <inheritdoc />
         IObservable<string> TestNested.INestedGitHubApi.GetIndexObservable()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndexObservable", ArgumentTypes_9e2bf872a17442de8da56891287387a4);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndexObservable", ArgumentTypes_27313f99110b46e994e50c9643dd3a21);
             return (IObservable<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_eaf258c5aece4d16a8aa15d76132f74a = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_01c44ff055ff436a878c23df9aa446e4 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task TestNested.INestedGitHubApi.NothingToSeeHere()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("NothingToSeeHere", ArgumentTypes_eaf258c5aece4d16a8aa15d76132f74a);
+            var func = requestBuilder.BuildRestResultFuncForMethod("NothingToSeeHere", ArgumentTypes_01c44ff055ff436a878c23df9aa446e4);
             return (Task)func(Client, arguments);
         }
     }
@@ -2263,7 +2263,7 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static class TypeHelper_b5a47e4eeca84837bffd25d3bdc03246<T>
+        private static class TypeHelper_cc44cb02aefb46bdaba2b3e363f9f14a<T>
         {
             public static readonly Type[] ArgumentTypes = new Type[] { typeof(T) };
             public static readonly Type[] TypeParameters = new Type[] { typeof(T) };
@@ -2273,11 +2273,11 @@ namespace Refit.Tests
         Task INonGenericInterfaceWithGenericMethod.PostMessage<T>(T message)
         {
             var arguments = new object[] { message };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostMessage", TypeHelper_b5a47e4eeca84837bffd25d3bdc03246<T>.ArgumentTypes, TypeHelper_b5a47e4eeca84837bffd25d3bdc03246<T>.TypeParameters);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostMessage", TypeHelper_cc44cb02aefb46bdaba2b3e363f9f14a<T>.ArgumentTypes, TypeHelper_cc44cb02aefb46bdaba2b3e363f9f14a<T>.TypeParameters);
             return (Task)func(Client, arguments);
         }
 
-        private static class TypeHelper_49dffda4257642a8a6776c46de4ae559<T, U, V>
+        private static class TypeHelper_2c635ff944134eca827ad0f89d58a2dc<T, U, V>
         {
             public static readonly Type[] ArgumentTypes = new Type[] { typeof(T), typeof(U), typeof(V) };
             public static readonly Type[] TypeParameters = new Type[] { typeof(T), typeof(U), typeof(V) };
@@ -2287,7 +2287,7 @@ namespace Refit.Tests
         Task INonGenericInterfaceWithGenericMethod.PostMessage<T, U, V>(T message, U param1, V param2)
         {
             var arguments = new object[] { message, param1, param2 };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostMessage", TypeHelper_49dffda4257642a8a6776c46de4ae559<T, U, V>.ArgumentTypes, TypeHelper_49dffda4257642a8a6776c46de4ae559<T, U, V>.TypeParameters);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostMessage", TypeHelper_2c635ff944134eca827ad0f89d58a2dc<T, U, V>.ArgumentTypes, TypeHelper_2c635ff944134eca827ad0f89d58a2dc<T, U, V>.TypeParameters);
             return (Task)func(Client, arguments);
         }
     }
@@ -2328,13 +2328,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_56dfebaefcdb47fba923abfd59d5f52a = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_de40d528bbb44dfda6b25a60c61317e9 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<RootObject> INpmJs.GetCongruence()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetCongruence", ArgumentTypes_56dfebaefcdb47fba923abfd59d5f52a);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetCongruence", ArgumentTypes_de40d528bbb44dfda6b25a60c61317e9);
             return (Task<RootObject>)func(Client, arguments);
         }
     }
@@ -2363,13 +2363,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_1cb3ee5c77114f4ea08663ccf509dc30 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_eca5f3514570487dab2bd0e1c41eeecd = Array.Empty<Type>();
 
         /// <inheritdoc />
         string? INullableReferenceService.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_1cb3ee5c77114f4ea08663ccf509dc30);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_eca5f3514570487dab2bd0e1c41eeecd);
             return (string?)func(Client, arguments);
         }
     }
@@ -2398,13 +2398,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_650c6af1b28c46e188b58894f6704f12 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_38481ff9a1aa4a9d99f13f2012826f08 = Array.Empty<Type>();
 
         /// <inheritdoc />
         int? INullableValueService.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_650c6af1b28c46e188b58894f6704f12);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_38481ff9a1aa4a9d99f13f2012826f08);
             return (int?)func(Client, arguments);
         }
     }
@@ -2434,13 +2434,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_cd62d3f3d196464a8592542f094b7329 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_e1026191ae0542459d5681530aef66af = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<SomeType> IReducedUsingInsideNamespaceApi.SomeRequest()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", ArgumentTypes_cd62d3f3d196464a8592542f094b7329);
+            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", ArgumentTypes_e1026191ae0542459d5681530aef66af);
             return (Task<SomeType>)func(Client, arguments);
         }
     }
@@ -2469,13 +2469,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_7f7ee8bf304e4de2a8862981e3ab9f48 = new Type[] { ToNullable(typeof(string)), ToNullable(typeof(int)) };
+        private static readonly Type[] ArgumentTypes_b854b536248445aa90ba6b7393eb5cb9 = new Type[] { ToNullable(typeof(string)), ToNullable(typeof(int)) };
 
         /// <inheritdoc />
         Task IReferenceAndValueParametersService.Get(string? reference, int? value)
         {
             var arguments = new object[] { reference, value };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_7f7ee8bf304e4de2a8862981e3ab9f48);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_b854b536248445aa90ba6b7393eb5cb9);
             return (Task)func(Client, arguments);
         }
 
@@ -2518,13 +2518,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_0ba8586508b24ec59a6906d46a2c3b48 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_3ea0a901846549018dacce2e090c79f6 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IRefitInterfaceWithStaticMethod.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_0ba8586508b24ec59a6906d46a2c3b48);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_3ea0a901846549018dacce2e090c79f6);
             return (Task)func(Client, arguments);
         }
     }
@@ -2565,47 +2565,47 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_b87b0a5485bc445b9df0033f245b6567 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_ab39b9e0693d453c9846d548131807f3 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IRequestBin.Post()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Post", ArgumentTypes_b87b0a5485bc445b9df0033f245b6567);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Post", ArgumentTypes_ab39b9e0693d453c9846d548131807f3);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_11a1cb839e35442ba3f9a1b150916c32 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_30a3ba0b20684a56847a21ee9a84294f = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task IRequestBin.PostRawStringDefault(string str)
         {
             var arguments = new object[] { str };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostRawStringDefault", ArgumentTypes_11a1cb839e35442ba3f9a1b150916c32);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostRawStringDefault", ArgumentTypes_30a3ba0b20684a56847a21ee9a84294f);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_dd7da2dba1a5425e97470899507e5c11 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_6f5d4527917b40b8a7419c164e2b04bf = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task IRequestBin.PostRawStringJson(string str)
         {
             var arguments = new object[] { str };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostRawStringJson", ArgumentTypes_dd7da2dba1a5425e97470899507e5c11);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostRawStringJson", ArgumentTypes_6f5d4527917b40b8a7419c164e2b04bf);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_324ef6691f064a8eb5e6a4b0bb0fb94b = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_7a72a289a3b4491f80c074bbafba16e4 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task IRequestBin.PostRawStringUrlEncoded(string str)
         {
             var arguments = new object[] { str };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostRawStringUrlEncoded", ArgumentTypes_324ef6691f064a8eb5e6a4b0bb0fb94b);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostRawStringUrlEncoded", ArgumentTypes_7a72a289a3b4491f80c074bbafba16e4);
             return (Task)func(Client, arguments);
         }
 
-        private static class TypeHelper_2141e5a6a02e4cf5839bc0680b10d8bf<T>
+        private static class TypeHelper_bafd5bc5e66e4a81a68d38d6bf9c1023<T>
         {
             public static readonly Type[] ArgumentTypes = new Type[] { typeof(T) };
             public static readonly Type[] TypeParameters = new Type[] { typeof(T) };
@@ -2615,7 +2615,7 @@ namespace Refit.Tests
         Task IRequestBin.PostGeneric<T>(T param)
         {
             var arguments = new object[] { param };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostGeneric", TypeHelper_2141e5a6a02e4cf5839bc0680b10d8bf<T>.ArgumentTypes, TypeHelper_2141e5a6a02e4cf5839bc0680b10d8bf<T>.TypeParameters);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostGeneric", TypeHelper_bafd5bc5e66e4a81a68d38d6bf9c1023<T>.ArgumentTypes, TypeHelper_bafd5bc5e66e4a81a68d38d6bf9c1023<T>.TypeParameters);
             return (Task)func(Client, arguments);
         }
     }
@@ -2656,133 +2656,133 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_88f3792289c243ecb97a877fb738cff7 = new Type[] { typeof(Stream) };
+        private static readonly Type[] ArgumentTypes_92793d040eb64afc99b08814cf8c6c32 = new Type[] { typeof(Stream) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadStream(Stream stream)
         {
             var arguments = new object[] { stream };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStream", ArgumentTypes_88f3792289c243ecb97a877fb738cff7);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStream", ArgumentTypes_92793d040eb64afc99b08814cf8c6c32);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_45ff912751d64992aaa609889048a177 = new Type[] { typeof(Stream) };
+        private static readonly Type[] ArgumentTypes_9d691d17d8b54c088ddae81d2dfac6dd = new Type[] { typeof(Stream) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadStreamWithCustomBoundary(Stream stream)
         {
             var arguments = new object[] { stream };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStreamWithCustomBoundary", ArgumentTypes_45ff912751d64992aaa609889048a177);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStreamWithCustomBoundary", ArgumentTypes_9d691d17d8b54c088ddae81d2dfac6dd);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_093b9c0127ef45839492246b5fbe4893 = new Type[] { typeof(StreamPart) };
+        private static readonly Type[] ArgumentTypes_9e1b93ce7a9747e8a4b04faf84b7b9e3 = new Type[] { typeof(StreamPart) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadStreamPart(StreamPart stream)
         {
             var arguments = new object[] { stream };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStreamPart", ArgumentTypes_093b9c0127ef45839492246b5fbe4893);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStreamPart", ArgumentTypes_9e1b93ce7a9747e8a4b04faf84b7b9e3);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_63cef04ab489449d9276e88c089c60b0 = new Type[] { typeof(ModelObject), typeof(StreamPart) };
+        private static readonly Type[] ArgumentTypes_cf71bb58e48d41a38af4746ffcfd1013 = new Type[] { typeof(ModelObject), typeof(StreamPart) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadStreamPart(ModelObject someQueryParams, StreamPart stream)
         {
             var arguments = new object[] { someQueryParams, stream };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStreamPart", ArgumentTypes_63cef04ab489449d9276e88c089c60b0);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStreamPart", ArgumentTypes_cf71bb58e48d41a38af4746ffcfd1013);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_a510e7e908a249e78f972d86f5bea4ba = new Type[] { typeof(byte[]) };
+        private static readonly Type[] ArgumentTypes_93436928ef3a4e93a9daafd41806d21a = new Type[] { typeof(byte[]) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadBytes(byte[] bytes)
         {
             var arguments = new object[] { bytes };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadBytes", ArgumentTypes_a510e7e908a249e78f972d86f5bea4ba);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadBytes", ArgumentTypes_93436928ef3a4e93a9daafd41806d21a);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_5350e490399a4b3987f20ec366630fee = new Type[] { typeof(ByteArrayPart) };
+        private static readonly Type[] ArgumentTypes_25ccac5fc1b44b46880ced61fa872793 = new Type[] { typeof(ByteArrayPart) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadBytesPart(ByteArrayPart bytes)
         {
             var arguments = new object[] { bytes };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadBytesPart", ArgumentTypes_5350e490399a4b3987f20ec366630fee);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadBytesPart", ArgumentTypes_25ccac5fc1b44b46880ced61fa872793);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_205eb88081a2422f817bf24482155579 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_4c483e4c52fe4d0a9e10500e6958e012 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadString(string someString)
         {
             var arguments = new object[] { someString };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadString", ArgumentTypes_205eb88081a2422f817bf24482155579);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadString", ArgumentTypes_4c483e4c52fe4d0a9e10500e6958e012);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_6d4a02ff94b44fa89a1269febe1fbf0a = new Type[] { typeof(IEnumerable<FileInfo>), typeof(FileInfo) };
+        private static readonly Type[] ArgumentTypes_528a488692a64a59acef12627ff3e70a = new Type[] { typeof(IEnumerable<FileInfo>), typeof(FileInfo) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadFileInfo(IEnumerable<FileInfo> fileInfos, FileInfo anotherFile)
         {
             var arguments = new object[] { fileInfos, anotherFile };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadFileInfo", ArgumentTypes_6d4a02ff94b44fa89a1269febe1fbf0a);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadFileInfo", ArgumentTypes_528a488692a64a59acef12627ff3e70a);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_8859056121734edc9c99aa562505231f = new Type[] { typeof(IEnumerable<FileInfoPart>), typeof(FileInfoPart) };
+        private static readonly Type[] ArgumentTypes_8083d98ba0684bc8ac148ac4633ebc98 = new Type[] { typeof(IEnumerable<FileInfoPart>), typeof(FileInfoPart) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadFileInfoPart(IEnumerable<FileInfoPart> fileInfos, FileInfoPart anotherFile)
         {
             var arguments = new object[] { fileInfos, anotherFile };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadFileInfoPart", ArgumentTypes_8859056121734edc9c99aa562505231f);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadFileInfoPart", ArgumentTypes_8083d98ba0684bc8ac148ac4633ebc98);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_c5c283f30d7147a686bdbb42873042df = new Type[] { typeof(ModelObject) };
+        private static readonly Type[] ArgumentTypes_dea109eab23544c990acc0a423f5b452 = new Type[] { typeof(ModelObject) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadJsonObject(ModelObject theObject)
         {
             var arguments = new object[] { theObject };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadJsonObject", ArgumentTypes_c5c283f30d7147a686bdbb42873042df);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadJsonObject", ArgumentTypes_dea109eab23544c990acc0a423f5b452);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_287c7ab35dc84dddb7f7cc5656e16394 = new Type[] { typeof(IEnumerable<ModelObject>) };
+        private static readonly Type[] ArgumentTypes_21a97a3182ec4f30b09847a257e2a50c = new Type[] { typeof(IEnumerable<ModelObject>) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadJsonObjects(IEnumerable<ModelObject> theObjects)
         {
             var arguments = new object[] { theObjects };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadJsonObjects", ArgumentTypes_287c7ab35dc84dddb7f7cc5656e16394);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadJsonObjects", ArgumentTypes_21a97a3182ec4f30b09847a257e2a50c);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_e06638eb1f2d4226a27f66f226084289 = new Type[] { typeof(IEnumerable<ModelObject>), typeof(AnotherModel), typeof(FileInfo), typeof(AnEnum), typeof(string), typeof(int) };
+        private static readonly Type[] ArgumentTypes_61966fc1e02e4521b007879ac8eacaa1 = new Type[] { typeof(IEnumerable<ModelObject>), typeof(AnotherModel), typeof(FileInfo), typeof(AnEnum), typeof(string), typeof(int) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadMixedObjects(IEnumerable<ModelObject> theObjects, AnotherModel anotherModel, FileInfo aFile, AnEnum anEnum, string aString, int anInt)
         {
             var arguments = new object[] { theObjects, anotherModel, aFile, anEnum, aString, anInt };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadMixedObjects", ArgumentTypes_e06638eb1f2d4226a27f66f226084289);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadMixedObjects", ArgumentTypes_61966fc1e02e4521b007879ac8eacaa1);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_ca6132b180dc4cdbb67609eb8d37a18a = new Type[] { typeof(HttpContent) };
+        private static readonly Type[] ArgumentTypes_753a20dfa6cc4ba1b76da37a4b557368 = new Type[] { typeof(HttpContent) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadHttpContent(HttpContent content)
         {
             var arguments = new object[] { content };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadHttpContent", ArgumentTypes_ca6132b180dc4cdbb67609eb8d37a18a);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadHttpContent", ArgumentTypes_753a20dfa6cc4ba1b76da37a4b557368);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
     }
@@ -2814,23 +2814,23 @@ namespace AutoGeneratedIServiceWithoutNamespace
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_e776cab422f34342a86d28d182293e8b = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_4f2db53a6b8f44ca88697958b94415c9 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IServiceWithoutNamespace.GetRoot()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetRoot", ArgumentTypes_e776cab422f34342a86d28d182293e8b);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetRoot", ArgumentTypes_4f2db53a6b8f44ca88697958b94415c9);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_721c873c7a864c1f88e198ab8ec3b24d = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_40bf5b3941b04a26bce6fdb4b8db310b = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IServiceWithoutNamespace.PostRoot()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostRoot", ArgumentTypes_721c873c7a864c1f88e198ab8ec3b24d);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostRoot", ArgumentTypes_40bf5b3941b04a26bce6fdb4b8db310b);
             return (Task)func(Client, arguments);
         }
     }
@@ -2871,23 +2871,23 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_924436df0bb149298ef71acee4e3a3f4 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_454352e006f84c2697b51eedee8873b7 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<Stream> IStreamApi.GetRemoteFile(string filename)
         {
             var arguments = new object[] { filename };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetRemoteFile", ArgumentTypes_924436df0bb149298ef71acee4e3a3f4);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetRemoteFile", ArgumentTypes_454352e006f84c2697b51eedee8873b7);
             return (Task<Stream>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_6ae54bf7e5ec4a61b87e0a0ee61ff662 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_fb6662beb1684c0988d7e8f4cbc1c2a2 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<ApiResponse<Stream>> IStreamApi.GetRemoteFileWithMetadata(string filename)
         {
             var arguments = new object[] { filename };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetRemoteFileWithMetadata", ArgumentTypes_6ae54bf7e5ec4a61b87e0a0ee61ff662);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetRemoteFileWithMetadata", ArgumentTypes_fb6662beb1684c0988d7e8f4cbc1c2a2);
             return (Task<ApiResponse<Stream>>)func(Client, arguments);
         }
     }
@@ -2928,13 +2928,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_7a3f93a2e3674b30b73d9c2a05f4ad9f = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_fdf80ec7baef4ad48e71a602f992d108 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task ITrimTrailingForwardSlashApi.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_7a3f93a2e3674b30b73d9c2a05f4ad9f);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_fdf80ec7baef4ad48e71a602f992d108);
             return (Task)func(Client, arguments);
         }
     }
@@ -2964,13 +2964,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_435ba311aa2f403faecf2bd64c22bc50 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_f913063644914261aea5b3876590334b = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<SomeType> ITypeCollisionApiA.SomeARequest()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("SomeARequest", ArgumentTypes_435ba311aa2f403faecf2bd64c22bc50);
+            var func = requestBuilder.BuildRestResultFuncForMethod("SomeARequest", ArgumentTypes_f913063644914261aea5b3876590334b);
             return (Task<SomeType>)func(Client, arguments);
         }
     }
@@ -3000,13 +3000,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_c05a98bdd827409aab48a634ea5c15f9 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_48d9680fb6374837bcd9695dc82621bd = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<SomeType> ITypeCollisionApiB.SomeBRequest()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("SomeBRequest", ArgumentTypes_c05a98bdd827409aab48a634ea5c15f9);
+            var func = requestBuilder.BuildRestResultFuncForMethod("SomeBRequest", ArgumentTypes_48d9680fb6374837bcd9695dc82621bd);
             return (Task<SomeType>)func(Client, arguments);
         }
     }
@@ -3045,47 +3045,47 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_22c7e3b6a764407498875eb0254488ca = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_8b4de2910e6840f0b27b5c661cb4503d = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> IUseOverloadedGenericMethods<TResponse, TParam, THeader>.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_22c7e3b6a764407498875eb0254488ca);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_8b4de2910e6840f0b27b5c661cb4503d);
             return (Task<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_5ca05f21c5464503869c9766eb5919f9 = new Type[] { typeof(TParam), typeof(THeader) };
+        private static readonly Type[] ArgumentTypes_164053e3383e4c31811822c3fb5a9009 = new Type[] { typeof(TParam), typeof(THeader) };
 
         /// <inheritdoc />
         Task<TResponse> IUseOverloadedGenericMethods<TResponse, TParam, THeader>.Get(TParam param, THeader header)
         {
             var arguments = new object[] { param, header };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_5ca05f21c5464503869c9766eb5919f9);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_164053e3383e4c31811822c3fb5a9009);
             return (Task<TResponse>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_c59678da0be04ebfbb12e4092ccfd3da = new Type[] { typeof(THeader), typeof(TParam) };
+        private static readonly Type[] ArgumentTypes_0e090ff90421432ba01be9312230a1b2 = new Type[] { typeof(THeader), typeof(TParam) };
 
         /// <inheritdoc />
         Task<TResponse> IUseOverloadedGenericMethods<TResponse, TParam, THeader>.Get(THeader param, TParam header)
         {
             var arguments = new object[] { param, header };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_c59678da0be04ebfbb12e4092ccfd3da);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_0e090ff90421432ba01be9312230a1b2);
             return (Task<TResponse>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_e0b091b222ae48dfb45015b6f2bd2b3a = new Type[] { typeof(int) };
+        private static readonly Type[] ArgumentTypes_4e4c7ae5f1ba472db90ecdfabeacce93 = new Type[] { typeof(int) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IUseOverloadedGenericMethods<TResponse, TParam, THeader>.Get(int httpstatuscode)
         {
             var arguments = new object[] { httpstatuscode };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_e0b091b222ae48dfb45015b6f2bd2b3a);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_4e4c7ae5f1ba472db90ecdfabeacce93);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static class TypeHelper_c924631c1ae54481b40a9f6bb5204c66<TValue>
+        private static class TypeHelper_8636de4f5c4641ff9853ba48a3f8a084<TValue>
         {
             public static readonly Type[] ArgumentTypes = new Type[] { typeof(int) };
             public static readonly Type[] TypeParameters = new Type[] { typeof(TValue) };
@@ -3095,11 +3095,11 @@ namespace Refit.Tests
         Task<TValue> IUseOverloadedGenericMethods<TResponse, TParam, THeader>.Get<TValue>(int someVal)
         {
             var arguments = new object[] { someVal };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", TypeHelper_c924631c1ae54481b40a9f6bb5204c66<TValue>.ArgumentTypes, TypeHelper_c924631c1ae54481b40a9f6bb5204c66<TValue>.TypeParameters);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", TypeHelper_8636de4f5c4641ff9853ba48a3f8a084<TValue>.ArgumentTypes, TypeHelper_8636de4f5c4641ff9853ba48a3f8a084<TValue>.TypeParameters);
             return (Task<TValue>)func(Client, arguments);
         }
 
-        private static class TypeHelper_476335ac19a94bb0997e7a24c1644168<TValue, TInput>
+        private static class TypeHelper_08b60cab0edb46f6a8fee5688112f696<TValue, TInput>
         {
             public static readonly Type[] ArgumentTypes = new Type[] { typeof(TInput) };
             public static readonly Type[] TypeParameters = new Type[] { typeof(TValue), typeof(TInput) };
@@ -3109,11 +3109,11 @@ namespace Refit.Tests
         Task<TValue> IUseOverloadedGenericMethods<TResponse, TParam, THeader>.Get<TValue, TInput>(TInput input)
         {
             var arguments = new object[] { input };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", TypeHelper_476335ac19a94bb0997e7a24c1644168<TValue, TInput>.ArgumentTypes, TypeHelper_476335ac19a94bb0997e7a24c1644168<TValue, TInput>.TypeParameters);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", TypeHelper_08b60cab0edb46f6a8fee5688112f696<TValue, TInput>.ArgumentTypes, TypeHelper_08b60cab0edb46f6a8fee5688112f696<TValue, TInput>.TypeParameters);
             return (Task<TValue>)func(Client, arguments);
         }
 
-        private static class TypeHelper_e03b91f334714b879db4aab11e07612d<TInput1, TInput2>
+        private static class TypeHelper_ed662afbcd3c4414a11386129c395550<TInput1, TInput2>
         {
             public static readonly Type[] ArgumentTypes = new Type[] { typeof(TInput1), typeof(TInput2) };
             public static readonly Type[] TypeParameters = new Type[] { typeof(TInput1), typeof(TInput2) };
@@ -3123,7 +3123,7 @@ namespace Refit.Tests
         Task IUseOverloadedGenericMethods<TResponse, TParam, THeader>.Get<TInput1, TInput2>(TInput1 input1, TInput2 input2)
         {
             var arguments = new object[] { input1, input2 };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", TypeHelper_e03b91f334714b879db4aab11e07612d<TInput1, TInput2>.ArgumentTypes, TypeHelper_e03b91f334714b879db4aab11e07612d<TInput1, TInput2>.TypeParameters);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", TypeHelper_ed662afbcd3c4414a11386129c395550<TInput1, TInput2>.ArgumentTypes, TypeHelper_ed662afbcd3c4414a11386129c395550<TInput1, TInput2>.TypeParameters);
             return (Task)func(Client, arguments);
         }
     }
@@ -3158,23 +3158,23 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_60dc6b71a25144929593d89ba5ff2264 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_b3f8f6f1c0d2406aad991851b892ee24 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> IUseOverloadedMethods.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_60dc6b71a25144929593d89ba5ff2264);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_b3f8f6f1c0d2406aad991851b892ee24);
             return (Task<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_07028f211ed74e48b1c062f574b4aa79 = new Type[] { typeof(int) };
+        private static readonly Type[] ArgumentTypes_7f8aa790114f4991bc86c91ef0d08b29 = new Type[] { typeof(int) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IUseOverloadedMethods.Get(int httpstatuscode)
         {
             var arguments = new object[] { httpstatuscode };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_07028f211ed74e48b1c062f574b4aa79);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_7f8aa790114f4991bc86c91ef0d08b29);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
     }
@@ -3215,13 +3215,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_10c8310e2d33499aab173cbb1f92fa45 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_14bd736bd00245599e9e60aeb836dd7a = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IValidApi.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_10c8310e2d33499aab173cbb1f92fa45);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_14bd736bd00245599e9e60aeb836dd7a);
             return (Task)func(Client, arguments);
         }
     }
@@ -3251,13 +3251,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_8a31d25c22b34166bc3105f3abaf6b58 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_cae0559fb0804ce294c7753e847a5387 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<SomeType> NamespaceWithGlobalAliasApi.SomeRequest()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", ArgumentTypes_8a31d25c22b34166bc3105f3abaf6b58);
+            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", ArgumentTypes_cae0559fb0804ce294c7753e847a5387);
             return (Task<SomeType>)func(Client, arguments);
         }
     }

--- a/Refit.Tests/RefitStubs.NetCore3.cs
+++ b/Refit.Tests/RefitStubs.NetCore3.cs
@@ -62,21 +62,27 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_d8b00b09dc5a450aa177a2e9b88c3590 = new Type[] {  };
+
         /// <inheritdoc />
         Task IAmARefitInterfaceButNobodyUsesMe.RefitMethod()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("RefitMethod", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("RefitMethod", ArgumentTypes_d8b00b09dc5a450aa177a2e9b88c3590);
             return (Task)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_451653fe1a5e4ee7ac2059d56a98659f = new Type[] {  };
 
         /// <inheritdoc />
         Task IAmARefitInterfaceButNobodyUsesMe.AnotherRefitMethod()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("AnotherRefitMethod", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("AnotherRefitMethod", ArgumentTypes_451653fe1a5e4ee7ac2059d56a98659f);
             return (Task)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_9451ed9f22494e12826453be4da77fc4 = new Type[] {  };
 
         /// <inheritdoc />
         Task IAmARefitInterfaceButNobodyUsesMe.NoConstantsAllowed()
@@ -84,19 +90,23 @@ namespace Refit.Tests
             throw new NotImplementedException("Either this method has no Refit HTTP method attribute or you've used something other than a string literal for the 'path' argument.");
         }
 
+        private static readonly Type[] ArgumentTypes_0f5a40be66e647959399b4e2374a297c = new Type[] {  };
+
         /// <inheritdoc />
         Task IAmARefitInterfaceButNobodyUsesMe.SpacesShouldntBreakMe()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("SpacesShouldntBreakMe", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("SpacesShouldntBreakMe", ArgumentTypes_0f5a40be66e647959399b4e2374a297c);
             return (Task)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_5c48b9c2eadf4d228f88276514b866fc = new Type[] { typeof(int), typeof(string), typeof(float) };
 
         /// <inheritdoc />
         Task IAmARefitInterfaceButNobodyUsesMe.ReservedWordsForParameterNames(int @int, string @string, float @long)
         {
             var arguments = new object[] { @int, @string, @long };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReservedWordsForParameterNames", new Type[] { typeof(int), typeof(string), typeof(float) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReservedWordsForParameterNames", ArgumentTypes_5c48b9c2eadf4d228f88276514b866fc);
             return (Task)func(Client, arguments);
         }
     }
@@ -137,13 +147,17 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_c42d84726e964804b0c8e40d9f4d1201 = new Type[] {  };
+
         /// <inheritdoc />
         Task IAmHalfRefit.Post()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Post", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Post", ArgumentTypes_c42d84726e964804b0c8e40d9f4d1201);
             return (Task)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_09bc692dc6874c3194b776ed28f746a4 = new Type[] {  };
 
         /// <inheritdoc />
         Task IAmHalfRefit.Get()
@@ -177,35 +191,43 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_5805b02a0f2d41219fd413bf60e59de2 = new Type[] {  };
+
         /// <inheritdoc />
         Task<string> IAmInterface.Pang()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Pang", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Pang", ArgumentTypes_5805b02a0f2d41219fd413bf60e59de2);
             return (Task<string>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_ca108c87fa554b1dbe8a414685fc5142 = new Type[] {  };
 
         /// <inheritdoc />
         Task<string> IAmInterfaceB.Pong()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Pong", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Pong", ArgumentTypes_ca108c87fa554b1dbe8a414685fc5142);
             return (Task<string>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_208bf354c73c4c14a3c21f850472fac5 = new Type[] {  };
 
         /// <inheritdoc />
         Task<string> IAmInterfaceD.Test()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Test", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Test", ArgumentTypes_208bf354c73c4c14a3c21f850472fac5);
             return (Task<string>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_8a392d4648974e518879930ee59470eb = new Type[] {  };
 
         /// <inheritdoc />
         Task<string> IAmInterfaceA.Ping()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Ping", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Ping", ArgumentTypes_8a392d4648974e518879930ee59470eb);
             return (Task<string>)func(Client, arguments);
         }
     }
@@ -235,11 +257,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_8ecb390d820f4abb9f3a61ed6add6151 = new Type[] {  };
+
         /// <inheritdoc />
         Task<string> IAmInterfaceA.Ping()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Ping", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Ping", ArgumentTypes_8ecb390d820f4abb9f3a61ed6add6151);
             return (Task<string>)func(Client, arguments);
         }
     }
@@ -269,19 +293,23 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_667acd2061ff4f909ff2418ea88f13d5 = new Type[] {  };
+
         /// <inheritdoc />
         Task<string> IAmInterfaceB.Pong()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Pong", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Pong", ArgumentTypes_667acd2061ff4f909ff2418ea88f13d5);
             return (Task<string>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_4c20765db1ba4467ba5b41d74d493feb = new Type[] {  };
 
         /// <inheritdoc />
         Task<string> IAmInterfaceD.Test()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Test", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Test", ArgumentTypes_4c20765db1ba4467ba5b41d74d493feb);
             return (Task<string>)func(Client, arguments);
         }
     }
@@ -311,35 +339,43 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_4278e21343e04de2bbedc95614b150a7 = new Type[] {  };
+
         /// <inheritdoc />
         Task<string> IAmInterfaceC.Pang()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Pang", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Pang", ArgumentTypes_4278e21343e04de2bbedc95614b150a7);
             return (Task<string>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_5120e2f1d5704d4f857ff9f4b280160d = new Type[] {  };
 
         /// <inheritdoc />
         Task<string> IAmInterfaceB.Pong()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Pong", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Pong", ArgumentTypes_5120e2f1d5704d4f857ff9f4b280160d);
             return (Task<string>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_59ab2b560d9e445a94efd9a7330aa9ad = new Type[] {  };
 
         /// <inheritdoc />
         Task<string> IAmInterfaceD.Test()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Test", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Test", ArgumentTypes_59ab2b560d9e445a94efd9a7330aa9ad);
             return (Task<string>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_bd02964331cb40b38d2cd0747dbd0270 = new Type[] {  };
 
         /// <inheritdoc />
         Task<string> IAmInterfaceA.Ping()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Ping", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Ping", ArgumentTypes_bd02964331cb40b38d2cd0747dbd0270);
             return (Task<string>)func(Client, arguments);
         }
     }
@@ -369,11 +405,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_3bb760dfabb04f5d9e557f74b4e14ba6 = new Type[] {  };
+
         /// <inheritdoc />
         Task<string> IAmInterfaceD.Test()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Test", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Test", ArgumentTypes_3bb760dfabb04f5d9e557f74b4e14ba6);
             return (Task<string>)func(Client, arguments);
         }
     }
@@ -414,123 +452,153 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_104792e5546347e49e178d3df4600f4f = new Type[] { typeof(PathBoundObject) };
+
         /// <inheritdoc />
         Task IApiBindPathToObject.GetFooBars(PathBoundObject request)
         {
             var arguments = new object[] { request };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBars", new Type[] { typeof(PathBoundObject) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBars", ArgumentTypes_104792e5546347e49e178d3df4600f4f);
             return (Task)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_4a97b899de2c4fa68b244eb5ff0b293b = new Type[] { typeof(PathBoundObject) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetFooBarsWithDifferentCasing(PathBoundObject requestParams)
         {
             var arguments = new object[] { requestParams };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBarsWithDifferentCasing", new Type[] { typeof(PathBoundObject) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBarsWithDifferentCasing", ArgumentTypes_4a97b899de2c4fa68b244eb5ff0b293b);
             return (Task)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_e0ba7f87b237430187371646109336b9 = new Type[] { typeof(string), typeof(PathBoundObject) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetBarsByFoo(string id, PathBoundObject request)
         {
             var arguments = new object[] { id, request };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetBarsByFoo", new Type[] { typeof(string), typeof(PathBoundObject) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetBarsByFoo", ArgumentTypes_e0ba7f87b237430187371646109336b9);
             return (Task)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_18675fb6c1f94a68be274f15250f3c4c = new Type[] { typeof(PathBoundObject), typeof(string) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetFooBars(PathBoundObject request, string someProperty)
         {
             var arguments = new object[] { request, someProperty };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBars", new Type[] { typeof(PathBoundObject), typeof(string) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBars", ArgumentTypes_18675fb6c1f94a68be274f15250f3c4c);
             return (Task)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_31c69a44d5a441d1b29442c157574f33 = new Type[] { typeof(PathBoundObject) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetBarsByFoo(PathBoundObject request)
         {
             var arguments = new object[] { request };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetBarsByFoo", new Type[] { typeof(PathBoundObject) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetBarsByFoo", ArgumentTypes_31c69a44d5a441d1b29442c157574f33);
             return (Task)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_360fcad1da834aaca59aade579cdd670 = new Type[] { typeof(PathBoundObjectWithQueryFormat) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetBarsWithCustomQueryFormat(PathBoundObjectWithQueryFormat request)
         {
             var arguments = new object[] { request };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetBarsWithCustomQueryFormat", new Type[] { typeof(PathBoundObjectWithQueryFormat) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetBarsWithCustomQueryFormat", ArgumentTypes_360fcad1da834aaca59aade579cdd670);
             return (Task)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_0dc958dc7d78451b87fc71a2cca0168c = new Type[] { typeof(PathBoundDerivedObject) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetFooBarsDerived(PathBoundDerivedObject request)
         {
             var arguments = new object[] { request };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBarsDerived", new Type[] { typeof(PathBoundDerivedObject) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBarsDerived", ArgumentTypes_0dc958dc7d78451b87fc71a2cca0168c);
             return (Task)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_8f99038fefbd400c8578e254fea89b94 = new Type[] { typeof(PathBoundList) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetFoos(PathBoundList request)
         {
             var arguments = new object[] { request };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetFoos", new Type[] { typeof(PathBoundList) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetFoos", ArgumentTypes_8f99038fefbd400c8578e254fea89b94);
             return (Task)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_5051934f2c94418499500d29fe13aa9d = new Type[] { typeof(List<int>) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetFoos2(List<int> Values)
         {
             var arguments = new object[] { Values };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetFoos2", new Type[] { typeof(List<int>) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetFoos2", ArgumentTypes_5051934f2c94418499500d29fe13aa9d);
             return (Task)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_f71c19f10a80483bb4c155c29336fd52 = new Type[] { typeof(PathBoundObject), typeof(object) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.PostFooBar(PathBoundObject request, object someObject)
         {
             var arguments = new object[] { request, someObject };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBar", new Type[] { typeof(PathBoundObject), typeof(object) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBar", ArgumentTypes_f71c19f10a80483bb4c155c29336fd52);
             return (Task)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_cae235beda7344b88dbba9b6c268ccb0 = new Type[] { typeof(PathBoundObjectWithQuery) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetFooBars(PathBoundObjectWithQuery request)
         {
             var arguments = new object[] { request };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBars", new Type[] { typeof(PathBoundObjectWithQuery) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBars", ArgumentTypes_cae235beda7344b88dbba9b6c268ccb0);
             return (Task)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_2c8f0e70ba974a769d263d7707ac9291 = new Type[] { typeof(PathBoundObject), typeof(ModelObject) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IApiBindPathToObject.PostFooBar(PathBoundObject request, ModelObject someQueryParams)
         {
             var arguments = new object[] { request, someQueryParams };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBar", new Type[] { typeof(PathBoundObject), typeof(ModelObject) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBar", ArgumentTypes_2c8f0e70ba974a769d263d7707ac9291);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_be8f20f50c9746f0a1aed3fc1cdcd539 = new Type[] { typeof(PathBoundObject), typeof(ModelObject), typeof(StreamPart) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IApiBindPathToObject.PostFooBarStreamPart(PathBoundObject request, ModelObject someQueryParams, StreamPart stream)
         {
             var arguments = new object[] { request, someQueryParams, stream };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBarStreamPart", new Type[] { typeof(PathBoundObject), typeof(ModelObject), typeof(StreamPart) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBarStreamPart", ArgumentTypes_be8f20f50c9746f0a1aed3fc1cdcd539);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_b1f31e20085f4a9ba18165a0c51da724 = new Type[] { typeof(PathBoundObject), typeof(StreamPart) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IApiBindPathToObject.PostFooBarStreamPart(PathBoundObject request, StreamPart stream)
         {
             var arguments = new object[] { request, stream };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBarStreamPart", new Type[] { typeof(PathBoundObject), typeof(StreamPart) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBarStreamPart", ArgumentTypes_b1f31e20085f4a9ba18165a0c51da724);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_be90f8db210a41ff8950a8af70ebc309 = new Type[] { typeof(PathBoundObjectWithQuery), typeof(StreamPart) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IApiBindPathToObject.PostFooBarStreamPart(PathBoundObjectWithQuery request, StreamPart stream)
         {
             var arguments = new object[] { request, stream };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBarStreamPart", new Type[] { typeof(PathBoundObjectWithQuery), typeof(StreamPart) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBarStreamPart", ArgumentTypes_be90f8db210a41ff8950a8af70ebc309);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
     }
@@ -571,11 +639,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_29a282ea925c40efa50459cb25838965 = new Type[] { typeof(decimal) };
+
         /// <inheritdoc />
         Task<string> IApiWithDecimal.GetWithDecimal(decimal value)
         {
             var arguments = new object[] { value };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetWithDecimal", new Type[] { typeof(decimal) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetWithDecimal", ArgumentTypes_29a282ea925c40efa50459cb25838965);
             return (Task<string>)func(Client, arguments);
         }
     }
@@ -616,27 +686,33 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_886520919c5c4e969bb1708b4df1cff4 = new Type[] {  };
+
         /// <inheritdoc />
         Task IBodylessApi.Post()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Post", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Post", ArgumentTypes_886520919c5c4e969bb1708b4df1cff4);
             return (Task)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_65e800484bfc492baaa84b2c08cc38af = new Type[] {  };
 
         /// <inheritdoc />
         Task IBodylessApi.Get()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_65e800484bfc492baaa84b2c08cc38af);
             return (Task)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_09f0b1e963904459a5275c26beeba8ef = new Type[] {  };
 
         /// <inheritdoc />
         Task IBodylessApi.Head()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Head", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Head", ArgumentTypes_09f0b1e963904459a5275c26beeba8ef);
             return (Task)func(Client, arguments);
         }
     }
@@ -677,43 +753,53 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_9e271e7c3fd44c4fb92de93278b950e9 = new Type[] { typeof(T) };
+
         /// <inheritdoc />
         Task<T> IBoringCrudApi<T, TKey>.Create(T paylod)
         {
             var arguments = new object[] { paylod };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Create", new Type[] { typeof(T) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_9e271e7c3fd44c4fb92de93278b950e9);
             return (Task<T>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_0900ec85e4134d99911b066038363cf5 = new Type[] {  };
 
         /// <inheritdoc />
         Task<List<T>> IBoringCrudApi<T, TKey>.ReadAll()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_0900ec85e4134d99911b066038363cf5);
             return (Task<List<T>>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_3b52ca4e61da4d67bafbd434899c601d = new Type[] { typeof(TKey) };
 
         /// <inheritdoc />
         Task<T> IBoringCrudApi<T, TKey>.ReadOne(TKey key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", new Type[] { typeof(TKey) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_3b52ca4e61da4d67bafbd434899c601d);
             return (Task<T>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_0b56fe062fa64b34acd524e67bbfbec3 = new Type[] { typeof(TKey), typeof(T) };
 
         /// <inheritdoc />
         Task IBoringCrudApi<T, TKey>.Update(TKey key, T payload)
         {
             var arguments = new object[] { key, payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Update", new Type[] { typeof(TKey), typeof(T) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_0b56fe062fa64b34acd524e67bbfbec3);
             return (Task)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_77da64faa19f41ed938144dabe5a4eff = new Type[] { typeof(TKey) };
 
         /// <inheritdoc />
         Task IBoringCrudApi<T, TKey>.Delete(TKey key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", new Type[] { typeof(TKey) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_77da64faa19f41ed938144dabe5a4eff);
             return (Task)func(Client, arguments);
         }
     }
@@ -754,11 +840,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_f258361eb0264d4680de7991c24d3d53 = new Type[] { typeof(string) };
+
         /// <inheritdoc />
         Task<bool> IBrokenWebApi.PostAValue(string derp)
         {
             var arguments = new object[] { derp };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostAValue", new Type[] { typeof(string) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostAValue", ArgumentTypes_f258361eb0264d4680de7991c24d3d53);
             return (Task<bool>)func(Client, arguments);
         }
     }
@@ -787,11 +875,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_6ffab681926e4b0f9625aa8bd6c9758f = new Type[] {  };
+
         /// <inheritdoc />
         CustomReferenceType? ICustomNullableReferenceService.Get()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_6ffab681926e4b0f9625aa8bd6c9758f);
             return (CustomReferenceType?)func(Client, arguments);
         }
     }
@@ -820,11 +910,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_0f9be87fb4b44adfbe2452411e6bde50 = new Type[] {  };
+
         /// <inheritdoc />
         CustomValueType? ICustomNullableValueService.Get()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_0f9be87fb4b44adfbe2452411e6bde50);
             return (CustomValueType?)func(Client, arguments);
         }
     }
@@ -853,11 +945,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_0fa164f7b3a54a02b68c930f3f83d9a4 = new Type[] { ToNullable(typeof(CustomReferenceType)), ToNullable(typeof(CustomValueType)) };
+
         /// <inheritdoc />
         Task ICustomReferenceAndValueParametersService.Get(CustomReferenceType? reference, CustomValueType? value)
         {
             var arguments = new object[] { reference, value };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", new Type[] { ToNullable(typeof(CustomReferenceType)), ToNullable(typeof(CustomValueType)) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_0fa164f7b3a54a02b68c930f3f83d9a4);
             return (Task)func(Client, arguments);
         }
 
@@ -890,59 +984,73 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_868e1166306140958fb0ecb18f19e79e = new Type[] {  };
+
         /// <inheritdoc />
         Task IDataApiA.PingA()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PingA", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("PingA", ArgumentTypes_868e1166306140958fb0ecb18f19e79e);
             return (Task)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_a4d42f8f98b24588a0eb08e99f32b027 = new Type[] { typeof(DataEntity) };
 
         /// <inheritdoc />
         Task<DataEntity> IDataCrudApi<DataEntity>.Copy(DataEntity payload)
         {
             var arguments = new object[] { payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Copy", new Type[] { typeof(DataEntity) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Copy", ArgumentTypes_a4d42f8f98b24588a0eb08e99f32b027);
             return (Task<DataEntity>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_24a49af5c9a54bfb905f5a4a5b0e9f13 = new Type[] { typeof(DataEntity) };
 
         /// <inheritdoc />
         Task<DataEntity> IDataCrudApi<DataEntity, long>.Create(DataEntity payload)
         {
             var arguments = new object[] { payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Create", new Type[] { typeof(DataEntity) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_24a49af5c9a54bfb905f5a4a5b0e9f13);
             return (Task<DataEntity>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_01b1c35ec591494dae4da0652ebe44c8 = new Type[] {  };
 
         /// <inheritdoc />
         Task<List<DataEntity>> IDataCrudApi<DataEntity, long>.ReadAll()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_01b1c35ec591494dae4da0652ebe44c8);
             return (Task<List<DataEntity>>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_f275d572610f44149cae905904779ae0 = new Type[] { typeof(long) };
 
         /// <inheritdoc />
         Task<DataEntity> IDataCrudApi<DataEntity, long>.ReadOne(long key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", new Type[] { typeof(long) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_f275d572610f44149cae905904779ae0);
             return (Task<DataEntity>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_c544f41e94d3447bb84debc36934d776 = new Type[] { typeof(long), typeof(DataEntity) };
 
         /// <inheritdoc />
         Task IDataCrudApi<DataEntity, long>.Update(long key, DataEntity payload)
         {
             var arguments = new object[] { key, payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Update", new Type[] { typeof(long), typeof(DataEntity) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_c544f41e94d3447bb84debc36934d776);
             return (Task)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_30f78e448d9e4ba28d07d577b0f920d6 = new Type[] { typeof(long) };
 
         /// <inheritdoc />
         Task IDataCrudApi<DataEntity, long>.Delete(long key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", new Type[] { typeof(long) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_30f78e448d9e4ba28d07d577b0f920d6);
             return (Task)func(Client, arguments);
         }
     }
@@ -973,51 +1081,63 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_9ae0c3f9c1da4249976c9bdb378ce259 = new Type[] {  };
+
         /// <inheritdoc />
         Task IDataApiB.PingB()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PingB", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("PingB", ArgumentTypes_9ae0c3f9c1da4249976c9bdb378ce259);
             return (Task)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_037d41f754064fdd9d129c46ea312dae = new Type[] { typeof(DataEntity) };
 
         /// <inheritdoc />
         Task<DataEntity> IDataCrudApi<DataEntity, int>.Create(DataEntity payload)
         {
             var arguments = new object[] { payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Create", new Type[] { typeof(DataEntity) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_037d41f754064fdd9d129c46ea312dae);
             return (Task<DataEntity>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_63cb9ae95fe4406197a54050db1484dc = new Type[] {  };
 
         /// <inheritdoc />
         Task<List<DataEntity>> IDataCrudApi<DataEntity, int>.ReadAll()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_63cb9ae95fe4406197a54050db1484dc);
             return (Task<List<DataEntity>>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_5eaf1e12ce82458ea2845017749c47b8 = new Type[] { typeof(int) };
 
         /// <inheritdoc />
         Task<DataEntity> IDataCrudApi<DataEntity, int>.ReadOne(int key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", new Type[] { typeof(int) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_5eaf1e12ce82458ea2845017749c47b8);
             return (Task<DataEntity>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_211495ce085142499fefc3214b30348f = new Type[] { typeof(int), typeof(DataEntity) };
 
         /// <inheritdoc />
         Task IDataCrudApi<DataEntity, int>.Update(int key, DataEntity payload)
         {
             var arguments = new object[] { key, payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Update", new Type[] { typeof(int), typeof(DataEntity) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_211495ce085142499fefc3214b30348f);
             return (Task)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_3f8443bab12f45ddb28183f61a597629 = new Type[] { typeof(int) };
 
         /// <inheritdoc />
         Task IDataCrudApi<DataEntity, int>.Delete(int key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", new Type[] { typeof(int) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_3f8443bab12f45ddb28183f61a597629);
             return (Task)func(Client, arguments);
         }
     }
@@ -1051,51 +1171,63 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_b37a0569057b4a0e9f6ba827f16e873c = new Type[] { typeof(T) };
+
         /// <inheritdoc />
         Task<T> IDataCrudApi<T>.Copy(T payload)
         {
             var arguments = new object[] { payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Copy", new Type[] { typeof(T) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Copy", ArgumentTypes_b37a0569057b4a0e9f6ba827f16e873c);
             return (Task<T>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_c3eaa0375dd04fee9a06718b1b2af33f = new Type[] { typeof(T) };
 
         /// <inheritdoc />
         Task<T> IDataCrudApi<T, long>.Create(T payload)
         {
             var arguments = new object[] { payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Create", new Type[] { typeof(T) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_c3eaa0375dd04fee9a06718b1b2af33f);
             return (Task<T>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_ecfd7936f22c449a89269a4fc279ae11 = new Type[] {  };
 
         /// <inheritdoc />
         Task<List<T>> IDataCrudApi<T, long>.ReadAll()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_ecfd7936f22c449a89269a4fc279ae11);
             return (Task<List<T>>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_23a068b188724597bcb9d6f20094d4e7 = new Type[] { typeof(long) };
 
         /// <inheritdoc />
         Task<T> IDataCrudApi<T, long>.ReadOne(long key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", new Type[] { typeof(long) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_23a068b188724597bcb9d6f20094d4e7);
             return (Task<T>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_f7d97b6f22bc4179a3216b732e5df7d7 = new Type[] { typeof(long), typeof(T) };
 
         /// <inheritdoc />
         Task IDataCrudApi<T, long>.Update(long key, T payload)
         {
             var arguments = new object[] { key, payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Update", new Type[] { typeof(long), typeof(T) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_f7d97b6f22bc4179a3216b732e5df7d7);
             return (Task)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_db1b4b23ae0645c79f3b5f7f33f391f7 = new Type[] { typeof(long) };
 
         /// <inheritdoc />
         Task IDataCrudApi<T, long>.Delete(long key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", new Type[] { typeof(long) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_db1b4b23ae0645c79f3b5f7f33f391f7);
             return (Task)func(Client, arguments);
         }
     }
@@ -1129,43 +1261,53 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_893b5ca82b29434aafbcf18bbc050349 = new Type[] { typeof(T) };
+
         /// <inheritdoc />
         Task<T> IDataCrudApi<T, TKey>.Create(T payload)
         {
             var arguments = new object[] { payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Create", new Type[] { typeof(T) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_893b5ca82b29434aafbcf18bbc050349);
             return (Task<T>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_c8772979ada84c758e3d86a2d60f0e27 = new Type[] {  };
 
         /// <inheritdoc />
         Task<List<T>> IDataCrudApi<T, TKey>.ReadAll()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_c8772979ada84c758e3d86a2d60f0e27);
             return (Task<List<T>>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_2842e482a92449efa4e1596bb9a59492 = new Type[] { typeof(TKey) };
 
         /// <inheritdoc />
         Task<T> IDataCrudApi<T, TKey>.ReadOne(TKey key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", new Type[] { typeof(TKey) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_2842e482a92449efa4e1596bb9a59492);
             return (Task<T>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_96b4612a037647ca82f6c863342781e1 = new Type[] { typeof(TKey), typeof(T) };
 
         /// <inheritdoc />
         Task IDataCrudApi<T, TKey>.Update(TKey key, T payload)
         {
             var arguments = new object[] { key, payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Update", new Type[] { typeof(TKey), typeof(T) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_96b4612a037647ca82f6c863342781e1);
             return (Task)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_3b6c0599a02a4ad1bb3f7b48378bc4c3 = new Type[] { typeof(TKey) };
 
         /// <inheritdoc />
         Task IDataCrudApi<T, TKey>.Delete(TKey key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", new Type[] { typeof(TKey) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_3b6c0599a02a4ad1bb3f7b48378bc4c3);
             return (Task)func(Client, arguments);
         }
     }
@@ -1194,11 +1336,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_dc64a9fd393f4bacb03d7e2df0d5b23d = new Type[] { ToNullable(typeof(System.Collections.Generic.List<string>)) };
+
         /// <inheritdoc />
         Task IGenericNullableReferenceParameterService.Get(System.Collections.Generic.List<string>? reference)
         {
             var arguments = new object[] { reference };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", new Type[] { ToNullable(typeof(System.Collections.Generic.List<string>)) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_dc64a9fd393f4bacb03d7e2df0d5b23d);
             return (Task)func(Client, arguments);
         }
 
@@ -1229,11 +1373,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_44b76ef17d95485e95dfb68514cb0620 = new Type[] {  };
+
         /// <inheritdoc />
         Task<string>? IGenericNullableReferenceService.Get()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_44b76ef17d95485e95dfb68514cb0620);
             return (Task<string>?)func(Client, arguments);
         }
     }
@@ -1262,11 +1408,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_23a802f3848644d2a4266fd9e1e1d4dd = new Type[] {  };
+
         /// <inheritdoc />
         ValueTask<int>? IGenericNullableValueService.Get()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_23a802f3848644d2a4266fd9e1e1d4dd);
             return (ValueTask<int>?)func(Client, arguments);
         }
     }
@@ -1295,11 +1443,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_c655f7dee36e4366a33311e960305c46 = new Type[] { ToNullable(typeof(System.Collections.Generic.List<string?>)) };
+
         /// <inheritdoc />
         Task IGenericNullableWithNullableReferenceParameterService.Get(System.Collections.Generic.List<string?>? reference)
         {
             var arguments = new object[] { reference };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", new Type[] { ToNullable(typeof(System.Collections.Generic.List<string?>)) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_c655f7dee36e4366a33311e960305c46);
             return (Task)func(Client, arguments);
         }
 
@@ -1330,11 +1480,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_fa4d60a9893046c6b86a258e3082581d = new Type[] {  };
+
         /// <inheritdoc />
         Task<string?>? IGenericNullableWithNullableReferenceService.Get()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_fa4d60a9893046c6b86a258e3082581d);
             return (Task<string?>?)func(Client, arguments);
         }
     }
@@ -1363,11 +1515,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_3ce7a8054dc045e7bfd385e7ac13a4ef = new Type[] {  };
+
         /// <inheritdoc />
         ValueTask<int?>? IGenericNullableWithNullableValueService.Get()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_3ce7a8054dc045e7bfd385e7ac13a4ef);
             return (ValueTask<int?>?)func(Client, arguments);
         }
     }
@@ -1396,11 +1550,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_4354221e532a49698acdd6949d4fbe3d = new Type[] { typeof(System.Collections.Generic.List<string?>) };
+
         /// <inheritdoc />
         Task IGenericWithNullableReferenceParameterService.Get(System.Collections.Generic.List<string?> reference)
         {
             var arguments = new object[] { reference };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", new Type[] { typeof(System.Collections.Generic.List<string?>) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_4354221e532a49698acdd6949d4fbe3d);
             return (Task)func(Client, arguments);
         }
     }
@@ -1429,11 +1585,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_ed9b54c322184fdc8d151b75c4750385 = new Type[] {  };
+
         /// <inheritdoc />
         Task<int?> IGenericWithNullableValueService.Get()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_ed9b54c322184fdc8d151b75c4750385);
             return (Task<int?>)func(Client, arguments);
         }
     }
@@ -1462,11 +1620,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_d1d0654d1659460cb178e9cf952d1c33 = new Type[] {  };
+
         /// <inheritdoc />
         Task<string?> IGenericWithResultService.Get()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_d1d0654d1659460cb178e9cf952d1c33);
             return (Task<string?>)func(Client, arguments);
         }
     }
@@ -1501,107 +1661,133 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_68a0ef18470a4b138cc57fa5a69943fa = new Type[] { typeof(string) };
+
         /// <inheritdoc />
         Task<User> IGitHubApi.GetUser(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUser", new Type[] { typeof(string) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUser", ArgumentTypes_68a0ef18470a4b138cc57fa5a69943fa);
             return (Task<User>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_bbbe7c39d27049b3b8a21e2a2fa12b65 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         IObservable<User> IGitHubApi.GetUserObservable(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserObservable", new Type[] { typeof(string) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserObservable", ArgumentTypes_bbbe7c39d27049b3b8a21e2a2fa12b65);
             return (IObservable<User>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_338c76d5ffcb4f048cfe4c07a156ca04 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         IObservable<User> IGitHubApi.GetUserCamelCase(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserCamelCase", new Type[] { typeof(string) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserCamelCase", ArgumentTypes_338c76d5ffcb4f048cfe4c07a156ca04);
             return (IObservable<User>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_80d7e575ff5a4823b23efbc303ee746e = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<List<User>> IGitHubApi.GetOrgMembers(string orgName)
         {
             var arguments = new object[] { orgName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetOrgMembers", new Type[] { typeof(string) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetOrgMembers", ArgumentTypes_80d7e575ff5a4823b23efbc303ee746e);
             return (Task<List<User>>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_0cf4bb0e47554c609c69836bac69820f = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<UserSearchResult> IGitHubApi.FindUsers(string q)
         {
             var arguments = new object[] { q };
-            var func = requestBuilder.BuildRestResultFuncForMethod("FindUsers", new Type[] { typeof(string) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("FindUsers", ArgumentTypes_0cf4bb0e47554c609c69836bac69820f);
             return (Task<UserSearchResult>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_a2afd15639f041d498c06c40e19b1e7b = new Type[] {  };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IGitHubApi.GetIndex()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndex", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndex", ArgumentTypes_a2afd15639f041d498c06c40e19b1e7b);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_9ebddda0f0f841aaa5b04e03e6b56235 = new Type[] {  };
 
         /// <inheritdoc />
         IObservable<string> IGitHubApi.GetIndexObservable()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndexObservable", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndexObservable", ArgumentTypes_9ebddda0f0f841aaa5b04e03e6b56235);
             return (IObservable<string>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_df6fe0f591564f1f89d67ce5ddee9416 = new Type[] {  };
 
         /// <inheritdoc />
         Task<User> IGitHubApi.NothingToSeeHere()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("NothingToSeeHere", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("NothingToSeeHere", ArgumentTypes_df6fe0f591564f1f89d67ce5ddee9416);
             return (Task<User>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_97a9b0c05a3f44a1b33a2905d48c3fad = new Type[] {  };
 
         /// <inheritdoc />
         Task<ApiResponse<User>> IGitHubApi.NothingToSeeHereWithMetadata()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("NothingToSeeHereWithMetadata", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("NothingToSeeHereWithMetadata", ArgumentTypes_97a9b0c05a3f44a1b33a2905d48c3fad);
             return (Task<ApiResponse<User>>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_eb0a21065d544dc986691262e558dba3 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<ApiResponse<User>> IGitHubApi.GetUserWithMetadata(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserWithMetadata", new Type[] { typeof(string) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserWithMetadata", ArgumentTypes_eb0a21065d544dc986691262e558dba3);
             return (Task<ApiResponse<User>>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_f6a78e71706444eabb5520032c765c16 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         IObservable<ApiResponse<User>> IGitHubApi.GetUserObservableWithMetadata(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserObservableWithMetadata", new Type[] { typeof(string) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserObservableWithMetadata", ArgumentTypes_f6a78e71706444eabb5520032c765c16);
             return (IObservable<ApiResponse<User>>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_78ab4f2d244c4486aed97f9b8741dc9a = new Type[] { typeof(User) };
 
         /// <inheritdoc />
         Task<User> IGitHubApi.CreateUser(User user)
         {
             var arguments = new object[] { user };
-            var func = requestBuilder.BuildRestResultFuncForMethod("CreateUser", new Type[] { typeof(User) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("CreateUser", ArgumentTypes_78ab4f2d244c4486aed97f9b8741dc9a);
             return (Task<User>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_b3589a1bf5d74facbd3003f508a4b635 = new Type[] { typeof(User) };
 
         /// <inheritdoc />
         Task<ApiResponse<User>> IGitHubApi.CreateUserWithMetadata(User user)
         {
             var arguments = new object[] { user };
-            var func = requestBuilder.BuildRestResultFuncForMethod("CreateUserWithMetadata", new Type[] { typeof(User) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("CreateUserWithMetadata", ArgumentTypes_b3589a1bf5d74facbd3003f508a4b635);
             return (Task<ApiResponse<User>>)func(Client, arguments);
         }
     }
@@ -1646,43 +1832,57 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_31b5bc4aa6d3406e961a3dc5d0452cd8 = new Type[] { typeof(TParam), typeof(THeader) };
+
         /// <inheritdoc />
         Task<TResponse> IHttpBinApi<TResponse, TParam, THeader>.Get(TParam param, THeader header)
         {
             var arguments = new object[] { param, header };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", new Type[] { typeof(TParam), typeof(THeader) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_31b5bc4aa6d3406e961a3dc5d0452cd8);
             return (Task<TResponse>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_523821ee2c474ee4becbe83c9c4ed973 = new Type[] { typeof(TParam) };
 
         /// <inheritdoc />
         Task<TResponse> IHttpBinApi<TResponse, TParam, THeader>.GetQuery(TParam param)
         {
             var arguments = new object[] { param };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetQuery", new Type[] { typeof(TParam) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetQuery", ArgumentTypes_523821ee2c474ee4becbe83c9c4ed973);
             return (Task<TResponse>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_ad4584768f064347b45cf861a0d2362d = new Type[] { typeof(TParam) };
 
         /// <inheritdoc />
         Task<TResponse> IHttpBinApi<TResponse, TParam, THeader>.PostQuery(TParam param)
         {
             var arguments = new object[] { param };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostQuery", new Type[] { typeof(TParam) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostQuery", ArgumentTypes_ad4584768f064347b45cf861a0d2362d);
             return (Task<TResponse>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_82df63f31ec347468f2993a678e2d39a = new Type[] { typeof(TParam) };
 
         /// <inheritdoc />
         Task<TResponse> IHttpBinApi<TResponse, TParam, THeader>.GetQueryWithIncludeParameterName(TParam param)
         {
             var arguments = new object[] { param };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetQueryWithIncludeParameterName", new Type[] { typeof(TParam) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetQueryWithIncludeParameterName", ArgumentTypes_82df63f31ec347468f2993a678e2d39a);
             return (Task<TResponse>)func(Client, arguments);
+        }
+
+        private static class TypeHelper_56f0710c826f480889828c549210fb2e<TValue>
+        {
+            public static readonly Type[] ArgumentTypes = new Type[] { typeof(TParam) };
+            public static readonly Type[] TypeParameters = new Type[] { typeof(TValue) };
         }
 
         /// <inheritdoc />
         Task<TValue> IHttpBinApi<TResponse, TParam, THeader>.GetQuery1<TValue>(TParam param)
         {
             var arguments = new object[] { param };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetQuery1", new Type[] { typeof(TParam) }, new Type[] { typeof(TValue) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetQuery1", TypeHelper_56f0710c826f480889828c549210fb2e<TValue>.ArgumentTypes, TypeHelper_56f0710c826f480889828c549210fb2e<TValue>.TypeParameters);
             return (Task<TValue>)func(Client, arguments);
         }
     }
@@ -1723,19 +1923,23 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_413a64c81bb24d6984bfc77dfb21dbed = new Type[] { typeof(HttpContent) };
+
         /// <inheritdoc />
         Task<HttpContent> IHttpContentApi.PostFileUpload(HttpContent content)
         {
             var arguments = new object[] { content };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostFileUpload", new Type[] { typeof(HttpContent) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostFileUpload", ArgumentTypes_413a64c81bb24d6984bfc77dfb21dbed);
             return (Task<HttpContent>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_997bba8c9bdd4a54a5a904d5be3b8454 = new Type[] { typeof(HttpContent) };
 
         /// <inheritdoc />
         Task<ApiResponse<HttpContent>> IHttpContentApi.PostFileUploadWithMetadata(HttpContent content)
         {
             var arguments = new object[] { content };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostFileUploadWithMetadata", new Type[] { typeof(HttpContent) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostFileUploadWithMetadata", ArgumentTypes_997bba8c9bdd4a54a5a904d5be3b8454);
             return (Task<ApiResponse<HttpContent>>)func(Client, arguments);
         }
     }
@@ -1777,11 +1981,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_a3483f830bdd4a73a6bef95050f7424d = new Type[] {  };
+
         /// <inheritdoc />
         Task<TestAliasObject> ResponseTests.IMyAliasService.GetTestObject()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetTestObject", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetTestObject", ArgumentTypes_a3483f830bdd4a73a6bef95050f7424d);
             return (Task<TestAliasObject>)func(Client, arguments);
         }
     }
@@ -1817,19 +2023,23 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_38cc1d36a1e64138b5aab947b939a223 = new Type[] {  };
+
         /// <inheritdoc />
         Task<string> AuthenticatedClientHandlerTests.IMyAuthenticatedService.GetUnauthenticated()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUnauthenticated", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUnauthenticated", ArgumentTypes_38cc1d36a1e64138b5aab947b939a223);
             return (Task<string>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_bd2368e7ae16460c903a0eca7bcfe0c0 = new Type[] {  };
 
         /// <inheritdoc />
         Task<string> AuthenticatedClientHandlerTests.IMyAuthenticatedService.GetAuthenticated()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetAuthenticated", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetAuthenticated", ArgumentTypes_bd2368e7ae16460c903a0eca7bcfe0c0);
             return (Task<string>)func(Client, arguments);
         }
     }
@@ -1860,11 +2070,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_9911abe5ad41420ba71270f7df1545b6 = new Type[] {  };
+
         /// <inheritdoc />
         Task<SomeType> INamespaceCollisionApi.SomeRequest()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", ArgumentTypes_9911abe5ad41420ba71270f7df1545b6);
             return (Task<SomeType>)func(Client, arguments);
         }
     }
@@ -1896,11 +2108,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_2efd03bcd7f046e1925d96ba207aee55 = new Type[] {  };
+
         /// <inheritdoc />
         Task<SomeOtherType> INamespaceOverlapApi.SomeRequest()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", ArgumentTypes_2efd03bcd7f046e1925d96ba207aee55);
             return (Task<SomeOtherType>)func(Client, arguments);
         }
     }
@@ -1935,67 +2149,83 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_ca128e96a68a448aae3ffa470c69d429 = new Type[] { typeof(string) };
+
         /// <inheritdoc />
         Task<User> TestNested.INestedGitHubApi.GetUser(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUser", new Type[] { typeof(string) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUser", ArgumentTypes_ca128e96a68a448aae3ffa470c69d429);
             return (Task<User>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_6a82aa9de5f64be583d6bd05837536f6 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         IObservable<User> TestNested.INestedGitHubApi.GetUserObservable(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserObservable", new Type[] { typeof(string) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserObservable", ArgumentTypes_6a82aa9de5f64be583d6bd05837536f6);
             return (IObservable<User>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_92b863e5f17548fcaf8ed2d5224574a1 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         IObservable<User> TestNested.INestedGitHubApi.GetUserCamelCase(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserCamelCase", new Type[] { typeof(string) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserCamelCase", ArgumentTypes_92b863e5f17548fcaf8ed2d5224574a1);
             return (IObservable<User>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_10983d1a274743e3acf343a3ba9ac272 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<List<User>> TestNested.INestedGitHubApi.GetOrgMembers(string orgName)
         {
             var arguments = new object[] { orgName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetOrgMembers", new Type[] { typeof(string) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetOrgMembers", ArgumentTypes_10983d1a274743e3acf343a3ba9ac272);
             return (Task<List<User>>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_516844aa2de445b19e0c9ab4cb676306 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<UserSearchResult> TestNested.INestedGitHubApi.FindUsers(string q)
         {
             var arguments = new object[] { q };
-            var func = requestBuilder.BuildRestResultFuncForMethod("FindUsers", new Type[] { typeof(string) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("FindUsers", ArgumentTypes_516844aa2de445b19e0c9ab4cb676306);
             return (Task<UserSearchResult>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_059e9b9642fe4c9d9f45992fcbbe1937 = new Type[] {  };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> TestNested.INestedGitHubApi.GetIndex()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndex", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndex", ArgumentTypes_059e9b9642fe4c9d9f45992fcbbe1937);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_fa820803d66e4cd68dce0113db9fccbb = new Type[] {  };
 
         /// <inheritdoc />
         IObservable<string> TestNested.INestedGitHubApi.GetIndexObservable()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndexObservable", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndexObservable", ArgumentTypes_fa820803d66e4cd68dce0113db9fccbb);
             return (IObservable<string>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_1e1f799dd91046a8bdda7eac2c0cf810 = new Type[] {  };
 
         /// <inheritdoc />
         Task TestNested.INestedGitHubApi.NothingToSeeHere()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("NothingToSeeHere", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("NothingToSeeHere", ArgumentTypes_1e1f799dd91046a8bdda7eac2c0cf810);
             return (Task)func(Client, arguments);
         }
     }
@@ -2033,19 +2263,33 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static class TypeHelper_5f95e73ce67d4fb48b45db9ed3ef73c3<T>
+        {
+            public static readonly Type[] ArgumentTypes = new Type[] { typeof(T) };
+            public static readonly Type[] TypeParameters = new Type[] { typeof(T) };
+        }
+
         /// <inheritdoc />
         Task INonGenericInterfaceWithGenericMethod.PostMessage<T>(T message)
         {
             var arguments = new object[] { message };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostMessage", new Type[] { typeof(T) }, new Type[] { typeof(T) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostMessage", TypeHelper_5f95e73ce67d4fb48b45db9ed3ef73c3<T>.ArgumentTypes, TypeHelper_5f95e73ce67d4fb48b45db9ed3ef73c3<T>.TypeParameters);
             return (Task)func(Client, arguments);
+        }
+
+        private static class TypeHelper_f360ca9bda774fa1aa0434b8efb6f90f<T, U, V>
+        {
+            public static readonly Type[] ArgumentTypes = new Type[] { typeof(T), typeof(U), typeof(V) };
+            public static readonly Type[] TypeParameters = new Type[] { typeof(T), typeof(U), typeof(V) };
         }
 
         /// <inheritdoc />
         Task INonGenericInterfaceWithGenericMethod.PostMessage<T, U, V>(T message, U param1, V param2)
         {
             var arguments = new object[] { message, param1, param2 };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostMessage", new Type[] { typeof(T), typeof(U), typeof(V) }, new Type[] { typeof(T), typeof(U), typeof(V) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostMessage",
+                TypeHelper_f360ca9bda774fa1aa0434b8efb6f90f<T, U, V>.ArgumentTypes,
+                TypeHelper_f360ca9bda774fa1aa0434b8efb6f90f<T, U, V>.TypeParameters);
             return (Task)func(Client, arguments);
         }
     }
@@ -2086,11 +2330,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_07059728cf9a452894467f5fe3adcfaa = new Type[] {  };
+
         /// <inheritdoc />
         Task<RootObject> INpmJs.GetCongruence()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetCongruence", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetCongruence", ArgumentTypes_07059728cf9a452894467f5fe3adcfaa);
             return (Task<RootObject>)func(Client, arguments);
         }
     }
@@ -2119,11 +2365,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_c575b32c73d946cfa4667db26f1bd762 = new Type[] {  };
+
         /// <inheritdoc />
         string? INullableReferenceService.Get()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_c575b32c73d946cfa4667db26f1bd762);
             return (string?)func(Client, arguments);
         }
     }
@@ -2152,11 +2400,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_c670bec8146e49349bb73174b47553bf = new Type[] {  };
+
         /// <inheritdoc />
         int? INullableValueService.Get()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_c670bec8146e49349bb73174b47553bf);
             return (int?)func(Client, arguments);
         }
     }
@@ -2186,11 +2436,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_4fa4eda88ece4c40a7a1026cc9e390bc = new Type[] {  };
+
         /// <inheritdoc />
         Task<SomeType> IReducedUsingInsideNamespaceApi.SomeRequest()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", ArgumentTypes_4fa4eda88ece4c40a7a1026cc9e390bc);
             return (Task<SomeType>)func(Client, arguments);
         }
     }
@@ -2219,11 +2471,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_514faf2869ca4e0fb0d6531330d6b1e8 = new Type[] { ToNullable(typeof(string)), ToNullable(typeof(int)) };
+
         /// <inheritdoc />
         Task IReferenceAndValueParametersService.Get(string? reference, int? value)
         {
             var arguments = new object[] { reference, value };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", new Type[] { ToNullable(typeof(string)), ToNullable(typeof(int)) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_514faf2869ca4e0fb0d6531330d6b1e8);
             return (Task)func(Client, arguments);
         }
 
@@ -2266,11 +2520,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_95531f8a31de4cd6b22b5d54b37df993 = new Type[] {  };
+
         /// <inheritdoc />
         Task IRefitInterfaceWithStaticMethod.Get()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_95531f8a31de4cd6b22b5d54b37df993);
             return (Task)func(Client, arguments);
         }
     }
@@ -2311,43 +2567,57 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_50cd317596d040239a6a636bbdcf073e = new Type[] {  };
+
         /// <inheritdoc />
         Task IRequestBin.Post()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Post", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Post", ArgumentTypes_50cd317596d040239a6a636bbdcf073e);
             return (Task)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_c0b97a5113724d4baf00fcfef5c03e82 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task IRequestBin.PostRawStringDefault(string str)
         {
             var arguments = new object[] { str };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostRawStringDefault", new Type[] { typeof(string) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostRawStringDefault", ArgumentTypes_c0b97a5113724d4baf00fcfef5c03e82);
             return (Task)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_08bc4f247e2d4bd8acaa18c3980c0b70 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task IRequestBin.PostRawStringJson(string str)
         {
             var arguments = new object[] { str };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostRawStringJson", new Type[] { typeof(string) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostRawStringJson", ArgumentTypes_08bc4f247e2d4bd8acaa18c3980c0b70);
             return (Task)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_ba4cc876f4f3443cbc901448effb70c3 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task IRequestBin.PostRawStringUrlEncoded(string str)
         {
             var arguments = new object[] { str };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostRawStringUrlEncoded", new Type[] { typeof(string) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostRawStringUrlEncoded", ArgumentTypes_ba4cc876f4f3443cbc901448effb70c3);
             return (Task)func(Client, arguments);
+        }
+
+        private static class TypeHelper_59f0be91b892435f98677633fbf75961<T>
+        {
+            public static readonly Type[] ArgumentTypes = new Type[] { typeof(T) };
+            public static readonly Type[] TypeParameters = new Type[] { typeof(T) };
         }
 
         /// <inheritdoc />
         Task IRequestBin.PostGeneric<T>(T param)
         {
             var arguments = new object[] { param };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostGeneric", new Type[] { typeof(T) }, new Type[] { typeof(T) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostGeneric", TypeHelper_59f0be91b892435f98677633fbf75961<T>.ArgumentTypes, TypeHelper_59f0be91b892435f98677633fbf75961<T>.TypeParameters);
             return (Task)func(Client, arguments);
         }
     }
@@ -2388,107 +2658,133 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_eb46c38605514aa7bfe6cc196648ef79 = new Type[] { typeof(Stream) };
+
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadStream(Stream stream)
         {
             var arguments = new object[] { stream };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStream", new Type[] { typeof(Stream) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStream", ArgumentTypes_eb46c38605514aa7bfe6cc196648ef79);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_6cd69fb078d7401fae9ad2c40bab165e = new Type[] { typeof(Stream) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadStreamWithCustomBoundary(Stream stream)
         {
             var arguments = new object[] { stream };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStreamWithCustomBoundary", new Type[] { typeof(Stream) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStreamWithCustomBoundary", ArgumentTypes_6cd69fb078d7401fae9ad2c40bab165e);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_10b42e5fb02045c49673ddd851dc5c5e = new Type[] { typeof(StreamPart) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadStreamPart(StreamPart stream)
         {
             var arguments = new object[] { stream };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStreamPart", new Type[] { typeof(StreamPart) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStreamPart", ArgumentTypes_10b42e5fb02045c49673ddd851dc5c5e);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_07eaec2244254706b9fddec546d22c83 = new Type[] { typeof(ModelObject), typeof(StreamPart) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadStreamPart(ModelObject someQueryParams, StreamPart stream)
         {
             var arguments = new object[] { someQueryParams, stream };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStreamPart", new Type[] { typeof(ModelObject), typeof(StreamPart) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStreamPart", ArgumentTypes_07eaec2244254706b9fddec546d22c83);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_eb61c907c8d248ed82af2bc10c0c7ad8 = new Type[] { typeof(byte[]) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadBytes(byte[] bytes)
         {
             var arguments = new object[] { bytes };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadBytes", new Type[] { typeof(byte[]) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadBytes", ArgumentTypes_eb61c907c8d248ed82af2bc10c0c7ad8);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_c913da9f313849b0bb9fb561fcee3136 = new Type[] { typeof(ByteArrayPart) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadBytesPart(ByteArrayPart bytes)
         {
             var arguments = new object[] { bytes };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadBytesPart", new Type[] { typeof(ByteArrayPart) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadBytesPart", ArgumentTypes_c913da9f313849b0bb9fb561fcee3136);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_f1c0199a5d7644e1bd70b8844bbbe96a = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadString(string someString)
         {
             var arguments = new object[] { someString };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadString", new Type[] { typeof(string) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadString", ArgumentTypes_f1c0199a5d7644e1bd70b8844bbbe96a);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_ac0baa0ac5aa42b49dd6392f75501f0a = new Type[] { typeof(IEnumerable<FileInfo>), typeof(FileInfo) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadFileInfo(IEnumerable<FileInfo> fileInfos, FileInfo anotherFile)
         {
             var arguments = new object[] { fileInfos, anotherFile };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadFileInfo", new Type[] { typeof(IEnumerable<FileInfo>), typeof(FileInfo) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadFileInfo", ArgumentTypes_ac0baa0ac5aa42b49dd6392f75501f0a);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_08321518aea04a36983a1f7dbe74f6b0 = new Type[] { typeof(IEnumerable<FileInfoPart>), typeof(FileInfoPart) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadFileInfoPart(IEnumerable<FileInfoPart> fileInfos, FileInfoPart anotherFile)
         {
             var arguments = new object[] { fileInfos, anotherFile };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadFileInfoPart", new Type[] { typeof(IEnumerable<FileInfoPart>), typeof(FileInfoPart) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadFileInfoPart", ArgumentTypes_08321518aea04a36983a1f7dbe74f6b0);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_a62f7a15fc854af7bacf31e66cdf6d5f = new Type[] { typeof(ModelObject) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadJsonObject(ModelObject theObject)
         {
             var arguments = new object[] { theObject };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadJsonObject", new Type[] { typeof(ModelObject) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadJsonObject", ArgumentTypes_a62f7a15fc854af7bacf31e66cdf6d5f);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_5f7e504292744634a5468ab2fee2d782 = new Type[] { typeof(IEnumerable<ModelObject>) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadJsonObjects(IEnumerable<ModelObject> theObjects)
         {
             var arguments = new object[] { theObjects };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadJsonObjects", new Type[] { typeof(IEnumerable<ModelObject>) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadJsonObjects", ArgumentTypes_5f7e504292744634a5468ab2fee2d782);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_6cc62e85c0ff4fdbb942107b4a50d205 = new Type[] { typeof(IEnumerable<ModelObject>), typeof(AnotherModel), typeof(FileInfo), typeof(AnEnum), typeof(string), typeof(int) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadMixedObjects(IEnumerable<ModelObject> theObjects, AnotherModel anotherModel, FileInfo aFile, AnEnum anEnum, string aString, int anInt)
         {
             var arguments = new object[] { theObjects, anotherModel, aFile, anEnum, aString, anInt };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadMixedObjects", new Type[] { typeof(IEnumerable<ModelObject>), typeof(AnotherModel), typeof(FileInfo), typeof(AnEnum), typeof(string), typeof(int) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadMixedObjects", ArgumentTypes_6cc62e85c0ff4fdbb942107b4a50d205);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_d75eba2f4d87445f9373f1195003e580 = new Type[] { typeof(HttpContent) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadHttpContent(HttpContent content)
         {
             var arguments = new object[] { content };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadHttpContent", new Type[] { typeof(HttpContent) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadHttpContent", ArgumentTypes_d75eba2f4d87445f9373f1195003e580);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
     }
@@ -2520,19 +2816,23 @@ namespace AutoGeneratedIServiceWithoutNamespace
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_df5241209ed847c282ba15912c1685f1 = new Type[] {  };
+
         /// <inheritdoc />
         Task IServiceWithoutNamespace.GetRoot()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetRoot", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetRoot", ArgumentTypes_df5241209ed847c282ba15912c1685f1);
             return (Task)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_d93dcf5fba8541569143835e202a84d3 = new Type[] {  };
 
         /// <inheritdoc />
         Task IServiceWithoutNamespace.PostRoot()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostRoot", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostRoot", ArgumentTypes_d93dcf5fba8541569143835e202a84d3);
             return (Task)func(Client, arguments);
         }
     }
@@ -2573,19 +2873,23 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_8fc2e9c5a120421fa04f82d354241fd6 = new Type[] { typeof(string) };
+
         /// <inheritdoc />
         Task<Stream> IStreamApi.GetRemoteFile(string filename)
         {
             var arguments = new object[] { filename };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetRemoteFile", new Type[] { typeof(string) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetRemoteFile", ArgumentTypes_8fc2e9c5a120421fa04f82d354241fd6);
             return (Task<Stream>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_24d3dff0cc4e4b84b1bc3aa07ba8d80c = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<ApiResponse<Stream>> IStreamApi.GetRemoteFileWithMetadata(string filename)
         {
             var arguments = new object[] { filename };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetRemoteFileWithMetadata", new Type[] { typeof(string) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetRemoteFileWithMetadata", ArgumentTypes_24d3dff0cc4e4b84b1bc3aa07ba8d80c);
             return (Task<ApiResponse<Stream>>)func(Client, arguments);
         }
     }
@@ -2626,11 +2930,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_044c5362e682411882ad0f45b7ea2925 = new Type[] {  };
+
         /// <inheritdoc />
         Task ITrimTrailingForwardSlashApi.Get()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_044c5362e682411882ad0f45b7ea2925);
             return (Task)func(Client, arguments);
         }
     }
@@ -2660,11 +2966,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_4c98d265f3ca428ebdb99c7aff7aaca8 = new Type[] {  };
+
         /// <inheritdoc />
         Task<SomeType> ITypeCollisionApiA.SomeARequest()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("SomeARequest", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("SomeARequest", ArgumentTypes_4c98d265f3ca428ebdb99c7aff7aaca8);
             return (Task<SomeType>)func(Client, arguments);
         }
     }
@@ -2694,11 +3002,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_5f343a5e10b64564b247613e3396d2b4 = new Type[] {  };
+
         /// <inheritdoc />
         Task<SomeType> ITypeCollisionApiB.SomeBRequest()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("SomeBRequest", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("SomeBRequest", ArgumentTypes_5f343a5e10b64564b247613e3396d2b4);
             return (Task<SomeType>)func(Client, arguments);
         }
     }
@@ -2737,59 +3047,85 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_59fe0ba97b974293a225aca5c441b522 = new Type[] {  };
+
         /// <inheritdoc />
         Task<string> IUseOverloadedGenericMethods<TResponse, TParam, THeader>.Get()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_59fe0ba97b974293a225aca5c441b522);
             return (Task<string>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_3d5d041e148542e0ac1fae3fa5294282 = new Type[] { typeof(TParam), typeof(THeader) };
 
         /// <inheritdoc />
         Task<TResponse> IUseOverloadedGenericMethods<TResponse, TParam, THeader>.Get(TParam param, THeader header)
         {
             var arguments = new object[] { param, header };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", new Type[] { typeof(TParam), typeof(THeader) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_3d5d041e148542e0ac1fae3fa5294282);
             return (Task<TResponse>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_eaff7c02948f466f850531be1ead605f = new Type[] { typeof(THeader), typeof(TParam) };
 
         /// <inheritdoc />
         Task<TResponse> IUseOverloadedGenericMethods<TResponse, TParam, THeader>.Get(THeader param, TParam header)
         {
             var arguments = new object[] { param, header };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", new Type[] { typeof(THeader), typeof(TParam) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_eaff7c02948f466f850531be1ead605f);
             return (Task<TResponse>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_a297c3c6ea1642a9a23f1efdcb171212 = new Type[] { typeof(int) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IUseOverloadedGenericMethods<TResponse, TParam, THeader>.Get(int httpstatuscode)
         {
             var arguments = new object[] { httpstatuscode };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", new Type[] { typeof(int) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_a297c3c6ea1642a9a23f1efdcb171212);
             return (Task<HttpResponseMessage>)func(Client, arguments);
+        }
+
+        private static class TypeHelper_b4fb4c5e4fd54ff6bba78cd1529dbacc<TValue>
+        {
+            public static readonly Type[] ArgumentTypes = new Type[] { typeof(int) };
+            public static readonly Type[] TypeParameters = new Type[] { typeof(TValue) };
         }
 
         /// <inheritdoc />
         Task<TValue> IUseOverloadedGenericMethods<TResponse, TParam, THeader>.Get<TValue>(int someVal)
         {
             var arguments = new object[] { someVal };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", new Type[] { typeof(int) }, new Type[] { typeof(TValue) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", TypeHelper_b4fb4c5e4fd54ff6bba78cd1529dbacc<TValue>.ArgumentTypes, TypeHelper_b4fb4c5e4fd54ff6bba78cd1529dbacc<TValue>.TypeParameters);
             return (Task<TValue>)func(Client, arguments);
+        }
+
+        private static class TypeHelper_43622c55166f4de38abb99ab6e57e07b<TValue, TInput>
+        {
+            public static readonly Type[] ArgumentTypes = new Type[] { typeof(TInput) };
+            public static readonly Type[] TypeParameters = new Type[] { typeof(TValue), typeof(TInput) };
         }
 
         /// <inheritdoc />
         Task<TValue> IUseOverloadedGenericMethods<TResponse, TParam, THeader>.Get<TValue, TInput>(TInput input)
         {
             var arguments = new object[] { input };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", new Type[] { typeof(TInput) }, new Type[] { typeof(TValue), typeof(TInput) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", TypeHelper_43622c55166f4de38abb99ab6e57e07b<TValue, TInput>.ArgumentTypes, TypeHelper_43622c55166f4de38abb99ab6e57e07b<TValue, TInput>.TypeParameters);
             return (Task<TValue>)func(Client, arguments);
+        }
+
+        private static class TypeHelper_467221a8a32d4f64b81ca9c558001f20<TInput1, TInput2>
+        {
+            public static readonly Type[] ArgumentTypes = new Type[] { typeof(TInput1), typeof(TInput2) };
+            public static readonly Type[] TypeParameters = new Type[] { typeof(TInput1), typeof(TInput2) };
         }
 
         /// <inheritdoc />
         Task IUseOverloadedGenericMethods<TResponse, TParam, THeader>.Get<TInput1, TInput2>(TInput1 input1, TInput2 input2)
         {
             var arguments = new object[] { input1, input2 };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", new Type[] { typeof(TInput1), typeof(TInput2) }, new Type[] { typeof(TInput1), typeof(TInput2) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", TypeHelper_467221a8a32d4f64b81ca9c558001f20<TInput1, TInput2>.ArgumentTypes, TypeHelper_467221a8a32d4f64b81ca9c558001f20<TInput1, TInput2>.TypeParameters);
             return (Task)func(Client, arguments);
         }
     }
@@ -2824,19 +3160,23 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_c3ab7b0990264a78aef31962f701af7f = new Type[] {  };
+
         /// <inheritdoc />
         Task<string> IUseOverloadedMethods.Get()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_c3ab7b0990264a78aef31962f701af7f);
             return (Task<string>)func(Client, arguments);
         }
+
+        private static readonly Type[] ArgumentTypes_184bf7e08cc1438aaa91d1100c2681ba = new Type[] { typeof(int) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IUseOverloadedMethods.Get(int httpstatuscode)
         {
             var arguments = new object[] { httpstatuscode };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", new Type[] { typeof(int) });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_184bf7e08cc1438aaa91d1100c2681ba);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
     }
@@ -2877,11 +3217,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_9be8666e0f094ddaa2a9d71a60607557 = new Type[] {  };
+
         /// <inheritdoc />
         Task IValidApi.Get()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_9be8666e0f094ddaa2a9d71a60607557);
             return (Task)func(Client, arguments);
         }
     }
@@ -2911,11 +3253,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
+        private static readonly Type[] ArgumentTypes_e2bcc1f9cc56466b862fecf9c7b14c8d = new Type[] {  };
+
         /// <inheritdoc />
         Task<SomeType> NamespaceWithGlobalAliasApi.SomeRequest()
         {
             var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", new Type[] {  });
+            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", ArgumentTypes_e2bcc1f9cc56466b862fecf9c7b14c8d);
             return (Task<SomeType>)func(Client, arguments);
         }
     }

--- a/Refit.Tests/RefitStubs.NetCore3.cs
+++ b/Refit.Tests/RefitStubs.NetCore3.cs
@@ -62,27 +62,27 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_a33898cae1424f04ac90e19b114938bf = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_4fb19815237f4083aadaa0e9d139923a = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IAmARefitInterfaceButNobodyUsesMe.RefitMethod()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("RefitMethod", ArgumentTypes_a33898cae1424f04ac90e19b114938bf);
+            var func = requestBuilder.BuildRestResultFuncForMethod("RefitMethod", ArgumentTypes_4fb19815237f4083aadaa0e9d139923a);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_999eb22bf4ce4c81ab78c8fba135650b = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_637b6166889d449d96660eac092e89be = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IAmARefitInterfaceButNobodyUsesMe.AnotherRefitMethod()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("AnotherRefitMethod", ArgumentTypes_999eb22bf4ce4c81ab78c8fba135650b);
+            var func = requestBuilder.BuildRestResultFuncForMethod("AnotherRefitMethod", ArgumentTypes_637b6166889d449d96660eac092e89be);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_be7bf8c223984dd7a7a905f1ad4a6af1 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_dd92f177b0cd4e1780f9d80413ee9285 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IAmARefitInterfaceButNobodyUsesMe.NoConstantsAllowed()
@@ -90,23 +90,23 @@ namespace Refit.Tests
             throw new NotImplementedException("Either this method has no Refit HTTP method attribute or you've used something other than a string literal for the 'path' argument.");
         }
 
-        private static readonly Type[] ArgumentTypes_6c24145dba474e3d8705ea67be58ff14 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_ba12e6f238b744aa843514408c8ecb94 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IAmARefitInterfaceButNobodyUsesMe.SpacesShouldntBreakMe()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("SpacesShouldntBreakMe", ArgumentTypes_6c24145dba474e3d8705ea67be58ff14);
+            var func = requestBuilder.BuildRestResultFuncForMethod("SpacesShouldntBreakMe", ArgumentTypes_ba12e6f238b744aa843514408c8ecb94);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_5e33a67e1d424b35b9d6831080287c99 = new Type[] { typeof(int), typeof(string), typeof(float) };
+        private static readonly Type[] ArgumentTypes_259d311143c64903a53c695901542d74 = new Type[] { typeof(int), typeof(string), typeof(float) };
 
         /// <inheritdoc />
         Task IAmARefitInterfaceButNobodyUsesMe.ReservedWordsForParameterNames(int @int, string @string, float @long)
         {
             var arguments = new object[] { @int, @string, @long };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReservedWordsForParameterNames", ArgumentTypes_5e33a67e1d424b35b9d6831080287c99);
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReservedWordsForParameterNames", ArgumentTypes_259d311143c64903a53c695901542d74);
             return (Task)func(Client, arguments);
         }
     }
@@ -147,17 +147,17 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_8a5f3ad34f1645e9834fc717c71fd412 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_a1bfd88146a74e30b600b1a105eecd37 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IAmHalfRefit.Post()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Post", ArgumentTypes_8a5f3ad34f1645e9834fc717c71fd412);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Post", ArgumentTypes_a1bfd88146a74e30b600b1a105eecd37);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_adf3e23374b64794a82a71c27944d970 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_7fe6a45f0b1545fcbba87105c549a3f0 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IAmHalfRefit.Get()
@@ -191,43 +191,43 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_a1ac46e26dcd4bbe83496ab645c0a335 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_24b200c4c8794bcbbdb8ab833f1fc9f3 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> IAmInterface.Pang()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Pang", ArgumentTypes_a1ac46e26dcd4bbe83496ab645c0a335);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Pang", ArgumentTypes_24b200c4c8794bcbbdb8ab833f1fc9f3);
             return (Task<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_7eb5679aabda4721abb7f1cc9b4ba7f8 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_e480a487229b4618904a42e0883b2acc = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> IAmInterfaceB.Pong()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Pong", ArgumentTypes_7eb5679aabda4721abb7f1cc9b4ba7f8);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Pong", ArgumentTypes_e480a487229b4618904a42e0883b2acc);
             return (Task<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_c26d225af41c463ba3cc89dbb751b673 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_6abcae130331449b8da132ecfd447599 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> IAmInterfaceD.Test()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Test", ArgumentTypes_c26d225af41c463ba3cc89dbb751b673);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Test", ArgumentTypes_6abcae130331449b8da132ecfd447599);
             return (Task<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_3527bdf7f5e14e3487ae6a35eb3f2463 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_94d0f3c718b341f7a13222052d61f29d = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> IAmInterfaceA.Ping()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Ping", ArgumentTypes_3527bdf7f5e14e3487ae6a35eb3f2463);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Ping", ArgumentTypes_94d0f3c718b341f7a13222052d61f29d);
             return (Task<string>)func(Client, arguments);
         }
     }
@@ -257,13 +257,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_c7c7a0b2b5214cfba14ad6cbb57580c3 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_dfc7ac031c9b41ce87a8c096a1974585 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> IAmInterfaceA.Ping()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Ping", ArgumentTypes_c7c7a0b2b5214cfba14ad6cbb57580c3);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Ping", ArgumentTypes_dfc7ac031c9b41ce87a8c096a1974585);
             return (Task<string>)func(Client, arguments);
         }
     }
@@ -293,23 +293,23 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_bac788abd15044c88591d32e590d7a69 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_ed4e46d8dca547029fbe593b603067d5 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> IAmInterfaceB.Pong()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Pong", ArgumentTypes_bac788abd15044c88591d32e590d7a69);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Pong", ArgumentTypes_ed4e46d8dca547029fbe593b603067d5);
             return (Task<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_c4c2d14d024e456190d66d4157f621a0 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_e4c334d2aa86452290a4de8ab1456fac = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> IAmInterfaceD.Test()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Test", ArgumentTypes_c4c2d14d024e456190d66d4157f621a0);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Test", ArgumentTypes_e4c334d2aa86452290a4de8ab1456fac);
             return (Task<string>)func(Client, arguments);
         }
     }
@@ -339,43 +339,43 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_845a59a5a30046c5aced2c210032c784 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_154e2c89eb504b2cbb7b87b5b36447cf = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> IAmInterfaceC.Pang()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Pang", ArgumentTypes_845a59a5a30046c5aced2c210032c784);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Pang", ArgumentTypes_154e2c89eb504b2cbb7b87b5b36447cf);
             return (Task<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_671198dfe55c4a1eb164a2fa1c6725d3 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_7f1f55a4ba604ef59ce68f86dd43c054 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> IAmInterfaceB.Pong()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Pong", ArgumentTypes_671198dfe55c4a1eb164a2fa1c6725d3);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Pong", ArgumentTypes_7f1f55a4ba604ef59ce68f86dd43c054);
             return (Task<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_f67764b160be44519fbb73cb127908c9 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_0fe0ec6439b24c9a95a10f38d2775888 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> IAmInterfaceD.Test()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Test", ArgumentTypes_f67764b160be44519fbb73cb127908c9);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Test", ArgumentTypes_0fe0ec6439b24c9a95a10f38d2775888);
             return (Task<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_d22b6f531d3f4ff49ed1e3eb8f29870e = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_002781729c25445d9b091c3280a2bcfa = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> IAmInterfaceA.Ping()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Ping", ArgumentTypes_d22b6f531d3f4ff49ed1e3eb8f29870e);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Ping", ArgumentTypes_002781729c25445d9b091c3280a2bcfa);
             return (Task<string>)func(Client, arguments);
         }
     }
@@ -405,13 +405,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_8b8977467c3f482a9a2205b6fc18d51d = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_2ee9e800678d408c8741623c6218569a = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> IAmInterfaceD.Test()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Test", ArgumentTypes_8b8977467c3f482a9a2205b6fc18d51d);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Test", ArgumentTypes_2ee9e800678d408c8741623c6218569a);
             return (Task<string>)func(Client, arguments);
         }
     }
@@ -452,153 +452,153 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_54e2a831d49f4b2abc27443f89da87f4 = new Type[] { typeof(PathBoundObject) };
+        private static readonly Type[] ArgumentTypes_4439ab0a18c942cfbf1a78a8cf1c369e = new Type[] { typeof(PathBoundObject) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetFooBars(PathBoundObject request)
         {
             var arguments = new object[] { request };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBars", ArgumentTypes_54e2a831d49f4b2abc27443f89da87f4);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBars", ArgumentTypes_4439ab0a18c942cfbf1a78a8cf1c369e);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_1b53c24b71c543598d20fbd4ea306cdc = new Type[] { typeof(PathBoundObject) };
+        private static readonly Type[] ArgumentTypes_20a6706f07e644c0a9882ac2d82b87c2 = new Type[] { typeof(PathBoundObject) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetFooBarsWithDifferentCasing(PathBoundObject requestParams)
         {
             var arguments = new object[] { requestParams };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBarsWithDifferentCasing", ArgumentTypes_1b53c24b71c543598d20fbd4ea306cdc);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBarsWithDifferentCasing", ArgumentTypes_20a6706f07e644c0a9882ac2d82b87c2);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_1a1c369628f8408db992a8efd1b7a6c3 = new Type[] { typeof(string), typeof(PathBoundObject) };
+        private static readonly Type[] ArgumentTypes_ecaef8a57023448dbb863be670120b91 = new Type[] { typeof(string), typeof(PathBoundObject) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetBarsByFoo(string id, PathBoundObject request)
         {
             var arguments = new object[] { id, request };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetBarsByFoo", ArgumentTypes_1a1c369628f8408db992a8efd1b7a6c3);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetBarsByFoo", ArgumentTypes_ecaef8a57023448dbb863be670120b91);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_67b05d70a64549fbb3fafb95b1d6d2a6 = new Type[] { typeof(PathBoundObject), typeof(string) };
+        private static readonly Type[] ArgumentTypes_251481b0763d4dacba93e893e93c8203 = new Type[] { typeof(PathBoundObject), typeof(string) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetFooBars(PathBoundObject request, string someProperty)
         {
             var arguments = new object[] { request, someProperty };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBars", ArgumentTypes_67b05d70a64549fbb3fafb95b1d6d2a6);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBars", ArgumentTypes_251481b0763d4dacba93e893e93c8203);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_75130c933bc84e8389014e3a34ea24cb = new Type[] { typeof(PathBoundObject) };
+        private static readonly Type[] ArgumentTypes_8393ae7b048642af81659f368c83a742 = new Type[] { typeof(PathBoundObject) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetBarsByFoo(PathBoundObject request)
         {
             var arguments = new object[] { request };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetBarsByFoo", ArgumentTypes_75130c933bc84e8389014e3a34ea24cb);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetBarsByFoo", ArgumentTypes_8393ae7b048642af81659f368c83a742);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_5d6427e339da478b8513efb42f8046c1 = new Type[] { typeof(PathBoundObjectWithQueryFormat) };
+        private static readonly Type[] ArgumentTypes_184f27dfd30c4698ab0600878c78cee7 = new Type[] { typeof(PathBoundObjectWithQueryFormat) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetBarsWithCustomQueryFormat(PathBoundObjectWithQueryFormat request)
         {
             var arguments = new object[] { request };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetBarsWithCustomQueryFormat", ArgumentTypes_5d6427e339da478b8513efb42f8046c1);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetBarsWithCustomQueryFormat", ArgumentTypes_184f27dfd30c4698ab0600878c78cee7);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_ee1879b281054091884e31424e02f0eb = new Type[] { typeof(PathBoundDerivedObject) };
+        private static readonly Type[] ArgumentTypes_f934d9a64f044ca89d81e449866f17ca = new Type[] { typeof(PathBoundDerivedObject) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetFooBarsDerived(PathBoundDerivedObject request)
         {
             var arguments = new object[] { request };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBarsDerived", ArgumentTypes_ee1879b281054091884e31424e02f0eb);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBarsDerived", ArgumentTypes_f934d9a64f044ca89d81e449866f17ca);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_f2358e3269ab438e8b228103ae1c7a60 = new Type[] { typeof(PathBoundList) };
+        private static readonly Type[] ArgumentTypes_d099f5dc885044628ba1071b0e13fa92 = new Type[] { typeof(PathBoundList) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetFoos(PathBoundList request)
         {
             var arguments = new object[] { request };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetFoos", ArgumentTypes_f2358e3269ab438e8b228103ae1c7a60);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetFoos", ArgumentTypes_d099f5dc885044628ba1071b0e13fa92);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_4dca8047875b485e9f602361b36966fd = new Type[] { typeof(List<int>) };
+        private static readonly Type[] ArgumentTypes_237c9bc2a4014803a1aad965a0bfacd4 = new Type[] { typeof(List<int>) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetFoos2(List<int> Values)
         {
             var arguments = new object[] { Values };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetFoos2", ArgumentTypes_4dca8047875b485e9f602361b36966fd);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetFoos2", ArgumentTypes_237c9bc2a4014803a1aad965a0bfacd4);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_bf0841a8e36645f1a9bf6ad33dd616fe = new Type[] { typeof(PathBoundObject), typeof(object) };
+        private static readonly Type[] ArgumentTypes_1137f2df6a4d497c97b6aa56155114fc = new Type[] { typeof(PathBoundObject), typeof(object) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.PostFooBar(PathBoundObject request, object someObject)
         {
             var arguments = new object[] { request, someObject };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBar", ArgumentTypes_bf0841a8e36645f1a9bf6ad33dd616fe);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBar", ArgumentTypes_1137f2df6a4d497c97b6aa56155114fc);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_ef1edc71e5f8413b8211212efcfc1984 = new Type[] { typeof(PathBoundObjectWithQuery) };
+        private static readonly Type[] ArgumentTypes_8da75a0a7919494fabfbfa253b1b3ced = new Type[] { typeof(PathBoundObjectWithQuery) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetFooBars(PathBoundObjectWithQuery request)
         {
             var arguments = new object[] { request };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBars", ArgumentTypes_ef1edc71e5f8413b8211212efcfc1984);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBars", ArgumentTypes_8da75a0a7919494fabfbfa253b1b3ced);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_b96a64a45020426e8755fd58baf0d915 = new Type[] { typeof(PathBoundObject), typeof(ModelObject) };
+        private static readonly Type[] ArgumentTypes_ecedec4c78584237987d9538c184fcdb = new Type[] { typeof(PathBoundObject), typeof(ModelObject) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IApiBindPathToObject.PostFooBar(PathBoundObject request, ModelObject someQueryParams)
         {
             var arguments = new object[] { request, someQueryParams };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBar", ArgumentTypes_b96a64a45020426e8755fd58baf0d915);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBar", ArgumentTypes_ecedec4c78584237987d9538c184fcdb);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_7d81bc45f8cd4c1ca2efdfc4cb01a30c = new Type[] { typeof(PathBoundObject), typeof(ModelObject), typeof(StreamPart) };
+        private static readonly Type[] ArgumentTypes_3de46d1ae5ae42acbbdd3f612bdc6510 = new Type[] { typeof(PathBoundObject), typeof(ModelObject), typeof(StreamPart) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IApiBindPathToObject.PostFooBarStreamPart(PathBoundObject request, ModelObject someQueryParams, StreamPart stream)
         {
             var arguments = new object[] { request, someQueryParams, stream };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBarStreamPart", ArgumentTypes_7d81bc45f8cd4c1ca2efdfc4cb01a30c);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBarStreamPart", ArgumentTypes_3de46d1ae5ae42acbbdd3f612bdc6510);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_6aa030039162443595412fa42000be13 = new Type[] { typeof(PathBoundObject), typeof(StreamPart) };
+        private static readonly Type[] ArgumentTypes_7ea8d330058b418c9250d4b518b5fbe4 = new Type[] { typeof(PathBoundObject), typeof(StreamPart) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IApiBindPathToObject.PostFooBarStreamPart(PathBoundObject request, StreamPart stream)
         {
             var arguments = new object[] { request, stream };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBarStreamPart", ArgumentTypes_6aa030039162443595412fa42000be13);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBarStreamPart", ArgumentTypes_7ea8d330058b418c9250d4b518b5fbe4);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_aa6f10bcf850457fbcac790bfe3257c9 = new Type[] { typeof(PathBoundObjectWithQuery), typeof(StreamPart) };
+        private static readonly Type[] ArgumentTypes_260b14b341dd4afe855224519ce6509c = new Type[] { typeof(PathBoundObjectWithQuery), typeof(StreamPart) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IApiBindPathToObject.PostFooBarStreamPart(PathBoundObjectWithQuery request, StreamPart stream)
         {
             var arguments = new object[] { request, stream };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBarStreamPart", ArgumentTypes_aa6f10bcf850457fbcac790bfe3257c9);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBarStreamPart", ArgumentTypes_260b14b341dd4afe855224519ce6509c);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
     }
@@ -639,13 +639,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_d9084c5e880747d4a2331810b573d7ee = new Type[] { typeof(decimal) };
+        private static readonly Type[] ArgumentTypes_6980f39ffbca4f5cb3749aa20b3c451c = new Type[] { typeof(decimal) };
 
         /// <inheritdoc />
         Task<string> IApiWithDecimal.GetWithDecimal(decimal value)
         {
             var arguments = new object[] { value };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetWithDecimal", ArgumentTypes_d9084c5e880747d4a2331810b573d7ee);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetWithDecimal", ArgumentTypes_6980f39ffbca4f5cb3749aa20b3c451c);
             return (Task<string>)func(Client, arguments);
         }
     }
@@ -686,33 +686,33 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_680a119f30b34566956dfecc61326680 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_b0a77551c5274e76812b32ec0075e236 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IBodylessApi.Post()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Post", ArgumentTypes_680a119f30b34566956dfecc61326680);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Post", ArgumentTypes_b0a77551c5274e76812b32ec0075e236);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_48e4640f5cd54c84bea039d718ddaebe = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_4004bba546244c06a0553b5d85f7d71a = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IBodylessApi.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_48e4640f5cd54c84bea039d718ddaebe);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_4004bba546244c06a0553b5d85f7d71a);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_7cbb17127c70441b949632dc1eba52dd = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_fadada51c0cb4f63aa4cab15be7fd49f = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IBodylessApi.Head()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Head", ArgumentTypes_7cbb17127c70441b949632dc1eba52dd);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Head", ArgumentTypes_fadada51c0cb4f63aa4cab15be7fd49f);
             return (Task)func(Client, arguments);
         }
     }
@@ -753,53 +753,53 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_a295ef3f61e241a7b5e3bcf273ca4189 = new Type[] { typeof(T) };
+        private static readonly Type[] ArgumentTypes_2a704134ef5c49289a848760bccee135 = new Type[] { typeof(T) };
 
         /// <inheritdoc />
         Task<T> IBoringCrudApi<T, TKey>.Create(T paylod)
         {
             var arguments = new object[] { paylod };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_a295ef3f61e241a7b5e3bcf273ca4189);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_2a704134ef5c49289a848760bccee135);
             return (Task<T>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_5b56e31c023a41b3944b33df9dd06c2e = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_1de36d1330ac45f9ad2a08d53ea90a48 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<List<T>> IBoringCrudApi<T, TKey>.ReadAll()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_5b56e31c023a41b3944b33df9dd06c2e);
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_1de36d1330ac45f9ad2a08d53ea90a48);
             return (Task<List<T>>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_8f42d07d116743798d836836a25c55a9 = new Type[] { typeof(TKey) };
+        private static readonly Type[] ArgumentTypes_d676e76ac308420bb9198aa340d27cc5 = new Type[] { typeof(TKey) };
 
         /// <inheritdoc />
         Task<T> IBoringCrudApi<T, TKey>.ReadOne(TKey key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_8f42d07d116743798d836836a25c55a9);
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_d676e76ac308420bb9198aa340d27cc5);
             return (Task<T>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_5393f68687ec4717a26a6b554ad5c049 = new Type[] { typeof(TKey), typeof(T) };
+        private static readonly Type[] ArgumentTypes_75bfaa13654a4ef1b3913af2529e05dd = new Type[] { typeof(TKey), typeof(T) };
 
         /// <inheritdoc />
         Task IBoringCrudApi<T, TKey>.Update(TKey key, T payload)
         {
             var arguments = new object[] { key, payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_5393f68687ec4717a26a6b554ad5c049);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_75bfaa13654a4ef1b3913af2529e05dd);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_00e628b9a2444657bd2b9cecf242c248 = new Type[] { typeof(TKey) };
+        private static readonly Type[] ArgumentTypes_fdfe30cefb4f44f9bcb13c1ebb6ec8d7 = new Type[] { typeof(TKey) };
 
         /// <inheritdoc />
         Task IBoringCrudApi<T, TKey>.Delete(TKey key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_00e628b9a2444657bd2b9cecf242c248);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_fdfe30cefb4f44f9bcb13c1ebb6ec8d7);
             return (Task)func(Client, arguments);
         }
     }
@@ -840,13 +840,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_df79977b5f30496081238d12bb5451be = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_98e417b1a39e4ad4a91277878626573b = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<bool> IBrokenWebApi.PostAValue(string derp)
         {
             var arguments = new object[] { derp };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostAValue", ArgumentTypes_df79977b5f30496081238d12bb5451be);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostAValue", ArgumentTypes_98e417b1a39e4ad4a91277878626573b);
             return (Task<bool>)func(Client, arguments);
         }
     }
@@ -875,13 +875,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_b1d60eae6b10482c9e21744f1bd54c74 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_37a38bd3b30d4febb7282bbbd6f66b15 = Array.Empty<Type>();
 
         /// <inheritdoc />
         CustomReferenceType? ICustomNullableReferenceService.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_b1d60eae6b10482c9e21744f1bd54c74);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_37a38bd3b30d4febb7282bbbd6f66b15);
             return (CustomReferenceType?)func(Client, arguments);
         }
     }
@@ -910,13 +910,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_0a18f2e3030a447cbf17ac80abab1551 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_7d7e8312ad394a898376bce8c5f50fed = Array.Empty<Type>();
 
         /// <inheritdoc />
         CustomValueType? ICustomNullableValueService.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_0a18f2e3030a447cbf17ac80abab1551);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_7d7e8312ad394a898376bce8c5f50fed);
             return (CustomValueType?)func(Client, arguments);
         }
     }
@@ -945,13 +945,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_cdc0f4cb2dce42159c28bf6839f187da = new Type[] { ToNullable(typeof(CustomReferenceType)), ToNullable(typeof(CustomValueType)) };
+        private static readonly Type[] ArgumentTypes_713bbee79cb04ff4861810f9302d2594 = new Type[] { ToNullable(typeof(CustomReferenceType)), ToNullable(typeof(CustomValueType)) };
 
         /// <inheritdoc />
         Task ICustomReferenceAndValueParametersService.Get(CustomReferenceType? reference, CustomValueType? value)
         {
             var arguments = new object[] { reference, value };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_cdc0f4cb2dce42159c28bf6839f187da);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_713bbee79cb04ff4861810f9302d2594);
             return (Task)func(Client, arguments);
         }
 
@@ -984,73 +984,73 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_de526eb49e3946e48d66f3bb32a7be8c = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_d6f6d60fbe8e425db60bad7342f4a6fb = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IDataApiA.PingA()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("PingA", ArgumentTypes_de526eb49e3946e48d66f3bb32a7be8c);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PingA", ArgumentTypes_d6f6d60fbe8e425db60bad7342f4a6fb);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_e0311a448c12407c967b7d3765fa4513 = new Type[] { typeof(DataEntity) };
+        private static readonly Type[] ArgumentTypes_b95b5e240d7c4637b90a3bde2f0add97 = new Type[] { typeof(DataEntity) };
 
         /// <inheritdoc />
         Task<DataEntity> IDataCrudApi<DataEntity>.Copy(DataEntity payload)
         {
             var arguments = new object[] { payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Copy", ArgumentTypes_e0311a448c12407c967b7d3765fa4513);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Copy", ArgumentTypes_b95b5e240d7c4637b90a3bde2f0add97);
             return (Task<DataEntity>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_5f328ab3b648463c8bd309521518b1d2 = new Type[] { typeof(DataEntity) };
+        private static readonly Type[] ArgumentTypes_c66bae15a43042e39e33b9c6270c4ea4 = new Type[] { typeof(DataEntity) };
 
         /// <inheritdoc />
         Task<DataEntity> IDataCrudApi<DataEntity, long>.Create(DataEntity payload)
         {
             var arguments = new object[] { payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_5f328ab3b648463c8bd309521518b1d2);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_c66bae15a43042e39e33b9c6270c4ea4);
             return (Task<DataEntity>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_973c73002b8840ebbc69942ac8f05423 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_a705cc637ec84a4982b4e9e38a338d59 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<List<DataEntity>> IDataCrudApi<DataEntity, long>.ReadAll()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_973c73002b8840ebbc69942ac8f05423);
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_a705cc637ec84a4982b4e9e38a338d59);
             return (Task<List<DataEntity>>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_37b484153aed4c46b0fbccdff6887453 = new Type[] { typeof(long) };
+        private static readonly Type[] ArgumentTypes_a12af4da19c2493db12b0daa04e4011a = new Type[] { typeof(long) };
 
         /// <inheritdoc />
         Task<DataEntity> IDataCrudApi<DataEntity, long>.ReadOne(long key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_37b484153aed4c46b0fbccdff6887453);
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_a12af4da19c2493db12b0daa04e4011a);
             return (Task<DataEntity>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_0255242aad1c4136bf098d37eafe2baa = new Type[] { typeof(long), typeof(DataEntity) };
+        private static readonly Type[] ArgumentTypes_9a877614fc9f4d7ba703732e35c25fc3 = new Type[] { typeof(long), typeof(DataEntity) };
 
         /// <inheritdoc />
         Task IDataCrudApi<DataEntity, long>.Update(long key, DataEntity payload)
         {
             var arguments = new object[] { key, payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_0255242aad1c4136bf098d37eafe2baa);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_9a877614fc9f4d7ba703732e35c25fc3);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_135224ca51894787b1448f5c35b0ca4c = new Type[] { typeof(long) };
+        private static readonly Type[] ArgumentTypes_4c7707783af24f0bbcb53e2df5b2a3f6 = new Type[] { typeof(long) };
 
         /// <inheritdoc />
         Task IDataCrudApi<DataEntity, long>.Delete(long key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_135224ca51894787b1448f5c35b0ca4c);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_4c7707783af24f0bbcb53e2df5b2a3f6);
             return (Task)func(Client, arguments);
         }
     }
@@ -1081,63 +1081,63 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_ddc38815682443ca81daca3c6837a3a0 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_4d8b96ab60cc42f99e67b8763279be6a = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IDataApiB.PingB()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("PingB", ArgumentTypes_ddc38815682443ca81daca3c6837a3a0);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PingB", ArgumentTypes_4d8b96ab60cc42f99e67b8763279be6a);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_d97663ad2a42452eb5e4a5438e490dc7 = new Type[] { typeof(DataEntity) };
+        private static readonly Type[] ArgumentTypes_ef20d6f33ba4489999617c0c87e15dad = new Type[] { typeof(DataEntity) };
 
         /// <inheritdoc />
         Task<DataEntity> IDataCrudApi<DataEntity, int>.Create(DataEntity payload)
         {
             var arguments = new object[] { payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_d97663ad2a42452eb5e4a5438e490dc7);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_ef20d6f33ba4489999617c0c87e15dad);
             return (Task<DataEntity>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_cb5b3c8698f44bd5ba1ba4793e54d1de = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_9c528ed5c2a140f0afb51bf96944ab94 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<List<DataEntity>> IDataCrudApi<DataEntity, int>.ReadAll()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_cb5b3c8698f44bd5ba1ba4793e54d1de);
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_9c528ed5c2a140f0afb51bf96944ab94);
             return (Task<List<DataEntity>>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_fbff89e6a8fa440b9c984600ea5c9c9c = new Type[] { typeof(int) };
+        private static readonly Type[] ArgumentTypes_8af99142aced4d9096165935ea35dafb = new Type[] { typeof(int) };
 
         /// <inheritdoc />
         Task<DataEntity> IDataCrudApi<DataEntity, int>.ReadOne(int key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_fbff89e6a8fa440b9c984600ea5c9c9c);
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_8af99142aced4d9096165935ea35dafb);
             return (Task<DataEntity>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_c7954ce7ec1d47f9a2951ce0bf8559e7 = new Type[] { typeof(int), typeof(DataEntity) };
+        private static readonly Type[] ArgumentTypes_e4ca0729208c42108a0ce1edefd47e5e = new Type[] { typeof(int), typeof(DataEntity) };
 
         /// <inheritdoc />
         Task IDataCrudApi<DataEntity, int>.Update(int key, DataEntity payload)
         {
             var arguments = new object[] { key, payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_c7954ce7ec1d47f9a2951ce0bf8559e7);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_e4ca0729208c42108a0ce1edefd47e5e);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_d490d7b5c1c34a5b868a9e72247dd97d = new Type[] { typeof(int) };
+        private static readonly Type[] ArgumentTypes_70214198d4db4df9b07e1bed1df36bf4 = new Type[] { typeof(int) };
 
         /// <inheritdoc />
         Task IDataCrudApi<DataEntity, int>.Delete(int key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_d490d7b5c1c34a5b868a9e72247dd97d);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_70214198d4db4df9b07e1bed1df36bf4);
             return (Task)func(Client, arguments);
         }
     }
@@ -1171,63 +1171,63 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_ee9add6f1b2c44cd93b813dda1169074 = new Type[] { typeof(T) };
+        private static readonly Type[] ArgumentTypes_7f40432c44834a259d3e9f20f58d129c = new Type[] { typeof(T) };
 
         /// <inheritdoc />
         Task<T> IDataCrudApi<T>.Copy(T payload)
         {
             var arguments = new object[] { payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Copy", ArgumentTypes_ee9add6f1b2c44cd93b813dda1169074);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Copy", ArgumentTypes_7f40432c44834a259d3e9f20f58d129c);
             return (Task<T>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_55f24174d7304dfe9d475cf5aab7d53a = new Type[] { typeof(T) };
+        private static readonly Type[] ArgumentTypes_b1218505fefa442584ede68c1229d394 = new Type[] { typeof(T) };
 
         /// <inheritdoc />
         Task<T> IDataCrudApi<T, long>.Create(T payload)
         {
             var arguments = new object[] { payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_55f24174d7304dfe9d475cf5aab7d53a);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_b1218505fefa442584ede68c1229d394);
             return (Task<T>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_9023dc0aed3a4bc295a51d202956aeed = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_e73e25586826425eaf3e203f2858d700 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<List<T>> IDataCrudApi<T, long>.ReadAll()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_9023dc0aed3a4bc295a51d202956aeed);
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_e73e25586826425eaf3e203f2858d700);
             return (Task<List<T>>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_c7e4d49f45a34cffb045bfac57d90d91 = new Type[] { typeof(long) };
+        private static readonly Type[] ArgumentTypes_639652ddf03c4d7f8d03f81d5d5503f9 = new Type[] { typeof(long) };
 
         /// <inheritdoc />
         Task<T> IDataCrudApi<T, long>.ReadOne(long key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_c7e4d49f45a34cffb045bfac57d90d91);
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_639652ddf03c4d7f8d03f81d5d5503f9);
             return (Task<T>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_08a7f31964c14c389f574fdef547f67c = new Type[] { typeof(long), typeof(T) };
+        private static readonly Type[] ArgumentTypes_ac88eb105a954ccfb02de3a44a0ecd2c = new Type[] { typeof(long), typeof(T) };
 
         /// <inheritdoc />
         Task IDataCrudApi<T, long>.Update(long key, T payload)
         {
             var arguments = new object[] { key, payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_08a7f31964c14c389f574fdef547f67c);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_ac88eb105a954ccfb02de3a44a0ecd2c);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_d1cfac6bb4264607b19cbd2033880dd7 = new Type[] { typeof(long) };
+        private static readonly Type[] ArgumentTypes_a37f9d6cdcf5404684e2f280745c56b8 = new Type[] { typeof(long) };
 
         /// <inheritdoc />
         Task IDataCrudApi<T, long>.Delete(long key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_d1cfac6bb4264607b19cbd2033880dd7);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_a37f9d6cdcf5404684e2f280745c56b8);
             return (Task)func(Client, arguments);
         }
     }
@@ -1261,53 +1261,53 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_608562f8e817435894acec597c553c3e = new Type[] { typeof(T) };
+        private static readonly Type[] ArgumentTypes_ba179f443d7e47fb8904df4bd88df394 = new Type[] { typeof(T) };
 
         /// <inheritdoc />
         Task<T> IDataCrudApi<T, TKey>.Create(T payload)
         {
             var arguments = new object[] { payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_608562f8e817435894acec597c553c3e);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_ba179f443d7e47fb8904df4bd88df394);
             return (Task<T>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_72dceaa1e37544dca20fc733da7ac43e = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_60caf102389e4a91a959675d50a774ca = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<List<T>> IDataCrudApi<T, TKey>.ReadAll()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_72dceaa1e37544dca20fc733da7ac43e);
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_60caf102389e4a91a959675d50a774ca);
             return (Task<List<T>>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_723ab5fa685d46cb9763e516734be5b0 = new Type[] { typeof(TKey) };
+        private static readonly Type[] ArgumentTypes_686151fed998404d93507a9bf9d076b9 = new Type[] { typeof(TKey) };
 
         /// <inheritdoc />
         Task<T> IDataCrudApi<T, TKey>.ReadOne(TKey key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_723ab5fa685d46cb9763e516734be5b0);
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_686151fed998404d93507a9bf9d076b9);
             return (Task<T>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_4df6dbe9c3cf41658eec4429ab711813 = new Type[] { typeof(TKey), typeof(T) };
+        private static readonly Type[] ArgumentTypes_86b49ea2ae254faf9db743cdc59769d6 = new Type[] { typeof(TKey), typeof(T) };
 
         /// <inheritdoc />
         Task IDataCrudApi<T, TKey>.Update(TKey key, T payload)
         {
             var arguments = new object[] { key, payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_4df6dbe9c3cf41658eec4429ab711813);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_86b49ea2ae254faf9db743cdc59769d6);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_9402fdd8c27044e8a5b04865ce307999 = new Type[] { typeof(TKey) };
+        private static readonly Type[] ArgumentTypes_afe909d5e12f48169701abbc666807d7 = new Type[] { typeof(TKey) };
 
         /// <inheritdoc />
         Task IDataCrudApi<T, TKey>.Delete(TKey key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_9402fdd8c27044e8a5b04865ce307999);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_afe909d5e12f48169701abbc666807d7);
             return (Task)func(Client, arguments);
         }
     }
@@ -1336,13 +1336,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_fd305f7f69684f819d775da6a36218b3 = new Type[] { ToNullable(typeof(System.Collections.Generic.List<string>)) };
+        private static readonly Type[] ArgumentTypes_7c7c6e7f77b84b6bbafaeed5bbea6b8e = new Type[] { ToNullable(typeof(System.Collections.Generic.List<string>)) };
 
         /// <inheritdoc />
         Task IGenericNullableReferenceParameterService.Get(System.Collections.Generic.List<string>? reference)
         {
             var arguments = new object[] { reference };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_fd305f7f69684f819d775da6a36218b3);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_7c7c6e7f77b84b6bbafaeed5bbea6b8e);
             return (Task)func(Client, arguments);
         }
 
@@ -1373,13 +1373,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_cb9218d3c95f4121afa837d17bd3517a = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_ff7b9a78a4654df98a535a58ce69a33c = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string>? IGenericNullableReferenceService.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_cb9218d3c95f4121afa837d17bd3517a);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_ff7b9a78a4654df98a535a58ce69a33c);
             return (Task<string>?)func(Client, arguments);
         }
     }
@@ -1408,13 +1408,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_d5d0fc5fa0154da1930d4f23a19d95a7 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_ddfc7be926064f83a6c969a87dfff18d = Array.Empty<Type>();
 
         /// <inheritdoc />
         ValueTask<int>? IGenericNullableValueService.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_d5d0fc5fa0154da1930d4f23a19d95a7);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_ddfc7be926064f83a6c969a87dfff18d);
             return (ValueTask<int>?)func(Client, arguments);
         }
     }
@@ -1443,13 +1443,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_8bcfccb4335948a884f76127e3d735de = new Type[] { ToNullable(typeof(System.Collections.Generic.List<string?>)) };
+        private static readonly Type[] ArgumentTypes_99fdc7fa8e3f465ea07359cdf0da3922 = new Type[] { ToNullable(typeof(System.Collections.Generic.List<string?>)) };
 
         /// <inheritdoc />
         Task IGenericNullableWithNullableReferenceParameterService.Get(System.Collections.Generic.List<string?>? reference)
         {
             var arguments = new object[] { reference };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_8bcfccb4335948a884f76127e3d735de);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_99fdc7fa8e3f465ea07359cdf0da3922);
             return (Task)func(Client, arguments);
         }
 
@@ -1480,13 +1480,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_76e398d47bd74c75ae56bef40ee8f29e = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_9d8c4b3dd7a34f41bd0e3d490dd38e6b = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string?>? IGenericNullableWithNullableReferenceService.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_76e398d47bd74c75ae56bef40ee8f29e);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_9d8c4b3dd7a34f41bd0e3d490dd38e6b);
             return (Task<string?>?)func(Client, arguments);
         }
     }
@@ -1515,13 +1515,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_7217f85bf4d94731b6ea65adc43a7f6e = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_85b1a39e6219474bb7a1a87a38bbd811 = Array.Empty<Type>();
 
         /// <inheritdoc />
         ValueTask<int?>? IGenericNullableWithNullableValueService.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_7217f85bf4d94731b6ea65adc43a7f6e);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_85b1a39e6219474bb7a1a87a38bbd811);
             return (ValueTask<int?>?)func(Client, arguments);
         }
     }
@@ -1550,13 +1550,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_1e18bff7739f44f8b0116bab128c8d6c = new Type[] { typeof(System.Collections.Generic.List<string?>) };
+        private static readonly Type[] ArgumentTypes_517dcd10f1f147709ba86c8c4dd5d30d = new Type[] { typeof(System.Collections.Generic.List<string?>) };
 
         /// <inheritdoc />
         Task IGenericWithNullableReferenceParameterService.Get(System.Collections.Generic.List<string?> reference)
         {
             var arguments = new object[] { reference };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_1e18bff7739f44f8b0116bab128c8d6c);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_517dcd10f1f147709ba86c8c4dd5d30d);
             return (Task)func(Client, arguments);
         }
     }
@@ -1585,13 +1585,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_cb95e433deae4db6b3dc94163d451b4b = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_528ad8b9430d43108c5196d25e0ec586 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<int?> IGenericWithNullableValueService.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_cb95e433deae4db6b3dc94163d451b4b);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_528ad8b9430d43108c5196d25e0ec586);
             return (Task<int?>)func(Client, arguments);
         }
     }
@@ -1620,13 +1620,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_cf51b8524e2d4b73849c22d47402c4c7 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_b42079a79e7742c3817eb2a3a7958fd7 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string?> IGenericWithResultService.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_cf51b8524e2d4b73849c22d47402c4c7);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_b42079a79e7742c3817eb2a3a7958fd7);
             return (Task<string?>)func(Client, arguments);
         }
     }
@@ -1661,133 +1661,133 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_22efa10588f0498780786fdb4cd9aa88 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_380701db2ff243599bb8953d7a54a02e = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<User> IGitHubApi.GetUser(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUser", ArgumentTypes_22efa10588f0498780786fdb4cd9aa88);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUser", ArgumentTypes_380701db2ff243599bb8953d7a54a02e);
             return (Task<User>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_f36206221fc94bbda95858ec2cc32c0e = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_a73d3db4250e49629d2b5c3010449dfa = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         IObservable<User> IGitHubApi.GetUserObservable(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserObservable", ArgumentTypes_f36206221fc94bbda95858ec2cc32c0e);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserObservable", ArgumentTypes_a73d3db4250e49629d2b5c3010449dfa);
             return (IObservable<User>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_37324b76df034cf29dcdf4c7bff07e6b = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_3e76cea0b5724c66bd86518afcaed124 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         IObservable<User> IGitHubApi.GetUserCamelCase(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserCamelCase", ArgumentTypes_37324b76df034cf29dcdf4c7bff07e6b);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserCamelCase", ArgumentTypes_3e76cea0b5724c66bd86518afcaed124);
             return (IObservable<User>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_612b3bfbebc84e23bf1c4412b07c6aa3 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_857528a801c94121b73ce192723553cd = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<List<User>> IGitHubApi.GetOrgMembers(string orgName)
         {
             var arguments = new object[] { orgName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetOrgMembers", ArgumentTypes_612b3bfbebc84e23bf1c4412b07c6aa3);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetOrgMembers", ArgumentTypes_857528a801c94121b73ce192723553cd);
             return (Task<List<User>>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_4cefdbf334ab4fbc946e390822b78740 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_7d208f32325a4bed82f8d8cc2a954513 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<UserSearchResult> IGitHubApi.FindUsers(string q)
         {
             var arguments = new object[] { q };
-            var func = requestBuilder.BuildRestResultFuncForMethod("FindUsers", ArgumentTypes_4cefdbf334ab4fbc946e390822b78740);
+            var func = requestBuilder.BuildRestResultFuncForMethod("FindUsers", ArgumentTypes_7d208f32325a4bed82f8d8cc2a954513);
             return (Task<UserSearchResult>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_acc4394aaf8b48088420ffdac6557e08 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_ddb47942c76547469ae9cb35c284e424 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IGitHubApi.GetIndex()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndex", ArgumentTypes_acc4394aaf8b48088420ffdac6557e08);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndex", ArgumentTypes_ddb47942c76547469ae9cb35c284e424);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_dd787f9da7164be58c606058cba7fec1 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_c198f33c1b044c7fb47b1bf540849d6b = Array.Empty<Type>();
 
         /// <inheritdoc />
         IObservable<string> IGitHubApi.GetIndexObservable()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndexObservable", ArgumentTypes_dd787f9da7164be58c606058cba7fec1);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndexObservable", ArgumentTypes_c198f33c1b044c7fb47b1bf540849d6b);
             return (IObservable<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_f106657f59ad433495627449c7b0cd0c = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_649dcccdfeef487b8cfe636370db238d = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<User> IGitHubApi.NothingToSeeHere()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("NothingToSeeHere", ArgumentTypes_f106657f59ad433495627449c7b0cd0c);
+            var func = requestBuilder.BuildRestResultFuncForMethod("NothingToSeeHere", ArgumentTypes_649dcccdfeef487b8cfe636370db238d);
             return (Task<User>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_fe6147603f5e45fabad554d48b041058 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_c069126551cf45cabb8930f37a4215c2 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<ApiResponse<User>> IGitHubApi.NothingToSeeHereWithMetadata()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("NothingToSeeHereWithMetadata", ArgumentTypes_fe6147603f5e45fabad554d48b041058);
+            var func = requestBuilder.BuildRestResultFuncForMethod("NothingToSeeHereWithMetadata", ArgumentTypes_c069126551cf45cabb8930f37a4215c2);
             return (Task<ApiResponse<User>>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_7fc4701d89a64d63951d3d8ff3c9dd14 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_f1c177c2e6cb445b9affe455d7933cee = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<ApiResponse<User>> IGitHubApi.GetUserWithMetadata(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserWithMetadata", ArgumentTypes_7fc4701d89a64d63951d3d8ff3c9dd14);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserWithMetadata", ArgumentTypes_f1c177c2e6cb445b9affe455d7933cee);
             return (Task<ApiResponse<User>>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_dba70b90b1ea4ff08e699f3cc07a1922 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_c6bc40b397934d1dae1efd11e14fb75c = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         IObservable<ApiResponse<User>> IGitHubApi.GetUserObservableWithMetadata(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserObservableWithMetadata", ArgumentTypes_dba70b90b1ea4ff08e699f3cc07a1922);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserObservableWithMetadata", ArgumentTypes_c6bc40b397934d1dae1efd11e14fb75c);
             return (IObservable<ApiResponse<User>>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_28e826a054514e5ca085ffdf02ca3c7e = new Type[] { typeof(User) };
+        private static readonly Type[] ArgumentTypes_474c0730998448e5bbb394450a75c15b = new Type[] { typeof(User) };
 
         /// <inheritdoc />
         Task<User> IGitHubApi.CreateUser(User user)
         {
             var arguments = new object[] { user };
-            var func = requestBuilder.BuildRestResultFuncForMethod("CreateUser", ArgumentTypes_28e826a054514e5ca085ffdf02ca3c7e);
+            var func = requestBuilder.BuildRestResultFuncForMethod("CreateUser", ArgumentTypes_474c0730998448e5bbb394450a75c15b);
             return (Task<User>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_4f7a0261e2164171b33c5f0f9ced4f3b = new Type[] { typeof(User) };
+        private static readonly Type[] ArgumentTypes_bda1749d26ab4bd39550741611cad352 = new Type[] { typeof(User) };
 
         /// <inheritdoc />
         Task<ApiResponse<User>> IGitHubApi.CreateUserWithMetadata(User user)
         {
             var arguments = new object[] { user };
-            var func = requestBuilder.BuildRestResultFuncForMethod("CreateUserWithMetadata", ArgumentTypes_4f7a0261e2164171b33c5f0f9ced4f3b);
+            var func = requestBuilder.BuildRestResultFuncForMethod("CreateUserWithMetadata", ArgumentTypes_bda1749d26ab4bd39550741611cad352);
             return (Task<ApiResponse<User>>)func(Client, arguments);
         }
     }
@@ -1832,47 +1832,47 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_ef37d6e887b6478fbf70b37de44cdf72 = new Type[] { typeof(TParam), typeof(THeader) };
+        private static readonly Type[] ArgumentTypes_06193ec75cd8417fb73fc7443cf6000d = new Type[] { typeof(TParam), typeof(THeader) };
 
         /// <inheritdoc />
         Task<TResponse> IHttpBinApi<TResponse, TParam, THeader>.Get(TParam param, THeader header)
         {
             var arguments = new object[] { param, header };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_ef37d6e887b6478fbf70b37de44cdf72);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_06193ec75cd8417fb73fc7443cf6000d);
             return (Task<TResponse>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_4b57287ee9f147068f57a2291b964ac9 = new Type[] { typeof(TParam) };
+        private static readonly Type[] ArgumentTypes_f7b6c47c8e074e08b396e44a4e249536 = new Type[] { typeof(TParam) };
 
         /// <inheritdoc />
         Task<TResponse> IHttpBinApi<TResponse, TParam, THeader>.GetQuery(TParam param)
         {
             var arguments = new object[] { param };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetQuery", ArgumentTypes_4b57287ee9f147068f57a2291b964ac9);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetQuery", ArgumentTypes_f7b6c47c8e074e08b396e44a4e249536);
             return (Task<TResponse>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_d06829932a094e51bf0802cdcccc69c2 = new Type[] { typeof(TParam) };
+        private static readonly Type[] ArgumentTypes_74f3692f0d014b00a5f42ca8a902f98d = new Type[] { typeof(TParam) };
 
         /// <inheritdoc />
         Task<TResponse> IHttpBinApi<TResponse, TParam, THeader>.PostQuery(TParam param)
         {
             var arguments = new object[] { param };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostQuery", ArgumentTypes_d06829932a094e51bf0802cdcccc69c2);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostQuery", ArgumentTypes_74f3692f0d014b00a5f42ca8a902f98d);
             return (Task<TResponse>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_c6585d4bd8df4698a2af26f56240a1c1 = new Type[] { typeof(TParam) };
+        private static readonly Type[] ArgumentTypes_41fc8f1bba9340e0833c5517b2e98b76 = new Type[] { typeof(TParam) };
 
         /// <inheritdoc />
         Task<TResponse> IHttpBinApi<TResponse, TParam, THeader>.GetQueryWithIncludeParameterName(TParam param)
         {
             var arguments = new object[] { param };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetQueryWithIncludeParameterName", ArgumentTypes_c6585d4bd8df4698a2af26f56240a1c1);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetQueryWithIncludeParameterName", ArgumentTypes_41fc8f1bba9340e0833c5517b2e98b76);
             return (Task<TResponse>)func(Client, arguments);
         }
 
-        private static class TypeHelper_1b98a930160d456a86a38322f857ee60<TValue>
+        private static class TypeHelper_c6eef0dad3bb413ba537071113a625af<TValue>
         {
             public static readonly Type[] ArgumentTypes = new Type[] { typeof(TParam) };
             public static readonly Type[] TypeParameters = new Type[] { typeof(TValue) };
@@ -1882,7 +1882,7 @@ namespace Refit.Tests
         Task<TValue> IHttpBinApi<TResponse, TParam, THeader>.GetQuery1<TValue>(TParam param)
         {
             var arguments = new object[] { param };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetQuery1", TypeHelper_1b98a930160d456a86a38322f857ee60<TValue>.ArgumentTypes, TypeHelper_1b98a930160d456a86a38322f857ee60<TValue>.TypeParameters);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetQuery1", TypeHelper_c6eef0dad3bb413ba537071113a625af<TValue>.ArgumentTypes, TypeHelper_c6eef0dad3bb413ba537071113a625af<TValue>.TypeParameters);
             return (Task<TValue>)func(Client, arguments);
         }
     }
@@ -1923,23 +1923,23 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_860021ba1cc349c99b218b105b7802cd = new Type[] { typeof(HttpContent) };
+        private static readonly Type[] ArgumentTypes_90529adbf61744c5a831191f49c49161 = new Type[] { typeof(HttpContent) };
 
         /// <inheritdoc />
         Task<HttpContent> IHttpContentApi.PostFileUpload(HttpContent content)
         {
             var arguments = new object[] { content };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostFileUpload", ArgumentTypes_860021ba1cc349c99b218b105b7802cd);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostFileUpload", ArgumentTypes_90529adbf61744c5a831191f49c49161);
             return (Task<HttpContent>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_25acd23e4dea4a9a8eed60dac7024263 = new Type[] { typeof(HttpContent) };
+        private static readonly Type[] ArgumentTypes_bf6b49dbe4d540cc859aa42dbec48b03 = new Type[] { typeof(HttpContent) };
 
         /// <inheritdoc />
         Task<ApiResponse<HttpContent>> IHttpContentApi.PostFileUploadWithMetadata(HttpContent content)
         {
             var arguments = new object[] { content };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostFileUploadWithMetadata", ArgumentTypes_25acd23e4dea4a9a8eed60dac7024263);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostFileUploadWithMetadata", ArgumentTypes_bf6b49dbe4d540cc859aa42dbec48b03);
             return (Task<ApiResponse<HttpContent>>)func(Client, arguments);
         }
     }
@@ -1981,13 +1981,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_5b667542e0e148deb1da664f1ce410fe = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_bfd0f29f7ee647f0a12cccadbbaec128 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<TestAliasObject> ResponseTests.IMyAliasService.GetTestObject()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetTestObject", ArgumentTypes_5b667542e0e148deb1da664f1ce410fe);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetTestObject", ArgumentTypes_bfd0f29f7ee647f0a12cccadbbaec128);
             return (Task<TestAliasObject>)func(Client, arguments);
         }
     }
@@ -2023,23 +2023,23 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_c87126b718ad46ebb4c8a8105418af23 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_c0a075420a6e4527b78489be253ed77a = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> AuthenticatedClientHandlerTests.IMyAuthenticatedService.GetUnauthenticated()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUnauthenticated", ArgumentTypes_c87126b718ad46ebb4c8a8105418af23);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUnauthenticated", ArgumentTypes_c0a075420a6e4527b78489be253ed77a);
             return (Task<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_208efdb7033540699a4ebcfc85b04380 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_678b84ae204a484e8495d371603b0c0a = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> AuthenticatedClientHandlerTests.IMyAuthenticatedService.GetAuthenticated()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetAuthenticated", ArgumentTypes_208efdb7033540699a4ebcfc85b04380);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetAuthenticated", ArgumentTypes_678b84ae204a484e8495d371603b0c0a);
             return (Task<string>)func(Client, arguments);
         }
     }
@@ -2070,13 +2070,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_6e06f8cb18fc40e8b73e3ddf9afd0485 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_f8be50cb813943ebaac386a4d0703e57 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<SomeType> INamespaceCollisionApi.SomeRequest()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", ArgumentTypes_6e06f8cb18fc40e8b73e3ddf9afd0485);
+            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", ArgumentTypes_f8be50cb813943ebaac386a4d0703e57);
             return (Task<SomeType>)func(Client, arguments);
         }
     }
@@ -2108,13 +2108,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_f9e7e2137a144f9c8f8b3122ac1289e9 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_b6b874d51dfe4f0d8f3cf9245aef6c46 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<SomeOtherType> INamespaceOverlapApi.SomeRequest()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", ArgumentTypes_f9e7e2137a144f9c8f8b3122ac1289e9);
+            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", ArgumentTypes_b6b874d51dfe4f0d8f3cf9245aef6c46);
             return (Task<SomeOtherType>)func(Client, arguments);
         }
     }
@@ -2149,83 +2149,83 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_dca6d7f9083f453f81df64b3afa88b25 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_a430349527c64f44ac8c978c42f591c5 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<User> TestNested.INestedGitHubApi.GetUser(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUser", ArgumentTypes_dca6d7f9083f453f81df64b3afa88b25);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUser", ArgumentTypes_a430349527c64f44ac8c978c42f591c5);
             return (Task<User>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_c3f09c4e72f8408fbba5ed72d925f7dc = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_70b62ba2e147441f81e8ef28d7247f0c = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         IObservable<User> TestNested.INestedGitHubApi.GetUserObservable(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserObservable", ArgumentTypes_c3f09c4e72f8408fbba5ed72d925f7dc);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserObservable", ArgumentTypes_70b62ba2e147441f81e8ef28d7247f0c);
             return (IObservable<User>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_4606b63ffe5e469f95d9b16444e554c4 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_d08e15bc70024a99b58110ae00c5221f = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         IObservable<User> TestNested.INestedGitHubApi.GetUserCamelCase(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserCamelCase", ArgumentTypes_4606b63ffe5e469f95d9b16444e554c4);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserCamelCase", ArgumentTypes_d08e15bc70024a99b58110ae00c5221f);
             return (IObservable<User>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_c9dfbe864d7c4618a9f7edafdb324b95 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_eb8a13eadc1147c487a80d9240125c75 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<List<User>> TestNested.INestedGitHubApi.GetOrgMembers(string orgName)
         {
             var arguments = new object[] { orgName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetOrgMembers", ArgumentTypes_c9dfbe864d7c4618a9f7edafdb324b95);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetOrgMembers", ArgumentTypes_eb8a13eadc1147c487a80d9240125c75);
             return (Task<List<User>>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_fcd895bbca2240d2b9e881b694d4d689 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_6711e41af7da401ca3ff705164eb6f75 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<UserSearchResult> TestNested.INestedGitHubApi.FindUsers(string q)
         {
             var arguments = new object[] { q };
-            var func = requestBuilder.BuildRestResultFuncForMethod("FindUsers", ArgumentTypes_fcd895bbca2240d2b9e881b694d4d689);
+            var func = requestBuilder.BuildRestResultFuncForMethod("FindUsers", ArgumentTypes_6711e41af7da401ca3ff705164eb6f75);
             return (Task<UserSearchResult>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_6d49d359b3f44fdab7b3b15349ee9123 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_efcf362a9a5e4bfbbe5a0a25e776d31f = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<HttpResponseMessage> TestNested.INestedGitHubApi.GetIndex()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndex", ArgumentTypes_6d49d359b3f44fdab7b3b15349ee9123);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndex", ArgumentTypes_efcf362a9a5e4bfbbe5a0a25e776d31f);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_d7b34740ecb84442ab0f3dd4125a96a9 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_7902d50b86494f45a9457bd520d1eb8d = Array.Empty<Type>();
 
         /// <inheritdoc />
         IObservable<string> TestNested.INestedGitHubApi.GetIndexObservable()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndexObservable", ArgumentTypes_d7b34740ecb84442ab0f3dd4125a96a9);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndexObservable", ArgumentTypes_7902d50b86494f45a9457bd520d1eb8d);
             return (IObservable<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_e9a636d835964b0ab6603fab2bc0fbd7 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_a4fdcecd8fa54bf1a56d17aa2a1dabd2 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task TestNested.INestedGitHubApi.NothingToSeeHere()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("NothingToSeeHere", ArgumentTypes_e9a636d835964b0ab6603fab2bc0fbd7);
+            var func = requestBuilder.BuildRestResultFuncForMethod("NothingToSeeHere", ArgumentTypes_a4fdcecd8fa54bf1a56d17aa2a1dabd2);
             return (Task)func(Client, arguments);
         }
     }
@@ -2263,7 +2263,7 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static class TypeHelper_9faf9503e3a64a929953fdffd2f78260<T>
+        private static class TypeHelper_b889c630279e4519b3d851c5978a5eec<T>
         {
             public static readonly Type[] ArgumentTypes = new Type[] { typeof(T) };
             public static readonly Type[] TypeParameters = new Type[] { typeof(T) };
@@ -2273,11 +2273,11 @@ namespace Refit.Tests
         Task INonGenericInterfaceWithGenericMethod.PostMessage<T>(T message)
         {
             var arguments = new object[] { message };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostMessage", TypeHelper_9faf9503e3a64a929953fdffd2f78260<T>.ArgumentTypes, TypeHelper_9faf9503e3a64a929953fdffd2f78260<T>.TypeParameters);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostMessage", TypeHelper_b889c630279e4519b3d851c5978a5eec<T>.ArgumentTypes, TypeHelper_b889c630279e4519b3d851c5978a5eec<T>.TypeParameters);
             return (Task)func(Client, arguments);
         }
 
-        private static class TypeHelper_6bd033e0eff648c88d8d6913f448f2d3<T, U, V>
+        private static class TypeHelper_1a981ad2b8d3438fbcb9a8f209038877<T, U, V>
         {
             public static readonly Type[] ArgumentTypes = new Type[] { typeof(T), typeof(U), typeof(V) };
             public static readonly Type[] TypeParameters = new Type[] { typeof(T), typeof(U), typeof(V) };
@@ -2287,7 +2287,7 @@ namespace Refit.Tests
         Task INonGenericInterfaceWithGenericMethod.PostMessage<T, U, V>(T message, U param1, V param2)
         {
             var arguments = new object[] { message, param1, param2 };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostMessage", TypeHelper_6bd033e0eff648c88d8d6913f448f2d3<T, U, V>.ArgumentTypes, TypeHelper_6bd033e0eff648c88d8d6913f448f2d3<T, U, V>.TypeParameters);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostMessage", TypeHelper_1a981ad2b8d3438fbcb9a8f209038877<T, U, V>.ArgumentTypes, TypeHelper_1a981ad2b8d3438fbcb9a8f209038877<T, U, V>.TypeParameters);
             return (Task)func(Client, arguments);
         }
     }
@@ -2328,13 +2328,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_8c2c0aed76f44e1b9af23cd4e64d7493 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_b5f001f47a6644b0bf731d546529b6e4 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<RootObject> INpmJs.GetCongruence()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetCongruence", ArgumentTypes_8c2c0aed76f44e1b9af23cd4e64d7493);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetCongruence", ArgumentTypes_b5f001f47a6644b0bf731d546529b6e4);
             return (Task<RootObject>)func(Client, arguments);
         }
     }
@@ -2363,13 +2363,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_c15006c70e3345de826be41bcb376132 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_45fa3b17785e4f11884f93a5cfe4b74c = Array.Empty<Type>();
 
         /// <inheritdoc />
         string? INullableReferenceService.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_c15006c70e3345de826be41bcb376132);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_45fa3b17785e4f11884f93a5cfe4b74c);
             return (string?)func(Client, arguments);
         }
     }
@@ -2398,13 +2398,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_065b4b83c6124ac2ad679ef25adfff91 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_d2dac6196fd04f76805346b266b73109 = Array.Empty<Type>();
 
         /// <inheritdoc />
         int? INullableValueService.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_065b4b83c6124ac2ad679ef25adfff91);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_d2dac6196fd04f76805346b266b73109);
             return (int?)func(Client, arguments);
         }
     }
@@ -2434,13 +2434,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_b6eb40ecc8cb46acb64b1fdbba14e17a = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_1a6e4d2b56d74525bdd83b07398ceb5d = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<SomeType> IReducedUsingInsideNamespaceApi.SomeRequest()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", ArgumentTypes_b6eb40ecc8cb46acb64b1fdbba14e17a);
+            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", ArgumentTypes_1a6e4d2b56d74525bdd83b07398ceb5d);
             return (Task<SomeType>)func(Client, arguments);
         }
     }
@@ -2469,13 +2469,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_4c3931b5368f4073b4229f7a1f129e2d = new Type[] { ToNullable(typeof(string)), ToNullable(typeof(int)) };
+        private static readonly Type[] ArgumentTypes_45e9ac026f114d349d9e3eb4c9821f4a = new Type[] { ToNullable(typeof(string)), ToNullable(typeof(int)) };
 
         /// <inheritdoc />
         Task IReferenceAndValueParametersService.Get(string? reference, int? value)
         {
             var arguments = new object[] { reference, value };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_4c3931b5368f4073b4229f7a1f129e2d);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_45e9ac026f114d349d9e3eb4c9821f4a);
             return (Task)func(Client, arguments);
         }
 
@@ -2518,13 +2518,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_5c4e156234594557bd8fa6547588a92c = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_041608a4df2545b88fa524c8ead947ee = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IRefitInterfaceWithStaticMethod.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_5c4e156234594557bd8fa6547588a92c);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_041608a4df2545b88fa524c8ead947ee);
             return (Task)func(Client, arguments);
         }
     }
@@ -2565,47 +2565,47 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_0e9b43b42bbe4cc58f20414b6cc637d7 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_8aae29f557ef4d9b8f36c67fce8e2ddf = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IRequestBin.Post()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Post", ArgumentTypes_0e9b43b42bbe4cc58f20414b6cc637d7);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Post", ArgumentTypes_8aae29f557ef4d9b8f36c67fce8e2ddf);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_8c2469fa7d614ea7baaffd3c149e1a94 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_84ba01aad0ca4a60823ecc8a277ed4f7 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task IRequestBin.PostRawStringDefault(string str)
         {
             var arguments = new object[] { str };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostRawStringDefault", ArgumentTypes_8c2469fa7d614ea7baaffd3c149e1a94);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostRawStringDefault", ArgumentTypes_84ba01aad0ca4a60823ecc8a277ed4f7);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_2574daa025254aeabc3113323e27bf79 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_fa40c3c2926c4ab79bc510071ee5d3c4 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task IRequestBin.PostRawStringJson(string str)
         {
             var arguments = new object[] { str };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostRawStringJson", ArgumentTypes_2574daa025254aeabc3113323e27bf79);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostRawStringJson", ArgumentTypes_fa40c3c2926c4ab79bc510071ee5d3c4);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_c1a63060808845dca08d8f0556d9b30a = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_4d1682eb1a354f13b33174f797ecdaa5 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task IRequestBin.PostRawStringUrlEncoded(string str)
         {
             var arguments = new object[] { str };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostRawStringUrlEncoded", ArgumentTypes_c1a63060808845dca08d8f0556d9b30a);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostRawStringUrlEncoded", ArgumentTypes_4d1682eb1a354f13b33174f797ecdaa5);
             return (Task)func(Client, arguments);
         }
 
-        private static class TypeHelper_78f0caea71174665add47a15311d6b97<T>
+        private static class TypeHelper_fde5aefa86af4843a402d9f9a3b60b88<T>
         {
             public static readonly Type[] ArgumentTypes = new Type[] { typeof(T) };
             public static readonly Type[] TypeParameters = new Type[] { typeof(T) };
@@ -2615,7 +2615,7 @@ namespace Refit.Tests
         Task IRequestBin.PostGeneric<T>(T param)
         {
             var arguments = new object[] { param };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostGeneric", TypeHelper_78f0caea71174665add47a15311d6b97<T>.ArgumentTypes, TypeHelper_78f0caea71174665add47a15311d6b97<T>.TypeParameters);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostGeneric", TypeHelper_fde5aefa86af4843a402d9f9a3b60b88<T>.ArgumentTypes, TypeHelper_fde5aefa86af4843a402d9f9a3b60b88<T>.TypeParameters);
             return (Task)func(Client, arguments);
         }
     }
@@ -2656,133 +2656,133 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_8d8c701d4dba475a922ac2217e57d9cb = new Type[] { typeof(Stream) };
+        private static readonly Type[] ArgumentTypes_684d625ec98541d5a0a8be05f7d49755 = new Type[] { typeof(Stream) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadStream(Stream stream)
         {
             var arguments = new object[] { stream };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStream", ArgumentTypes_8d8c701d4dba475a922ac2217e57d9cb);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStream", ArgumentTypes_684d625ec98541d5a0a8be05f7d49755);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_f1a39d1015f04bf4ad35a7bd6c7cc35b = new Type[] { typeof(Stream) };
+        private static readonly Type[] ArgumentTypes_fe4cdc2b5df341948d92f7d558ca413d = new Type[] { typeof(Stream) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadStreamWithCustomBoundary(Stream stream)
         {
             var arguments = new object[] { stream };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStreamWithCustomBoundary", ArgumentTypes_f1a39d1015f04bf4ad35a7bd6c7cc35b);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStreamWithCustomBoundary", ArgumentTypes_fe4cdc2b5df341948d92f7d558ca413d);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_3865d1d733814bef9a0ebceb02b7a8d7 = new Type[] { typeof(StreamPart) };
+        private static readonly Type[] ArgumentTypes_7adfa51417ff4dec84da224f19820e73 = new Type[] { typeof(StreamPart) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadStreamPart(StreamPart stream)
         {
             var arguments = new object[] { stream };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStreamPart", ArgumentTypes_3865d1d733814bef9a0ebceb02b7a8d7);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStreamPart", ArgumentTypes_7adfa51417ff4dec84da224f19820e73);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_54a7c4db15f544f2abccc0aaecb8d3f9 = new Type[] { typeof(ModelObject), typeof(StreamPart) };
+        private static readonly Type[] ArgumentTypes_fca3caac8faf4c62919761db17ec7d3a = new Type[] { typeof(ModelObject), typeof(StreamPart) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadStreamPart(ModelObject someQueryParams, StreamPart stream)
         {
             var arguments = new object[] { someQueryParams, stream };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStreamPart", ArgumentTypes_54a7c4db15f544f2abccc0aaecb8d3f9);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStreamPart", ArgumentTypes_fca3caac8faf4c62919761db17ec7d3a);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_f34f705797214ba99fdbda90c6e0e5ef = new Type[] { typeof(byte[]) };
+        private static readonly Type[] ArgumentTypes_cd1e2404075449b5be02bc5d6fc99c68 = new Type[] { typeof(byte[]) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadBytes(byte[] bytes)
         {
             var arguments = new object[] { bytes };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadBytes", ArgumentTypes_f34f705797214ba99fdbda90c6e0e5ef);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadBytes", ArgumentTypes_cd1e2404075449b5be02bc5d6fc99c68);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_9054801237af4f7fb7744a74ed03b5fb = new Type[] { typeof(ByteArrayPart) };
+        private static readonly Type[] ArgumentTypes_0feafdcd26044aa3b968e6ca6f5806d4 = new Type[] { typeof(ByteArrayPart) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadBytesPart(ByteArrayPart bytes)
         {
             var arguments = new object[] { bytes };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadBytesPart", ArgumentTypes_9054801237af4f7fb7744a74ed03b5fb);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadBytesPart", ArgumentTypes_0feafdcd26044aa3b968e6ca6f5806d4);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_57a342f452c14cbd8708a43e13d5a9a6 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_d39be899581c43e296ba98f32506831e = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadString(string someString)
         {
             var arguments = new object[] { someString };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadString", ArgumentTypes_57a342f452c14cbd8708a43e13d5a9a6);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadString", ArgumentTypes_d39be899581c43e296ba98f32506831e);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_18702cb2105341e1a160dfe42d00a7b2 = new Type[] { typeof(IEnumerable<FileInfo>), typeof(FileInfo) };
+        private static readonly Type[] ArgumentTypes_9d4f399f50f94feb85557f84d2ab1096 = new Type[] { typeof(IEnumerable<FileInfo>), typeof(FileInfo) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadFileInfo(IEnumerable<FileInfo> fileInfos, FileInfo anotherFile)
         {
             var arguments = new object[] { fileInfos, anotherFile };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadFileInfo", ArgumentTypes_18702cb2105341e1a160dfe42d00a7b2);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadFileInfo", ArgumentTypes_9d4f399f50f94feb85557f84d2ab1096);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_647aa0e7e0794d92b552c38ec061d1f7 = new Type[] { typeof(IEnumerable<FileInfoPart>), typeof(FileInfoPart) };
+        private static readonly Type[] ArgumentTypes_c4c322984f67484291a5e8519e56bbac = new Type[] { typeof(IEnumerable<FileInfoPart>), typeof(FileInfoPart) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadFileInfoPart(IEnumerable<FileInfoPart> fileInfos, FileInfoPart anotherFile)
         {
             var arguments = new object[] { fileInfos, anotherFile };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadFileInfoPart", ArgumentTypes_647aa0e7e0794d92b552c38ec061d1f7);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadFileInfoPart", ArgumentTypes_c4c322984f67484291a5e8519e56bbac);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_421b3d0c31bc4353918b610460d2a91f = new Type[] { typeof(ModelObject) };
+        private static readonly Type[] ArgumentTypes_c65c5847413e44b1a35eceff6a5bc150 = new Type[] { typeof(ModelObject) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadJsonObject(ModelObject theObject)
         {
             var arguments = new object[] { theObject };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadJsonObject", ArgumentTypes_421b3d0c31bc4353918b610460d2a91f);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadJsonObject", ArgumentTypes_c65c5847413e44b1a35eceff6a5bc150);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_5ebccbd5dc064fac8f2ea3c6c94b66e1 = new Type[] { typeof(IEnumerable<ModelObject>) };
+        private static readonly Type[] ArgumentTypes_6bb04ba2c13f49f9a6a02ca0497e7297 = new Type[] { typeof(IEnumerable<ModelObject>) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadJsonObjects(IEnumerable<ModelObject> theObjects)
         {
             var arguments = new object[] { theObjects };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadJsonObjects", ArgumentTypes_5ebccbd5dc064fac8f2ea3c6c94b66e1);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadJsonObjects", ArgumentTypes_6bb04ba2c13f49f9a6a02ca0497e7297);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_3dae92c860564131ad5740c5fd8a2f71 = new Type[] { typeof(IEnumerable<ModelObject>), typeof(AnotherModel), typeof(FileInfo), typeof(AnEnum), typeof(string), typeof(int) };
+        private static readonly Type[] ArgumentTypes_de9cf24454df48c4a3f0be6f036d3148 = new Type[] { typeof(IEnumerable<ModelObject>), typeof(AnotherModel), typeof(FileInfo), typeof(AnEnum), typeof(string), typeof(int) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadMixedObjects(IEnumerable<ModelObject> theObjects, AnotherModel anotherModel, FileInfo aFile, AnEnum anEnum, string aString, int anInt)
         {
             var arguments = new object[] { theObjects, anotherModel, aFile, anEnum, aString, anInt };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadMixedObjects", ArgumentTypes_3dae92c860564131ad5740c5fd8a2f71);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadMixedObjects", ArgumentTypes_de9cf24454df48c4a3f0be6f036d3148);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_18fe028ec8ca4e4f9af667138ae8ab2d = new Type[] { typeof(HttpContent) };
+        private static readonly Type[] ArgumentTypes_f051d362881246f28ca8f09086f0abac = new Type[] { typeof(HttpContent) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadHttpContent(HttpContent content)
         {
             var arguments = new object[] { content };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadHttpContent", ArgumentTypes_18fe028ec8ca4e4f9af667138ae8ab2d);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadHttpContent", ArgumentTypes_f051d362881246f28ca8f09086f0abac);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
     }
@@ -2814,23 +2814,23 @@ namespace AutoGeneratedIServiceWithoutNamespace
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_c390abe63d40479c97cb3599ee2da20e = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_bb0e6a7c468c4dd3a6210267d6b9cad9 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IServiceWithoutNamespace.GetRoot()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetRoot", ArgumentTypes_c390abe63d40479c97cb3599ee2da20e);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetRoot", ArgumentTypes_bb0e6a7c468c4dd3a6210267d6b9cad9);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_ac474723686a400aa7872d929635adef = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_7f6605636b19400d94135ec4d92a0763 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IServiceWithoutNamespace.PostRoot()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostRoot", ArgumentTypes_ac474723686a400aa7872d929635adef);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostRoot", ArgumentTypes_7f6605636b19400d94135ec4d92a0763);
             return (Task)func(Client, arguments);
         }
     }
@@ -2871,23 +2871,23 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_2679f58be1e448abb1774c04a578c30f = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_a609f44b3e3c450cb19beb6de256880d = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<Stream> IStreamApi.GetRemoteFile(string filename)
         {
             var arguments = new object[] { filename };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetRemoteFile", ArgumentTypes_2679f58be1e448abb1774c04a578c30f);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetRemoteFile", ArgumentTypes_a609f44b3e3c450cb19beb6de256880d);
             return (Task<Stream>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_b7b8c92b7dbb4b2da18fcd145ce9d9ff = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_6032b3c0af634f8e9ce7cadf6f8608b6 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<ApiResponse<Stream>> IStreamApi.GetRemoteFileWithMetadata(string filename)
         {
             var arguments = new object[] { filename };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetRemoteFileWithMetadata", ArgumentTypes_b7b8c92b7dbb4b2da18fcd145ce9d9ff);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetRemoteFileWithMetadata", ArgumentTypes_6032b3c0af634f8e9ce7cadf6f8608b6);
             return (Task<ApiResponse<Stream>>)func(Client, arguments);
         }
     }
@@ -2928,13 +2928,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_5e651d014f50421a8c367cbc7266d229 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_0696eae660514552a23e3fb09f8f2ca5 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task ITrimTrailingForwardSlashApi.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_5e651d014f50421a8c367cbc7266d229);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_0696eae660514552a23e3fb09f8f2ca5);
             return (Task)func(Client, arguments);
         }
     }
@@ -2964,13 +2964,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_b44f46680c894b459be81e966f8b8452 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_3ad36489d3924039b7930d393433e92b = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<SomeType> ITypeCollisionApiA.SomeARequest()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("SomeARequest", ArgumentTypes_b44f46680c894b459be81e966f8b8452);
+            var func = requestBuilder.BuildRestResultFuncForMethod("SomeARequest", ArgumentTypes_3ad36489d3924039b7930d393433e92b);
             return (Task<SomeType>)func(Client, arguments);
         }
     }
@@ -3000,13 +3000,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_408c33407ab340dd9a804892b3ed42b9 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_be5e5b598e0c42c1a71031959a2b48c5 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<SomeType> ITypeCollisionApiB.SomeBRequest()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("SomeBRequest", ArgumentTypes_408c33407ab340dd9a804892b3ed42b9);
+            var func = requestBuilder.BuildRestResultFuncForMethod("SomeBRequest", ArgumentTypes_be5e5b598e0c42c1a71031959a2b48c5);
             return (Task<SomeType>)func(Client, arguments);
         }
     }
@@ -3045,47 +3045,47 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_92157ae4b2094789896c1ba6f0d37edd = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_b2e52dc636ae4b97a6dc089c5451995e = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> IUseOverloadedGenericMethods<TResponse, TParam, THeader>.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_92157ae4b2094789896c1ba6f0d37edd);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_b2e52dc636ae4b97a6dc089c5451995e);
             return (Task<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_22020599fba944c9a87c23487ac98043 = new Type[] { typeof(TParam), typeof(THeader) };
+        private static readonly Type[] ArgumentTypes_178ba7de1daa426992a6a41650b86c16 = new Type[] { typeof(TParam), typeof(THeader) };
 
         /// <inheritdoc />
         Task<TResponse> IUseOverloadedGenericMethods<TResponse, TParam, THeader>.Get(TParam param, THeader header)
         {
             var arguments = new object[] { param, header };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_22020599fba944c9a87c23487ac98043);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_178ba7de1daa426992a6a41650b86c16);
             return (Task<TResponse>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_6279ee13f4c94f2ebcc6a1efb4fcc379 = new Type[] { typeof(THeader), typeof(TParam) };
+        private static readonly Type[] ArgumentTypes_e71df52916364e49aee7343278d40be3 = new Type[] { typeof(THeader), typeof(TParam) };
 
         /// <inheritdoc />
         Task<TResponse> IUseOverloadedGenericMethods<TResponse, TParam, THeader>.Get(THeader param, TParam header)
         {
             var arguments = new object[] { param, header };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_6279ee13f4c94f2ebcc6a1efb4fcc379);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_e71df52916364e49aee7343278d40be3);
             return (Task<TResponse>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_646ad1a02dcf45dd8b9c35bb89d02df1 = new Type[] { typeof(int) };
+        private static readonly Type[] ArgumentTypes_b460c9806256456287323f3a99620e54 = new Type[] { typeof(int) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IUseOverloadedGenericMethods<TResponse, TParam, THeader>.Get(int httpstatuscode)
         {
             var arguments = new object[] { httpstatuscode };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_646ad1a02dcf45dd8b9c35bb89d02df1);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_b460c9806256456287323f3a99620e54);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static class TypeHelper_6dc35fe1f52941cab9aea1e057cf8ebd<TValue>
+        private static class TypeHelper_16663a294a3747d58d9f4de74773314b<TValue>
         {
             public static readonly Type[] ArgumentTypes = new Type[] { typeof(int) };
             public static readonly Type[] TypeParameters = new Type[] { typeof(TValue) };
@@ -3095,11 +3095,11 @@ namespace Refit.Tests
         Task<TValue> IUseOverloadedGenericMethods<TResponse, TParam, THeader>.Get<TValue>(int someVal)
         {
             var arguments = new object[] { someVal };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", TypeHelper_6dc35fe1f52941cab9aea1e057cf8ebd<TValue>.ArgumentTypes, TypeHelper_6dc35fe1f52941cab9aea1e057cf8ebd<TValue>.TypeParameters);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", TypeHelper_16663a294a3747d58d9f4de74773314b<TValue>.ArgumentTypes, TypeHelper_16663a294a3747d58d9f4de74773314b<TValue>.TypeParameters);
             return (Task<TValue>)func(Client, arguments);
         }
 
-        private static class TypeHelper_005ec7be7e064cb480566fa4751266c8<TValue, TInput>
+        private static class TypeHelper_709be579e09e4928b0846592e9755f37<TValue, TInput>
         {
             public static readonly Type[] ArgumentTypes = new Type[] { typeof(TInput) };
             public static readonly Type[] TypeParameters = new Type[] { typeof(TValue), typeof(TInput) };
@@ -3109,11 +3109,11 @@ namespace Refit.Tests
         Task<TValue> IUseOverloadedGenericMethods<TResponse, TParam, THeader>.Get<TValue, TInput>(TInput input)
         {
             var arguments = new object[] { input };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", TypeHelper_005ec7be7e064cb480566fa4751266c8<TValue, TInput>.ArgumentTypes, TypeHelper_005ec7be7e064cb480566fa4751266c8<TValue, TInput>.TypeParameters);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", TypeHelper_709be579e09e4928b0846592e9755f37<TValue, TInput>.ArgumentTypes, TypeHelper_709be579e09e4928b0846592e9755f37<TValue, TInput>.TypeParameters);
             return (Task<TValue>)func(Client, arguments);
         }
 
-        private static class TypeHelper_76069f642cdc46e7a22bcf380d19a3de<TInput1, TInput2>
+        private static class TypeHelper_bbea10926f144c5b970ee04637b14c68<TInput1, TInput2>
         {
             public static readonly Type[] ArgumentTypes = new Type[] { typeof(TInput1), typeof(TInput2) };
             public static readonly Type[] TypeParameters = new Type[] { typeof(TInput1), typeof(TInput2) };
@@ -3123,7 +3123,7 @@ namespace Refit.Tests
         Task IUseOverloadedGenericMethods<TResponse, TParam, THeader>.Get<TInput1, TInput2>(TInput1 input1, TInput2 input2)
         {
             var arguments = new object[] { input1, input2 };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", TypeHelper_76069f642cdc46e7a22bcf380d19a3de<TInput1, TInput2>.ArgumentTypes, TypeHelper_76069f642cdc46e7a22bcf380d19a3de<TInput1, TInput2>.TypeParameters);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", TypeHelper_bbea10926f144c5b970ee04637b14c68<TInput1, TInput2>.ArgumentTypes, TypeHelper_bbea10926f144c5b970ee04637b14c68<TInput1, TInput2>.TypeParameters);
             return (Task)func(Client, arguments);
         }
     }
@@ -3158,23 +3158,23 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_dfdff52c52fa491fa7d7c9e9b72aca25 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_fc80a89649564f49a5686f9edd681fda = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> IUseOverloadedMethods.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_dfdff52c52fa491fa7d7c9e9b72aca25);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_fc80a89649564f49a5686f9edd681fda);
             return (Task<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_655aad381a3b43fcb8b0dd9adf274aff = new Type[] { typeof(int) };
+        private static readonly Type[] ArgumentTypes_d44f45f888e74028b19bd19bb70b9231 = new Type[] { typeof(int) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IUseOverloadedMethods.Get(int httpstatuscode)
         {
             var arguments = new object[] { httpstatuscode };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_655aad381a3b43fcb8b0dd9adf274aff);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_d44f45f888e74028b19bd19bb70b9231);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
     }
@@ -3215,13 +3215,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_4b2ea6c70034430e9bb5ef3ddcbdc085 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_d7658779b2ac415da648b980145d9a98 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IValidApi.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_4b2ea6c70034430e9bb5ef3ddcbdc085);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_d7658779b2ac415da648b980145d9a98);
             return (Task)func(Client, arguments);
         }
     }
@@ -3251,13 +3251,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_8fe66bcc0f494894ba3f2eeef9d89ac3 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_3f48c36fd66d40339da0d66d4d03c0fc = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<SomeType> NamespaceWithGlobalAliasApi.SomeRequest()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", ArgumentTypes_8fe66bcc0f494894ba3f2eeef9d89ac3);
+            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", ArgumentTypes_3f48c36fd66d40339da0d66d4d03c0fc);
             return (Task<SomeType>)func(Client, arguments);
         }
     }

--- a/Refit.Tests/RefitStubs.NetCore3.cs
+++ b/Refit.Tests/RefitStubs.NetCore3.cs
@@ -62,27 +62,27 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_4fb19815237f4083aadaa0e9d139923a = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_22065d48f4d24ffd8a189b6fccd7b321 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IAmARefitInterfaceButNobodyUsesMe.RefitMethod()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("RefitMethod", ArgumentTypes_4fb19815237f4083aadaa0e9d139923a);
+            var func = requestBuilder.BuildRestResultFuncForMethod("RefitMethod", ArgumentTypes_22065d48f4d24ffd8a189b6fccd7b321);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_637b6166889d449d96660eac092e89be = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_3c7b5ebe31d74f6f82bb1086e9ed1ede = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IAmARefitInterfaceButNobodyUsesMe.AnotherRefitMethod()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("AnotherRefitMethod", ArgumentTypes_637b6166889d449d96660eac092e89be);
+            var func = requestBuilder.BuildRestResultFuncForMethod("AnotherRefitMethod", ArgumentTypes_3c7b5ebe31d74f6f82bb1086e9ed1ede);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_dd92f177b0cd4e1780f9d80413ee9285 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_56d3bdab41c245258277a5e1419c4ce7 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IAmARefitInterfaceButNobodyUsesMe.NoConstantsAllowed()
@@ -90,23 +90,23 @@ namespace Refit.Tests
             throw new NotImplementedException("Either this method has no Refit HTTP method attribute or you've used something other than a string literal for the 'path' argument.");
         }
 
-        private static readonly Type[] ArgumentTypes_ba12e6f238b744aa843514408c8ecb94 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_07e1bea14e384414bcef31bb7948f0af = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IAmARefitInterfaceButNobodyUsesMe.SpacesShouldntBreakMe()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("SpacesShouldntBreakMe", ArgumentTypes_ba12e6f238b744aa843514408c8ecb94);
+            var func = requestBuilder.BuildRestResultFuncForMethod("SpacesShouldntBreakMe", ArgumentTypes_07e1bea14e384414bcef31bb7948f0af);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_259d311143c64903a53c695901542d74 = new Type[] { typeof(int), typeof(string), typeof(float) };
+        private static readonly Type[] ArgumentTypes_c0d956c2aca5403cbb9625c946903a8d = new Type[] { typeof(int), typeof(string), typeof(float) };
 
         /// <inheritdoc />
         Task IAmARefitInterfaceButNobodyUsesMe.ReservedWordsForParameterNames(int @int, string @string, float @long)
         {
             var arguments = new object[] { @int, @string, @long };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReservedWordsForParameterNames", ArgumentTypes_259d311143c64903a53c695901542d74);
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReservedWordsForParameterNames", ArgumentTypes_c0d956c2aca5403cbb9625c946903a8d);
             return (Task)func(Client, arguments);
         }
     }
@@ -147,17 +147,17 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_a1bfd88146a74e30b600b1a105eecd37 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_591ba265582449109178c33946ec7ad6 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IAmHalfRefit.Post()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Post", ArgumentTypes_a1bfd88146a74e30b600b1a105eecd37);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Post", ArgumentTypes_591ba265582449109178c33946ec7ad6);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_7fe6a45f0b1545fcbba87105c549a3f0 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_845ef242566043c799eade8aaea24dfb = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IAmHalfRefit.Get()
@@ -191,43 +191,43 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_24b200c4c8794bcbbdb8ab833f1fc9f3 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_ade0ecec24c7457293aea04c31322205 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> IAmInterface.Pang()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Pang", ArgumentTypes_24b200c4c8794bcbbdb8ab833f1fc9f3);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Pang", ArgumentTypes_ade0ecec24c7457293aea04c31322205);
             return (Task<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_e480a487229b4618904a42e0883b2acc = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_c94060438611411d97ed407cbf1634a3 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> IAmInterfaceB.Pong()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Pong", ArgumentTypes_e480a487229b4618904a42e0883b2acc);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Pong", ArgumentTypes_c94060438611411d97ed407cbf1634a3);
             return (Task<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_6abcae130331449b8da132ecfd447599 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_206f5e0a1e6047f4802de8ab10f2255c = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> IAmInterfaceD.Test()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Test", ArgumentTypes_6abcae130331449b8da132ecfd447599);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Test", ArgumentTypes_206f5e0a1e6047f4802de8ab10f2255c);
             return (Task<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_94d0f3c718b341f7a13222052d61f29d = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_481fb086bc824ad7bb08b64c91fdc9ce = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> IAmInterfaceA.Ping()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Ping", ArgumentTypes_94d0f3c718b341f7a13222052d61f29d);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Ping", ArgumentTypes_481fb086bc824ad7bb08b64c91fdc9ce);
             return (Task<string>)func(Client, arguments);
         }
     }
@@ -257,13 +257,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_dfc7ac031c9b41ce87a8c096a1974585 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_ae76fcb211ca4d5c8a17c5a1d0396dbf = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> IAmInterfaceA.Ping()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Ping", ArgumentTypes_dfc7ac031c9b41ce87a8c096a1974585);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Ping", ArgumentTypes_ae76fcb211ca4d5c8a17c5a1d0396dbf);
             return (Task<string>)func(Client, arguments);
         }
     }
@@ -293,23 +293,23 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_ed4e46d8dca547029fbe593b603067d5 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_8257260eac834aeabc0e98cf27e55711 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> IAmInterfaceB.Pong()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Pong", ArgumentTypes_ed4e46d8dca547029fbe593b603067d5);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Pong", ArgumentTypes_8257260eac834aeabc0e98cf27e55711);
             return (Task<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_e4c334d2aa86452290a4de8ab1456fac = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_be967b768949424abb3978c683af3d94 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> IAmInterfaceD.Test()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Test", ArgumentTypes_e4c334d2aa86452290a4de8ab1456fac);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Test", ArgumentTypes_be967b768949424abb3978c683af3d94);
             return (Task<string>)func(Client, arguments);
         }
     }
@@ -339,43 +339,43 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_154e2c89eb504b2cbb7b87b5b36447cf = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_23e15df3f8ba40d78535d553f38dd2d6 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> IAmInterfaceC.Pang()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Pang", ArgumentTypes_154e2c89eb504b2cbb7b87b5b36447cf);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Pang", ArgumentTypes_23e15df3f8ba40d78535d553f38dd2d6);
             return (Task<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_7f1f55a4ba604ef59ce68f86dd43c054 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_2e5992d858644a41a04cb6a6f9b9d883 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> IAmInterfaceB.Pong()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Pong", ArgumentTypes_7f1f55a4ba604ef59ce68f86dd43c054);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Pong", ArgumentTypes_2e5992d858644a41a04cb6a6f9b9d883);
             return (Task<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_0fe0ec6439b24c9a95a10f38d2775888 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_c779ae64849f4053a004aee5eadfe214 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> IAmInterfaceD.Test()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Test", ArgumentTypes_0fe0ec6439b24c9a95a10f38d2775888);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Test", ArgumentTypes_c779ae64849f4053a004aee5eadfe214);
             return (Task<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_002781729c25445d9b091c3280a2bcfa = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_02298b660a4f4e49a1f4ead4db19ea8b = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> IAmInterfaceA.Ping()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Ping", ArgumentTypes_002781729c25445d9b091c3280a2bcfa);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Ping", ArgumentTypes_02298b660a4f4e49a1f4ead4db19ea8b);
             return (Task<string>)func(Client, arguments);
         }
     }
@@ -405,13 +405,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_2ee9e800678d408c8741623c6218569a = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_deb51810d564472ea6237de9d57403bf = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> IAmInterfaceD.Test()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Test", ArgumentTypes_2ee9e800678d408c8741623c6218569a);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Test", ArgumentTypes_deb51810d564472ea6237de9d57403bf);
             return (Task<string>)func(Client, arguments);
         }
     }
@@ -452,153 +452,153 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_4439ab0a18c942cfbf1a78a8cf1c369e = new Type[] { typeof(PathBoundObject) };
+        private static readonly Type[] ArgumentTypes_2f1921e4e8cd458aafa224fb8f7c2d9c = new Type[] { typeof(PathBoundObject) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetFooBars(PathBoundObject request)
         {
             var arguments = new object[] { request };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBars", ArgumentTypes_4439ab0a18c942cfbf1a78a8cf1c369e);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBars", ArgumentTypes_2f1921e4e8cd458aafa224fb8f7c2d9c);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_20a6706f07e644c0a9882ac2d82b87c2 = new Type[] { typeof(PathBoundObject) };
+        private static readonly Type[] ArgumentTypes_29005f335b2a4e9db554427208169e63 = new Type[] { typeof(PathBoundObject) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetFooBarsWithDifferentCasing(PathBoundObject requestParams)
         {
             var arguments = new object[] { requestParams };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBarsWithDifferentCasing", ArgumentTypes_20a6706f07e644c0a9882ac2d82b87c2);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBarsWithDifferentCasing", ArgumentTypes_29005f335b2a4e9db554427208169e63);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_ecaef8a57023448dbb863be670120b91 = new Type[] { typeof(string), typeof(PathBoundObject) };
+        private static readonly Type[] ArgumentTypes_20e7ad5cf54543f689a44bd2ce597e70 = new Type[] { typeof(string), typeof(PathBoundObject) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetBarsByFoo(string id, PathBoundObject request)
         {
             var arguments = new object[] { id, request };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetBarsByFoo", ArgumentTypes_ecaef8a57023448dbb863be670120b91);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetBarsByFoo", ArgumentTypes_20e7ad5cf54543f689a44bd2ce597e70);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_251481b0763d4dacba93e893e93c8203 = new Type[] { typeof(PathBoundObject), typeof(string) };
+        private static readonly Type[] ArgumentTypes_a51b92bcb8cd4484bc1fcdef645330ec = new Type[] { typeof(PathBoundObject), typeof(string) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetFooBars(PathBoundObject request, string someProperty)
         {
             var arguments = new object[] { request, someProperty };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBars", ArgumentTypes_251481b0763d4dacba93e893e93c8203);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBars", ArgumentTypes_a51b92bcb8cd4484bc1fcdef645330ec);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_8393ae7b048642af81659f368c83a742 = new Type[] { typeof(PathBoundObject) };
+        private static readonly Type[] ArgumentTypes_84d02603987a496594579cc15dab8168 = new Type[] { typeof(PathBoundObject) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetBarsByFoo(PathBoundObject request)
         {
             var arguments = new object[] { request };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetBarsByFoo", ArgumentTypes_8393ae7b048642af81659f368c83a742);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetBarsByFoo", ArgumentTypes_84d02603987a496594579cc15dab8168);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_184f27dfd30c4698ab0600878c78cee7 = new Type[] { typeof(PathBoundObjectWithQueryFormat) };
+        private static readonly Type[] ArgumentTypes_2fdea158653f44fa8361119a0e2ecfe5 = new Type[] { typeof(PathBoundObjectWithQueryFormat) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetBarsWithCustomQueryFormat(PathBoundObjectWithQueryFormat request)
         {
             var arguments = new object[] { request };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetBarsWithCustomQueryFormat", ArgumentTypes_184f27dfd30c4698ab0600878c78cee7);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetBarsWithCustomQueryFormat", ArgumentTypes_2fdea158653f44fa8361119a0e2ecfe5);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_f934d9a64f044ca89d81e449866f17ca = new Type[] { typeof(PathBoundDerivedObject) };
+        private static readonly Type[] ArgumentTypes_f0b18748f9d741b1b683044cd99ff5ec = new Type[] { typeof(PathBoundDerivedObject) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetFooBarsDerived(PathBoundDerivedObject request)
         {
             var arguments = new object[] { request };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBarsDerived", ArgumentTypes_f934d9a64f044ca89d81e449866f17ca);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBarsDerived", ArgumentTypes_f0b18748f9d741b1b683044cd99ff5ec);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_d099f5dc885044628ba1071b0e13fa92 = new Type[] { typeof(PathBoundList) };
+        private static readonly Type[] ArgumentTypes_7207399a14c34ab0ab0e059183449ff6 = new Type[] { typeof(PathBoundList) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetFoos(PathBoundList request)
         {
             var arguments = new object[] { request };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetFoos", ArgumentTypes_d099f5dc885044628ba1071b0e13fa92);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetFoos", ArgumentTypes_7207399a14c34ab0ab0e059183449ff6);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_237c9bc2a4014803a1aad965a0bfacd4 = new Type[] { typeof(List<int>) };
+        private static readonly Type[] ArgumentTypes_3a8b69bbd21047cf90671382c43f2b3c = new Type[] { typeof(List<int>) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetFoos2(List<int> Values)
         {
             var arguments = new object[] { Values };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetFoos2", ArgumentTypes_237c9bc2a4014803a1aad965a0bfacd4);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetFoos2", ArgumentTypes_3a8b69bbd21047cf90671382c43f2b3c);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_1137f2df6a4d497c97b6aa56155114fc = new Type[] { typeof(PathBoundObject), typeof(object) };
+        private static readonly Type[] ArgumentTypes_6fba2b6bf80a457c8376eca5b089b2db = new Type[] { typeof(PathBoundObject), typeof(object) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.PostFooBar(PathBoundObject request, object someObject)
         {
             var arguments = new object[] { request, someObject };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBar", ArgumentTypes_1137f2df6a4d497c97b6aa56155114fc);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBar", ArgumentTypes_6fba2b6bf80a457c8376eca5b089b2db);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_8da75a0a7919494fabfbfa253b1b3ced = new Type[] { typeof(PathBoundObjectWithQuery) };
+        private static readonly Type[] ArgumentTypes_8eabd5f74ba14b5b934a03980f37b01c = new Type[] { typeof(PathBoundObjectWithQuery) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetFooBars(PathBoundObjectWithQuery request)
         {
             var arguments = new object[] { request };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBars", ArgumentTypes_8da75a0a7919494fabfbfa253b1b3ced);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBars", ArgumentTypes_8eabd5f74ba14b5b934a03980f37b01c);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_ecedec4c78584237987d9538c184fcdb = new Type[] { typeof(PathBoundObject), typeof(ModelObject) };
+        private static readonly Type[] ArgumentTypes_4ae7659f2e534f6a99ffa76ceb478fa9 = new Type[] { typeof(PathBoundObject), typeof(ModelObject) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IApiBindPathToObject.PostFooBar(PathBoundObject request, ModelObject someQueryParams)
         {
             var arguments = new object[] { request, someQueryParams };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBar", ArgumentTypes_ecedec4c78584237987d9538c184fcdb);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBar", ArgumentTypes_4ae7659f2e534f6a99ffa76ceb478fa9);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_3de46d1ae5ae42acbbdd3f612bdc6510 = new Type[] { typeof(PathBoundObject), typeof(ModelObject), typeof(StreamPart) };
+        private static readonly Type[] ArgumentTypes_e5c6708886264aebb8424d0933097a47 = new Type[] { typeof(PathBoundObject), typeof(ModelObject), typeof(StreamPart) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IApiBindPathToObject.PostFooBarStreamPart(PathBoundObject request, ModelObject someQueryParams, StreamPart stream)
         {
             var arguments = new object[] { request, someQueryParams, stream };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBarStreamPart", ArgumentTypes_3de46d1ae5ae42acbbdd3f612bdc6510);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBarStreamPart", ArgumentTypes_e5c6708886264aebb8424d0933097a47);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_7ea8d330058b418c9250d4b518b5fbe4 = new Type[] { typeof(PathBoundObject), typeof(StreamPart) };
+        private static readonly Type[] ArgumentTypes_1c7a7d35f3094f78bf3bc7fbe585e76b = new Type[] { typeof(PathBoundObject), typeof(StreamPart) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IApiBindPathToObject.PostFooBarStreamPart(PathBoundObject request, StreamPart stream)
         {
             var arguments = new object[] { request, stream };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBarStreamPart", ArgumentTypes_7ea8d330058b418c9250d4b518b5fbe4);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBarStreamPart", ArgumentTypes_1c7a7d35f3094f78bf3bc7fbe585e76b);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_260b14b341dd4afe855224519ce6509c = new Type[] { typeof(PathBoundObjectWithQuery), typeof(StreamPart) };
+        private static readonly Type[] ArgumentTypes_9eae242b9fb7475396b1b61691b5bba8 = new Type[] { typeof(PathBoundObjectWithQuery), typeof(StreamPart) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IApiBindPathToObject.PostFooBarStreamPart(PathBoundObjectWithQuery request, StreamPart stream)
         {
             var arguments = new object[] { request, stream };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBarStreamPart", ArgumentTypes_260b14b341dd4afe855224519ce6509c);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBarStreamPart", ArgumentTypes_9eae242b9fb7475396b1b61691b5bba8);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
     }
@@ -639,13 +639,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_6980f39ffbca4f5cb3749aa20b3c451c = new Type[] { typeof(decimal) };
+        private static readonly Type[] ArgumentTypes_5f3a5971164e455cb38642a6c552e6c6 = new Type[] { typeof(decimal) };
 
         /// <inheritdoc />
         Task<string> IApiWithDecimal.GetWithDecimal(decimal value)
         {
             var arguments = new object[] { value };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetWithDecimal", ArgumentTypes_6980f39ffbca4f5cb3749aa20b3c451c);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetWithDecimal", ArgumentTypes_5f3a5971164e455cb38642a6c552e6c6);
             return (Task<string>)func(Client, arguments);
         }
     }
@@ -686,33 +686,33 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_b0a77551c5274e76812b32ec0075e236 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_af73cadb00a54d2e901c31593e7a2673 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IBodylessApi.Post()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Post", ArgumentTypes_b0a77551c5274e76812b32ec0075e236);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Post", ArgumentTypes_af73cadb00a54d2e901c31593e7a2673);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_4004bba546244c06a0553b5d85f7d71a = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_d4337923a6c94c11abfb3968409b1119 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IBodylessApi.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_4004bba546244c06a0553b5d85f7d71a);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_d4337923a6c94c11abfb3968409b1119);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_fadada51c0cb4f63aa4cab15be7fd49f = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_8f89584bff424850b5c2d525c141a25f = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IBodylessApi.Head()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Head", ArgumentTypes_fadada51c0cb4f63aa4cab15be7fd49f);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Head", ArgumentTypes_8f89584bff424850b5c2d525c141a25f);
             return (Task)func(Client, arguments);
         }
     }
@@ -753,53 +753,53 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_2a704134ef5c49289a848760bccee135 = new Type[] { typeof(T) };
+        private static readonly Type[] ArgumentTypes_ad1f4c2cf69c4850857c9c75f359b7bd = new Type[] { typeof(T) };
 
         /// <inheritdoc />
         Task<T> IBoringCrudApi<T, TKey>.Create(T paylod)
         {
             var arguments = new object[] { paylod };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_2a704134ef5c49289a848760bccee135);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_ad1f4c2cf69c4850857c9c75f359b7bd);
             return (Task<T>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_1de36d1330ac45f9ad2a08d53ea90a48 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_04c8fd0955014438a173f357dc5c83d6 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<List<T>> IBoringCrudApi<T, TKey>.ReadAll()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_1de36d1330ac45f9ad2a08d53ea90a48);
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_04c8fd0955014438a173f357dc5c83d6);
             return (Task<List<T>>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_d676e76ac308420bb9198aa340d27cc5 = new Type[] { typeof(TKey) };
+        private static readonly Type[] ArgumentTypes_d78fb9c8e82c4d87babcc7d8c5343c9a = new Type[] { typeof(TKey) };
 
         /// <inheritdoc />
         Task<T> IBoringCrudApi<T, TKey>.ReadOne(TKey key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_d676e76ac308420bb9198aa340d27cc5);
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_d78fb9c8e82c4d87babcc7d8c5343c9a);
             return (Task<T>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_75bfaa13654a4ef1b3913af2529e05dd = new Type[] { typeof(TKey), typeof(T) };
+        private static readonly Type[] ArgumentTypes_187e13d080c84b9e815cb3786c3020ed = new Type[] { typeof(TKey), typeof(T) };
 
         /// <inheritdoc />
         Task IBoringCrudApi<T, TKey>.Update(TKey key, T payload)
         {
             var arguments = new object[] { key, payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_75bfaa13654a4ef1b3913af2529e05dd);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_187e13d080c84b9e815cb3786c3020ed);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_fdfe30cefb4f44f9bcb13c1ebb6ec8d7 = new Type[] { typeof(TKey) };
+        private static readonly Type[] ArgumentTypes_66dd32d3e64d43d693e1869de566c1c7 = new Type[] { typeof(TKey) };
 
         /// <inheritdoc />
         Task IBoringCrudApi<T, TKey>.Delete(TKey key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_fdfe30cefb4f44f9bcb13c1ebb6ec8d7);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_66dd32d3e64d43d693e1869de566c1c7);
             return (Task)func(Client, arguments);
         }
     }
@@ -840,13 +840,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_98e417b1a39e4ad4a91277878626573b = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_0d072c7a679047f69582a78eef3f89f2 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<bool> IBrokenWebApi.PostAValue(string derp)
         {
             var arguments = new object[] { derp };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostAValue", ArgumentTypes_98e417b1a39e4ad4a91277878626573b);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostAValue", ArgumentTypes_0d072c7a679047f69582a78eef3f89f2);
             return (Task<bool>)func(Client, arguments);
         }
     }
@@ -875,13 +875,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_37a38bd3b30d4febb7282bbbd6f66b15 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_57e4561dcea74ecb94f2577f87bad031 = Array.Empty<Type>();
 
         /// <inheritdoc />
         CustomReferenceType? ICustomNullableReferenceService.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_37a38bd3b30d4febb7282bbbd6f66b15);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_57e4561dcea74ecb94f2577f87bad031);
             return (CustomReferenceType?)func(Client, arguments);
         }
     }
@@ -910,13 +910,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_7d7e8312ad394a898376bce8c5f50fed = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_8fb3c8d82e97414bb00dabf02e3ee213 = Array.Empty<Type>();
 
         /// <inheritdoc />
         CustomValueType? ICustomNullableValueService.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_7d7e8312ad394a898376bce8c5f50fed);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_8fb3c8d82e97414bb00dabf02e3ee213);
             return (CustomValueType?)func(Client, arguments);
         }
     }
@@ -945,13 +945,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_713bbee79cb04ff4861810f9302d2594 = new Type[] { ToNullable(typeof(CustomReferenceType)), ToNullable(typeof(CustomValueType)) };
+        private static readonly Type[] ArgumentTypes_fcc63410fda9457982c2c9edc7914075 = new Type[] { ToNullable(typeof(CustomReferenceType)), ToNullable(typeof(CustomValueType)) };
 
         /// <inheritdoc />
         Task ICustomReferenceAndValueParametersService.Get(CustomReferenceType? reference, CustomValueType? value)
         {
             var arguments = new object[] { reference, value };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_713bbee79cb04ff4861810f9302d2594);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_fcc63410fda9457982c2c9edc7914075);
             return (Task)func(Client, arguments);
         }
 
@@ -984,73 +984,73 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_d6f6d60fbe8e425db60bad7342f4a6fb = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_b10ce986992240fca116c065375af711 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IDataApiA.PingA()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("PingA", ArgumentTypes_d6f6d60fbe8e425db60bad7342f4a6fb);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PingA", ArgumentTypes_b10ce986992240fca116c065375af711);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_b95b5e240d7c4637b90a3bde2f0add97 = new Type[] { typeof(DataEntity) };
+        private static readonly Type[] ArgumentTypes_a20f48f432424a18bdf114fe0ae6f4e0 = new Type[] { typeof(DataEntity) };
 
         /// <inheritdoc />
         Task<DataEntity> IDataCrudApi<DataEntity>.Copy(DataEntity payload)
         {
             var arguments = new object[] { payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Copy", ArgumentTypes_b95b5e240d7c4637b90a3bde2f0add97);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Copy", ArgumentTypes_a20f48f432424a18bdf114fe0ae6f4e0);
             return (Task<DataEntity>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_c66bae15a43042e39e33b9c6270c4ea4 = new Type[] { typeof(DataEntity) };
+        private static readonly Type[] ArgumentTypes_628553263d8d4c798d53f3c302bb42c1 = new Type[] { typeof(DataEntity) };
 
         /// <inheritdoc />
         Task<DataEntity> IDataCrudApi<DataEntity, long>.Create(DataEntity payload)
         {
             var arguments = new object[] { payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_c66bae15a43042e39e33b9c6270c4ea4);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_628553263d8d4c798d53f3c302bb42c1);
             return (Task<DataEntity>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_a705cc637ec84a4982b4e9e38a338d59 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_c2a7fa79b01b4ab7b57c7f82d8624d77 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<List<DataEntity>> IDataCrudApi<DataEntity, long>.ReadAll()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_a705cc637ec84a4982b4e9e38a338d59);
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_c2a7fa79b01b4ab7b57c7f82d8624d77);
             return (Task<List<DataEntity>>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_a12af4da19c2493db12b0daa04e4011a = new Type[] { typeof(long) };
+        private static readonly Type[] ArgumentTypes_064a70c8bcf049f29a3f2e04f2a47635 = new Type[] { typeof(long) };
 
         /// <inheritdoc />
         Task<DataEntity> IDataCrudApi<DataEntity, long>.ReadOne(long key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_a12af4da19c2493db12b0daa04e4011a);
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_064a70c8bcf049f29a3f2e04f2a47635);
             return (Task<DataEntity>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_9a877614fc9f4d7ba703732e35c25fc3 = new Type[] { typeof(long), typeof(DataEntity) };
+        private static readonly Type[] ArgumentTypes_1b47a6afec0e42e8b5ebbdc4b090db37 = new Type[] { typeof(long), typeof(DataEntity) };
 
         /// <inheritdoc />
         Task IDataCrudApi<DataEntity, long>.Update(long key, DataEntity payload)
         {
             var arguments = new object[] { key, payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_9a877614fc9f4d7ba703732e35c25fc3);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_1b47a6afec0e42e8b5ebbdc4b090db37);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_4c7707783af24f0bbcb53e2df5b2a3f6 = new Type[] { typeof(long) };
+        private static readonly Type[] ArgumentTypes_6e3dd647665b4fd7898ec5c3c00e7d40 = new Type[] { typeof(long) };
 
         /// <inheritdoc />
         Task IDataCrudApi<DataEntity, long>.Delete(long key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_4c7707783af24f0bbcb53e2df5b2a3f6);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_6e3dd647665b4fd7898ec5c3c00e7d40);
             return (Task)func(Client, arguments);
         }
     }
@@ -1081,63 +1081,63 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_4d8b96ab60cc42f99e67b8763279be6a = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_d238b19041f54c8da7f723599dcf925a = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IDataApiB.PingB()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("PingB", ArgumentTypes_4d8b96ab60cc42f99e67b8763279be6a);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PingB", ArgumentTypes_d238b19041f54c8da7f723599dcf925a);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_ef20d6f33ba4489999617c0c87e15dad = new Type[] { typeof(DataEntity) };
+        private static readonly Type[] ArgumentTypes_4e981407577f46ef8a229d05c5068080 = new Type[] { typeof(DataEntity) };
 
         /// <inheritdoc />
         Task<DataEntity> IDataCrudApi<DataEntity, int>.Create(DataEntity payload)
         {
             var arguments = new object[] { payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_ef20d6f33ba4489999617c0c87e15dad);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_4e981407577f46ef8a229d05c5068080);
             return (Task<DataEntity>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_9c528ed5c2a140f0afb51bf96944ab94 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_8d0cd886e9244c55aae31dc9dab933c4 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<List<DataEntity>> IDataCrudApi<DataEntity, int>.ReadAll()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_9c528ed5c2a140f0afb51bf96944ab94);
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_8d0cd886e9244c55aae31dc9dab933c4);
             return (Task<List<DataEntity>>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_8af99142aced4d9096165935ea35dafb = new Type[] { typeof(int) };
+        private static readonly Type[] ArgumentTypes_9d4ee44cc7ff4067a0156a7ec5a3536e = new Type[] { typeof(int) };
 
         /// <inheritdoc />
         Task<DataEntity> IDataCrudApi<DataEntity, int>.ReadOne(int key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_8af99142aced4d9096165935ea35dafb);
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_9d4ee44cc7ff4067a0156a7ec5a3536e);
             return (Task<DataEntity>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_e4ca0729208c42108a0ce1edefd47e5e = new Type[] { typeof(int), typeof(DataEntity) };
+        private static readonly Type[] ArgumentTypes_45ba3a64c91241ec9c2178f4e831ca17 = new Type[] { typeof(int), typeof(DataEntity) };
 
         /// <inheritdoc />
         Task IDataCrudApi<DataEntity, int>.Update(int key, DataEntity payload)
         {
             var arguments = new object[] { key, payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_e4ca0729208c42108a0ce1edefd47e5e);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_45ba3a64c91241ec9c2178f4e831ca17);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_70214198d4db4df9b07e1bed1df36bf4 = new Type[] { typeof(int) };
+        private static readonly Type[] ArgumentTypes_6eaf378a13834759946a257eb19fbf0e = new Type[] { typeof(int) };
 
         /// <inheritdoc />
         Task IDataCrudApi<DataEntity, int>.Delete(int key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_70214198d4db4df9b07e1bed1df36bf4);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_6eaf378a13834759946a257eb19fbf0e);
             return (Task)func(Client, arguments);
         }
     }
@@ -1171,63 +1171,63 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_7f40432c44834a259d3e9f20f58d129c = new Type[] { typeof(T) };
+        private static readonly Type[] ArgumentTypes_71b9bcddb7564c499b08639f0af919c4 = new Type[] { typeof(T) };
 
         /// <inheritdoc />
         Task<T> IDataCrudApi<T>.Copy(T payload)
         {
             var arguments = new object[] { payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Copy", ArgumentTypes_7f40432c44834a259d3e9f20f58d129c);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Copy", ArgumentTypes_71b9bcddb7564c499b08639f0af919c4);
             return (Task<T>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_b1218505fefa442584ede68c1229d394 = new Type[] { typeof(T) };
+        private static readonly Type[] ArgumentTypes_87992fa8fa1a4b6aaa0e9892675eb22a = new Type[] { typeof(T) };
 
         /// <inheritdoc />
         Task<T> IDataCrudApi<T, long>.Create(T payload)
         {
             var arguments = new object[] { payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_b1218505fefa442584ede68c1229d394);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_87992fa8fa1a4b6aaa0e9892675eb22a);
             return (Task<T>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_e73e25586826425eaf3e203f2858d700 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_1322cfe918d94ee189c5313d3ebb01ba = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<List<T>> IDataCrudApi<T, long>.ReadAll()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_e73e25586826425eaf3e203f2858d700);
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_1322cfe918d94ee189c5313d3ebb01ba);
             return (Task<List<T>>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_639652ddf03c4d7f8d03f81d5d5503f9 = new Type[] { typeof(long) };
+        private static readonly Type[] ArgumentTypes_d31ab71a47924c3288cd3faa08914d2e = new Type[] { typeof(long) };
 
         /// <inheritdoc />
         Task<T> IDataCrudApi<T, long>.ReadOne(long key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_639652ddf03c4d7f8d03f81d5d5503f9);
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_d31ab71a47924c3288cd3faa08914d2e);
             return (Task<T>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_ac88eb105a954ccfb02de3a44a0ecd2c = new Type[] { typeof(long), typeof(T) };
+        private static readonly Type[] ArgumentTypes_7bb86e7105f24ab7b9e20be1d3105460 = new Type[] { typeof(long), typeof(T) };
 
         /// <inheritdoc />
         Task IDataCrudApi<T, long>.Update(long key, T payload)
         {
             var arguments = new object[] { key, payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_ac88eb105a954ccfb02de3a44a0ecd2c);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_7bb86e7105f24ab7b9e20be1d3105460);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_a37f9d6cdcf5404684e2f280745c56b8 = new Type[] { typeof(long) };
+        private static readonly Type[] ArgumentTypes_2f8e8d0e95dc4e8b8ba08496bc000ee8 = new Type[] { typeof(long) };
 
         /// <inheritdoc />
         Task IDataCrudApi<T, long>.Delete(long key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_a37f9d6cdcf5404684e2f280745c56b8);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_2f8e8d0e95dc4e8b8ba08496bc000ee8);
             return (Task)func(Client, arguments);
         }
     }
@@ -1261,53 +1261,53 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_ba179f443d7e47fb8904df4bd88df394 = new Type[] { typeof(T) };
+        private static readonly Type[] ArgumentTypes_d5a7e938cf7b4b7ba17a98963dc7940d = new Type[] { typeof(T) };
 
         /// <inheritdoc />
         Task<T> IDataCrudApi<T, TKey>.Create(T payload)
         {
             var arguments = new object[] { payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_ba179f443d7e47fb8904df4bd88df394);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_d5a7e938cf7b4b7ba17a98963dc7940d);
             return (Task<T>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_60caf102389e4a91a959675d50a774ca = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_4bf9309833c1481482ec612e321acfb6 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<List<T>> IDataCrudApi<T, TKey>.ReadAll()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_60caf102389e4a91a959675d50a774ca);
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_4bf9309833c1481482ec612e321acfb6);
             return (Task<List<T>>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_686151fed998404d93507a9bf9d076b9 = new Type[] { typeof(TKey) };
+        private static readonly Type[] ArgumentTypes_57d0411c4ca14539b79045be9b8ca682 = new Type[] { typeof(TKey) };
 
         /// <inheritdoc />
         Task<T> IDataCrudApi<T, TKey>.ReadOne(TKey key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_686151fed998404d93507a9bf9d076b9);
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_57d0411c4ca14539b79045be9b8ca682);
             return (Task<T>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_86b49ea2ae254faf9db743cdc59769d6 = new Type[] { typeof(TKey), typeof(T) };
+        private static readonly Type[] ArgumentTypes_893103671d944130b4e9d213a8b3813e = new Type[] { typeof(TKey), typeof(T) };
 
         /// <inheritdoc />
         Task IDataCrudApi<T, TKey>.Update(TKey key, T payload)
         {
             var arguments = new object[] { key, payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_86b49ea2ae254faf9db743cdc59769d6);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_893103671d944130b4e9d213a8b3813e);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_afe909d5e12f48169701abbc666807d7 = new Type[] { typeof(TKey) };
+        private static readonly Type[] ArgumentTypes_db96b481f5a34e91abb2d2c1c94e4224 = new Type[] { typeof(TKey) };
 
         /// <inheritdoc />
         Task IDataCrudApi<T, TKey>.Delete(TKey key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_afe909d5e12f48169701abbc666807d7);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_db96b481f5a34e91abb2d2c1c94e4224);
             return (Task)func(Client, arguments);
         }
     }
@@ -1336,13 +1336,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_7c7c6e7f77b84b6bbafaeed5bbea6b8e = new Type[] { ToNullable(typeof(System.Collections.Generic.List<string>)) };
+        private static readonly Type[] ArgumentTypes_13a15dc7c6b242418b4227b4574c5f4f = new Type[] { ToNullable(typeof(System.Collections.Generic.List<string>)) };
 
         /// <inheritdoc />
         Task IGenericNullableReferenceParameterService.Get(System.Collections.Generic.List<string>? reference)
         {
             var arguments = new object[] { reference };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_7c7c6e7f77b84b6bbafaeed5bbea6b8e);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_13a15dc7c6b242418b4227b4574c5f4f);
             return (Task)func(Client, arguments);
         }
 
@@ -1373,13 +1373,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_ff7b9a78a4654df98a535a58ce69a33c = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_106f2fae1601495aa447df1f0adb0048 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string>? IGenericNullableReferenceService.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_ff7b9a78a4654df98a535a58ce69a33c);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_106f2fae1601495aa447df1f0adb0048);
             return (Task<string>?)func(Client, arguments);
         }
     }
@@ -1408,13 +1408,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_ddfc7be926064f83a6c969a87dfff18d = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_cb06d7afda124ee2b3b5450e88980c50 = Array.Empty<Type>();
 
         /// <inheritdoc />
         ValueTask<int>? IGenericNullableValueService.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_ddfc7be926064f83a6c969a87dfff18d);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_cb06d7afda124ee2b3b5450e88980c50);
             return (ValueTask<int>?)func(Client, arguments);
         }
     }
@@ -1443,13 +1443,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_99fdc7fa8e3f465ea07359cdf0da3922 = new Type[] { ToNullable(typeof(System.Collections.Generic.List<string?>)) };
+        private static readonly Type[] ArgumentTypes_fe6eb6a4a342420684e6093279ff29ef = new Type[] { ToNullable(typeof(System.Collections.Generic.List<string?>)) };
 
         /// <inheritdoc />
         Task IGenericNullableWithNullableReferenceParameterService.Get(System.Collections.Generic.List<string?>? reference)
         {
             var arguments = new object[] { reference };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_99fdc7fa8e3f465ea07359cdf0da3922);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_fe6eb6a4a342420684e6093279ff29ef);
             return (Task)func(Client, arguments);
         }
 
@@ -1480,13 +1480,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_9d8c4b3dd7a34f41bd0e3d490dd38e6b = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_84753181f37d4a6596523635fb48df1e = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string?>? IGenericNullableWithNullableReferenceService.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_9d8c4b3dd7a34f41bd0e3d490dd38e6b);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_84753181f37d4a6596523635fb48df1e);
             return (Task<string?>?)func(Client, arguments);
         }
     }
@@ -1515,13 +1515,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_85b1a39e6219474bb7a1a87a38bbd811 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_d52bf53f49844242998c1be469980469 = Array.Empty<Type>();
 
         /// <inheritdoc />
         ValueTask<int?>? IGenericNullableWithNullableValueService.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_85b1a39e6219474bb7a1a87a38bbd811);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_d52bf53f49844242998c1be469980469);
             return (ValueTask<int?>?)func(Client, arguments);
         }
     }
@@ -1550,13 +1550,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_517dcd10f1f147709ba86c8c4dd5d30d = new Type[] { typeof(System.Collections.Generic.List<string?>) };
+        private static readonly Type[] ArgumentTypes_4ce35c41b2b743e9a69aa06af81ace35 = new Type[] { typeof(System.Collections.Generic.List<string?>) };
 
         /// <inheritdoc />
         Task IGenericWithNullableReferenceParameterService.Get(System.Collections.Generic.List<string?> reference)
         {
             var arguments = new object[] { reference };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_517dcd10f1f147709ba86c8c4dd5d30d);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_4ce35c41b2b743e9a69aa06af81ace35);
             return (Task)func(Client, arguments);
         }
     }
@@ -1585,13 +1585,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_528ad8b9430d43108c5196d25e0ec586 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_7e391892bdf2446eaed38150550852cb = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<int?> IGenericWithNullableValueService.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_528ad8b9430d43108c5196d25e0ec586);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_7e391892bdf2446eaed38150550852cb);
             return (Task<int?>)func(Client, arguments);
         }
     }
@@ -1620,13 +1620,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_b42079a79e7742c3817eb2a3a7958fd7 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_4e8c5fed565a4a739a481c8ddfb5a0c7 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string?> IGenericWithResultService.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_b42079a79e7742c3817eb2a3a7958fd7);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_4e8c5fed565a4a739a481c8ddfb5a0c7);
             return (Task<string?>)func(Client, arguments);
         }
     }
@@ -1661,133 +1661,133 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_380701db2ff243599bb8953d7a54a02e = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_08827eccfd2c4d45bfdf98f75a00091d = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<User> IGitHubApi.GetUser(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUser", ArgumentTypes_380701db2ff243599bb8953d7a54a02e);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUser", ArgumentTypes_08827eccfd2c4d45bfdf98f75a00091d);
             return (Task<User>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_a73d3db4250e49629d2b5c3010449dfa = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_c44f3b4253ad480a9d04b66ac3c06964 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         IObservable<User> IGitHubApi.GetUserObservable(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserObservable", ArgumentTypes_a73d3db4250e49629d2b5c3010449dfa);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserObservable", ArgumentTypes_c44f3b4253ad480a9d04b66ac3c06964);
             return (IObservable<User>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_3e76cea0b5724c66bd86518afcaed124 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_7472f7d9d38447a089fbf00142d3f7eb = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         IObservable<User> IGitHubApi.GetUserCamelCase(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserCamelCase", ArgumentTypes_3e76cea0b5724c66bd86518afcaed124);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserCamelCase", ArgumentTypes_7472f7d9d38447a089fbf00142d3f7eb);
             return (IObservable<User>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_857528a801c94121b73ce192723553cd = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_f9dfd342159a4602a49f9200af3b3e1c = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<List<User>> IGitHubApi.GetOrgMembers(string orgName)
         {
             var arguments = new object[] { orgName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetOrgMembers", ArgumentTypes_857528a801c94121b73ce192723553cd);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetOrgMembers", ArgumentTypes_f9dfd342159a4602a49f9200af3b3e1c);
             return (Task<List<User>>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_7d208f32325a4bed82f8d8cc2a954513 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_6a6f9a5cb8c645b4855255d8ca4e62e0 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<UserSearchResult> IGitHubApi.FindUsers(string q)
         {
             var arguments = new object[] { q };
-            var func = requestBuilder.BuildRestResultFuncForMethod("FindUsers", ArgumentTypes_7d208f32325a4bed82f8d8cc2a954513);
+            var func = requestBuilder.BuildRestResultFuncForMethod("FindUsers", ArgumentTypes_6a6f9a5cb8c645b4855255d8ca4e62e0);
             return (Task<UserSearchResult>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_ddb47942c76547469ae9cb35c284e424 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_57f5d94227ec4fd687bfab14a53ed648 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IGitHubApi.GetIndex()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndex", ArgumentTypes_ddb47942c76547469ae9cb35c284e424);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndex", ArgumentTypes_57f5d94227ec4fd687bfab14a53ed648);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_c198f33c1b044c7fb47b1bf540849d6b = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_02e3cf72bad442009c720637219a1640 = Array.Empty<Type>();
 
         /// <inheritdoc />
         IObservable<string> IGitHubApi.GetIndexObservable()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndexObservable", ArgumentTypes_c198f33c1b044c7fb47b1bf540849d6b);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndexObservable", ArgumentTypes_02e3cf72bad442009c720637219a1640);
             return (IObservable<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_649dcccdfeef487b8cfe636370db238d = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_1fb8bc4848e94599b67e76fe74cf9419 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<User> IGitHubApi.NothingToSeeHere()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("NothingToSeeHere", ArgumentTypes_649dcccdfeef487b8cfe636370db238d);
+            var func = requestBuilder.BuildRestResultFuncForMethod("NothingToSeeHere", ArgumentTypes_1fb8bc4848e94599b67e76fe74cf9419);
             return (Task<User>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_c069126551cf45cabb8930f37a4215c2 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_3503f77eddf34694a7c4240c12b5eac7 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<ApiResponse<User>> IGitHubApi.NothingToSeeHereWithMetadata()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("NothingToSeeHereWithMetadata", ArgumentTypes_c069126551cf45cabb8930f37a4215c2);
+            var func = requestBuilder.BuildRestResultFuncForMethod("NothingToSeeHereWithMetadata", ArgumentTypes_3503f77eddf34694a7c4240c12b5eac7);
             return (Task<ApiResponse<User>>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_f1c177c2e6cb445b9affe455d7933cee = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_4e1875d3185242d3b9022bb51787d3d5 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<ApiResponse<User>> IGitHubApi.GetUserWithMetadata(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserWithMetadata", ArgumentTypes_f1c177c2e6cb445b9affe455d7933cee);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserWithMetadata", ArgumentTypes_4e1875d3185242d3b9022bb51787d3d5);
             return (Task<ApiResponse<User>>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_c6bc40b397934d1dae1efd11e14fb75c = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_73aa5c1516034da5b5be26b37ef05ce5 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         IObservable<ApiResponse<User>> IGitHubApi.GetUserObservableWithMetadata(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserObservableWithMetadata", ArgumentTypes_c6bc40b397934d1dae1efd11e14fb75c);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserObservableWithMetadata", ArgumentTypes_73aa5c1516034da5b5be26b37ef05ce5);
             return (IObservable<ApiResponse<User>>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_474c0730998448e5bbb394450a75c15b = new Type[] { typeof(User) };
+        private static readonly Type[] ArgumentTypes_8047d2aac080409682eb919d9cbd4aa2 = new Type[] { typeof(User) };
 
         /// <inheritdoc />
         Task<User> IGitHubApi.CreateUser(User user)
         {
             var arguments = new object[] { user };
-            var func = requestBuilder.BuildRestResultFuncForMethod("CreateUser", ArgumentTypes_474c0730998448e5bbb394450a75c15b);
+            var func = requestBuilder.BuildRestResultFuncForMethod("CreateUser", ArgumentTypes_8047d2aac080409682eb919d9cbd4aa2);
             return (Task<User>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_bda1749d26ab4bd39550741611cad352 = new Type[] { typeof(User) };
+        private static readonly Type[] ArgumentTypes_f9b299236b14499c84997b0c46fe7f4f = new Type[] { typeof(User) };
 
         /// <inheritdoc />
         Task<ApiResponse<User>> IGitHubApi.CreateUserWithMetadata(User user)
         {
             var arguments = new object[] { user };
-            var func = requestBuilder.BuildRestResultFuncForMethod("CreateUserWithMetadata", ArgumentTypes_bda1749d26ab4bd39550741611cad352);
+            var func = requestBuilder.BuildRestResultFuncForMethod("CreateUserWithMetadata", ArgumentTypes_f9b299236b14499c84997b0c46fe7f4f);
             return (Task<ApiResponse<User>>)func(Client, arguments);
         }
     }
@@ -1832,47 +1832,47 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_06193ec75cd8417fb73fc7443cf6000d = new Type[] { typeof(TParam), typeof(THeader) };
+        private static readonly Type[] ArgumentTypes_7462d234985c4b138baf92b6009294be = new Type[] { typeof(TParam), typeof(THeader) };
 
         /// <inheritdoc />
         Task<TResponse> IHttpBinApi<TResponse, TParam, THeader>.Get(TParam param, THeader header)
         {
             var arguments = new object[] { param, header };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_06193ec75cd8417fb73fc7443cf6000d);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_7462d234985c4b138baf92b6009294be);
             return (Task<TResponse>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_f7b6c47c8e074e08b396e44a4e249536 = new Type[] { typeof(TParam) };
+        private static readonly Type[] ArgumentTypes_73d40996634b46319b667ddf93abc1aa = new Type[] { typeof(TParam) };
 
         /// <inheritdoc />
         Task<TResponse> IHttpBinApi<TResponse, TParam, THeader>.GetQuery(TParam param)
         {
             var arguments = new object[] { param };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetQuery", ArgumentTypes_f7b6c47c8e074e08b396e44a4e249536);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetQuery", ArgumentTypes_73d40996634b46319b667ddf93abc1aa);
             return (Task<TResponse>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_74f3692f0d014b00a5f42ca8a902f98d = new Type[] { typeof(TParam) };
+        private static readonly Type[] ArgumentTypes_e6f82073b1f1401c8456163eb281d42c = new Type[] { typeof(TParam) };
 
         /// <inheritdoc />
         Task<TResponse> IHttpBinApi<TResponse, TParam, THeader>.PostQuery(TParam param)
         {
             var arguments = new object[] { param };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostQuery", ArgumentTypes_74f3692f0d014b00a5f42ca8a902f98d);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostQuery", ArgumentTypes_e6f82073b1f1401c8456163eb281d42c);
             return (Task<TResponse>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_41fc8f1bba9340e0833c5517b2e98b76 = new Type[] { typeof(TParam) };
+        private static readonly Type[] ArgumentTypes_aa587154de2d4f48a95a09945b8e4170 = new Type[] { typeof(TParam) };
 
         /// <inheritdoc />
         Task<TResponse> IHttpBinApi<TResponse, TParam, THeader>.GetQueryWithIncludeParameterName(TParam param)
         {
             var arguments = new object[] { param };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetQueryWithIncludeParameterName", ArgumentTypes_41fc8f1bba9340e0833c5517b2e98b76);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetQueryWithIncludeParameterName", ArgumentTypes_aa587154de2d4f48a95a09945b8e4170);
             return (Task<TResponse>)func(Client, arguments);
         }
 
-        private static class TypeHelper_c6eef0dad3bb413ba537071113a625af<TValue>
+        private static class TypeHelper_615f12a0486b46839c98dc067a2d61ec<TValue>
         {
             public static readonly Type[] ArgumentTypes = new Type[] { typeof(TParam) };
             public static readonly Type[] TypeParameters = new Type[] { typeof(TValue) };
@@ -1882,7 +1882,7 @@ namespace Refit.Tests
         Task<TValue> IHttpBinApi<TResponse, TParam, THeader>.GetQuery1<TValue>(TParam param)
         {
             var arguments = new object[] { param };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetQuery1", TypeHelper_c6eef0dad3bb413ba537071113a625af<TValue>.ArgumentTypes, TypeHelper_c6eef0dad3bb413ba537071113a625af<TValue>.TypeParameters);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetQuery1", TypeHelper_615f12a0486b46839c98dc067a2d61ec<TValue>.ArgumentTypes, TypeHelper_615f12a0486b46839c98dc067a2d61ec<TValue>.TypeParameters);
             return (Task<TValue>)func(Client, arguments);
         }
     }
@@ -1923,23 +1923,23 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_90529adbf61744c5a831191f49c49161 = new Type[] { typeof(HttpContent) };
+        private static readonly Type[] ArgumentTypes_e2ea08a6e5e54463b53c344dccc24ddf = new Type[] { typeof(HttpContent) };
 
         /// <inheritdoc />
         Task<HttpContent> IHttpContentApi.PostFileUpload(HttpContent content)
         {
             var arguments = new object[] { content };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostFileUpload", ArgumentTypes_90529adbf61744c5a831191f49c49161);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostFileUpload", ArgumentTypes_e2ea08a6e5e54463b53c344dccc24ddf);
             return (Task<HttpContent>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_bf6b49dbe4d540cc859aa42dbec48b03 = new Type[] { typeof(HttpContent) };
+        private static readonly Type[] ArgumentTypes_64a4bcba5e804b858f44ccb5f9986393 = new Type[] { typeof(HttpContent) };
 
         /// <inheritdoc />
         Task<ApiResponse<HttpContent>> IHttpContentApi.PostFileUploadWithMetadata(HttpContent content)
         {
             var arguments = new object[] { content };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostFileUploadWithMetadata", ArgumentTypes_bf6b49dbe4d540cc859aa42dbec48b03);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostFileUploadWithMetadata", ArgumentTypes_64a4bcba5e804b858f44ccb5f9986393);
             return (Task<ApiResponse<HttpContent>>)func(Client, arguments);
         }
     }
@@ -1981,13 +1981,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_bfd0f29f7ee647f0a12cccadbbaec128 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_76e470c0d0c0470b94ef7d43f6ba67d4 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<TestAliasObject> ResponseTests.IMyAliasService.GetTestObject()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetTestObject", ArgumentTypes_bfd0f29f7ee647f0a12cccadbbaec128);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetTestObject", ArgumentTypes_76e470c0d0c0470b94ef7d43f6ba67d4);
             return (Task<TestAliasObject>)func(Client, arguments);
         }
     }
@@ -2023,23 +2023,23 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_c0a075420a6e4527b78489be253ed77a = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_bfaaaf9ef3994a84ac6724945bfa21d5 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> AuthenticatedClientHandlerTests.IMyAuthenticatedService.GetUnauthenticated()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUnauthenticated", ArgumentTypes_c0a075420a6e4527b78489be253ed77a);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUnauthenticated", ArgumentTypes_bfaaaf9ef3994a84ac6724945bfa21d5);
             return (Task<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_678b84ae204a484e8495d371603b0c0a = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_731b09ad02d4473ab9dea4516f49a7ff = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> AuthenticatedClientHandlerTests.IMyAuthenticatedService.GetAuthenticated()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetAuthenticated", ArgumentTypes_678b84ae204a484e8495d371603b0c0a);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetAuthenticated", ArgumentTypes_731b09ad02d4473ab9dea4516f49a7ff);
             return (Task<string>)func(Client, arguments);
         }
     }
@@ -2070,13 +2070,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_f8be50cb813943ebaac386a4d0703e57 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_63b43004cd89457b8ecf74cb77cc5f97 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<SomeType> INamespaceCollisionApi.SomeRequest()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", ArgumentTypes_f8be50cb813943ebaac386a4d0703e57);
+            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", ArgumentTypes_63b43004cd89457b8ecf74cb77cc5f97);
             return (Task<SomeType>)func(Client, arguments);
         }
     }
@@ -2108,13 +2108,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_b6b874d51dfe4f0d8f3cf9245aef6c46 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_e856e1ac33e4458d8c313597017b1350 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<SomeOtherType> INamespaceOverlapApi.SomeRequest()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", ArgumentTypes_b6b874d51dfe4f0d8f3cf9245aef6c46);
+            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", ArgumentTypes_e856e1ac33e4458d8c313597017b1350);
             return (Task<SomeOtherType>)func(Client, arguments);
         }
     }
@@ -2149,83 +2149,83 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_a430349527c64f44ac8c978c42f591c5 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_61a0872b3fde4c9bb0eabecadeb53eb5 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<User> TestNested.INestedGitHubApi.GetUser(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUser", ArgumentTypes_a430349527c64f44ac8c978c42f591c5);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUser", ArgumentTypes_61a0872b3fde4c9bb0eabecadeb53eb5);
             return (Task<User>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_70b62ba2e147441f81e8ef28d7247f0c = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_3b9da3c2726f46979e37ff575a9a0794 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         IObservable<User> TestNested.INestedGitHubApi.GetUserObservable(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserObservable", ArgumentTypes_70b62ba2e147441f81e8ef28d7247f0c);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserObservable", ArgumentTypes_3b9da3c2726f46979e37ff575a9a0794);
             return (IObservable<User>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_d08e15bc70024a99b58110ae00c5221f = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_31422dd8e33d456081e297fe3c83168b = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         IObservable<User> TestNested.INestedGitHubApi.GetUserCamelCase(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserCamelCase", ArgumentTypes_d08e15bc70024a99b58110ae00c5221f);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserCamelCase", ArgumentTypes_31422dd8e33d456081e297fe3c83168b);
             return (IObservable<User>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_eb8a13eadc1147c487a80d9240125c75 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_dc1b45a292724ac4ad1b3616413146cf = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<List<User>> TestNested.INestedGitHubApi.GetOrgMembers(string orgName)
         {
             var arguments = new object[] { orgName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetOrgMembers", ArgumentTypes_eb8a13eadc1147c487a80d9240125c75);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetOrgMembers", ArgumentTypes_dc1b45a292724ac4ad1b3616413146cf);
             return (Task<List<User>>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_6711e41af7da401ca3ff705164eb6f75 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_3ef60de74f79404691afec75c14456be = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<UserSearchResult> TestNested.INestedGitHubApi.FindUsers(string q)
         {
             var arguments = new object[] { q };
-            var func = requestBuilder.BuildRestResultFuncForMethod("FindUsers", ArgumentTypes_6711e41af7da401ca3ff705164eb6f75);
+            var func = requestBuilder.BuildRestResultFuncForMethod("FindUsers", ArgumentTypes_3ef60de74f79404691afec75c14456be);
             return (Task<UserSearchResult>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_efcf362a9a5e4bfbbe5a0a25e776d31f = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_08687d32f5354f31affcebc1124ece68 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<HttpResponseMessage> TestNested.INestedGitHubApi.GetIndex()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndex", ArgumentTypes_efcf362a9a5e4bfbbe5a0a25e776d31f);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndex", ArgumentTypes_08687d32f5354f31affcebc1124ece68);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_7902d50b86494f45a9457bd520d1eb8d = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_752c7fb223be4c89b39c5535d5250d5c = Array.Empty<Type>();
 
         /// <inheritdoc />
         IObservable<string> TestNested.INestedGitHubApi.GetIndexObservable()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndexObservable", ArgumentTypes_7902d50b86494f45a9457bd520d1eb8d);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndexObservable", ArgumentTypes_752c7fb223be4c89b39c5535d5250d5c);
             return (IObservable<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_a4fdcecd8fa54bf1a56d17aa2a1dabd2 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_8ecd080fbb864c6ca5c950f638a0a9a9 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task TestNested.INestedGitHubApi.NothingToSeeHere()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("NothingToSeeHere", ArgumentTypes_a4fdcecd8fa54bf1a56d17aa2a1dabd2);
+            var func = requestBuilder.BuildRestResultFuncForMethod("NothingToSeeHere", ArgumentTypes_8ecd080fbb864c6ca5c950f638a0a9a9);
             return (Task)func(Client, arguments);
         }
     }
@@ -2263,7 +2263,7 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static class TypeHelper_b889c630279e4519b3d851c5978a5eec<T>
+        private static class TypeHelper_91379a84f25140deb11fa9ecc447450d<T>
         {
             public static readonly Type[] ArgumentTypes = new Type[] { typeof(T) };
             public static readonly Type[] TypeParameters = new Type[] { typeof(T) };
@@ -2273,11 +2273,11 @@ namespace Refit.Tests
         Task INonGenericInterfaceWithGenericMethod.PostMessage<T>(T message)
         {
             var arguments = new object[] { message };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostMessage", TypeHelper_b889c630279e4519b3d851c5978a5eec<T>.ArgumentTypes, TypeHelper_b889c630279e4519b3d851c5978a5eec<T>.TypeParameters);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostMessage", TypeHelper_91379a84f25140deb11fa9ecc447450d<T>.ArgumentTypes, TypeHelper_91379a84f25140deb11fa9ecc447450d<T>.TypeParameters);
             return (Task)func(Client, arguments);
         }
 
-        private static class TypeHelper_1a981ad2b8d3438fbcb9a8f209038877<T, U, V>
+        private static class TypeHelper_e53edc8622c343ae95bd7264a78bac0e<T, U, V>
         {
             public static readonly Type[] ArgumentTypes = new Type[] { typeof(T), typeof(U), typeof(V) };
             public static readonly Type[] TypeParameters = new Type[] { typeof(T), typeof(U), typeof(V) };
@@ -2287,7 +2287,7 @@ namespace Refit.Tests
         Task INonGenericInterfaceWithGenericMethod.PostMessage<T, U, V>(T message, U param1, V param2)
         {
             var arguments = new object[] { message, param1, param2 };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostMessage", TypeHelper_1a981ad2b8d3438fbcb9a8f209038877<T, U, V>.ArgumentTypes, TypeHelper_1a981ad2b8d3438fbcb9a8f209038877<T, U, V>.TypeParameters);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostMessage", TypeHelper_e53edc8622c343ae95bd7264a78bac0e<T, U, V>.ArgumentTypes, TypeHelper_e53edc8622c343ae95bd7264a78bac0e<T, U, V>.TypeParameters);
             return (Task)func(Client, arguments);
         }
     }
@@ -2328,13 +2328,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_b5f001f47a6644b0bf731d546529b6e4 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_4b9ff09972274b34b98e679bdf2d7ed1 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<RootObject> INpmJs.GetCongruence()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetCongruence", ArgumentTypes_b5f001f47a6644b0bf731d546529b6e4);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetCongruence", ArgumentTypes_4b9ff09972274b34b98e679bdf2d7ed1);
             return (Task<RootObject>)func(Client, arguments);
         }
     }
@@ -2363,13 +2363,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_45fa3b17785e4f11884f93a5cfe4b74c = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_e39714ce6aa94c25895ae617703cf78a = Array.Empty<Type>();
 
         /// <inheritdoc />
         string? INullableReferenceService.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_45fa3b17785e4f11884f93a5cfe4b74c);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_e39714ce6aa94c25895ae617703cf78a);
             return (string?)func(Client, arguments);
         }
     }
@@ -2398,13 +2398,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_d2dac6196fd04f76805346b266b73109 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_cf3beb54606f442c9b1d9fd281294566 = Array.Empty<Type>();
 
         /// <inheritdoc />
         int? INullableValueService.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_d2dac6196fd04f76805346b266b73109);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_cf3beb54606f442c9b1d9fd281294566);
             return (int?)func(Client, arguments);
         }
     }
@@ -2434,13 +2434,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_1a6e4d2b56d74525bdd83b07398ceb5d = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_9c8afa49c773482aa88e01c54c2b15f4 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<SomeType> IReducedUsingInsideNamespaceApi.SomeRequest()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", ArgumentTypes_1a6e4d2b56d74525bdd83b07398ceb5d);
+            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", ArgumentTypes_9c8afa49c773482aa88e01c54c2b15f4);
             return (Task<SomeType>)func(Client, arguments);
         }
     }
@@ -2469,13 +2469,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_45e9ac026f114d349d9e3eb4c9821f4a = new Type[] { ToNullable(typeof(string)), ToNullable(typeof(int)) };
+        private static readonly Type[] ArgumentTypes_ac13163a88a14e2b88c41fe32af39bcf = new Type[] { ToNullable(typeof(string)), ToNullable(typeof(int)) };
 
         /// <inheritdoc />
         Task IReferenceAndValueParametersService.Get(string? reference, int? value)
         {
             var arguments = new object[] { reference, value };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_45e9ac026f114d349d9e3eb4c9821f4a);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_ac13163a88a14e2b88c41fe32af39bcf);
             return (Task)func(Client, arguments);
         }
 
@@ -2518,13 +2518,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_041608a4df2545b88fa524c8ead947ee = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_09e9fb482d7a4a0081a02a7dfb836d45 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IRefitInterfaceWithStaticMethod.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_041608a4df2545b88fa524c8ead947ee);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_09e9fb482d7a4a0081a02a7dfb836d45);
             return (Task)func(Client, arguments);
         }
     }
@@ -2565,47 +2565,47 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_8aae29f557ef4d9b8f36c67fce8e2ddf = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_d15a22864af54a7e976dcf14ad5e68e8 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IRequestBin.Post()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Post", ArgumentTypes_8aae29f557ef4d9b8f36c67fce8e2ddf);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Post", ArgumentTypes_d15a22864af54a7e976dcf14ad5e68e8);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_84ba01aad0ca4a60823ecc8a277ed4f7 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_f8e9348c171b48e7b5893e22c1a9818c = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task IRequestBin.PostRawStringDefault(string str)
         {
             var arguments = new object[] { str };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostRawStringDefault", ArgumentTypes_84ba01aad0ca4a60823ecc8a277ed4f7);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostRawStringDefault", ArgumentTypes_f8e9348c171b48e7b5893e22c1a9818c);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_fa40c3c2926c4ab79bc510071ee5d3c4 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_52c9988566414b2faa6b577546881f63 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task IRequestBin.PostRawStringJson(string str)
         {
             var arguments = new object[] { str };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostRawStringJson", ArgumentTypes_fa40c3c2926c4ab79bc510071ee5d3c4);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostRawStringJson", ArgumentTypes_52c9988566414b2faa6b577546881f63);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_4d1682eb1a354f13b33174f797ecdaa5 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_87eb3765a57c40cab9d7aeb304387ef5 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task IRequestBin.PostRawStringUrlEncoded(string str)
         {
             var arguments = new object[] { str };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostRawStringUrlEncoded", ArgumentTypes_4d1682eb1a354f13b33174f797ecdaa5);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostRawStringUrlEncoded", ArgumentTypes_87eb3765a57c40cab9d7aeb304387ef5);
             return (Task)func(Client, arguments);
         }
 
-        private static class TypeHelper_fde5aefa86af4843a402d9f9a3b60b88<T>
+        private static class TypeHelper_8d0d4ee30d3845749ceb8bfd11caf4e3<T>
         {
             public static readonly Type[] ArgumentTypes = new Type[] { typeof(T) };
             public static readonly Type[] TypeParameters = new Type[] { typeof(T) };
@@ -2615,7 +2615,7 @@ namespace Refit.Tests
         Task IRequestBin.PostGeneric<T>(T param)
         {
             var arguments = new object[] { param };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostGeneric", TypeHelper_fde5aefa86af4843a402d9f9a3b60b88<T>.ArgumentTypes, TypeHelper_fde5aefa86af4843a402d9f9a3b60b88<T>.TypeParameters);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostGeneric", TypeHelper_8d0d4ee30d3845749ceb8bfd11caf4e3<T>.ArgumentTypes, TypeHelper_8d0d4ee30d3845749ceb8bfd11caf4e3<T>.TypeParameters);
             return (Task)func(Client, arguments);
         }
     }
@@ -2656,133 +2656,133 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_684d625ec98541d5a0a8be05f7d49755 = new Type[] { typeof(Stream) };
+        private static readonly Type[] ArgumentTypes_7ad030782b094718b7d25d64be4a9522 = new Type[] { typeof(Stream) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadStream(Stream stream)
         {
             var arguments = new object[] { stream };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStream", ArgumentTypes_684d625ec98541d5a0a8be05f7d49755);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStream", ArgumentTypes_7ad030782b094718b7d25d64be4a9522);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_fe4cdc2b5df341948d92f7d558ca413d = new Type[] { typeof(Stream) };
+        private static readonly Type[] ArgumentTypes_111763696c5d4b9581ac088e4336b758 = new Type[] { typeof(Stream) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadStreamWithCustomBoundary(Stream stream)
         {
             var arguments = new object[] { stream };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStreamWithCustomBoundary", ArgumentTypes_fe4cdc2b5df341948d92f7d558ca413d);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStreamWithCustomBoundary", ArgumentTypes_111763696c5d4b9581ac088e4336b758);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_7adfa51417ff4dec84da224f19820e73 = new Type[] { typeof(StreamPart) };
+        private static readonly Type[] ArgumentTypes_96e8812a28b5432ea3ddc69f4ffc218f = new Type[] { typeof(StreamPart) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadStreamPart(StreamPart stream)
         {
             var arguments = new object[] { stream };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStreamPart", ArgumentTypes_7adfa51417ff4dec84da224f19820e73);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStreamPart", ArgumentTypes_96e8812a28b5432ea3ddc69f4ffc218f);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_fca3caac8faf4c62919761db17ec7d3a = new Type[] { typeof(ModelObject), typeof(StreamPart) };
+        private static readonly Type[] ArgumentTypes_86594e83435c4663b3afbe5d9e95c0f1 = new Type[] { typeof(ModelObject), typeof(StreamPart) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadStreamPart(ModelObject someQueryParams, StreamPart stream)
         {
             var arguments = new object[] { someQueryParams, stream };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStreamPart", ArgumentTypes_fca3caac8faf4c62919761db17ec7d3a);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStreamPart", ArgumentTypes_86594e83435c4663b3afbe5d9e95c0f1);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_cd1e2404075449b5be02bc5d6fc99c68 = new Type[] { typeof(byte[]) };
+        private static readonly Type[] ArgumentTypes_f1eda21b7753499aa811dc46f11fa7a1 = new Type[] { typeof(byte[]) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadBytes(byte[] bytes)
         {
             var arguments = new object[] { bytes };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadBytes", ArgumentTypes_cd1e2404075449b5be02bc5d6fc99c68);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadBytes", ArgumentTypes_f1eda21b7753499aa811dc46f11fa7a1);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_0feafdcd26044aa3b968e6ca6f5806d4 = new Type[] { typeof(ByteArrayPart) };
+        private static readonly Type[] ArgumentTypes_9ab437657b834a6d9350ecd1feec740d = new Type[] { typeof(ByteArrayPart) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadBytesPart(ByteArrayPart bytes)
         {
             var arguments = new object[] { bytes };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadBytesPart", ArgumentTypes_0feafdcd26044aa3b968e6ca6f5806d4);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadBytesPart", ArgumentTypes_9ab437657b834a6d9350ecd1feec740d);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_d39be899581c43e296ba98f32506831e = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_b74c8c9978134656887602ad1b07f9a9 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadString(string someString)
         {
             var arguments = new object[] { someString };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadString", ArgumentTypes_d39be899581c43e296ba98f32506831e);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadString", ArgumentTypes_b74c8c9978134656887602ad1b07f9a9);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_9d4f399f50f94feb85557f84d2ab1096 = new Type[] { typeof(IEnumerable<FileInfo>), typeof(FileInfo) };
+        private static readonly Type[] ArgumentTypes_9e3b885f46c44c579881bd00bce76638 = new Type[] { typeof(IEnumerable<FileInfo>), typeof(FileInfo) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadFileInfo(IEnumerable<FileInfo> fileInfos, FileInfo anotherFile)
         {
             var arguments = new object[] { fileInfos, anotherFile };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadFileInfo", ArgumentTypes_9d4f399f50f94feb85557f84d2ab1096);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadFileInfo", ArgumentTypes_9e3b885f46c44c579881bd00bce76638);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_c4c322984f67484291a5e8519e56bbac = new Type[] { typeof(IEnumerable<FileInfoPart>), typeof(FileInfoPart) };
+        private static readonly Type[] ArgumentTypes_a8ecfda03cca43d9ba4c5418e5cd1477 = new Type[] { typeof(IEnumerable<FileInfoPart>), typeof(FileInfoPart) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadFileInfoPart(IEnumerable<FileInfoPart> fileInfos, FileInfoPart anotherFile)
         {
             var arguments = new object[] { fileInfos, anotherFile };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadFileInfoPart", ArgumentTypes_c4c322984f67484291a5e8519e56bbac);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadFileInfoPart", ArgumentTypes_a8ecfda03cca43d9ba4c5418e5cd1477);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_c65c5847413e44b1a35eceff6a5bc150 = new Type[] { typeof(ModelObject) };
+        private static readonly Type[] ArgumentTypes_b06da44a5a0646ffa8419d53a34d1b8a = new Type[] { typeof(ModelObject) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadJsonObject(ModelObject theObject)
         {
             var arguments = new object[] { theObject };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadJsonObject", ArgumentTypes_c65c5847413e44b1a35eceff6a5bc150);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadJsonObject", ArgumentTypes_b06da44a5a0646ffa8419d53a34d1b8a);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_6bb04ba2c13f49f9a6a02ca0497e7297 = new Type[] { typeof(IEnumerable<ModelObject>) };
+        private static readonly Type[] ArgumentTypes_5f5773e943084c51a4b6fa8e416cfd24 = new Type[] { typeof(IEnumerable<ModelObject>) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadJsonObjects(IEnumerable<ModelObject> theObjects)
         {
             var arguments = new object[] { theObjects };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadJsonObjects", ArgumentTypes_6bb04ba2c13f49f9a6a02ca0497e7297);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadJsonObjects", ArgumentTypes_5f5773e943084c51a4b6fa8e416cfd24);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_de9cf24454df48c4a3f0be6f036d3148 = new Type[] { typeof(IEnumerable<ModelObject>), typeof(AnotherModel), typeof(FileInfo), typeof(AnEnum), typeof(string), typeof(int) };
+        private static readonly Type[] ArgumentTypes_03b0f872e384449ea1e78d41aaf986a9 = new Type[] { typeof(IEnumerable<ModelObject>), typeof(AnotherModel), typeof(FileInfo), typeof(AnEnum), typeof(string), typeof(int) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadMixedObjects(IEnumerable<ModelObject> theObjects, AnotherModel anotherModel, FileInfo aFile, AnEnum anEnum, string aString, int anInt)
         {
             var arguments = new object[] { theObjects, anotherModel, aFile, anEnum, aString, anInt };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadMixedObjects", ArgumentTypes_de9cf24454df48c4a3f0be6f036d3148);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadMixedObjects", ArgumentTypes_03b0f872e384449ea1e78d41aaf986a9);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_f051d362881246f28ca8f09086f0abac = new Type[] { typeof(HttpContent) };
+        private static readonly Type[] ArgumentTypes_0b1a5cfe5c3c46d48f1bf824495725c3 = new Type[] { typeof(HttpContent) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadHttpContent(HttpContent content)
         {
             var arguments = new object[] { content };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadHttpContent", ArgumentTypes_f051d362881246f28ca8f09086f0abac);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadHttpContent", ArgumentTypes_0b1a5cfe5c3c46d48f1bf824495725c3);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
     }
@@ -2814,23 +2814,23 @@ namespace AutoGeneratedIServiceWithoutNamespace
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_bb0e6a7c468c4dd3a6210267d6b9cad9 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_949f9ab6756342ab9ea1958145c53f18 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IServiceWithoutNamespace.GetRoot()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetRoot", ArgumentTypes_bb0e6a7c468c4dd3a6210267d6b9cad9);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetRoot", ArgumentTypes_949f9ab6756342ab9ea1958145c53f18);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_7f6605636b19400d94135ec4d92a0763 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_99caddf7906f445ab8fa142da1921cfc = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IServiceWithoutNamespace.PostRoot()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostRoot", ArgumentTypes_7f6605636b19400d94135ec4d92a0763);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostRoot", ArgumentTypes_99caddf7906f445ab8fa142da1921cfc);
             return (Task)func(Client, arguments);
         }
     }
@@ -2871,23 +2871,23 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_a609f44b3e3c450cb19beb6de256880d = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_5287b6b604ff426e8209a100f88a6c25 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<Stream> IStreamApi.GetRemoteFile(string filename)
         {
             var arguments = new object[] { filename };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetRemoteFile", ArgumentTypes_a609f44b3e3c450cb19beb6de256880d);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetRemoteFile", ArgumentTypes_5287b6b604ff426e8209a100f88a6c25);
             return (Task<Stream>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_6032b3c0af634f8e9ce7cadf6f8608b6 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_d46f4ea5b7c64198aa3a3cbc775947c1 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<ApiResponse<Stream>> IStreamApi.GetRemoteFileWithMetadata(string filename)
         {
             var arguments = new object[] { filename };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetRemoteFileWithMetadata", ArgumentTypes_6032b3c0af634f8e9ce7cadf6f8608b6);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetRemoteFileWithMetadata", ArgumentTypes_d46f4ea5b7c64198aa3a3cbc775947c1);
             return (Task<ApiResponse<Stream>>)func(Client, arguments);
         }
     }
@@ -2928,13 +2928,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_0696eae660514552a23e3fb09f8f2ca5 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_3083b3aad308413899523930a416c5b6 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task ITrimTrailingForwardSlashApi.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_0696eae660514552a23e3fb09f8f2ca5);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_3083b3aad308413899523930a416c5b6);
             return (Task)func(Client, arguments);
         }
     }
@@ -2964,13 +2964,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_3ad36489d3924039b7930d393433e92b = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_01f48a7fae8b497c9061f12ac3c319a9 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<SomeType> ITypeCollisionApiA.SomeARequest()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("SomeARequest", ArgumentTypes_3ad36489d3924039b7930d393433e92b);
+            var func = requestBuilder.BuildRestResultFuncForMethod("SomeARequest", ArgumentTypes_01f48a7fae8b497c9061f12ac3c319a9);
             return (Task<SomeType>)func(Client, arguments);
         }
     }
@@ -3000,13 +3000,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_be5e5b598e0c42c1a71031959a2b48c5 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_ee4a61a3e7de48b3a12306c0352799f3 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<SomeType> ITypeCollisionApiB.SomeBRequest()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("SomeBRequest", ArgumentTypes_be5e5b598e0c42c1a71031959a2b48c5);
+            var func = requestBuilder.BuildRestResultFuncForMethod("SomeBRequest", ArgumentTypes_ee4a61a3e7de48b3a12306c0352799f3);
             return (Task<SomeType>)func(Client, arguments);
         }
     }
@@ -3045,47 +3045,47 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_b2e52dc636ae4b97a6dc089c5451995e = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_0c4a709b33334ff0bf8e879f15e0ae4b = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> IUseOverloadedGenericMethods<TResponse, TParam, THeader>.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_b2e52dc636ae4b97a6dc089c5451995e);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_0c4a709b33334ff0bf8e879f15e0ae4b);
             return (Task<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_178ba7de1daa426992a6a41650b86c16 = new Type[] { typeof(TParam), typeof(THeader) };
+        private static readonly Type[] ArgumentTypes_4773ee533d8c47f1ade3bb2c983512b2 = new Type[] { typeof(TParam), typeof(THeader) };
 
         /// <inheritdoc />
         Task<TResponse> IUseOverloadedGenericMethods<TResponse, TParam, THeader>.Get(TParam param, THeader header)
         {
             var arguments = new object[] { param, header };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_178ba7de1daa426992a6a41650b86c16);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_4773ee533d8c47f1ade3bb2c983512b2);
             return (Task<TResponse>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_e71df52916364e49aee7343278d40be3 = new Type[] { typeof(THeader), typeof(TParam) };
+        private static readonly Type[] ArgumentTypes_ef629becf89b4b4983ca601d307c7a55 = new Type[] { typeof(THeader), typeof(TParam) };
 
         /// <inheritdoc />
         Task<TResponse> IUseOverloadedGenericMethods<TResponse, TParam, THeader>.Get(THeader param, TParam header)
         {
             var arguments = new object[] { param, header };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_e71df52916364e49aee7343278d40be3);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_ef629becf89b4b4983ca601d307c7a55);
             return (Task<TResponse>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_b460c9806256456287323f3a99620e54 = new Type[] { typeof(int) };
+        private static readonly Type[] ArgumentTypes_d48c8988432c450183852d7cabdef1a9 = new Type[] { typeof(int) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IUseOverloadedGenericMethods<TResponse, TParam, THeader>.Get(int httpstatuscode)
         {
             var arguments = new object[] { httpstatuscode };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_b460c9806256456287323f3a99620e54);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_d48c8988432c450183852d7cabdef1a9);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static class TypeHelper_16663a294a3747d58d9f4de74773314b<TValue>
+        private static class TypeHelper_675e16dbe2db433baa1d534d8f836ce2<TValue>
         {
             public static readonly Type[] ArgumentTypes = new Type[] { typeof(int) };
             public static readonly Type[] TypeParameters = new Type[] { typeof(TValue) };
@@ -3095,11 +3095,11 @@ namespace Refit.Tests
         Task<TValue> IUseOverloadedGenericMethods<TResponse, TParam, THeader>.Get<TValue>(int someVal)
         {
             var arguments = new object[] { someVal };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", TypeHelper_16663a294a3747d58d9f4de74773314b<TValue>.ArgumentTypes, TypeHelper_16663a294a3747d58d9f4de74773314b<TValue>.TypeParameters);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", TypeHelper_675e16dbe2db433baa1d534d8f836ce2<TValue>.ArgumentTypes, TypeHelper_675e16dbe2db433baa1d534d8f836ce2<TValue>.TypeParameters);
             return (Task<TValue>)func(Client, arguments);
         }
 
-        private static class TypeHelper_709be579e09e4928b0846592e9755f37<TValue, TInput>
+        private static class TypeHelper_531f6c2269294e40b1eb070dda401682<TValue, TInput>
         {
             public static readonly Type[] ArgumentTypes = new Type[] { typeof(TInput) };
             public static readonly Type[] TypeParameters = new Type[] { typeof(TValue), typeof(TInput) };
@@ -3109,11 +3109,11 @@ namespace Refit.Tests
         Task<TValue> IUseOverloadedGenericMethods<TResponse, TParam, THeader>.Get<TValue, TInput>(TInput input)
         {
             var arguments = new object[] { input };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", TypeHelper_709be579e09e4928b0846592e9755f37<TValue, TInput>.ArgumentTypes, TypeHelper_709be579e09e4928b0846592e9755f37<TValue, TInput>.TypeParameters);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", TypeHelper_531f6c2269294e40b1eb070dda401682<TValue, TInput>.ArgumentTypes, TypeHelper_531f6c2269294e40b1eb070dda401682<TValue, TInput>.TypeParameters);
             return (Task<TValue>)func(Client, arguments);
         }
 
-        private static class TypeHelper_bbea10926f144c5b970ee04637b14c68<TInput1, TInput2>
+        private static class TypeHelper_c9290c092dbb4619aa01a61aa6828c2f<TInput1, TInput2>
         {
             public static readonly Type[] ArgumentTypes = new Type[] { typeof(TInput1), typeof(TInput2) };
             public static readonly Type[] TypeParameters = new Type[] { typeof(TInput1), typeof(TInput2) };
@@ -3123,7 +3123,7 @@ namespace Refit.Tests
         Task IUseOverloadedGenericMethods<TResponse, TParam, THeader>.Get<TInput1, TInput2>(TInput1 input1, TInput2 input2)
         {
             var arguments = new object[] { input1, input2 };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", TypeHelper_bbea10926f144c5b970ee04637b14c68<TInput1, TInput2>.ArgumentTypes, TypeHelper_bbea10926f144c5b970ee04637b14c68<TInput1, TInput2>.TypeParameters);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", TypeHelper_c9290c092dbb4619aa01a61aa6828c2f<TInput1, TInput2>.ArgumentTypes, TypeHelper_c9290c092dbb4619aa01a61aa6828c2f<TInput1, TInput2>.TypeParameters);
             return (Task)func(Client, arguments);
         }
     }
@@ -3158,23 +3158,23 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_fc80a89649564f49a5686f9edd681fda = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_e89279e885694515af82c9ddc6e1e41b = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<string> IUseOverloadedMethods.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_fc80a89649564f49a5686f9edd681fda);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_e89279e885694515af82c9ddc6e1e41b);
             return (Task<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_d44f45f888e74028b19bd19bb70b9231 = new Type[] { typeof(int) };
+        private static readonly Type[] ArgumentTypes_52dd3591d6e74383bc306034302db31b = new Type[] { typeof(int) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IUseOverloadedMethods.Get(int httpstatuscode)
         {
             var arguments = new object[] { httpstatuscode };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_d44f45f888e74028b19bd19bb70b9231);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_52dd3591d6e74383bc306034302db31b);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
     }
@@ -3215,13 +3215,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_d7658779b2ac415da648b980145d9a98 = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_6fe686927009464d819f516b3ef388c2 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task IValidApi.Get()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_d7658779b2ac415da648b980145d9a98);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_6fe686927009464d819f516b3ef388c2);
             return (Task)func(Client, arguments);
         }
     }
@@ -3251,13 +3251,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_3f48c36fd66d40339da0d66d4d03c0fc = Array.Empty<Type>();
+        private static readonly Type[] ArgumentTypes_8063544d1af84f46a59af3634f783f11 = Array.Empty<Type>();
 
         /// <inheritdoc />
         Task<SomeType> NamespaceWithGlobalAliasApi.SomeRequest()
         {
             var arguments = Array.Empty<object>();
-            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", ArgumentTypes_3f48c36fd66d40339da0d66d4d03c0fc);
+            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", ArgumentTypes_8063544d1af84f46a59af3634f783f11);
             return (Task<SomeType>)func(Client, arguments);
         }
     }

--- a/Refit.Tests/RefitStubs.NetCore3.cs
+++ b/Refit.Tests/RefitStubs.NetCore3.cs
@@ -62,27 +62,27 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_d8b00b09dc5a450aa177a2e9b88c3590 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_a33898cae1424f04ac90e19b114938bf = new Type[] {  };
 
         /// <inheritdoc />
         Task IAmARefitInterfaceButNobodyUsesMe.RefitMethod()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("RefitMethod", ArgumentTypes_d8b00b09dc5a450aa177a2e9b88c3590);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("RefitMethod", ArgumentTypes_a33898cae1424f04ac90e19b114938bf);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_451653fe1a5e4ee7ac2059d56a98659f = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_999eb22bf4ce4c81ab78c8fba135650b = new Type[] {  };
 
         /// <inheritdoc />
         Task IAmARefitInterfaceButNobodyUsesMe.AnotherRefitMethod()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("AnotherRefitMethod", ArgumentTypes_451653fe1a5e4ee7ac2059d56a98659f);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("AnotherRefitMethod", ArgumentTypes_999eb22bf4ce4c81ab78c8fba135650b);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_9451ed9f22494e12826453be4da77fc4 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_be7bf8c223984dd7a7a905f1ad4a6af1 = new Type[] {  };
 
         /// <inheritdoc />
         Task IAmARefitInterfaceButNobodyUsesMe.NoConstantsAllowed()
@@ -90,23 +90,23 @@ namespace Refit.Tests
             throw new NotImplementedException("Either this method has no Refit HTTP method attribute or you've used something other than a string literal for the 'path' argument.");
         }
 
-        private static readonly Type[] ArgumentTypes_0f5a40be66e647959399b4e2374a297c = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_6c24145dba474e3d8705ea67be58ff14 = new Type[] {  };
 
         /// <inheritdoc />
         Task IAmARefitInterfaceButNobodyUsesMe.SpacesShouldntBreakMe()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("SpacesShouldntBreakMe", ArgumentTypes_0f5a40be66e647959399b4e2374a297c);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("SpacesShouldntBreakMe", ArgumentTypes_6c24145dba474e3d8705ea67be58ff14);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_5c48b9c2eadf4d228f88276514b866fc = new Type[] { typeof(int), typeof(string), typeof(float) };
+        private static readonly Type[] ArgumentTypes_5e33a67e1d424b35b9d6831080287c99 = new Type[] { typeof(int), typeof(string), typeof(float) };
 
         /// <inheritdoc />
         Task IAmARefitInterfaceButNobodyUsesMe.ReservedWordsForParameterNames(int @int, string @string, float @long)
         {
             var arguments = new object[] { @int, @string, @long };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReservedWordsForParameterNames", ArgumentTypes_5c48b9c2eadf4d228f88276514b866fc);
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReservedWordsForParameterNames", ArgumentTypes_5e33a67e1d424b35b9d6831080287c99);
             return (Task)func(Client, arguments);
         }
     }
@@ -147,17 +147,17 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_c42d84726e964804b0c8e40d9f4d1201 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_8a5f3ad34f1645e9834fc717c71fd412 = new Type[] {  };
 
         /// <inheritdoc />
         Task IAmHalfRefit.Post()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Post", ArgumentTypes_c42d84726e964804b0c8e40d9f4d1201);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Post", ArgumentTypes_8a5f3ad34f1645e9834fc717c71fd412);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_09bc692dc6874c3194b776ed28f746a4 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_adf3e23374b64794a82a71c27944d970 = new Type[] {  };
 
         /// <inheritdoc />
         Task IAmHalfRefit.Get()
@@ -191,43 +191,43 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_5805b02a0f2d41219fd413bf60e59de2 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_a1ac46e26dcd4bbe83496ab645c0a335 = new Type[] {  };
 
         /// <inheritdoc />
         Task<string> IAmInterface.Pang()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Pang", ArgumentTypes_5805b02a0f2d41219fd413bf60e59de2);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Pang", ArgumentTypes_a1ac46e26dcd4bbe83496ab645c0a335);
             return (Task<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_ca108c87fa554b1dbe8a414685fc5142 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_7eb5679aabda4721abb7f1cc9b4ba7f8 = new Type[] {  };
 
         /// <inheritdoc />
         Task<string> IAmInterfaceB.Pong()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Pong", ArgumentTypes_ca108c87fa554b1dbe8a414685fc5142);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Pong", ArgumentTypes_7eb5679aabda4721abb7f1cc9b4ba7f8);
             return (Task<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_208bf354c73c4c14a3c21f850472fac5 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_c26d225af41c463ba3cc89dbb751b673 = new Type[] {  };
 
         /// <inheritdoc />
         Task<string> IAmInterfaceD.Test()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Test", ArgumentTypes_208bf354c73c4c14a3c21f850472fac5);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Test", ArgumentTypes_c26d225af41c463ba3cc89dbb751b673);
             return (Task<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_8a392d4648974e518879930ee59470eb = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_3527bdf7f5e14e3487ae6a35eb3f2463 = new Type[] {  };
 
         /// <inheritdoc />
         Task<string> IAmInterfaceA.Ping()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Ping", ArgumentTypes_8a392d4648974e518879930ee59470eb);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Ping", ArgumentTypes_3527bdf7f5e14e3487ae6a35eb3f2463);
             return (Task<string>)func(Client, arguments);
         }
     }
@@ -257,13 +257,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_8ecb390d820f4abb9f3a61ed6add6151 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_c7c7a0b2b5214cfba14ad6cbb57580c3 = new Type[] {  };
 
         /// <inheritdoc />
         Task<string> IAmInterfaceA.Ping()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Ping", ArgumentTypes_8ecb390d820f4abb9f3a61ed6add6151);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Ping", ArgumentTypes_c7c7a0b2b5214cfba14ad6cbb57580c3);
             return (Task<string>)func(Client, arguments);
         }
     }
@@ -293,23 +293,23 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_667acd2061ff4f909ff2418ea88f13d5 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_bac788abd15044c88591d32e590d7a69 = new Type[] {  };
 
         /// <inheritdoc />
         Task<string> IAmInterfaceB.Pong()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Pong", ArgumentTypes_667acd2061ff4f909ff2418ea88f13d5);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Pong", ArgumentTypes_bac788abd15044c88591d32e590d7a69);
             return (Task<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_4c20765db1ba4467ba5b41d74d493feb = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_c4c2d14d024e456190d66d4157f621a0 = new Type[] {  };
 
         /// <inheritdoc />
         Task<string> IAmInterfaceD.Test()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Test", ArgumentTypes_4c20765db1ba4467ba5b41d74d493feb);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Test", ArgumentTypes_c4c2d14d024e456190d66d4157f621a0);
             return (Task<string>)func(Client, arguments);
         }
     }
@@ -339,43 +339,43 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_4278e21343e04de2bbedc95614b150a7 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_845a59a5a30046c5aced2c210032c784 = new Type[] {  };
 
         /// <inheritdoc />
         Task<string> IAmInterfaceC.Pang()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Pang", ArgumentTypes_4278e21343e04de2bbedc95614b150a7);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Pang", ArgumentTypes_845a59a5a30046c5aced2c210032c784);
             return (Task<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_5120e2f1d5704d4f857ff9f4b280160d = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_671198dfe55c4a1eb164a2fa1c6725d3 = new Type[] {  };
 
         /// <inheritdoc />
         Task<string> IAmInterfaceB.Pong()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Pong", ArgumentTypes_5120e2f1d5704d4f857ff9f4b280160d);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Pong", ArgumentTypes_671198dfe55c4a1eb164a2fa1c6725d3);
             return (Task<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_59ab2b560d9e445a94efd9a7330aa9ad = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_f67764b160be44519fbb73cb127908c9 = new Type[] {  };
 
         /// <inheritdoc />
         Task<string> IAmInterfaceD.Test()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Test", ArgumentTypes_59ab2b560d9e445a94efd9a7330aa9ad);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Test", ArgumentTypes_f67764b160be44519fbb73cb127908c9);
             return (Task<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_bd02964331cb40b38d2cd0747dbd0270 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_d22b6f531d3f4ff49ed1e3eb8f29870e = new Type[] {  };
 
         /// <inheritdoc />
         Task<string> IAmInterfaceA.Ping()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Ping", ArgumentTypes_bd02964331cb40b38d2cd0747dbd0270);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Ping", ArgumentTypes_d22b6f531d3f4ff49ed1e3eb8f29870e);
             return (Task<string>)func(Client, arguments);
         }
     }
@@ -405,13 +405,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_3bb760dfabb04f5d9e557f74b4e14ba6 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_8b8977467c3f482a9a2205b6fc18d51d = new Type[] {  };
 
         /// <inheritdoc />
         Task<string> IAmInterfaceD.Test()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Test", ArgumentTypes_3bb760dfabb04f5d9e557f74b4e14ba6);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Test", ArgumentTypes_8b8977467c3f482a9a2205b6fc18d51d);
             return (Task<string>)func(Client, arguments);
         }
     }
@@ -452,153 +452,153 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_104792e5546347e49e178d3df4600f4f = new Type[] { typeof(PathBoundObject) };
+        private static readonly Type[] ArgumentTypes_54e2a831d49f4b2abc27443f89da87f4 = new Type[] { typeof(PathBoundObject) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetFooBars(PathBoundObject request)
         {
             var arguments = new object[] { request };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBars", ArgumentTypes_104792e5546347e49e178d3df4600f4f);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBars", ArgumentTypes_54e2a831d49f4b2abc27443f89da87f4);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_4a97b899de2c4fa68b244eb5ff0b293b = new Type[] { typeof(PathBoundObject) };
+        private static readonly Type[] ArgumentTypes_1b53c24b71c543598d20fbd4ea306cdc = new Type[] { typeof(PathBoundObject) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetFooBarsWithDifferentCasing(PathBoundObject requestParams)
         {
             var arguments = new object[] { requestParams };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBarsWithDifferentCasing", ArgumentTypes_4a97b899de2c4fa68b244eb5ff0b293b);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBarsWithDifferentCasing", ArgumentTypes_1b53c24b71c543598d20fbd4ea306cdc);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_e0ba7f87b237430187371646109336b9 = new Type[] { typeof(string), typeof(PathBoundObject) };
+        private static readonly Type[] ArgumentTypes_1a1c369628f8408db992a8efd1b7a6c3 = new Type[] { typeof(string), typeof(PathBoundObject) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetBarsByFoo(string id, PathBoundObject request)
         {
             var arguments = new object[] { id, request };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetBarsByFoo", ArgumentTypes_e0ba7f87b237430187371646109336b9);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetBarsByFoo", ArgumentTypes_1a1c369628f8408db992a8efd1b7a6c3);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_18675fb6c1f94a68be274f15250f3c4c = new Type[] { typeof(PathBoundObject), typeof(string) };
+        private static readonly Type[] ArgumentTypes_67b05d70a64549fbb3fafb95b1d6d2a6 = new Type[] { typeof(PathBoundObject), typeof(string) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetFooBars(PathBoundObject request, string someProperty)
         {
             var arguments = new object[] { request, someProperty };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBars", ArgumentTypes_18675fb6c1f94a68be274f15250f3c4c);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBars", ArgumentTypes_67b05d70a64549fbb3fafb95b1d6d2a6);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_31c69a44d5a441d1b29442c157574f33 = new Type[] { typeof(PathBoundObject) };
+        private static readonly Type[] ArgumentTypes_75130c933bc84e8389014e3a34ea24cb = new Type[] { typeof(PathBoundObject) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetBarsByFoo(PathBoundObject request)
         {
             var arguments = new object[] { request };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetBarsByFoo", ArgumentTypes_31c69a44d5a441d1b29442c157574f33);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetBarsByFoo", ArgumentTypes_75130c933bc84e8389014e3a34ea24cb);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_360fcad1da834aaca59aade579cdd670 = new Type[] { typeof(PathBoundObjectWithQueryFormat) };
+        private static readonly Type[] ArgumentTypes_5d6427e339da478b8513efb42f8046c1 = new Type[] { typeof(PathBoundObjectWithQueryFormat) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetBarsWithCustomQueryFormat(PathBoundObjectWithQueryFormat request)
         {
             var arguments = new object[] { request };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetBarsWithCustomQueryFormat", ArgumentTypes_360fcad1da834aaca59aade579cdd670);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetBarsWithCustomQueryFormat", ArgumentTypes_5d6427e339da478b8513efb42f8046c1);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_0dc958dc7d78451b87fc71a2cca0168c = new Type[] { typeof(PathBoundDerivedObject) };
+        private static readonly Type[] ArgumentTypes_ee1879b281054091884e31424e02f0eb = new Type[] { typeof(PathBoundDerivedObject) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetFooBarsDerived(PathBoundDerivedObject request)
         {
             var arguments = new object[] { request };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBarsDerived", ArgumentTypes_0dc958dc7d78451b87fc71a2cca0168c);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBarsDerived", ArgumentTypes_ee1879b281054091884e31424e02f0eb);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_8f99038fefbd400c8578e254fea89b94 = new Type[] { typeof(PathBoundList) };
+        private static readonly Type[] ArgumentTypes_f2358e3269ab438e8b228103ae1c7a60 = new Type[] { typeof(PathBoundList) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetFoos(PathBoundList request)
         {
             var arguments = new object[] { request };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetFoos", ArgumentTypes_8f99038fefbd400c8578e254fea89b94);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetFoos", ArgumentTypes_f2358e3269ab438e8b228103ae1c7a60);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_5051934f2c94418499500d29fe13aa9d = new Type[] { typeof(List<int>) };
+        private static readonly Type[] ArgumentTypes_4dca8047875b485e9f602361b36966fd = new Type[] { typeof(List<int>) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetFoos2(List<int> Values)
         {
             var arguments = new object[] { Values };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetFoos2", ArgumentTypes_5051934f2c94418499500d29fe13aa9d);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetFoos2", ArgumentTypes_4dca8047875b485e9f602361b36966fd);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_f71c19f10a80483bb4c155c29336fd52 = new Type[] { typeof(PathBoundObject), typeof(object) };
+        private static readonly Type[] ArgumentTypes_bf0841a8e36645f1a9bf6ad33dd616fe = new Type[] { typeof(PathBoundObject), typeof(object) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.PostFooBar(PathBoundObject request, object someObject)
         {
             var arguments = new object[] { request, someObject };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBar", ArgumentTypes_f71c19f10a80483bb4c155c29336fd52);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBar", ArgumentTypes_bf0841a8e36645f1a9bf6ad33dd616fe);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_cae235beda7344b88dbba9b6c268ccb0 = new Type[] { typeof(PathBoundObjectWithQuery) };
+        private static readonly Type[] ArgumentTypes_ef1edc71e5f8413b8211212efcfc1984 = new Type[] { typeof(PathBoundObjectWithQuery) };
 
         /// <inheritdoc />
         Task IApiBindPathToObject.GetFooBars(PathBoundObjectWithQuery request)
         {
             var arguments = new object[] { request };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBars", ArgumentTypes_cae235beda7344b88dbba9b6c268ccb0);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetFooBars", ArgumentTypes_ef1edc71e5f8413b8211212efcfc1984);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_2c8f0e70ba974a769d263d7707ac9291 = new Type[] { typeof(PathBoundObject), typeof(ModelObject) };
+        private static readonly Type[] ArgumentTypes_b96a64a45020426e8755fd58baf0d915 = new Type[] { typeof(PathBoundObject), typeof(ModelObject) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IApiBindPathToObject.PostFooBar(PathBoundObject request, ModelObject someQueryParams)
         {
             var arguments = new object[] { request, someQueryParams };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBar", ArgumentTypes_2c8f0e70ba974a769d263d7707ac9291);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBar", ArgumentTypes_b96a64a45020426e8755fd58baf0d915);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_be8f20f50c9746f0a1aed3fc1cdcd539 = new Type[] { typeof(PathBoundObject), typeof(ModelObject), typeof(StreamPart) };
+        private static readonly Type[] ArgumentTypes_7d81bc45f8cd4c1ca2efdfc4cb01a30c = new Type[] { typeof(PathBoundObject), typeof(ModelObject), typeof(StreamPart) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IApiBindPathToObject.PostFooBarStreamPart(PathBoundObject request, ModelObject someQueryParams, StreamPart stream)
         {
             var arguments = new object[] { request, someQueryParams, stream };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBarStreamPart", ArgumentTypes_be8f20f50c9746f0a1aed3fc1cdcd539);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBarStreamPart", ArgumentTypes_7d81bc45f8cd4c1ca2efdfc4cb01a30c);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_b1f31e20085f4a9ba18165a0c51da724 = new Type[] { typeof(PathBoundObject), typeof(StreamPart) };
+        private static readonly Type[] ArgumentTypes_6aa030039162443595412fa42000be13 = new Type[] { typeof(PathBoundObject), typeof(StreamPart) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IApiBindPathToObject.PostFooBarStreamPart(PathBoundObject request, StreamPart stream)
         {
             var arguments = new object[] { request, stream };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBarStreamPart", ArgumentTypes_b1f31e20085f4a9ba18165a0c51da724);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBarStreamPart", ArgumentTypes_6aa030039162443595412fa42000be13);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_be90f8db210a41ff8950a8af70ebc309 = new Type[] { typeof(PathBoundObjectWithQuery), typeof(StreamPart) };
+        private static readonly Type[] ArgumentTypes_aa6f10bcf850457fbcac790bfe3257c9 = new Type[] { typeof(PathBoundObjectWithQuery), typeof(StreamPart) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IApiBindPathToObject.PostFooBarStreamPart(PathBoundObjectWithQuery request, StreamPart stream)
         {
             var arguments = new object[] { request, stream };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBarStreamPart", ArgumentTypes_be90f8db210a41ff8950a8af70ebc309);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostFooBarStreamPart", ArgumentTypes_aa6f10bcf850457fbcac790bfe3257c9);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
     }
@@ -639,13 +639,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_29a282ea925c40efa50459cb25838965 = new Type[] { typeof(decimal) };
+        private static readonly Type[] ArgumentTypes_d9084c5e880747d4a2331810b573d7ee = new Type[] { typeof(decimal) };
 
         /// <inheritdoc />
         Task<string> IApiWithDecimal.GetWithDecimal(decimal value)
         {
             var arguments = new object[] { value };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetWithDecimal", ArgumentTypes_29a282ea925c40efa50459cb25838965);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetWithDecimal", ArgumentTypes_d9084c5e880747d4a2331810b573d7ee);
             return (Task<string>)func(Client, arguments);
         }
     }
@@ -686,33 +686,33 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_886520919c5c4e969bb1708b4df1cff4 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_680a119f30b34566956dfecc61326680 = new Type[] {  };
 
         /// <inheritdoc />
         Task IBodylessApi.Post()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Post", ArgumentTypes_886520919c5c4e969bb1708b4df1cff4);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Post", ArgumentTypes_680a119f30b34566956dfecc61326680);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_65e800484bfc492baaa84b2c08cc38af = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_48e4640f5cd54c84bea039d718ddaebe = new Type[] {  };
 
         /// <inheritdoc />
         Task IBodylessApi.Get()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_65e800484bfc492baaa84b2c08cc38af);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_48e4640f5cd54c84bea039d718ddaebe);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_09f0b1e963904459a5275c26beeba8ef = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_7cbb17127c70441b949632dc1eba52dd = new Type[] {  };
 
         /// <inheritdoc />
         Task IBodylessApi.Head()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Head", ArgumentTypes_09f0b1e963904459a5275c26beeba8ef);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Head", ArgumentTypes_7cbb17127c70441b949632dc1eba52dd);
             return (Task)func(Client, arguments);
         }
     }
@@ -753,53 +753,53 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_9e271e7c3fd44c4fb92de93278b950e9 = new Type[] { typeof(T) };
+        private static readonly Type[] ArgumentTypes_a295ef3f61e241a7b5e3bcf273ca4189 = new Type[] { typeof(T) };
 
         /// <inheritdoc />
         Task<T> IBoringCrudApi<T, TKey>.Create(T paylod)
         {
             var arguments = new object[] { paylod };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_9e271e7c3fd44c4fb92de93278b950e9);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_a295ef3f61e241a7b5e3bcf273ca4189);
             return (Task<T>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_0900ec85e4134d99911b066038363cf5 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_5b56e31c023a41b3944b33df9dd06c2e = new Type[] {  };
 
         /// <inheritdoc />
         Task<List<T>> IBoringCrudApi<T, TKey>.ReadAll()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_0900ec85e4134d99911b066038363cf5);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_5b56e31c023a41b3944b33df9dd06c2e);
             return (Task<List<T>>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_3b52ca4e61da4d67bafbd434899c601d = new Type[] { typeof(TKey) };
+        private static readonly Type[] ArgumentTypes_8f42d07d116743798d836836a25c55a9 = new Type[] { typeof(TKey) };
 
         /// <inheritdoc />
         Task<T> IBoringCrudApi<T, TKey>.ReadOne(TKey key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_3b52ca4e61da4d67bafbd434899c601d);
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_8f42d07d116743798d836836a25c55a9);
             return (Task<T>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_0b56fe062fa64b34acd524e67bbfbec3 = new Type[] { typeof(TKey), typeof(T) };
+        private static readonly Type[] ArgumentTypes_5393f68687ec4717a26a6b554ad5c049 = new Type[] { typeof(TKey), typeof(T) };
 
         /// <inheritdoc />
         Task IBoringCrudApi<T, TKey>.Update(TKey key, T payload)
         {
             var arguments = new object[] { key, payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_0b56fe062fa64b34acd524e67bbfbec3);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_5393f68687ec4717a26a6b554ad5c049);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_77da64faa19f41ed938144dabe5a4eff = new Type[] { typeof(TKey) };
+        private static readonly Type[] ArgumentTypes_00e628b9a2444657bd2b9cecf242c248 = new Type[] { typeof(TKey) };
 
         /// <inheritdoc />
         Task IBoringCrudApi<T, TKey>.Delete(TKey key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_77da64faa19f41ed938144dabe5a4eff);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_00e628b9a2444657bd2b9cecf242c248);
             return (Task)func(Client, arguments);
         }
     }
@@ -840,13 +840,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_f258361eb0264d4680de7991c24d3d53 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_df79977b5f30496081238d12bb5451be = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<bool> IBrokenWebApi.PostAValue(string derp)
         {
             var arguments = new object[] { derp };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostAValue", ArgumentTypes_f258361eb0264d4680de7991c24d3d53);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostAValue", ArgumentTypes_df79977b5f30496081238d12bb5451be);
             return (Task<bool>)func(Client, arguments);
         }
     }
@@ -875,13 +875,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_6ffab681926e4b0f9625aa8bd6c9758f = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_b1d60eae6b10482c9e21744f1bd54c74 = new Type[] {  };
 
         /// <inheritdoc />
         CustomReferenceType? ICustomNullableReferenceService.Get()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_6ffab681926e4b0f9625aa8bd6c9758f);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_b1d60eae6b10482c9e21744f1bd54c74);
             return (CustomReferenceType?)func(Client, arguments);
         }
     }
@@ -910,13 +910,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_0f9be87fb4b44adfbe2452411e6bde50 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_0a18f2e3030a447cbf17ac80abab1551 = new Type[] {  };
 
         /// <inheritdoc />
         CustomValueType? ICustomNullableValueService.Get()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_0f9be87fb4b44adfbe2452411e6bde50);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_0a18f2e3030a447cbf17ac80abab1551);
             return (CustomValueType?)func(Client, arguments);
         }
     }
@@ -945,13 +945,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_0fa164f7b3a54a02b68c930f3f83d9a4 = new Type[] { ToNullable(typeof(CustomReferenceType)), ToNullable(typeof(CustomValueType)) };
+        private static readonly Type[] ArgumentTypes_cdc0f4cb2dce42159c28bf6839f187da = new Type[] { ToNullable(typeof(CustomReferenceType)), ToNullable(typeof(CustomValueType)) };
 
         /// <inheritdoc />
         Task ICustomReferenceAndValueParametersService.Get(CustomReferenceType? reference, CustomValueType? value)
         {
             var arguments = new object[] { reference, value };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_0fa164f7b3a54a02b68c930f3f83d9a4);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_cdc0f4cb2dce42159c28bf6839f187da);
             return (Task)func(Client, arguments);
         }
 
@@ -984,73 +984,73 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_868e1166306140958fb0ecb18f19e79e = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_de526eb49e3946e48d66f3bb32a7be8c = new Type[] {  };
 
         /// <inheritdoc />
         Task IDataApiA.PingA()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PingA", ArgumentTypes_868e1166306140958fb0ecb18f19e79e);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("PingA", ArgumentTypes_de526eb49e3946e48d66f3bb32a7be8c);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_a4d42f8f98b24588a0eb08e99f32b027 = new Type[] { typeof(DataEntity) };
+        private static readonly Type[] ArgumentTypes_e0311a448c12407c967b7d3765fa4513 = new Type[] { typeof(DataEntity) };
 
         /// <inheritdoc />
         Task<DataEntity> IDataCrudApi<DataEntity>.Copy(DataEntity payload)
         {
             var arguments = new object[] { payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Copy", ArgumentTypes_a4d42f8f98b24588a0eb08e99f32b027);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Copy", ArgumentTypes_e0311a448c12407c967b7d3765fa4513);
             return (Task<DataEntity>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_24a49af5c9a54bfb905f5a4a5b0e9f13 = new Type[] { typeof(DataEntity) };
+        private static readonly Type[] ArgumentTypes_5f328ab3b648463c8bd309521518b1d2 = new Type[] { typeof(DataEntity) };
 
         /// <inheritdoc />
         Task<DataEntity> IDataCrudApi<DataEntity, long>.Create(DataEntity payload)
         {
             var arguments = new object[] { payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_24a49af5c9a54bfb905f5a4a5b0e9f13);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_5f328ab3b648463c8bd309521518b1d2);
             return (Task<DataEntity>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_01b1c35ec591494dae4da0652ebe44c8 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_973c73002b8840ebbc69942ac8f05423 = new Type[] {  };
 
         /// <inheritdoc />
         Task<List<DataEntity>> IDataCrudApi<DataEntity, long>.ReadAll()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_01b1c35ec591494dae4da0652ebe44c8);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_973c73002b8840ebbc69942ac8f05423);
             return (Task<List<DataEntity>>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_f275d572610f44149cae905904779ae0 = new Type[] { typeof(long) };
+        private static readonly Type[] ArgumentTypes_37b484153aed4c46b0fbccdff6887453 = new Type[] { typeof(long) };
 
         /// <inheritdoc />
         Task<DataEntity> IDataCrudApi<DataEntity, long>.ReadOne(long key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_f275d572610f44149cae905904779ae0);
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_37b484153aed4c46b0fbccdff6887453);
             return (Task<DataEntity>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_c544f41e94d3447bb84debc36934d776 = new Type[] { typeof(long), typeof(DataEntity) };
+        private static readonly Type[] ArgumentTypes_0255242aad1c4136bf098d37eafe2baa = new Type[] { typeof(long), typeof(DataEntity) };
 
         /// <inheritdoc />
         Task IDataCrudApi<DataEntity, long>.Update(long key, DataEntity payload)
         {
             var arguments = new object[] { key, payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_c544f41e94d3447bb84debc36934d776);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_0255242aad1c4136bf098d37eafe2baa);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_30f78e448d9e4ba28d07d577b0f920d6 = new Type[] { typeof(long) };
+        private static readonly Type[] ArgumentTypes_135224ca51894787b1448f5c35b0ca4c = new Type[] { typeof(long) };
 
         /// <inheritdoc />
         Task IDataCrudApi<DataEntity, long>.Delete(long key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_30f78e448d9e4ba28d07d577b0f920d6);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_135224ca51894787b1448f5c35b0ca4c);
             return (Task)func(Client, arguments);
         }
     }
@@ -1081,63 +1081,63 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_9ae0c3f9c1da4249976c9bdb378ce259 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_ddc38815682443ca81daca3c6837a3a0 = new Type[] {  };
 
         /// <inheritdoc />
         Task IDataApiB.PingB()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PingB", ArgumentTypes_9ae0c3f9c1da4249976c9bdb378ce259);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("PingB", ArgumentTypes_ddc38815682443ca81daca3c6837a3a0);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_037d41f754064fdd9d129c46ea312dae = new Type[] { typeof(DataEntity) };
+        private static readonly Type[] ArgumentTypes_d97663ad2a42452eb5e4a5438e490dc7 = new Type[] { typeof(DataEntity) };
 
         /// <inheritdoc />
         Task<DataEntity> IDataCrudApi<DataEntity, int>.Create(DataEntity payload)
         {
             var arguments = new object[] { payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_037d41f754064fdd9d129c46ea312dae);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_d97663ad2a42452eb5e4a5438e490dc7);
             return (Task<DataEntity>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_63cb9ae95fe4406197a54050db1484dc = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_cb5b3c8698f44bd5ba1ba4793e54d1de = new Type[] {  };
 
         /// <inheritdoc />
         Task<List<DataEntity>> IDataCrudApi<DataEntity, int>.ReadAll()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_63cb9ae95fe4406197a54050db1484dc);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_cb5b3c8698f44bd5ba1ba4793e54d1de);
             return (Task<List<DataEntity>>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_5eaf1e12ce82458ea2845017749c47b8 = new Type[] { typeof(int) };
+        private static readonly Type[] ArgumentTypes_fbff89e6a8fa440b9c984600ea5c9c9c = new Type[] { typeof(int) };
 
         /// <inheritdoc />
         Task<DataEntity> IDataCrudApi<DataEntity, int>.ReadOne(int key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_5eaf1e12ce82458ea2845017749c47b8);
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_fbff89e6a8fa440b9c984600ea5c9c9c);
             return (Task<DataEntity>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_211495ce085142499fefc3214b30348f = new Type[] { typeof(int), typeof(DataEntity) };
+        private static readonly Type[] ArgumentTypes_c7954ce7ec1d47f9a2951ce0bf8559e7 = new Type[] { typeof(int), typeof(DataEntity) };
 
         /// <inheritdoc />
         Task IDataCrudApi<DataEntity, int>.Update(int key, DataEntity payload)
         {
             var arguments = new object[] { key, payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_211495ce085142499fefc3214b30348f);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_c7954ce7ec1d47f9a2951ce0bf8559e7);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_3f8443bab12f45ddb28183f61a597629 = new Type[] { typeof(int) };
+        private static readonly Type[] ArgumentTypes_d490d7b5c1c34a5b868a9e72247dd97d = new Type[] { typeof(int) };
 
         /// <inheritdoc />
         Task IDataCrudApi<DataEntity, int>.Delete(int key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_3f8443bab12f45ddb28183f61a597629);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_d490d7b5c1c34a5b868a9e72247dd97d);
             return (Task)func(Client, arguments);
         }
     }
@@ -1171,63 +1171,63 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_b37a0569057b4a0e9f6ba827f16e873c = new Type[] { typeof(T) };
+        private static readonly Type[] ArgumentTypes_ee9add6f1b2c44cd93b813dda1169074 = new Type[] { typeof(T) };
 
         /// <inheritdoc />
         Task<T> IDataCrudApi<T>.Copy(T payload)
         {
             var arguments = new object[] { payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Copy", ArgumentTypes_b37a0569057b4a0e9f6ba827f16e873c);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Copy", ArgumentTypes_ee9add6f1b2c44cd93b813dda1169074);
             return (Task<T>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_c3eaa0375dd04fee9a06718b1b2af33f = new Type[] { typeof(T) };
+        private static readonly Type[] ArgumentTypes_55f24174d7304dfe9d475cf5aab7d53a = new Type[] { typeof(T) };
 
         /// <inheritdoc />
         Task<T> IDataCrudApi<T, long>.Create(T payload)
         {
             var arguments = new object[] { payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_c3eaa0375dd04fee9a06718b1b2af33f);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_55f24174d7304dfe9d475cf5aab7d53a);
             return (Task<T>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_ecfd7936f22c449a89269a4fc279ae11 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_9023dc0aed3a4bc295a51d202956aeed = new Type[] {  };
 
         /// <inheritdoc />
         Task<List<T>> IDataCrudApi<T, long>.ReadAll()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_ecfd7936f22c449a89269a4fc279ae11);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_9023dc0aed3a4bc295a51d202956aeed);
             return (Task<List<T>>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_23a068b188724597bcb9d6f20094d4e7 = new Type[] { typeof(long) };
+        private static readonly Type[] ArgumentTypes_c7e4d49f45a34cffb045bfac57d90d91 = new Type[] { typeof(long) };
 
         /// <inheritdoc />
         Task<T> IDataCrudApi<T, long>.ReadOne(long key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_23a068b188724597bcb9d6f20094d4e7);
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_c7e4d49f45a34cffb045bfac57d90d91);
             return (Task<T>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_f7d97b6f22bc4179a3216b732e5df7d7 = new Type[] { typeof(long), typeof(T) };
+        private static readonly Type[] ArgumentTypes_08a7f31964c14c389f574fdef547f67c = new Type[] { typeof(long), typeof(T) };
 
         /// <inheritdoc />
         Task IDataCrudApi<T, long>.Update(long key, T payload)
         {
             var arguments = new object[] { key, payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_f7d97b6f22bc4179a3216b732e5df7d7);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_08a7f31964c14c389f574fdef547f67c);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_db1b4b23ae0645c79f3b5f7f33f391f7 = new Type[] { typeof(long) };
+        private static readonly Type[] ArgumentTypes_d1cfac6bb4264607b19cbd2033880dd7 = new Type[] { typeof(long) };
 
         /// <inheritdoc />
         Task IDataCrudApi<T, long>.Delete(long key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_db1b4b23ae0645c79f3b5f7f33f391f7);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_d1cfac6bb4264607b19cbd2033880dd7);
             return (Task)func(Client, arguments);
         }
     }
@@ -1261,53 +1261,53 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_893b5ca82b29434aafbcf18bbc050349 = new Type[] { typeof(T) };
+        private static readonly Type[] ArgumentTypes_608562f8e817435894acec597c553c3e = new Type[] { typeof(T) };
 
         /// <inheritdoc />
         Task<T> IDataCrudApi<T, TKey>.Create(T payload)
         {
             var arguments = new object[] { payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_893b5ca82b29434aafbcf18bbc050349);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Create", ArgumentTypes_608562f8e817435894acec597c553c3e);
             return (Task<T>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_c8772979ada84c758e3d86a2d60f0e27 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_72dceaa1e37544dca20fc733da7ac43e = new Type[] {  };
 
         /// <inheritdoc />
         Task<List<T>> IDataCrudApi<T, TKey>.ReadAll()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_c8772979ada84c758e3d86a2d60f0e27);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadAll", ArgumentTypes_72dceaa1e37544dca20fc733da7ac43e);
             return (Task<List<T>>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_2842e482a92449efa4e1596bb9a59492 = new Type[] { typeof(TKey) };
+        private static readonly Type[] ArgumentTypes_723ab5fa685d46cb9763e516734be5b0 = new Type[] { typeof(TKey) };
 
         /// <inheritdoc />
         Task<T> IDataCrudApi<T, TKey>.ReadOne(TKey key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_2842e482a92449efa4e1596bb9a59492);
+            var func = requestBuilder.BuildRestResultFuncForMethod("ReadOne", ArgumentTypes_723ab5fa685d46cb9763e516734be5b0);
             return (Task<T>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_96b4612a037647ca82f6c863342781e1 = new Type[] { typeof(TKey), typeof(T) };
+        private static readonly Type[] ArgumentTypes_4df6dbe9c3cf41658eec4429ab711813 = new Type[] { typeof(TKey), typeof(T) };
 
         /// <inheritdoc />
         Task IDataCrudApi<T, TKey>.Update(TKey key, T payload)
         {
             var arguments = new object[] { key, payload };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_96b4612a037647ca82f6c863342781e1);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Update", ArgumentTypes_4df6dbe9c3cf41658eec4429ab711813);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_3b6c0599a02a4ad1bb3f7b48378bc4c3 = new Type[] { typeof(TKey) };
+        private static readonly Type[] ArgumentTypes_9402fdd8c27044e8a5b04865ce307999 = new Type[] { typeof(TKey) };
 
         /// <inheritdoc />
         Task IDataCrudApi<T, TKey>.Delete(TKey key)
         {
             var arguments = new object[] { key };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_3b6c0599a02a4ad1bb3f7b48378bc4c3);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Delete", ArgumentTypes_9402fdd8c27044e8a5b04865ce307999);
             return (Task)func(Client, arguments);
         }
     }
@@ -1336,13 +1336,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_dc64a9fd393f4bacb03d7e2df0d5b23d = new Type[] { ToNullable(typeof(System.Collections.Generic.List<string>)) };
+        private static readonly Type[] ArgumentTypes_fd305f7f69684f819d775da6a36218b3 = new Type[] { ToNullable(typeof(System.Collections.Generic.List<string>)) };
 
         /// <inheritdoc />
         Task IGenericNullableReferenceParameterService.Get(System.Collections.Generic.List<string>? reference)
         {
             var arguments = new object[] { reference };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_dc64a9fd393f4bacb03d7e2df0d5b23d);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_fd305f7f69684f819d775da6a36218b3);
             return (Task)func(Client, arguments);
         }
 
@@ -1373,13 +1373,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_44b76ef17d95485e95dfb68514cb0620 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_cb9218d3c95f4121afa837d17bd3517a = new Type[] {  };
 
         /// <inheritdoc />
         Task<string>? IGenericNullableReferenceService.Get()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_44b76ef17d95485e95dfb68514cb0620);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_cb9218d3c95f4121afa837d17bd3517a);
             return (Task<string>?)func(Client, arguments);
         }
     }
@@ -1408,13 +1408,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_23a802f3848644d2a4266fd9e1e1d4dd = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_d5d0fc5fa0154da1930d4f23a19d95a7 = new Type[] {  };
 
         /// <inheritdoc />
         ValueTask<int>? IGenericNullableValueService.Get()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_23a802f3848644d2a4266fd9e1e1d4dd);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_d5d0fc5fa0154da1930d4f23a19d95a7);
             return (ValueTask<int>?)func(Client, arguments);
         }
     }
@@ -1443,13 +1443,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_c655f7dee36e4366a33311e960305c46 = new Type[] { ToNullable(typeof(System.Collections.Generic.List<string?>)) };
+        private static readonly Type[] ArgumentTypes_8bcfccb4335948a884f76127e3d735de = new Type[] { ToNullable(typeof(System.Collections.Generic.List<string?>)) };
 
         /// <inheritdoc />
         Task IGenericNullableWithNullableReferenceParameterService.Get(System.Collections.Generic.List<string?>? reference)
         {
             var arguments = new object[] { reference };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_c655f7dee36e4366a33311e960305c46);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_8bcfccb4335948a884f76127e3d735de);
             return (Task)func(Client, arguments);
         }
 
@@ -1480,13 +1480,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_fa4d60a9893046c6b86a258e3082581d = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_76e398d47bd74c75ae56bef40ee8f29e = new Type[] {  };
 
         /// <inheritdoc />
         Task<string?>? IGenericNullableWithNullableReferenceService.Get()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_fa4d60a9893046c6b86a258e3082581d);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_76e398d47bd74c75ae56bef40ee8f29e);
             return (Task<string?>?)func(Client, arguments);
         }
     }
@@ -1515,13 +1515,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_3ce7a8054dc045e7bfd385e7ac13a4ef = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_7217f85bf4d94731b6ea65adc43a7f6e = new Type[] {  };
 
         /// <inheritdoc />
         ValueTask<int?>? IGenericNullableWithNullableValueService.Get()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_3ce7a8054dc045e7bfd385e7ac13a4ef);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_7217f85bf4d94731b6ea65adc43a7f6e);
             return (ValueTask<int?>?)func(Client, arguments);
         }
     }
@@ -1550,13 +1550,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_4354221e532a49698acdd6949d4fbe3d = new Type[] { typeof(System.Collections.Generic.List<string?>) };
+        private static readonly Type[] ArgumentTypes_1e18bff7739f44f8b0116bab128c8d6c = new Type[] { typeof(System.Collections.Generic.List<string?>) };
 
         /// <inheritdoc />
         Task IGenericWithNullableReferenceParameterService.Get(System.Collections.Generic.List<string?> reference)
         {
             var arguments = new object[] { reference };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_4354221e532a49698acdd6949d4fbe3d);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_1e18bff7739f44f8b0116bab128c8d6c);
             return (Task)func(Client, arguments);
         }
     }
@@ -1585,13 +1585,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_ed9b54c322184fdc8d151b75c4750385 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_cb95e433deae4db6b3dc94163d451b4b = new Type[] {  };
 
         /// <inheritdoc />
         Task<int?> IGenericWithNullableValueService.Get()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_ed9b54c322184fdc8d151b75c4750385);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_cb95e433deae4db6b3dc94163d451b4b);
             return (Task<int?>)func(Client, arguments);
         }
     }
@@ -1620,13 +1620,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_d1d0654d1659460cb178e9cf952d1c33 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_cf51b8524e2d4b73849c22d47402c4c7 = new Type[] {  };
 
         /// <inheritdoc />
         Task<string?> IGenericWithResultService.Get()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_d1d0654d1659460cb178e9cf952d1c33);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_cf51b8524e2d4b73849c22d47402c4c7);
             return (Task<string?>)func(Client, arguments);
         }
     }
@@ -1661,133 +1661,133 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_68a0ef18470a4b138cc57fa5a69943fa = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_22efa10588f0498780786fdb4cd9aa88 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<User> IGitHubApi.GetUser(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUser", ArgumentTypes_68a0ef18470a4b138cc57fa5a69943fa);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUser", ArgumentTypes_22efa10588f0498780786fdb4cd9aa88);
             return (Task<User>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_bbbe7c39d27049b3b8a21e2a2fa12b65 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_f36206221fc94bbda95858ec2cc32c0e = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         IObservable<User> IGitHubApi.GetUserObservable(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserObservable", ArgumentTypes_bbbe7c39d27049b3b8a21e2a2fa12b65);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserObservable", ArgumentTypes_f36206221fc94bbda95858ec2cc32c0e);
             return (IObservable<User>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_338c76d5ffcb4f048cfe4c07a156ca04 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_37324b76df034cf29dcdf4c7bff07e6b = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         IObservable<User> IGitHubApi.GetUserCamelCase(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserCamelCase", ArgumentTypes_338c76d5ffcb4f048cfe4c07a156ca04);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserCamelCase", ArgumentTypes_37324b76df034cf29dcdf4c7bff07e6b);
             return (IObservable<User>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_80d7e575ff5a4823b23efbc303ee746e = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_612b3bfbebc84e23bf1c4412b07c6aa3 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<List<User>> IGitHubApi.GetOrgMembers(string orgName)
         {
             var arguments = new object[] { orgName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetOrgMembers", ArgumentTypes_80d7e575ff5a4823b23efbc303ee746e);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetOrgMembers", ArgumentTypes_612b3bfbebc84e23bf1c4412b07c6aa3);
             return (Task<List<User>>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_0cf4bb0e47554c609c69836bac69820f = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_4cefdbf334ab4fbc946e390822b78740 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<UserSearchResult> IGitHubApi.FindUsers(string q)
         {
             var arguments = new object[] { q };
-            var func = requestBuilder.BuildRestResultFuncForMethod("FindUsers", ArgumentTypes_0cf4bb0e47554c609c69836bac69820f);
+            var func = requestBuilder.BuildRestResultFuncForMethod("FindUsers", ArgumentTypes_4cefdbf334ab4fbc946e390822b78740);
             return (Task<UserSearchResult>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_a2afd15639f041d498c06c40e19b1e7b = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_acc4394aaf8b48088420ffdac6557e08 = new Type[] {  };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IGitHubApi.GetIndex()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndex", ArgumentTypes_a2afd15639f041d498c06c40e19b1e7b);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndex", ArgumentTypes_acc4394aaf8b48088420ffdac6557e08);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_9ebddda0f0f841aaa5b04e03e6b56235 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_dd787f9da7164be58c606058cba7fec1 = new Type[] {  };
 
         /// <inheritdoc />
         IObservable<string> IGitHubApi.GetIndexObservable()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndexObservable", ArgumentTypes_9ebddda0f0f841aaa5b04e03e6b56235);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndexObservable", ArgumentTypes_dd787f9da7164be58c606058cba7fec1);
             return (IObservable<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_df6fe0f591564f1f89d67ce5ddee9416 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_f106657f59ad433495627449c7b0cd0c = new Type[] {  };
 
         /// <inheritdoc />
         Task<User> IGitHubApi.NothingToSeeHere()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("NothingToSeeHere", ArgumentTypes_df6fe0f591564f1f89d67ce5ddee9416);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("NothingToSeeHere", ArgumentTypes_f106657f59ad433495627449c7b0cd0c);
             return (Task<User>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_97a9b0c05a3f44a1b33a2905d48c3fad = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_fe6147603f5e45fabad554d48b041058 = new Type[] {  };
 
         /// <inheritdoc />
         Task<ApiResponse<User>> IGitHubApi.NothingToSeeHereWithMetadata()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("NothingToSeeHereWithMetadata", ArgumentTypes_97a9b0c05a3f44a1b33a2905d48c3fad);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("NothingToSeeHereWithMetadata", ArgumentTypes_fe6147603f5e45fabad554d48b041058);
             return (Task<ApiResponse<User>>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_eb0a21065d544dc986691262e558dba3 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_7fc4701d89a64d63951d3d8ff3c9dd14 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<ApiResponse<User>> IGitHubApi.GetUserWithMetadata(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserWithMetadata", ArgumentTypes_eb0a21065d544dc986691262e558dba3);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserWithMetadata", ArgumentTypes_7fc4701d89a64d63951d3d8ff3c9dd14);
             return (Task<ApiResponse<User>>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_f6a78e71706444eabb5520032c765c16 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_dba70b90b1ea4ff08e699f3cc07a1922 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         IObservable<ApiResponse<User>> IGitHubApi.GetUserObservableWithMetadata(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserObservableWithMetadata", ArgumentTypes_f6a78e71706444eabb5520032c765c16);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserObservableWithMetadata", ArgumentTypes_dba70b90b1ea4ff08e699f3cc07a1922);
             return (IObservable<ApiResponse<User>>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_78ab4f2d244c4486aed97f9b8741dc9a = new Type[] { typeof(User) };
+        private static readonly Type[] ArgumentTypes_28e826a054514e5ca085ffdf02ca3c7e = new Type[] { typeof(User) };
 
         /// <inheritdoc />
         Task<User> IGitHubApi.CreateUser(User user)
         {
             var arguments = new object[] { user };
-            var func = requestBuilder.BuildRestResultFuncForMethod("CreateUser", ArgumentTypes_78ab4f2d244c4486aed97f9b8741dc9a);
+            var func = requestBuilder.BuildRestResultFuncForMethod("CreateUser", ArgumentTypes_28e826a054514e5ca085ffdf02ca3c7e);
             return (Task<User>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_b3589a1bf5d74facbd3003f508a4b635 = new Type[] { typeof(User) };
+        private static readonly Type[] ArgumentTypes_4f7a0261e2164171b33c5f0f9ced4f3b = new Type[] { typeof(User) };
 
         /// <inheritdoc />
         Task<ApiResponse<User>> IGitHubApi.CreateUserWithMetadata(User user)
         {
             var arguments = new object[] { user };
-            var func = requestBuilder.BuildRestResultFuncForMethod("CreateUserWithMetadata", ArgumentTypes_b3589a1bf5d74facbd3003f508a4b635);
+            var func = requestBuilder.BuildRestResultFuncForMethod("CreateUserWithMetadata", ArgumentTypes_4f7a0261e2164171b33c5f0f9ced4f3b);
             return (Task<ApiResponse<User>>)func(Client, arguments);
         }
     }
@@ -1832,47 +1832,47 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_31b5bc4aa6d3406e961a3dc5d0452cd8 = new Type[] { typeof(TParam), typeof(THeader) };
+        private static readonly Type[] ArgumentTypes_ef37d6e887b6478fbf70b37de44cdf72 = new Type[] { typeof(TParam), typeof(THeader) };
 
         /// <inheritdoc />
         Task<TResponse> IHttpBinApi<TResponse, TParam, THeader>.Get(TParam param, THeader header)
         {
             var arguments = new object[] { param, header };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_31b5bc4aa6d3406e961a3dc5d0452cd8);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_ef37d6e887b6478fbf70b37de44cdf72);
             return (Task<TResponse>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_523821ee2c474ee4becbe83c9c4ed973 = new Type[] { typeof(TParam) };
+        private static readonly Type[] ArgumentTypes_4b57287ee9f147068f57a2291b964ac9 = new Type[] { typeof(TParam) };
 
         /// <inheritdoc />
         Task<TResponse> IHttpBinApi<TResponse, TParam, THeader>.GetQuery(TParam param)
         {
             var arguments = new object[] { param };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetQuery", ArgumentTypes_523821ee2c474ee4becbe83c9c4ed973);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetQuery", ArgumentTypes_4b57287ee9f147068f57a2291b964ac9);
             return (Task<TResponse>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_ad4584768f064347b45cf861a0d2362d = new Type[] { typeof(TParam) };
+        private static readonly Type[] ArgumentTypes_d06829932a094e51bf0802cdcccc69c2 = new Type[] { typeof(TParam) };
 
         /// <inheritdoc />
         Task<TResponse> IHttpBinApi<TResponse, TParam, THeader>.PostQuery(TParam param)
         {
             var arguments = new object[] { param };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostQuery", ArgumentTypes_ad4584768f064347b45cf861a0d2362d);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostQuery", ArgumentTypes_d06829932a094e51bf0802cdcccc69c2);
             return (Task<TResponse>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_82df63f31ec347468f2993a678e2d39a = new Type[] { typeof(TParam) };
+        private static readonly Type[] ArgumentTypes_c6585d4bd8df4698a2af26f56240a1c1 = new Type[] { typeof(TParam) };
 
         /// <inheritdoc />
         Task<TResponse> IHttpBinApi<TResponse, TParam, THeader>.GetQueryWithIncludeParameterName(TParam param)
         {
             var arguments = new object[] { param };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetQueryWithIncludeParameterName", ArgumentTypes_82df63f31ec347468f2993a678e2d39a);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetQueryWithIncludeParameterName", ArgumentTypes_c6585d4bd8df4698a2af26f56240a1c1);
             return (Task<TResponse>)func(Client, arguments);
         }
 
-        private static class TypeHelper_56f0710c826f480889828c549210fb2e<TValue>
+        private static class TypeHelper_1b98a930160d456a86a38322f857ee60<TValue>
         {
             public static readonly Type[] ArgumentTypes = new Type[] { typeof(TParam) };
             public static readonly Type[] TypeParameters = new Type[] { typeof(TValue) };
@@ -1882,7 +1882,7 @@ namespace Refit.Tests
         Task<TValue> IHttpBinApi<TResponse, TParam, THeader>.GetQuery1<TValue>(TParam param)
         {
             var arguments = new object[] { param };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetQuery1", TypeHelper_56f0710c826f480889828c549210fb2e<TValue>.ArgumentTypes, TypeHelper_56f0710c826f480889828c549210fb2e<TValue>.TypeParameters);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetQuery1", TypeHelper_1b98a930160d456a86a38322f857ee60<TValue>.ArgumentTypes, TypeHelper_1b98a930160d456a86a38322f857ee60<TValue>.TypeParameters);
             return (Task<TValue>)func(Client, arguments);
         }
     }
@@ -1923,23 +1923,23 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_413a64c81bb24d6984bfc77dfb21dbed = new Type[] { typeof(HttpContent) };
+        private static readonly Type[] ArgumentTypes_860021ba1cc349c99b218b105b7802cd = new Type[] { typeof(HttpContent) };
 
         /// <inheritdoc />
         Task<HttpContent> IHttpContentApi.PostFileUpload(HttpContent content)
         {
             var arguments = new object[] { content };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostFileUpload", ArgumentTypes_413a64c81bb24d6984bfc77dfb21dbed);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostFileUpload", ArgumentTypes_860021ba1cc349c99b218b105b7802cd);
             return (Task<HttpContent>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_997bba8c9bdd4a54a5a904d5be3b8454 = new Type[] { typeof(HttpContent) };
+        private static readonly Type[] ArgumentTypes_25acd23e4dea4a9a8eed60dac7024263 = new Type[] { typeof(HttpContent) };
 
         /// <inheritdoc />
         Task<ApiResponse<HttpContent>> IHttpContentApi.PostFileUploadWithMetadata(HttpContent content)
         {
             var arguments = new object[] { content };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostFileUploadWithMetadata", ArgumentTypes_997bba8c9bdd4a54a5a904d5be3b8454);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostFileUploadWithMetadata", ArgumentTypes_25acd23e4dea4a9a8eed60dac7024263);
             return (Task<ApiResponse<HttpContent>>)func(Client, arguments);
         }
     }
@@ -1981,13 +1981,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_a3483f830bdd4a73a6bef95050f7424d = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_5b667542e0e148deb1da664f1ce410fe = new Type[] {  };
 
         /// <inheritdoc />
         Task<TestAliasObject> ResponseTests.IMyAliasService.GetTestObject()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetTestObject", ArgumentTypes_a3483f830bdd4a73a6bef95050f7424d);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetTestObject", ArgumentTypes_5b667542e0e148deb1da664f1ce410fe);
             return (Task<TestAliasObject>)func(Client, arguments);
         }
     }
@@ -2023,23 +2023,23 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_38cc1d36a1e64138b5aab947b939a223 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_c87126b718ad46ebb4c8a8105418af23 = new Type[] {  };
 
         /// <inheritdoc />
         Task<string> AuthenticatedClientHandlerTests.IMyAuthenticatedService.GetUnauthenticated()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUnauthenticated", ArgumentTypes_38cc1d36a1e64138b5aab947b939a223);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUnauthenticated", ArgumentTypes_c87126b718ad46ebb4c8a8105418af23);
             return (Task<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_bd2368e7ae16460c903a0eca7bcfe0c0 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_208efdb7033540699a4ebcfc85b04380 = new Type[] {  };
 
         /// <inheritdoc />
         Task<string> AuthenticatedClientHandlerTests.IMyAuthenticatedService.GetAuthenticated()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetAuthenticated", ArgumentTypes_bd2368e7ae16460c903a0eca7bcfe0c0);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetAuthenticated", ArgumentTypes_208efdb7033540699a4ebcfc85b04380);
             return (Task<string>)func(Client, arguments);
         }
     }
@@ -2070,13 +2070,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_9911abe5ad41420ba71270f7df1545b6 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_6e06f8cb18fc40e8b73e3ddf9afd0485 = new Type[] {  };
 
         /// <inheritdoc />
         Task<SomeType> INamespaceCollisionApi.SomeRequest()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", ArgumentTypes_9911abe5ad41420ba71270f7df1545b6);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", ArgumentTypes_6e06f8cb18fc40e8b73e3ddf9afd0485);
             return (Task<SomeType>)func(Client, arguments);
         }
     }
@@ -2108,13 +2108,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_2efd03bcd7f046e1925d96ba207aee55 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_f9e7e2137a144f9c8f8b3122ac1289e9 = new Type[] {  };
 
         /// <inheritdoc />
         Task<SomeOtherType> INamespaceOverlapApi.SomeRequest()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", ArgumentTypes_2efd03bcd7f046e1925d96ba207aee55);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", ArgumentTypes_f9e7e2137a144f9c8f8b3122ac1289e9);
             return (Task<SomeOtherType>)func(Client, arguments);
         }
     }
@@ -2149,83 +2149,83 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_ca128e96a68a448aae3ffa470c69d429 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_dca6d7f9083f453f81df64b3afa88b25 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<User> TestNested.INestedGitHubApi.GetUser(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUser", ArgumentTypes_ca128e96a68a448aae3ffa470c69d429);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUser", ArgumentTypes_dca6d7f9083f453f81df64b3afa88b25);
             return (Task<User>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_6a82aa9de5f64be583d6bd05837536f6 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_c3f09c4e72f8408fbba5ed72d925f7dc = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         IObservable<User> TestNested.INestedGitHubApi.GetUserObservable(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserObservable", ArgumentTypes_6a82aa9de5f64be583d6bd05837536f6);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserObservable", ArgumentTypes_c3f09c4e72f8408fbba5ed72d925f7dc);
             return (IObservable<User>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_92b863e5f17548fcaf8ed2d5224574a1 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_4606b63ffe5e469f95d9b16444e554c4 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         IObservable<User> TestNested.INestedGitHubApi.GetUserCamelCase(string userName)
         {
             var arguments = new object[] { userName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserCamelCase", ArgumentTypes_92b863e5f17548fcaf8ed2d5224574a1);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetUserCamelCase", ArgumentTypes_4606b63ffe5e469f95d9b16444e554c4);
             return (IObservable<User>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_10983d1a274743e3acf343a3ba9ac272 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_c9dfbe864d7c4618a9f7edafdb324b95 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<List<User>> TestNested.INestedGitHubApi.GetOrgMembers(string orgName)
         {
             var arguments = new object[] { orgName };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetOrgMembers", ArgumentTypes_10983d1a274743e3acf343a3ba9ac272);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetOrgMembers", ArgumentTypes_c9dfbe864d7c4618a9f7edafdb324b95);
             return (Task<List<User>>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_516844aa2de445b19e0c9ab4cb676306 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_fcd895bbca2240d2b9e881b694d4d689 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<UserSearchResult> TestNested.INestedGitHubApi.FindUsers(string q)
         {
             var arguments = new object[] { q };
-            var func = requestBuilder.BuildRestResultFuncForMethod("FindUsers", ArgumentTypes_516844aa2de445b19e0c9ab4cb676306);
+            var func = requestBuilder.BuildRestResultFuncForMethod("FindUsers", ArgumentTypes_fcd895bbca2240d2b9e881b694d4d689);
             return (Task<UserSearchResult>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_059e9b9642fe4c9d9f45992fcbbe1937 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_6d49d359b3f44fdab7b3b15349ee9123 = new Type[] {  };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> TestNested.INestedGitHubApi.GetIndex()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndex", ArgumentTypes_059e9b9642fe4c9d9f45992fcbbe1937);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndex", ArgumentTypes_6d49d359b3f44fdab7b3b15349ee9123);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_fa820803d66e4cd68dce0113db9fccbb = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_d7b34740ecb84442ab0f3dd4125a96a9 = new Type[] {  };
 
         /// <inheritdoc />
         IObservable<string> TestNested.INestedGitHubApi.GetIndexObservable()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndexObservable", ArgumentTypes_fa820803d66e4cd68dce0113db9fccbb);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetIndexObservable", ArgumentTypes_d7b34740ecb84442ab0f3dd4125a96a9);
             return (IObservable<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_1e1f799dd91046a8bdda7eac2c0cf810 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_e9a636d835964b0ab6603fab2bc0fbd7 = new Type[] {  };
 
         /// <inheritdoc />
         Task TestNested.INestedGitHubApi.NothingToSeeHere()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("NothingToSeeHere", ArgumentTypes_1e1f799dd91046a8bdda7eac2c0cf810);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("NothingToSeeHere", ArgumentTypes_e9a636d835964b0ab6603fab2bc0fbd7);
             return (Task)func(Client, arguments);
         }
     }
@@ -2263,7 +2263,7 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static class TypeHelper_5f95e73ce67d4fb48b45db9ed3ef73c3<T>
+        private static class TypeHelper_9faf9503e3a64a929953fdffd2f78260<T>
         {
             public static readonly Type[] ArgumentTypes = new Type[] { typeof(T) };
             public static readonly Type[] TypeParameters = new Type[] { typeof(T) };
@@ -2273,11 +2273,11 @@ namespace Refit.Tests
         Task INonGenericInterfaceWithGenericMethod.PostMessage<T>(T message)
         {
             var arguments = new object[] { message };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostMessage", TypeHelper_5f95e73ce67d4fb48b45db9ed3ef73c3<T>.ArgumentTypes, TypeHelper_5f95e73ce67d4fb48b45db9ed3ef73c3<T>.TypeParameters);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostMessage", TypeHelper_9faf9503e3a64a929953fdffd2f78260<T>.ArgumentTypes, TypeHelper_9faf9503e3a64a929953fdffd2f78260<T>.TypeParameters);
             return (Task)func(Client, arguments);
         }
 
-        private static class TypeHelper_f360ca9bda774fa1aa0434b8efb6f90f<T, U, V>
+        private static class TypeHelper_6bd033e0eff648c88d8d6913f448f2d3<T, U, V>
         {
             public static readonly Type[] ArgumentTypes = new Type[] { typeof(T), typeof(U), typeof(V) };
             public static readonly Type[] TypeParameters = new Type[] { typeof(T), typeof(U), typeof(V) };
@@ -2287,9 +2287,7 @@ namespace Refit.Tests
         Task INonGenericInterfaceWithGenericMethod.PostMessage<T, U, V>(T message, U param1, V param2)
         {
             var arguments = new object[] { message, param1, param2 };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostMessage",
-                TypeHelper_f360ca9bda774fa1aa0434b8efb6f90f<T, U, V>.ArgumentTypes,
-                TypeHelper_f360ca9bda774fa1aa0434b8efb6f90f<T, U, V>.TypeParameters);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostMessage", TypeHelper_6bd033e0eff648c88d8d6913f448f2d3<T, U, V>.ArgumentTypes, TypeHelper_6bd033e0eff648c88d8d6913f448f2d3<T, U, V>.TypeParameters);
             return (Task)func(Client, arguments);
         }
     }
@@ -2330,13 +2328,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_07059728cf9a452894467f5fe3adcfaa = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_8c2c0aed76f44e1b9af23cd4e64d7493 = new Type[] {  };
 
         /// <inheritdoc />
         Task<RootObject> INpmJs.GetCongruence()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetCongruence", ArgumentTypes_07059728cf9a452894467f5fe3adcfaa);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetCongruence", ArgumentTypes_8c2c0aed76f44e1b9af23cd4e64d7493);
             return (Task<RootObject>)func(Client, arguments);
         }
     }
@@ -2365,13 +2363,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_c575b32c73d946cfa4667db26f1bd762 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_c15006c70e3345de826be41bcb376132 = new Type[] {  };
 
         /// <inheritdoc />
         string? INullableReferenceService.Get()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_c575b32c73d946cfa4667db26f1bd762);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_c15006c70e3345de826be41bcb376132);
             return (string?)func(Client, arguments);
         }
     }
@@ -2400,13 +2398,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_c670bec8146e49349bb73174b47553bf = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_065b4b83c6124ac2ad679ef25adfff91 = new Type[] {  };
 
         /// <inheritdoc />
         int? INullableValueService.Get()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_c670bec8146e49349bb73174b47553bf);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_065b4b83c6124ac2ad679ef25adfff91);
             return (int?)func(Client, arguments);
         }
     }
@@ -2436,13 +2434,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_4fa4eda88ece4c40a7a1026cc9e390bc = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_b6eb40ecc8cb46acb64b1fdbba14e17a = new Type[] {  };
 
         /// <inheritdoc />
         Task<SomeType> IReducedUsingInsideNamespaceApi.SomeRequest()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", ArgumentTypes_4fa4eda88ece4c40a7a1026cc9e390bc);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", ArgumentTypes_b6eb40ecc8cb46acb64b1fdbba14e17a);
             return (Task<SomeType>)func(Client, arguments);
         }
     }
@@ -2471,13 +2469,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_514faf2869ca4e0fb0d6531330d6b1e8 = new Type[] { ToNullable(typeof(string)), ToNullable(typeof(int)) };
+        private static readonly Type[] ArgumentTypes_4c3931b5368f4073b4229f7a1f129e2d = new Type[] { ToNullable(typeof(string)), ToNullable(typeof(int)) };
 
         /// <inheritdoc />
         Task IReferenceAndValueParametersService.Get(string? reference, int? value)
         {
             var arguments = new object[] { reference, value };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_514faf2869ca4e0fb0d6531330d6b1e8);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_4c3931b5368f4073b4229f7a1f129e2d);
             return (Task)func(Client, arguments);
         }
 
@@ -2520,13 +2518,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_95531f8a31de4cd6b22b5d54b37df993 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_5c4e156234594557bd8fa6547588a92c = new Type[] {  };
 
         /// <inheritdoc />
         Task IRefitInterfaceWithStaticMethod.Get()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_95531f8a31de4cd6b22b5d54b37df993);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_5c4e156234594557bd8fa6547588a92c);
             return (Task)func(Client, arguments);
         }
     }
@@ -2567,47 +2565,47 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_50cd317596d040239a6a636bbdcf073e = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_0e9b43b42bbe4cc58f20414b6cc637d7 = new Type[] {  };
 
         /// <inheritdoc />
         Task IRequestBin.Post()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Post", ArgumentTypes_50cd317596d040239a6a636bbdcf073e);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Post", ArgumentTypes_0e9b43b42bbe4cc58f20414b6cc637d7);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_c0b97a5113724d4baf00fcfef5c03e82 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_8c2469fa7d614ea7baaffd3c149e1a94 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task IRequestBin.PostRawStringDefault(string str)
         {
             var arguments = new object[] { str };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostRawStringDefault", ArgumentTypes_c0b97a5113724d4baf00fcfef5c03e82);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostRawStringDefault", ArgumentTypes_8c2469fa7d614ea7baaffd3c149e1a94);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_08bc4f247e2d4bd8acaa18c3980c0b70 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_2574daa025254aeabc3113323e27bf79 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task IRequestBin.PostRawStringJson(string str)
         {
             var arguments = new object[] { str };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostRawStringJson", ArgumentTypes_08bc4f247e2d4bd8acaa18c3980c0b70);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostRawStringJson", ArgumentTypes_2574daa025254aeabc3113323e27bf79);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_ba4cc876f4f3443cbc901448effb70c3 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_c1a63060808845dca08d8f0556d9b30a = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task IRequestBin.PostRawStringUrlEncoded(string str)
         {
             var arguments = new object[] { str };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostRawStringUrlEncoded", ArgumentTypes_ba4cc876f4f3443cbc901448effb70c3);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostRawStringUrlEncoded", ArgumentTypes_c1a63060808845dca08d8f0556d9b30a);
             return (Task)func(Client, arguments);
         }
 
-        private static class TypeHelper_59f0be91b892435f98677633fbf75961<T>
+        private static class TypeHelper_78f0caea71174665add47a15311d6b97<T>
         {
             public static readonly Type[] ArgumentTypes = new Type[] { typeof(T) };
             public static readonly Type[] TypeParameters = new Type[] { typeof(T) };
@@ -2617,7 +2615,7 @@ namespace Refit.Tests
         Task IRequestBin.PostGeneric<T>(T param)
         {
             var arguments = new object[] { param };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostGeneric", TypeHelper_59f0be91b892435f98677633fbf75961<T>.ArgumentTypes, TypeHelper_59f0be91b892435f98677633fbf75961<T>.TypeParameters);
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostGeneric", TypeHelper_78f0caea71174665add47a15311d6b97<T>.ArgumentTypes, TypeHelper_78f0caea71174665add47a15311d6b97<T>.TypeParameters);
             return (Task)func(Client, arguments);
         }
     }
@@ -2658,133 +2656,133 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_eb46c38605514aa7bfe6cc196648ef79 = new Type[] { typeof(Stream) };
+        private static readonly Type[] ArgumentTypes_8d8c701d4dba475a922ac2217e57d9cb = new Type[] { typeof(Stream) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadStream(Stream stream)
         {
             var arguments = new object[] { stream };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStream", ArgumentTypes_eb46c38605514aa7bfe6cc196648ef79);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStream", ArgumentTypes_8d8c701d4dba475a922ac2217e57d9cb);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_6cd69fb078d7401fae9ad2c40bab165e = new Type[] { typeof(Stream) };
+        private static readonly Type[] ArgumentTypes_f1a39d1015f04bf4ad35a7bd6c7cc35b = new Type[] { typeof(Stream) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadStreamWithCustomBoundary(Stream stream)
         {
             var arguments = new object[] { stream };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStreamWithCustomBoundary", ArgumentTypes_6cd69fb078d7401fae9ad2c40bab165e);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStreamWithCustomBoundary", ArgumentTypes_f1a39d1015f04bf4ad35a7bd6c7cc35b);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_10b42e5fb02045c49673ddd851dc5c5e = new Type[] { typeof(StreamPart) };
+        private static readonly Type[] ArgumentTypes_3865d1d733814bef9a0ebceb02b7a8d7 = new Type[] { typeof(StreamPart) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadStreamPart(StreamPart stream)
         {
             var arguments = new object[] { stream };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStreamPart", ArgumentTypes_10b42e5fb02045c49673ddd851dc5c5e);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStreamPart", ArgumentTypes_3865d1d733814bef9a0ebceb02b7a8d7);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_07eaec2244254706b9fddec546d22c83 = new Type[] { typeof(ModelObject), typeof(StreamPart) };
+        private static readonly Type[] ArgumentTypes_54a7c4db15f544f2abccc0aaecb8d3f9 = new Type[] { typeof(ModelObject), typeof(StreamPart) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadStreamPart(ModelObject someQueryParams, StreamPart stream)
         {
             var arguments = new object[] { someQueryParams, stream };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStreamPart", ArgumentTypes_07eaec2244254706b9fddec546d22c83);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadStreamPart", ArgumentTypes_54a7c4db15f544f2abccc0aaecb8d3f9);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_eb61c907c8d248ed82af2bc10c0c7ad8 = new Type[] { typeof(byte[]) };
+        private static readonly Type[] ArgumentTypes_f34f705797214ba99fdbda90c6e0e5ef = new Type[] { typeof(byte[]) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadBytes(byte[] bytes)
         {
             var arguments = new object[] { bytes };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadBytes", ArgumentTypes_eb61c907c8d248ed82af2bc10c0c7ad8);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadBytes", ArgumentTypes_f34f705797214ba99fdbda90c6e0e5ef);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_c913da9f313849b0bb9fb561fcee3136 = new Type[] { typeof(ByteArrayPart) };
+        private static readonly Type[] ArgumentTypes_9054801237af4f7fb7744a74ed03b5fb = new Type[] { typeof(ByteArrayPart) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadBytesPart(ByteArrayPart bytes)
         {
             var arguments = new object[] { bytes };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadBytesPart", ArgumentTypes_c913da9f313849b0bb9fb561fcee3136);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadBytesPart", ArgumentTypes_9054801237af4f7fb7744a74ed03b5fb);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_f1c0199a5d7644e1bd70b8844bbbe96a = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_57a342f452c14cbd8708a43e13d5a9a6 = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadString(string someString)
         {
             var arguments = new object[] { someString };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadString", ArgumentTypes_f1c0199a5d7644e1bd70b8844bbbe96a);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadString", ArgumentTypes_57a342f452c14cbd8708a43e13d5a9a6);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_ac0baa0ac5aa42b49dd6392f75501f0a = new Type[] { typeof(IEnumerable<FileInfo>), typeof(FileInfo) };
+        private static readonly Type[] ArgumentTypes_18702cb2105341e1a160dfe42d00a7b2 = new Type[] { typeof(IEnumerable<FileInfo>), typeof(FileInfo) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadFileInfo(IEnumerable<FileInfo> fileInfos, FileInfo anotherFile)
         {
             var arguments = new object[] { fileInfos, anotherFile };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadFileInfo", ArgumentTypes_ac0baa0ac5aa42b49dd6392f75501f0a);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadFileInfo", ArgumentTypes_18702cb2105341e1a160dfe42d00a7b2);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_08321518aea04a36983a1f7dbe74f6b0 = new Type[] { typeof(IEnumerable<FileInfoPart>), typeof(FileInfoPart) };
+        private static readonly Type[] ArgumentTypes_647aa0e7e0794d92b552c38ec061d1f7 = new Type[] { typeof(IEnumerable<FileInfoPart>), typeof(FileInfoPart) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadFileInfoPart(IEnumerable<FileInfoPart> fileInfos, FileInfoPart anotherFile)
         {
             var arguments = new object[] { fileInfos, anotherFile };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadFileInfoPart", ArgumentTypes_08321518aea04a36983a1f7dbe74f6b0);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadFileInfoPart", ArgumentTypes_647aa0e7e0794d92b552c38ec061d1f7);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_a62f7a15fc854af7bacf31e66cdf6d5f = new Type[] { typeof(ModelObject) };
+        private static readonly Type[] ArgumentTypes_421b3d0c31bc4353918b610460d2a91f = new Type[] { typeof(ModelObject) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadJsonObject(ModelObject theObject)
         {
             var arguments = new object[] { theObject };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadJsonObject", ArgumentTypes_a62f7a15fc854af7bacf31e66cdf6d5f);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadJsonObject", ArgumentTypes_421b3d0c31bc4353918b610460d2a91f);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_5f7e504292744634a5468ab2fee2d782 = new Type[] { typeof(IEnumerable<ModelObject>) };
+        private static readonly Type[] ArgumentTypes_5ebccbd5dc064fac8f2ea3c6c94b66e1 = new Type[] { typeof(IEnumerable<ModelObject>) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadJsonObjects(IEnumerable<ModelObject> theObjects)
         {
             var arguments = new object[] { theObjects };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadJsonObjects", ArgumentTypes_5f7e504292744634a5468ab2fee2d782);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadJsonObjects", ArgumentTypes_5ebccbd5dc064fac8f2ea3c6c94b66e1);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_6cc62e85c0ff4fdbb942107b4a50d205 = new Type[] { typeof(IEnumerable<ModelObject>), typeof(AnotherModel), typeof(FileInfo), typeof(AnEnum), typeof(string), typeof(int) };
+        private static readonly Type[] ArgumentTypes_3dae92c860564131ad5740c5fd8a2f71 = new Type[] { typeof(IEnumerable<ModelObject>), typeof(AnotherModel), typeof(FileInfo), typeof(AnEnum), typeof(string), typeof(int) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadMixedObjects(IEnumerable<ModelObject> theObjects, AnotherModel anotherModel, FileInfo aFile, AnEnum anEnum, string aString, int anInt)
         {
             var arguments = new object[] { theObjects, anotherModel, aFile, anEnum, aString, anInt };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadMixedObjects", ArgumentTypes_6cc62e85c0ff4fdbb942107b4a50d205);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadMixedObjects", ArgumentTypes_3dae92c860564131ad5740c5fd8a2f71);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_d75eba2f4d87445f9373f1195003e580 = new Type[] { typeof(HttpContent) };
+        private static readonly Type[] ArgumentTypes_18fe028ec8ca4e4f9af667138ae8ab2d = new Type[] { typeof(HttpContent) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IRunscopeApi.UploadHttpContent(HttpContent content)
         {
             var arguments = new object[] { content };
-            var func = requestBuilder.BuildRestResultFuncForMethod("UploadHttpContent", ArgumentTypes_d75eba2f4d87445f9373f1195003e580);
+            var func = requestBuilder.BuildRestResultFuncForMethod("UploadHttpContent", ArgumentTypes_18fe028ec8ca4e4f9af667138ae8ab2d);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
     }
@@ -2816,23 +2814,23 @@ namespace AutoGeneratedIServiceWithoutNamespace
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_df5241209ed847c282ba15912c1685f1 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_c390abe63d40479c97cb3599ee2da20e = new Type[] {  };
 
         /// <inheritdoc />
         Task IServiceWithoutNamespace.GetRoot()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetRoot", ArgumentTypes_df5241209ed847c282ba15912c1685f1);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetRoot", ArgumentTypes_c390abe63d40479c97cb3599ee2da20e);
             return (Task)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_d93dcf5fba8541569143835e202a84d3 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_ac474723686a400aa7872d929635adef = new Type[] {  };
 
         /// <inheritdoc />
         Task IServiceWithoutNamespace.PostRoot()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("PostRoot", ArgumentTypes_d93dcf5fba8541569143835e202a84d3);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostRoot", ArgumentTypes_ac474723686a400aa7872d929635adef);
             return (Task)func(Client, arguments);
         }
     }
@@ -2873,23 +2871,23 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_8fc2e9c5a120421fa04f82d354241fd6 = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_2679f58be1e448abb1774c04a578c30f = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<Stream> IStreamApi.GetRemoteFile(string filename)
         {
             var arguments = new object[] { filename };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetRemoteFile", ArgumentTypes_8fc2e9c5a120421fa04f82d354241fd6);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetRemoteFile", ArgumentTypes_2679f58be1e448abb1774c04a578c30f);
             return (Task<Stream>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_24d3dff0cc4e4b84b1bc3aa07ba8d80c = new Type[] { typeof(string) };
+        private static readonly Type[] ArgumentTypes_b7b8c92b7dbb4b2da18fcd145ce9d9ff = new Type[] { typeof(string) };
 
         /// <inheritdoc />
         Task<ApiResponse<Stream>> IStreamApi.GetRemoteFileWithMetadata(string filename)
         {
             var arguments = new object[] { filename };
-            var func = requestBuilder.BuildRestResultFuncForMethod("GetRemoteFileWithMetadata", ArgumentTypes_24d3dff0cc4e4b84b1bc3aa07ba8d80c);
+            var func = requestBuilder.BuildRestResultFuncForMethod("GetRemoteFileWithMetadata", ArgumentTypes_b7b8c92b7dbb4b2da18fcd145ce9d9ff);
             return (Task<ApiResponse<Stream>>)func(Client, arguments);
         }
     }
@@ -2930,13 +2928,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_044c5362e682411882ad0f45b7ea2925 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_5e651d014f50421a8c367cbc7266d229 = new Type[] {  };
 
         /// <inheritdoc />
         Task ITrimTrailingForwardSlashApi.Get()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_044c5362e682411882ad0f45b7ea2925);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_5e651d014f50421a8c367cbc7266d229);
             return (Task)func(Client, arguments);
         }
     }
@@ -2966,13 +2964,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_4c98d265f3ca428ebdb99c7aff7aaca8 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_b44f46680c894b459be81e966f8b8452 = new Type[] {  };
 
         /// <inheritdoc />
         Task<SomeType> ITypeCollisionApiA.SomeARequest()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("SomeARequest", ArgumentTypes_4c98d265f3ca428ebdb99c7aff7aaca8);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("SomeARequest", ArgumentTypes_b44f46680c894b459be81e966f8b8452);
             return (Task<SomeType>)func(Client, arguments);
         }
     }
@@ -3002,13 +3000,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_5f343a5e10b64564b247613e3396d2b4 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_408c33407ab340dd9a804892b3ed42b9 = new Type[] {  };
 
         /// <inheritdoc />
         Task<SomeType> ITypeCollisionApiB.SomeBRequest()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("SomeBRequest", ArgumentTypes_5f343a5e10b64564b247613e3396d2b4);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("SomeBRequest", ArgumentTypes_408c33407ab340dd9a804892b3ed42b9);
             return (Task<SomeType>)func(Client, arguments);
         }
     }
@@ -3047,47 +3045,47 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_59fe0ba97b974293a225aca5c441b522 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_92157ae4b2094789896c1ba6f0d37edd = new Type[] {  };
 
         /// <inheritdoc />
         Task<string> IUseOverloadedGenericMethods<TResponse, TParam, THeader>.Get()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_59fe0ba97b974293a225aca5c441b522);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_92157ae4b2094789896c1ba6f0d37edd);
             return (Task<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_3d5d041e148542e0ac1fae3fa5294282 = new Type[] { typeof(TParam), typeof(THeader) };
+        private static readonly Type[] ArgumentTypes_22020599fba944c9a87c23487ac98043 = new Type[] { typeof(TParam), typeof(THeader) };
 
         /// <inheritdoc />
         Task<TResponse> IUseOverloadedGenericMethods<TResponse, TParam, THeader>.Get(TParam param, THeader header)
         {
             var arguments = new object[] { param, header };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_3d5d041e148542e0ac1fae3fa5294282);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_22020599fba944c9a87c23487ac98043);
             return (Task<TResponse>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_eaff7c02948f466f850531be1ead605f = new Type[] { typeof(THeader), typeof(TParam) };
+        private static readonly Type[] ArgumentTypes_6279ee13f4c94f2ebcc6a1efb4fcc379 = new Type[] { typeof(THeader), typeof(TParam) };
 
         /// <inheritdoc />
         Task<TResponse> IUseOverloadedGenericMethods<TResponse, TParam, THeader>.Get(THeader param, TParam header)
         {
             var arguments = new object[] { param, header };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_eaff7c02948f466f850531be1ead605f);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_6279ee13f4c94f2ebcc6a1efb4fcc379);
             return (Task<TResponse>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_a297c3c6ea1642a9a23f1efdcb171212 = new Type[] { typeof(int) };
+        private static readonly Type[] ArgumentTypes_646ad1a02dcf45dd8b9c35bb89d02df1 = new Type[] { typeof(int) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IUseOverloadedGenericMethods<TResponse, TParam, THeader>.Get(int httpstatuscode)
         {
             var arguments = new object[] { httpstatuscode };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_a297c3c6ea1642a9a23f1efdcb171212);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_646ad1a02dcf45dd8b9c35bb89d02df1);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
 
-        private static class TypeHelper_b4fb4c5e4fd54ff6bba78cd1529dbacc<TValue>
+        private static class TypeHelper_6dc35fe1f52941cab9aea1e057cf8ebd<TValue>
         {
             public static readonly Type[] ArgumentTypes = new Type[] { typeof(int) };
             public static readonly Type[] TypeParameters = new Type[] { typeof(TValue) };
@@ -3097,11 +3095,11 @@ namespace Refit.Tests
         Task<TValue> IUseOverloadedGenericMethods<TResponse, TParam, THeader>.Get<TValue>(int someVal)
         {
             var arguments = new object[] { someVal };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", TypeHelper_b4fb4c5e4fd54ff6bba78cd1529dbacc<TValue>.ArgumentTypes, TypeHelper_b4fb4c5e4fd54ff6bba78cd1529dbacc<TValue>.TypeParameters);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", TypeHelper_6dc35fe1f52941cab9aea1e057cf8ebd<TValue>.ArgumentTypes, TypeHelper_6dc35fe1f52941cab9aea1e057cf8ebd<TValue>.TypeParameters);
             return (Task<TValue>)func(Client, arguments);
         }
 
-        private static class TypeHelper_43622c55166f4de38abb99ab6e57e07b<TValue, TInput>
+        private static class TypeHelper_005ec7be7e064cb480566fa4751266c8<TValue, TInput>
         {
             public static readonly Type[] ArgumentTypes = new Type[] { typeof(TInput) };
             public static readonly Type[] TypeParameters = new Type[] { typeof(TValue), typeof(TInput) };
@@ -3111,11 +3109,11 @@ namespace Refit.Tests
         Task<TValue> IUseOverloadedGenericMethods<TResponse, TParam, THeader>.Get<TValue, TInput>(TInput input)
         {
             var arguments = new object[] { input };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", TypeHelper_43622c55166f4de38abb99ab6e57e07b<TValue, TInput>.ArgumentTypes, TypeHelper_43622c55166f4de38abb99ab6e57e07b<TValue, TInput>.TypeParameters);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", TypeHelper_005ec7be7e064cb480566fa4751266c8<TValue, TInput>.ArgumentTypes, TypeHelper_005ec7be7e064cb480566fa4751266c8<TValue, TInput>.TypeParameters);
             return (Task<TValue>)func(Client, arguments);
         }
 
-        private static class TypeHelper_467221a8a32d4f64b81ca9c558001f20<TInput1, TInput2>
+        private static class TypeHelper_76069f642cdc46e7a22bcf380d19a3de<TInput1, TInput2>
         {
             public static readonly Type[] ArgumentTypes = new Type[] { typeof(TInput1), typeof(TInput2) };
             public static readonly Type[] TypeParameters = new Type[] { typeof(TInput1), typeof(TInput2) };
@@ -3125,7 +3123,7 @@ namespace Refit.Tests
         Task IUseOverloadedGenericMethods<TResponse, TParam, THeader>.Get<TInput1, TInput2>(TInput1 input1, TInput2 input2)
         {
             var arguments = new object[] { input1, input2 };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", TypeHelper_467221a8a32d4f64b81ca9c558001f20<TInput1, TInput2>.ArgumentTypes, TypeHelper_467221a8a32d4f64b81ca9c558001f20<TInput1, TInput2>.TypeParameters);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", TypeHelper_76069f642cdc46e7a22bcf380d19a3de<TInput1, TInput2>.ArgumentTypes, TypeHelper_76069f642cdc46e7a22bcf380d19a3de<TInput1, TInput2>.TypeParameters);
             return (Task)func(Client, arguments);
         }
     }
@@ -3160,23 +3158,23 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_c3ab7b0990264a78aef31962f701af7f = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_dfdff52c52fa491fa7d7c9e9b72aca25 = new Type[] {  };
 
         /// <inheritdoc />
         Task<string> IUseOverloadedMethods.Get()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_c3ab7b0990264a78aef31962f701af7f);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_dfdff52c52fa491fa7d7c9e9b72aca25);
             return (Task<string>)func(Client, arguments);
         }
 
-        private static readonly Type[] ArgumentTypes_184bf7e08cc1438aaa91d1100c2681ba = new Type[] { typeof(int) };
+        private static readonly Type[] ArgumentTypes_655aad381a3b43fcb8b0dd9adf274aff = new Type[] { typeof(int) };
 
         /// <inheritdoc />
         Task<HttpResponseMessage> IUseOverloadedMethods.Get(int httpstatuscode)
         {
             var arguments = new object[] { httpstatuscode };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_184bf7e08cc1438aaa91d1100c2681ba);
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_655aad381a3b43fcb8b0dd9adf274aff);
             return (Task<HttpResponseMessage>)func(Client, arguments);
         }
     }
@@ -3217,13 +3215,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_9be8666e0f094ddaa2a9d71a60607557 = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_4b2ea6c70034430e9bb5ef3ddcbdc085 = new Type[] {  };
 
         /// <inheritdoc />
         Task IValidApi.Get()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_9be8666e0f094ddaa2a9d71a60607557);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("Get", ArgumentTypes_4b2ea6c70034430e9bb5ef3ddcbdc085);
             return (Task)func(Client, arguments);
         }
     }
@@ -3253,13 +3251,13 @@ namespace Refit.Tests
             this.requestBuilder = requestBuilder;
         }
 
-        private static readonly Type[] ArgumentTypes_e2bcc1f9cc56466b862fecf9c7b14c8d = new Type[] {  };
+        private static readonly Type[] ArgumentTypes_8fe66bcc0f494894ba3f2eeef9d89ac3 = new Type[] {  };
 
         /// <inheritdoc />
         Task<SomeType> NamespaceWithGlobalAliasApi.SomeRequest()
         {
-            var arguments = new object[] {  };
-            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", ArgumentTypes_e2bcc1f9cc56466b862fecf9c7b14c8d);
+            var arguments = Array.Empty<object>();
+            var func = requestBuilder.BuildRestResultFuncForMethod("SomeRequest", ArgumentTypes_8fe66bcc0f494894ba3f2eeef9d89ac3);
             return (Task<SomeType>)func(Client, arguments);
         }
     }

--- a/Refit/Refit.csproj
+++ b/Refit/Refit.csproj
@@ -17,6 +17,10 @@
     <Reference Include="System.Net.Http" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.1'">
+    <PackageReference Include="Microsoft.Bcl.HashCode" Version="1.1.0" />
+  </ItemGroup>
+
   <ItemGroup Label="Package">
     <None Include="targets\refit.targets" PackagePath="build\net461" Pack="true" />
     <None Include="targets\refit.targets" PackagePath="buildTransitive\net461" Pack="true" />


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
This PR includes a few speed optimizations and memory usage reduction. It does so by employing a better caching system for generated rest methods, and by creating specific static fields/types to store reusable type info for the various generated methods, avoiding repeated allocations.


**Current/past behavior comparison**
As mentioned above, there are a number of improvements included in this PR:

<details>
  <summary><b>Use Array.Empty<T>() when possible</b></summary>
<br/>

The current version of `refit` ends up allocating a lot of empty arrays in the generated services. This results in repeated allocations that can be skipped entirely by using `Array.Empty<T>()` instead:

```csharp
// BEFORE
Task IRestService.Foo()
{
    var arguments = new object[] {  };
    var func = requestBuilder.BuildRestResultFuncForMethod("Foo", new Type[] {  });
    return (Task)func(Client, arguments);
}
```

```csharp
// AFTER
Task IRestService.Foo()
{
    var arguments = Array.Empty<object>();
    var func = requestBuilder.BuildRestResultFuncForMethod("Foo", Array.Empty<Type>());
    return (Task)func(Client, arguments);
}
```

</details>

<details>
  <summary><b>Use static cached fields for reused argument lists</b></summary>
<br/>

Right now `refit` ends up allocating a new array to represent the types of the parameters for each method being used. This array is passed to the `IRequestBuilder` method to build the rest function, and results in repeated allocations for what is essentially the same exact array every time. This PR solves this issue by just using a dedicated field for each generated method, storing a reusable instance of that array:

```csharp
// BEFORE
Task IRestService.Foo(PathBoundObject request, string someProperty)
{
    var arguments = new object[] { request, someProperty };
    var func = requestBuilder.BuildRestResultFuncForMethod("Foo", new Type[] { typeof(PathBoundObject), typeof(string) });
    return (Task)func(Client, arguments);
}
```

```csharp
// AFTER
private static readonly Type[] ArgumentTypes_18675fb6c1f94a68be274f15250f3c4c = new Type[] { typeof(PathBoundObject), typeof(string) };

Task IRestService.Foo(PathBoundObject request, string someProperty)
{
    var arguments = new object[] { request, someProperty };
    var func = requestBuilder.BuildRestResultFuncForMethod("Foo", ArgumentTypes_18675fb6c1f94a68be274f15250f3c4c);
    return (Task)func(Client, arguments);
}
```

</details>

<details>
  <summary><b>Use static cached fields for reused type parameters lists</b></summary>
<br/>

Same concept as before, but for type parameters. In this case we can't just use a field, as the concrete type parameters are not known at compile time. In order to still use the previous caching system, in this case `refit` will now generate a dedicated generic type that will act as a container for the static fields storing the reusable arrays. This lets us use this technique even for generic methods:

```csharp
// BEFORE
Task<TValue> IRestService.Foo<TResponse, TParam, THeader>.Get<TValue, TInput>(TInput input)
{
    var arguments = new object[] { input };
    var func = requestBuilder.BuildRestResultFuncForMethod("Get",
        new Type[] { typeof(TInput) },
        new Type[] { typeof(TValue), typeof(TInput) });
    return (Task<TValue>)func(Client, arguments);
}
```

```csharp
// AFTER
private static class TypeHelper_531f6c2269294e40b1eb070dda401682<TValue, TInput>
{
    public static readonly Type[] ArgumentTypes = new Type[] { typeof(TInput) };
    public static readonly Type[] TypeParameters = new Type[] { typeof(TValue), typeof(TInput) };
}

/// <inheritdoc />
Task<TValue> IUseOverloadedGenericMethods<TResponse, TParam, THeader>.Get<TValue, TInput>(TInput input)
{
    var arguments = new object[] { input };
    var func = requestBuilder.BuildRestResultFuncForMethod("Get",
        TypeHelper_531f6c2269294e40b1eb070dda401682<TValue, TInput>.ArgumentTypes,
        TypeHelper_531f6c2269294e40b1eb070dda401682<TValue, TInput>.TypeParameters);
    return (Task<TValue>)func(Client, arguments);
}
```

</details>

<details>
  <summary><b>Better caching in default IRequestBuilder implementation</b></summary>
<br/>

The current `RequestBuilderImplementation` class was doing some repeated work every time the `IRequestBuilder.BuildRestResultFuncForMethod` method was being called (specifically, quite a bit of reflection, and some unnecessary closures being allocated). This PR fixes that by using the `HashCode` type to quickly calculate a method-specific hash code used as key for the cached `Func<HttpClient, object[], object>` instance to retrieve, and then includes a fast path to quickly get the cached instance if present and return it immediately.

</details>


**What might this PR break?**
There should be no functional differences, and all the tests are passing.


**Please check if the PR fulfills these requirements**
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

**Other information**:
cc. @clairernovotny @Dreamescaper @martincostello 

