### PR TITLE
refactor: change verify url method exception message

### DIFF
--- a/Refit/RestMethodInfo.cs
+++ b/Refit/RestMethodInfo.cs
@@ -133,20 +133,7 @@ namespace Refit
                 return;
 
             if (!relativePath.StartsWith("/"))
-            {
-                goto bogusPath;
-            }
-
-            var parts = relativePath.Split('/');
-            if (parts.Length == 0)
-            {
-                goto bogusPath;
-            }
-
-            return;
-
-bogusPath:
-            throw new ArgumentException($"URL path {relativePath} must be of the form '/foo/bar/baz'");
+                throw new ArgumentException($"URL path {relativePath} must start with '/' and be of the form '/foo/bar/baz'");
         }
 
         Dictionary<int, RestMethodParameterInfo> BuildParameterMap(string relativePath, List<ParameterInfo> parameterInfo)


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
Add more information about exception in verify url method

**What is the current behavior?**
If url don't start with '/', refit throw exception that "URL path {relativePath} must be of the form '/foo/bar/baz'". 

**What is the new behavior?**
The only one thing that this method check - if path start with '/'. If it's start with '/' than we will have at least two parts, so second check make no sense.