### PR TITLE
Feature #903: AddRefitClient with IServiceProvider

### DIFF
--- a/Refit.HttpClientFactory/HttpClientFactoryExtensions.cs
+++ b/Refit.HttpClientFactory/HttpClientFactoryExtensions.cs
@@ -12,17 +12,37 @@ namespace Refit
         /// </summary>
         /// <typeparam name="T">Type of the Refit interface</typeparam>
         /// <param name="services">container</param>
+        /// <returns></returns>
+        public static IHttpClientBuilder AddRefitClient<T>(this IServiceCollection services) where T : class
+            => AddRefitClient<T>(services, provider => null);
+
+        /// <summary>
+        /// Adds a Refit client to the DI container
+        /// </summary>
+        /// <typeparam name="T">Type of the Refit interface</typeparam>
+        /// <param name="services">container</param>
         /// <param name="settings">Optional. Settings to configure the instance with</param>
         /// <returns></returns>
-        public static IHttpClientBuilder AddRefitClient<T>(this IServiceCollection services, RefitSettings settings = null) where T : class
+        public static IHttpClientBuilder AddRefitClient<T>(this IServiceCollection services, RefitSettings settings) where T : class
+            => AddRefitClient<T>(services, provider => settings);
+
+        /// <summary>
+        /// Adds a Refit client to the DI container
+        /// </summary>
+        /// <typeparam name="T">Type of the Refit interface</typeparam>
+        /// <param name="services">container</param>
+        /// <param name="settingsFactory">Optional. Settings to configure the instance with</param>
+        /// <returns></returns>
+        public static IHttpClientBuilder AddRefitClient<T>(this IServiceCollection services, Func<IServiceProvider, RefitSettings> settingsFactory) where T : class
         {
-            services.AddSingleton(provider => RequestBuilder.ForType<T>(settings));
+            services.AddSingleton(provider => RequestBuilder.ForType<T>(settingsFactory(provider)));
 
             return services.AddHttpClient(UniqueName.ForType<T>())
                            .ConfigureHttpMessageHandlerBuilder(builder =>
                            {
                                // check to see if user provided custom auth token
                                HttpMessageHandler innerHandler = null;
+                               var settings = settingsFactory(builder.Services);
                                if (settings != null)
                                {
                                    if (settings.HttpMessageHandlerFactory != null)
@@ -40,10 +60,10 @@ namespace Refit
                                    }
                                }
 
-                               if(innerHandler != null)
+                               if (innerHandler != null)
                                {
                                    builder.PrimaryHandler = innerHandler;
-                               }    
+                               }
 
                            })
                            .AddTypedClient((client, serviceProvider) => RestService.For<T>(client, serviceProvider.GetService<IRequestBuilder<T>>()));
@@ -54,15 +74,35 @@ namespace Refit
         /// </summary>
         /// <param name="services">container</param>
         /// <param name="refitInterfaceType">Type of the Refit interface</typeparam>
+        /// <returns></returns>
+        public static IHttpClientBuilder AddRefitClient(this IServiceCollection services, Type refitInterfaceType)
+            => AddRefitClient(services, refitInterfaceType, provider => null);
+
+        /// <summary>
+        /// Adds a Refit client to the DI container
+        /// </summary>
+        /// <param name="services">container</param>
+        /// <param name="refitInterfaceType">Type of the Refit interface</typeparam>
         /// <param name="settings">Optional. Settings to configure the instance with</param>
         /// <returns></returns>
-        public static IHttpClientBuilder AddRefitClient(this IServiceCollection services, Type refitInterfaceType, RefitSettings settings = null)
+        public static IHttpClientBuilder AddRefitClient(this IServiceCollection services, Type refitInterfaceType, RefitSettings settings)
+            => AddRefitClient(services, refitInterfaceType, provider => settings);
+
+        /// <summary>
+        /// Adds a Refit client to the DI container
+        /// </summary>
+        /// <param name="services">container</param>
+        /// <param name="refitInterfaceType">Type of the Refit interface</typeparam>
+        /// <param name="settings">Optional. Settings to configure the instance with</param>
+        /// <returns></returns>
+        public static IHttpClientBuilder AddRefitClient(this IServiceCollection services, Type refitInterfaceType, Func<IServiceProvider, RefitSettings> settingsFactory)
         {
             return services.AddHttpClient(UniqueName.ForType(refitInterfaceType))
                             .ConfigureHttpMessageHandlerBuilder(builder =>
                             {
                                 // check to see if user provided custom auth token
                                 HttpMessageHandler innerHandler = null;
+                                var settings = settingsFactory(builder.Services);
                                 if (settings != null)
                                 {
                                     if (settings.HttpMessageHandlerFactory != null)
@@ -86,7 +126,7 @@ namespace Refit
                                 }
 
                             })
-                           .AddTypedClient((client, serviceProvider) => RestService.For(refitInterfaceType, client, settings));
+                           .AddTypedClient((client, serviceProvider) => RestService.For(refitInterfaceType, client, settingsFactory(serviceProvider)));
         }
     }
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?**
#903 fix, providing IServiceProvider for RefitSettings creation



**What is the current behavior?**
We have to create a RefitSettings instance manually. 
It would be useful to get IServiceProvider here to resolve IContentSerializer, IUrlParameterFormatter and IFormUrlEncodedParameterFormatter instead of manual creation.



**What is the new behavior?**
We could new resolve all parameters needed in RefitSettings constructor.



**What might this PR break?**



**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

