### PR TITLE
fix: Allow for GenerateRefitStubs to be disabled with RefitDisableGenerateRefitStubs

### DIFF
--- a/README.md
+++ b/README.md
@@ -919,3 +919,7 @@ catch (ApiException exception)
 }
 // ...
 ```
+
+### MSBuild configuration
+
+- `RefitDisableGenerateRefitStubs`: This property allows for other Roslyn-based source generators to disable the Refit's stubs generation during they own generation phase.

--- a/Refit/targets/refit.targets
+++ b/Refit/targets/refit.targets
@@ -24,7 +24,7 @@
     BH: Checking that the project type is a csproj, otherwise don't execute
     https://github.com/reactiveui/refit/issues/811
   -->
-  <Target Name="GenerateRefitStubs" BeforeTargets="BeforeCompile;CoreCompile" Inputs="@(Compile)" Outputs="$(RefitGeneratedFile)" Condition="$(Language) == 'C#'">
+  <Target Name="GenerateRefitStubs" BeforeTargets="BeforeCompile;CoreCompile" Inputs="@(Compile)" Outputs="$(RefitGeneratedFile)" Condition="$(Language) == 'C#' and '$(RefitDisableGenerateRefitStubs)'==''">
     <Error Condition="'$(MSBuildRuntimeType)' == 'Core' and '$(RefitMinCoreVersionRequired)' > '$(RefitNetCoreAppVersion)' "
            Text="Refit requires at least the .NET Core SDK v2.1 to run with 'dotnet build'"
            ContinueOnError="false"


### PR DESCRIPTION
Fixes #942

**What kind of change does this PR introduce?**

This PR introduces the `RefitDisableGenerateRefitStubs` MSBuild property to allow for the `GenerateRefitStubs` to be skipped when other source generators based on roslyn are running.

**Please check if the PR fulfills these requirements**
- ~~[ ] Tests for the changes have been added (for bug fixes / features)~~
- [x] Docs have been added / updated (for bug fixes / features)
