### PR TITLE
Custom error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -919,3 +919,24 @@ catch (ApiException exception)
 }
 // ...
 ```
+
+
+If your service uses some specific error contract you can override error handling by setting ErrorHandler in RefitSetting
+
+```csharp
+// ...
+RestService.For<IGitHubApi>("https://api.github.com",
+                new RefitSettings() {ErrorHandler = new MyErrorHandler()});
+
+// ...
+
+public class MyErrorHandler : IErrorHandler
+{
+    public Task<Exception> HandleErrorAsync(HttpRequestMessage message, HttpMethod httpMethod, HttpResponseMessage response,
+        RefitSettings refitSettings = null)
+    {
+        // Handle errors here. This method will be called if the service responses a status other than 2xx
+        // You need to return the Exception object or its inheritor, this exception will be thrown
+    }
+}
+```

--- a/Refit.Tests/ErrorHandlerTests.cs
+++ b/Refit.Tests/ErrorHandlerTests.cs
@@ -1,0 +1,242 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using RichardSzalay.MockHttp;
+using Xunit;
+
+namespace Refit.Tests
+{
+    public class ErrorHandlerTests
+    {
+        [Fact]
+        public async Task ApiResponseErrorWithDefaultHandler()
+        {
+            var mockHttp = new MockHttpMessageHandler();
+            var mockErrorHandler = new MockDefaultErrorHandler();
+
+            var settings = new RefitSettings
+            {
+                HttpMessageHandlerFactory = () => mockHttp,
+                ContentSerializer = new NewtonsoftJsonContentSerializer(new JsonSerializerSettings() { ContractResolver = new SnakeCasePropertyNamesContractResolver() }),
+                ErrorHandler = mockErrorHandler
+            };
+
+            mockHttp.Expect(HttpMethod.Post, "https://api.github.com/users")
+                .Respond(HttpStatusCode.BadRequest, "application/json", "{ 'errors': [ 'error1', 'message' ]}");
+
+
+            var fixture = RestService.For<IGitHubApi>("https://api.github.com", settings);
+
+
+            using var response = await fixture.CreateUserWithMetadata(new User { Name = "foo" });
+            Assert.False(response.IsSuccessStatusCode);
+            Assert.NotNull(response.Error);
+            Assert.True(mockErrorHandler.HandleErrorAsyncCalled);
+
+            var apiException = (ApiException)response.Error;
+            var errors = await apiException.GetContentAsAsync<ErrorResponse>();
+
+            Assert.Contains("error1", errors.Errors);
+            Assert.Contains("message", errors.Errors);
+
+            mockHttp.VerifyNoOutstandingExpectation();
+        }
+
+        [Fact]
+        public async Task CancellableTaskErrorWithDefaultHandler()
+        {
+            var mockHttp = new MockHttpMessageHandler();
+            var mockErrorHandler = new MockDefaultErrorHandler();
+
+            var settings = new RefitSettings
+            {
+                HttpMessageHandlerFactory = () => mockHttp,
+                ContentSerializer = new NewtonsoftJsonContentSerializer(new JsonSerializerSettings() { ContractResolver = new SnakeCasePropertyNamesContractResolver() }),
+                ErrorHandler = mockErrorHandler
+            };
+
+            mockHttp.Expect(HttpMethod.Get, "https://api.github.com/users/octocat")
+                .Respond(HttpStatusCode.BadRequest, "application/json", "{ 'errors': [ 'error1', 'message' ]}");
+
+
+            var fixture = RestService.For<IGitHubApi>("https://api.github.com", settings);
+
+            ApiException apiException = null;
+            try
+            {
+                await fixture.GetUser("octocat");
+            }
+            catch (ApiException exception)
+            {
+                apiException = exception;
+            }
+            Assert.NotNull(apiException);
+            Assert.True(mockErrorHandler.HandleErrorAsyncCalled);
+            var errors = await apiException.GetContentAsAsync<ErrorResponse>();
+
+            Assert.Contains("error1", errors.Errors);
+            Assert.Contains("message", errors.Errors);
+
+            mockHttp.VerifyNoOutstandingExpectation();
+        }
+
+
+        [Fact]
+        public async Task ObservableErrorWithDefaultHandler()
+        {
+            var mockHttp = new MockHttpMessageHandler();
+            var mockErrorHandler = new MockDefaultErrorHandler();
+
+            var settings = new RefitSettings
+            {
+                HttpMessageHandlerFactory = () => mockHttp,
+                ContentSerializer = new NewtonsoftJsonContentSerializer(new JsonSerializerSettings() { ContractResolver = new SnakeCasePropertyNamesContractResolver() }),
+                ErrorHandler = mockErrorHandler
+            };
+
+            mockHttp.Expect(HttpMethod.Get, "https://api.github.com/users/octocat")
+                .Respond(HttpStatusCode.BadRequest, "application/json", "{ 'errors': [ 'error1', 'message' ]}");
+
+            var fixture = RestService.For<IGitHubApi>("https://api.github.com", settings);
+
+            ApiException apiException = null;
+            try
+            {
+                var user = await fixture.GetUserObservable("octocat")
+                    .Timeout(TimeSpan.FromSeconds(10));
+                Assert.Null(user);
+            }
+            catch (ApiException exception)
+            {
+                apiException = exception;
+            }
+            Assert.NotNull(apiException);
+            Assert.True(mockErrorHandler.HandleErrorAsyncCalled);
+            var errors = await apiException.GetContentAsAsync<ErrorResponse>();
+
+            Assert.Contains("error1", errors.Errors);
+            Assert.Contains("message", errors.Errors);
+
+            mockHttp.VerifyNoOutstandingExpectation();
+        }
+
+        [Fact]
+        public async Task VoidTaskErrorWithDefaultHandler()
+        {
+            var mockHttp = new MockHttpMessageHandler();
+            var mockErrorHandler = new MockDefaultErrorHandler();
+
+            var settings = new RefitSettings
+            {
+                HttpMessageHandlerFactory = () => mockHttp,
+                ContentSerializer = new NewtonsoftJsonContentSerializer(new JsonSerializerSettings() { ContractResolver = new SnakeCasePropertyNamesContractResolver() }),
+                ErrorHandler = mockErrorHandler
+            };
+
+            mockHttp.Expect(HttpMethod.Get, "https://api.github.com/give-me-some-404-action")
+                .Respond(HttpStatusCode.BadRequest, "application/json", "{ 'errors': [ 'error1', 'message' ]}");
+
+
+            var fixture = RestService.For<TestNested.INestedGitHubApi>("https://api.github.com", settings);
+
+            ApiException apiException = null;
+            try
+            {
+                await fixture.NothingToSeeHere();
+            }
+            catch (ApiException exception)
+            {
+                apiException = exception;
+            }
+            Assert.NotNull(apiException);
+            Assert.True(mockErrorHandler.HandleErrorAsyncCalled);
+            var errors = await apiException.GetContentAsAsync<ErrorResponse>();
+
+            Assert.Contains("error1", errors.Errors);
+            Assert.Contains("message", errors.Errors);
+
+            mockHttp.VerifyNoOutstandingExpectation();
+        }
+
+        [Fact]
+        public async Task CancellableTaskOverrideErrorHandler()
+        {
+            var mockHttp = new MockHttpMessageHandler();
+            var mockErrorHandler = new MockSampleErrorHandler();
+
+            var settings = new RefitSettings
+            {
+                HttpMessageHandlerFactory = () => mockHttp,
+                ContentSerializer = new NewtonsoftJsonContentSerializer(new JsonSerializerSettings() { ContractResolver = new SnakeCasePropertyNamesContractResolver() }),
+                ErrorHandler = mockErrorHandler
+            };
+
+            mockHttp.Expect(HttpMethod.Get, "https://api.github.com/users/octocat")
+                .Respond(HttpStatusCode.BadRequest, "application/json", "{ 'errors': [ 'error1', 'message' ]}");
+
+
+            var fixture = RestService.For<IGitHubApi>("https://api.github.com", settings);
+
+            MockSampleErrorHandler.SampleException sampleException = null;
+            try
+            {
+                await fixture.GetUser("octocat");
+            }
+            catch (MockSampleErrorHandler.SampleException exception)
+            {
+                sampleException = exception;
+            }
+            Assert.NotNull(sampleException);
+            Assert.True(mockErrorHandler.HandleErrorAsyncCalled);
+
+            Assert.Contains("error1", sampleException.Errors);
+            Assert.Contains("message", sampleException.Errors);
+
+            mockHttp.VerifyNoOutstandingExpectation();
+        }
+
+        public class MockDefaultErrorHandler : DefaultErrorHandler
+        {
+            public bool HandleErrorAsyncCalled { get; set; }
+            public override Task<Exception> HandleErrorAsync(HttpRequestMessage message, HttpMethod httpMethod, HttpResponseMessage response,
+                RefitSettings refitSettings = null)
+            {
+                HandleErrorAsyncCalled = true;
+                return base.HandleErrorAsync(message, httpMethod, response, refitSettings);
+            }
+        }
+
+
+        public class MockSampleErrorHandler : DefaultErrorHandler
+        {
+            public bool HandleErrorAsyncCalled { get; set; }
+            public override async Task<Exception> HandleErrorAsync(HttpRequestMessage message, HttpMethod httpMethod, HttpResponseMessage response,
+                RefitSettings refitSettings = null)
+            {
+                var content = await response.Content.ReadAsStringAsync();
+                var errors = JsonConvert.DeserializeObject<SampleErrorModel>(content);
+                HandleErrorAsyncCalled = true;
+                return new SampleException(errors.Errors);
+            }
+
+            public class SampleException: Exception
+            {
+                public SampleException(List<string> errors)
+                {
+                    Errors = errors;
+                }
+
+                public readonly List<string> Errors;
+            }
+            public class SampleErrorModel
+            {
+                [JsonProperty("errors")]
+                public List<string> Errors { get; set; }
+            }
+        }
+    }
+}

--- a/Refit.Tests/RestService.cs
+++ b/Refit.Tests/RestService.cs
@@ -1365,7 +1365,8 @@ namespace Refit.Tests
             Assert.False(response.IsSuccessStatusCode);
             Assert.NotNull(response.Error);
 
-            var errors = await response.Error.GetContentAsAsync<ErrorResponse>();
+            var apiException = (ApiException) response.Error;
+            var errors = await apiException.GetContentAsAsync<ErrorResponse>();
 
             Assert.Contains("error1", errors.Errors);
             Assert.Contains("message", errors.Errors);

--- a/Refit/ApiResponse.cs
+++ b/Refit/ApiResponse.cs
@@ -8,7 +8,7 @@ namespace Refit
 {
     static class ApiResponse
     {
-        internal static T Create<T, TBody>(HttpResponseMessage resp, object content, ApiException error = null)
+        internal static T Create<T, TBody>(HttpResponseMessage resp, object content, Exception error = null)
         {
             return (T)Activator.CreateInstance(typeof(ApiResponse<TBody>), resp, content, error);
         }
@@ -19,7 +19,7 @@ namespace Refit
         readonly HttpResponseMessage response;
         bool disposed;
 
-        public ApiResponse(HttpResponseMessage response, T content, ApiException error = null)
+        public ApiResponse(HttpResponseMessage response, T content, Exception error = null)
         {
             this.response = response ?? throw new ArgumentNullException(nameof(response));
             Error = error;
@@ -34,7 +34,7 @@ namespace Refit
         public HttpRequestMessage RequestMessage => response.RequestMessage;
         public HttpStatusCode StatusCode => response.StatusCode;
         public Version Version => response.Version;
-        public ApiException Error { get; private set; }
+        public Exception Error { get; private set; }
 
 
         public void Dispose()
@@ -81,6 +81,6 @@ namespace Refit
         HttpRequestMessage RequestMessage { get; }
         HttpStatusCode StatusCode { get; }
         Version Version { get; }
-        ApiException Error { get; }
+        Exception Error { get; }
     }
 }

--- a/Refit/DefaultErrorHandler.cs
+++ b/Refit/DefaultErrorHandler.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace Refit
+{
+    public class DefaultErrorHandler: IErrorHandler
+    {
+        public virtual async Task<Exception> HandleErrorAsync(HttpRequestMessage message, HttpMethod httpMethod, HttpResponseMessage response,
+            RefitSettings refitSettings = null)
+        {
+            var exception = await ApiException.Create(response.RequestMessage, response.RequestMessage.Method, response, refitSettings)
+                .ConfigureAwait(false);
+            return exception;
+        }
+    }
+}

--- a/Refit/IErrorHandler.cs
+++ b/Refit/IErrorHandler.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Refit
+{
+    public interface IErrorHandler
+    {
+        Task<Exception> HandleErrorAsync(HttpRequestMessage message, HttpMethod httpMethod, HttpResponseMessage response,
+            RefitSettings refitSettings = null);
+    }
+}

--- a/Refit/RefitSettings.cs
+++ b/Refit/RefitSettings.cs
@@ -30,14 +30,17 @@ namespace Refit
         /// <param name="contentSerializer">The <see cref="IContentSerializer"/> instance to use</param>
         /// <param name="urlParameterFormatter">The <see cref="IUrlParameterFormatter"/> instance to use (defaults to <see cref="DefaultUrlParameterFormatter"/>)</param>
         /// <param name="formUrlEncodedParameterFormatter">The <see cref="IFormUrlEncodedParameterFormatter"/> instance to use (defaults to <see cref="DefaultFormUrlEncodedParameterFormatter"/>)</param>
+        /// <param name="errorHandler"> instance to use (defaults to <see cref="DefaultErrorHandler"/>)</param>
         public RefitSettings(
             IContentSerializer contentSerializer,
             IUrlParameterFormatter urlParameterFormatter = null,
-            IFormUrlEncodedParameterFormatter formUrlEncodedParameterFormatter = null)
+            IFormUrlEncodedParameterFormatter formUrlEncodedParameterFormatter = null,
+            IErrorHandler errorHandler = null)
         {
             ContentSerializer = contentSerializer ?? throw new ArgumentNullException(nameof(contentSerializer), "The content serializer can't be null");
             UrlParameterFormatter = urlParameterFormatter ?? new DefaultUrlParameterFormatter();
             FormUrlEncodedParameterFormatter = formUrlEncodedParameterFormatter ?? new DefaultFormUrlEncodedParameterFormatter();
+            ErrorHandler = errorHandler ?? new DefaultErrorHandler();
         }
 
         /// <summary>
@@ -69,6 +72,7 @@ namespace Refit
         public IContentSerializer ContentSerializer { get; set; }
         public IUrlParameterFormatter UrlParameterFormatter { get; set; }
         public IFormUrlEncodedParameterFormatter FormUrlEncodedParameterFormatter { get; set; }
+        public IErrorHandler ErrorHandler { get; set; }
         public CollectionFormat CollectionFormat { get; set; } = CollectionFormat.RefitParameterFormatter;
         public bool Buffered { get; set; } = true;
     }

--- a/Refit/RequestBuilderImplementation.cs
+++ b/Refit/RequestBuilderImplementation.cs
@@ -244,13 +244,13 @@ namespace Refit
                 {
                     resp = await client.SendAsync(rq, HttpCompletionOption.ResponseHeadersRead, ct).ConfigureAwait(false);
                     content = resp.Content ?? new StringContent(string.Empty);
-                    ApiException e = null;
+                    Exception e = null;
                     disposeResponse = restMethod.ShouldDisposeResponse;
 
                     if (!resp.IsSuccessStatusCode && typeof(T) != typeof(HttpResponseMessage))
                     {
                         disposeResponse = false; // caller has to dispose
-                        e = await ApiException.Create(rq, restMethod.HttpMethod, resp, restMethod.RefitSettings).ConfigureAwait(false);
+                        e = await restMethod.ErrorHandler.HandleErrorAsync(rq, restMethod.HttpMethod, resp, restMethod.RefitSettings).ConfigureAwait(false);
                     }
 
                     if (restMethod.IsApiResponse)
@@ -788,7 +788,7 @@ namespace Refit
                 using var resp = await client.SendAsync(rq, ct).ConfigureAwait(false);
                 if (!resp.IsSuccessStatusCode)
                 {
-                    throw await ApiException.Create(rq, restMethod.HttpMethod, resp, settings).ConfigureAwait(false);
+                    throw await restMethod.ErrorHandler.HandleErrorAsync(rq, restMethod.HttpMethod, resp, settings).ConfigureAwait(false);
                 }
             };
         }

--- a/Refit/RestMethodInfo.cs
+++ b/Refit/RestMethodInfo.cs
@@ -33,6 +33,7 @@ namespace Refit
         public Type ReturnResultType { get; set; }
         public Type DeserializedResultType { get; set; }
         public RefitSettings RefitSettings { get; set; }
+        public IErrorHandler ErrorHandler { get; set; }
         public bool IsApiResponse { get; }
         public bool ShouldDisposeResponse { get; private set; }
 
@@ -118,6 +119,7 @@ namespace Refit
                             (ReturnResultType.GetGenericTypeDefinition() == typeof(ApiResponse<>)
                              || ReturnResultType.GetGenericTypeDefinition()  == typeof(IApiResponse<>)
                              || ReturnResultType == typeof(IApiResponse));
+            ErrorHandler = refitSettings?.ErrorHandler ?? new DefaultErrorHandler();
         }
 
         private PropertyInfo[] GetParameterProperties(ParameterInfo parameter)


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
feature



**What is the current behavior?**
<!-- You can also link to an open issue here. -->



**What is the new behavior?**
Provide the ability to independently manage errors instead of the current set of ApiException and ValidationApiException.

How doies it works?
I provided IErrorHandler that presented in RefitSettings and RestMethodInfo, by default it set to DefaultErrorHandler with current logic.

RequestBuilderImplementation for now is calling RestMethodInfo.IErrorHandler.HandleErrorAsync instead of ApiException.Create.


**What might this PR break?**
There is nothing to break. I provided `Refit.DefaultErrorHandler` with current exception management logic that used by default.


**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)

- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:

