### PR TITLE
Fix issue 617 (support EnumMember on enums within types for query string param objects)

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,16 @@ public class MyQueryParams
     public string SortOrder { get; set; }
 
     public int Limit { get; set; }
+
+    public KindOptions Kind { get; set; }
+}
+
+public enum KindOptions
+{
+    Foo,
+
+    [EnumMember(Value = "bar")]
+    Bar
 }
 
 
@@ -143,12 +153,13 @@ Task<List<User>> GroupListWithAttribute([AliasAs("id")] int groupId, [Query(".",
 
 params.SortOrder = "desc";
 params.Limit = 10;
+params.Kind = KindOptions.Bar;
 
 GroupList(4, params)
->>> "/group/4/users?order=desc&Limit=10"
+>>> "/group/4/users?order=desc&Limit=10&Kind=bar"
 
 GroupListWithAttribute(4, params)
->>> "/group/4/users?search.order=desc&search.Limit=10"
+>>> "/group/4/users?search.order=desc&search.Limit=10&search.Kind=bar"
 ```
 
 A similar behavior exists if using a Dictionary, but without the advantages of the `AliasAs` attributes and of course no intellisense and/or type safety.

--- a/Refit.Tests/RequestBuilder.cs
+++ b/Refit.Tests/RequestBuilder.cs
@@ -783,6 +783,9 @@ namespace Refit.Tests
         [Get("/query")]
         Task QueryWithEnum(FooWithEnumMember foo);
 
+        [Get("/query")]
+        Task QueryWithTypeWithEnum(TypeFooWithEnumMember foo);
+
         [Get("/api/{id}")]
         Task QueryWithOptionalParameters(int id, [Query]string text = null, [Query]int? optionalId = null, [Query(CollectionFormat = CollectionFormat.Multi)]string[] filters = null);
 
@@ -843,6 +846,12 @@ namespace Refit.Tests
 
         [EnumMember(Value = "b")]
         B
+    }
+
+    public class TypeFooWithEnumMember
+    {
+        [AliasAs("foo")]
+        public FooWithEnumMember Foo { get; set; }
     }
 
     public class SomeRequestData
@@ -1648,6 +1657,20 @@ namespace Refit.Tests
             var factory = fixture.BuildRequestFactoryForMethod("QueryWithEnum");
 
             var output = factory(new object[] { queryParameter });
+
+            var uri = new Uri(new Uri("http://api"), output.RequestUri);
+            Assert.Equal(expectedQuery, uri.PathAndQuery);
+        }
+
+        [Theory]
+        [InlineData(FooWithEnumMember.A, "/query?foo=A")]
+        [InlineData(FooWithEnumMember.B, "/query?foo=b")]
+        public void QueryStringUsesEnumMemberAttributeInTypeWithEnum(FooWithEnumMember queryParameter, string expectedQuery)
+        {
+            var fixture = new RequestBuilderImplementation<IDummyHttpApi>();
+            var factory = fixture.BuildRequestFactoryForMethod("QueryWithTypeWithEnum");
+
+            var output = factory(new object[] { new TypeFooWithEnumMember { Foo = queryParameter } });
 
             var uri = new Uri(new Uri("http://api"), output.RequestUri);
             Assert.Equal(expectedQuery, uri.PathAndQuery);

--- a/Refit/RefitSettings.cs
+++ b/Refit/RefitSettings.cs
@@ -104,10 +104,14 @@ namespace Refit
                 .FirstOrDefault()?.Format;
 
             EnumMemberAttribute enummember = null;
-            if (parameterValue != null && type.GetTypeInfo().IsEnum)
+            if (parameterValue != null)
             {
-                var cached = EnumMemberCache.GetOrAdd(type, t => new ConcurrentDictionary<string, EnumMemberAttribute>());
-                enummember = cached.GetOrAdd(parameterValue.ToString(), val => type.GetMember(val).First().GetCustomAttribute<EnumMemberAttribute>());
+                var parameterType = parameterValue.GetType();
+                if (parameterType.IsEnum)
+                {
+                    var cached = EnumMemberCache.GetOrAdd(parameterType, t => new ConcurrentDictionary<string, EnumMemberAttribute>());
+                    enummember = cached.GetOrAdd(parameterValue.ToString(), val => parameterType.GetMember(val).First().GetCustomAttribute<EnumMemberAttribute>());
+                }
             }
 
             return parameterValue == null


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Bug fix.

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

See: https://github.com/reactiveui/refit/issues/617.

**What is the new behavior?**
<!-- If this is a feature change -->

Query string paramter types that have enum properties will respect `[EnumMember(Value = "foo")]`.

i.e. Not just "direct parameter enums", but where your types have enum properties (see 617 for the example code).

**What might this PR break?**

I don't think it will break anything, as I have:

- Included appropriate passing tests.
- Checked that it doesn't break any existing tests.
- Should not break existing code (unless in the slim chance that they have types with enums for query string parameters which already have `EnumMember` on them, where that is currently achieving nothing, which would be "strange", but sadly not impossible...).

**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added / updated (for bug fixes / features).

**Other information**:

None.
