### PR TITLE
Support Xml default namespace

### DIFF
--- a/Refit/XmlContentSerializer.cs
+++ b/Refit/XmlContentSerializer.cs
@@ -39,7 +39,12 @@ namespace Refit
 
         public async Task<T> DeserializeAsync<T>(HttpContent content)
         {
-            var xmlSerializer = serializerCache.GetOrAdd(typeof(T), t => new XmlSerializer(t, settings.XmlAttributeOverrides));
+            var xmlSerializer = serializerCache.GetOrAdd(typeof(T), t => new XmlSerializer(
+                t,
+                settings.XmlAttributeOverrides,
+                Array.Empty<Type>(),
+                null,
+                settings.XmlDefaultNamespace));
 
             using var input = new StringReader(await content.ReadAsStringAsync().ConfigureAwait(false));
             using var reader = XmlReader.Create(input, settings.XmlReaderWriterSettings.ReaderSettings);
@@ -106,6 +111,7 @@ namespace Refit
     {
         public XmlContentSerializerSettings()
         {
+            XmlDefaultNamespace = null;
             XmlReaderWriterSettings = new XmlReaderWriterSettings();
             XmlNamespaces = new XmlSerializerNamespaces(
                 new[]
@@ -115,6 +121,8 @@ namespace Refit
 
             XmlAttributeOverrides = new XmlAttributeOverrides();
         }
+
+        public string XmlDefaultNamespace { get; set; }
 
         public XmlReaderWriterSettings XmlReaderWriterSettings { get; set; }
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Feature

**What is the current behavior?**
`XmlContentSerializer` won't pass default namespace to `XmlSerializer`'s constuctor

**What is the new behavior?**
`XmlContentSerializer` will pass default namespace to `XmlSerializer`'s constuctor. If there's no default namespace specified, then default behavior (using `null` as the default namespace) will be used.

**What might this PR break?**
It won't break any existing code in theory.

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
