### PR TITLE
Fix dictionary query request mapping

### DIFF
--- a/Refit/RequestBuilderImplementation.cs
+++ b/Refit/RequestBuilderImplementation.cs
@@ -416,9 +416,7 @@ namespace Refit
 
                 if (DoNotConvertToQueryMap(obj))
                 {
-                    var objType = obj.GetType();
-                    var formattedValue = settings.UrlParameterFormatter.Format(obj, objType, objType);
-                    kvps.Add(new KeyValuePair<string, object>(formattedKey, formattedValue));
+                    kvps.Add(new KeyValuePair<string, object>(formattedKey, obj));
                 }
                 else
                 {

--- a/Refit/RequestBuilderImplementation.cs
+++ b/Refit/RequestBuilderImplementation.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.ComponentModel.Design;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
@@ -410,15 +411,20 @@ namespace Refit
                 if (obj == null)
                     continue;
 
+                var keyType = key.GetType();
+                var formattedKey = settings.UrlParameterFormatter.Format(key, keyType, keyType);
+
                 if (DoNotConvertToQueryMap(obj))
                 {
-                    kvps.Add(new KeyValuePair<string, object>(key.ToString(), obj));
+                    var objType = obj.GetType();
+                    var formattedValue = settings.UrlParameterFormatter.Format(obj, objType, objType);
+                    kvps.Add(new KeyValuePair<string, object>(formattedKey, formattedValue));
                 }
                 else
                 {
                     foreach (var keyValuePair in BuildQueryMap(obj, delimiter))
                     {
-                        kvps.Add(new KeyValuePair<string, object>($"{key}{delimiter}{keyValuePair.Key}", keyValuePair.Value));
+                        kvps.Add(new KeyValuePair<string, object>($"{formattedKey}{delimiter}{keyValuePair.Key}", keyValuePair.Value));
                     }
                 }
             }

--- a/Refit/RequestBuilderImplementation.cs
+++ b/Refit/RequestBuilderImplementation.cs
@@ -361,7 +361,7 @@ namespace Refit
                 }
 
                 // If obj is IEnumerable - format it accounting for Query attribute and CollectionFormat
-                if (!(obj is string) && obj is IEnumerable ienu)
+                if (!(obj is string) && obj is IEnumerable ienu && !(obj is IDictionary))
                 {
                     foreach (var value in ParseEnumerableQueryParameterValue(ienu, propertyInfo, propertyInfo.PropertyType, queryAttribute))
                     {
@@ -404,8 +404,7 @@ namespace Refit
         {
             var kvps = new List<KeyValuePair<string, object>>();
 
-            var props = dictionary.Keys;
-            foreach (string key in props)
+            foreach (var key in dictionary.Keys)
             {
                 var obj = dictionary[key];
                 if (obj == null)
@@ -413,7 +412,7 @@ namespace Refit
 
                 if (DoNotConvertToQueryMap(obj))
                 {
-                    kvps.Add(new KeyValuePair<string, object>(key, obj));
+                    kvps.Add(new KeyValuePair<string, object>(key.ToString(), obj));
                 }
                 else
                 {


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bug fix


**What is the current behavior?**

In the current version (5.2.1), dictionary query parameters with non-string keys throw an exception: `'Unable to cast object of type 'Example.Enum' to type 'System.String'.'`.

Additionally, if the dictionary parameter is part of a complex object, the dictionary is serialized as `?DictionaryPropertyName=%5BKey%2C%20Value%5D`.

This latter issue is reported [here](https://github.com/reactiveui/refit/issues/971).


**What is the new behavior?**

The current query mapping code for IDictionary properties assumes that the dictionary key type is a string. This PR explicitly calls `ToString()` on the key before storing its value to the query map.

For dictionaries that are a property on a complex query object, the current behavior treats them the same as ordinary collections (e.g., implements `IEnumerable<T>`). This PR implements the quick fix offered by @ThomasSmeets to skip this handling and be handled by the appropriate query map method.


**What might this PR break?**

The change to handle IDictionary query parameters fixes an unhanded exception, this change is unlikely to break any existing assumptions.

The handling for IDictionary query properties that are part of a complex query objects may cause breaking changes for consumers who are expecting the previous serialization format (documented in [this issue](https://github.com/reactiveui/refit/issues/971)). However, prior to version 5.1.67, dictionary properties on query objects serialized as expected so this is likely a recent regression introduced by [issue #896](https://github.com/reactiveui/refit/pull/896) and consumers are unlikely to be relying on this strange serialization behavior.


**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
