### PR TITLE
fix [BUG] AuthorizeAttribute does not add a header to the request #946

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,10 +471,23 @@ Task<User> GetUser(string user, [Header("Authorization")] string authorization);
 var user = await GetUser("octocat", "token OAUTH-TOKEN"); 
 ```
 
-#### Authorization (Dynamic Headers redux)
+#### Dynamic authorization header with scheme
 The most common reason to use headers is for authorization. Today most API's use some flavor of oAuth with access tokens that expire and refresh tokens that are longer lived.
 
-One way to encapsulate these kinds of token usage, a custom `HttpClientHandler` can be inserted instead.  
+If you want to set an access token at runtime and specify the authorization scheme (e.g. "Bearer"),
+you can add a dynamic value to a request by applying an `Authorize` attribute to a parameter:
+
+```csharp
+[Get("/users/{user}")]
+Task<User> GetUser(string user, [Authorize("Bearer")] string token);
+
+// Will add the header "Authorization: Bearer OAUTH-TOKEN}" to the request
+var user = await GetUser("octocat", "OAUTH-TOKEN"); 
+```
+
+#### Authorization (Dynamic Headers redux)
+
+Another way to encapsulate these kinds of token usage, a custom `HttpClientHandler` can be inserted instead.  
 There are two classes for doing this: one is `AuthenticatedHttpClientHandler`, which takes a `Func<Task<string>>` parameter, where a signature can be generated without knowing about the request.
 The other is `AuthenticatedParameterizedHttpClientHandler`, which takes a `Func<HttpRequestMessage, Task<string>>` parameter, where the signature requires information about the request (see earlier notes about Twitter's API)
 

--- a/Refit.Tests/RequestBuilder.cs
+++ b/Refit.Tests/RequestBuilder.cs
@@ -51,6 +51,9 @@ namespace Refit.Tests
         IObservable<string> PostSomeUrlEncodedStuff([AliasAs("id")] int anId, [Body(BodySerializationMethod.UrlEncoded)] Dictionary<string, string> theData);
 
         [Get("/foo/bar/{id}")]
+        IObservable<string> FetchSomeStuffWithAuthorizationSchemeSpecified([AliasAs("id")] int anId, [Authorize("Bearer")] string token);
+
+        [Get("/foo/bar/{id}")]
         [Headers("Api-Version: 2 ")]
         Task<string> FetchSomeStuffWithHardcodedHeaders(int id);
 
@@ -480,6 +483,19 @@ namespace Refit.Tests
             Assert.NotNull(fixture.BodyParameterInfo);
             Assert.Empty(fixture.QueryParameterMap);
             Assert.Equal(1, fixture.BodyParameterInfo.Item3);
+        }
+
+        [Fact]
+        public void FindTheAuthorizeParameter()
+        {
+            var input = typeof(IRestMethodInfoTests);
+            var fixture = new RestMethodInfo(input, input.GetMethods().First(x => x.Name == nameof(IRestMethodInfoTests.FetchSomeStuffWithAuthorizationSchemeSpecified)));
+            Assert.Equal("id", fixture.ParameterMap[0].Name);
+            Assert.Equal(ParameterType.Normal, fixture.ParameterMap[0].Type);
+
+            Assert.NotNull(fixture.AuthorizeParameterInfo);
+            Assert.Empty(fixture.QueryParameterMap);
+            Assert.Equal(1, fixture.AuthorizeParameterInfo.Item2);
         }
 
         [Fact]

--- a/Refit/Attributes.cs
+++ b/Refit/Attributes.cs
@@ -207,10 +207,14 @@ namespace Refit
     }
 
     [AttributeUsage(AttributeTargets.Parameter)]
-    public class AuthorizeAttribute : HeaderAttribute
+    public class AuthorizeAttribute : Attribute
     {
         public AuthorizeAttribute(string scheme = "Bearer")
-            : base("Authorization: " + scheme) { }
+        {
+            Scheme = scheme;
+        }
+
+        public string Scheme { get; }
     }
 
     [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Property)] // Property is to allow for form url encoded data

--- a/Refit/RequestBuilderImplementation.cs
+++ b/Refit/RequestBuilderImplementation.cs
@@ -578,6 +578,12 @@ namespace Refit
                         isParameterMappedToRequest = true;
                     }
 
+                    //if authorize, add to request headers with scheme
+                    if (restMethod.AuthorizeParameterInfo != null && restMethod.AuthorizeParameterInfo.Item2 == i)
+                    {
+                        headersToAdd["Authorization"] = $"{restMethod.AuthorizeParameterInfo.Item1} {param}";
+                    }
+
                     // ignore nulls and already processed parameters
                     if (isParameterMappedToRequest || param == null) continue;
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**
This fixes the issue [BUG] AuthorizeAttribute does not add a header to the request #946



**What is the current behavior?**
In short: currently, the AuthorizeAttribute simply doesn't work. 
More in detail: there was an attempt to add an invalid header key, for example "Authorization: Bearer ", and a token as the value. This resulted in nothing being added at all.



**What is the new behavior?**
Now the AuthorizeAttribute isn't tightly coupled to the headers, but it's a self-contained Attribute instead, which allows us to build the correct Header and value in the RequestBuilderImplementation class.



**What might this PR break?**
May be something in rest info method could get read incorrectly.
However, I have fixed the query parameters map to ignore the value parameter with the AuthorizeAttribute.


**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:
I see two ways of fixing this issue:
1. Make the AuthorizeAttribute separate from the HeaderAttribute, so it can be handled in its own way.
2. Rewrite the HeaderAttribute handling logic to allow parsing more complex cases of header keys and values combinations.

I went with the first one, because it looked like the easy way and less chance to introduce bugs.

I have added a new section to the README file, thus I checked the "Docs have been added / updated (for bug fixes / features)". Is there any other docs that should've been updated?

I am open to comments and discussion on how to improve my PR. 
Or, if necessary, you can use this PR as inspiration to fix it yourself.