### PR TITLE
add a new property Name to MultipartItem class

### DIFF
--- a/Refit/MultipartItem.cs
+++ b/Refit/MultipartItem.cs
@@ -12,7 +12,11 @@ namespace Refit
             FileName = fileName ?? throw new ArgumentNullException("fileName");
             ContentType = contentType;
         }
-
+        public MultipartItem(string fileName, string contentType, string name) : this(fileName, contentType)
+        {
+            Name = name;
+        }
+        public string Name { get; }
         public string ContentType { get; }
 
         public string FileName { get; }
@@ -33,8 +37,8 @@ namespace Refit
 
     public class StreamPart : MultipartItem
     {
-        public StreamPart(Stream value, string fileName, string contentType = null) :
-            base(fileName, contentType)
+        public StreamPart(Stream value, string fileName, string contentType = null, string name = null) :
+            base(fileName, contentType, name)
         {
             Value = value ?? throw new ArgumentNullException("value");
         }
@@ -49,8 +53,8 @@ namespace Refit
 
     public class ByteArrayPart : MultipartItem
     {
-        public ByteArrayPart(byte[] value, string fileName, string contentType = null) :
-            base(fileName, contentType)
+        public ByteArrayPart(byte[] value, string fileName, string contentType = null, string name = null) :
+            base(fileName, contentType, name)
         {
             Value = value ?? throw new ArgumentNullException("value");
         }
@@ -65,8 +69,8 @@ namespace Refit
 
     public class FileInfoPart : MultipartItem
     {
-        public FileInfoPart(FileInfo value, string fileName, string contentType = null) :
-            base(fileName, contentType)
+        public FileInfoPart(FileInfo value, string fileName, string contentType = null, string name = null) :
+            base(fileName, contentType, name)
         {
             Value = value ?? throw new ArgumentNullException("value");
         }

--- a/Refit/RequestBuilderImplementation.cs
+++ b/Refit/RequestBuilderImplementation.cs
@@ -181,7 +181,7 @@ namespace Refit
             if (itemValue is MultipartItem multipartItem)
             {
                 var httpContent = multipartItem.ToContent();
-                multiPartContent.Add(httpContent, parameterName, string.IsNullOrEmpty(multipartItem.FileName) ? fileName : multipartItem.FileName);
+                multiPartContent.Add(httpContent, multipartItem.Name ?? parameterName, string.IsNullOrEmpty(multipartItem.FileName) ? fileName : multipartItem.FileName);
                 return;
             }
 


### PR DESCRIPTION
consider following suituation, my webapi get upload files from Request.Form.Files so that IFormFile.Name is very important.
```
[HttpPost("upload/{bucket}")]
public ApiResult<List<FileUploadResponseDTO>> FileUpload(string bucket)
{
    List<FileUploadResponseDTO> list = new List<FileUploadResponseDTO>();
    MediaFileUploadProvider mediaFile = new MediaFileUploadProvider(bucket);
    foreach (var file in Request.Form.Files)
    {
        var fileDTO = mediaFile.Execute(file.Name, file.FileName, file.OpenReadStream());
        if (fileDTO != null)
        {
            list.Add(fileDTO);
        }
    }
    return list;
}
```
IFormFile.Name determins file means, it can not use a fixed parameter name.

**What kind of change does this PR introduce?**
enhancement, let users can set Content-Disposition name  attribute when necessary.



**What is the current behavior?**
Always use the parameter name as the Content-Disposition name attribute.



**What is the new behavior?**
Add a new property Name to MultipartItem  class, so we can set it when necessary.



**What might this PR break?**
nothing


**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)



