### PR TITLE
Use System.Text.Json by default

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -18,6 +18,7 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)buildtask.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
+    <DebugType>embedded</DebugType>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TF_BUILD)' == 'true'">

--- a/Refit.HttpClientFactory/HttpClientFactoryExtensions.cs
+++ b/Refit.HttpClientFactory/HttpClientFactoryExtensions.cs
@@ -89,7 +89,7 @@ namespace Refit
                            .AddTypedClient(refitInterfaceType, (client, serviceProvider) => RestService.For(refitInterfaceType, client, settings));
         }
 
-        private static IHttpClientBuilder AddTypedClient(this IHttpClientBuilder builder, Type type, Func<HttpClient, IServiceProvider, object> factory)
+        static IHttpClientBuilder AddTypedClient(this IHttpClientBuilder builder, Type type, Func<HttpClient, IServiceProvider, object> factory)
         {
             if (builder == null)
             {

--- a/Refit.HttpClientFactory/Refit.HttpClientFactory.csproj
+++ b/Refit.HttpClientFactory/Refit.HttpClientFactory.csproj
@@ -3,8 +3,7 @@
   <PropertyGroup>
     <Product>Refit HTTP Client Factory Extensions</Product>
     <Description>Refit HTTP Client Factory Extensions</Description>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <DebugType>embedded</DebugType>
+    <TargetFramework>netstandard2.0</TargetFramework>    
   </PropertyGroup>
 
   <ItemGroup>

--- a/Refit.Newtonsoft.Json/NewtonsoftJsonContentSerializer.cs
+++ b/Refit.Newtonsoft.Json/NewtonsoftJsonContentSerializer.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.IO;
+using System.Linq;
 using System.Net.Http;
+using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
@@ -15,7 +17,7 @@ namespace Refit
         /// <summary>
         /// The <see cref="Lazy{T}"/> instance providing the JSON serialization settings to use
         /// </summary>
-        private readonly Lazy<JsonSerializerSettings> jsonSerializerSettings;
+        readonly Lazy<JsonSerializerSettings> jsonSerializerSettings;
 
         /// <summary>
         /// Creates a new <see cref="NewtonsoftJsonContentSerializer"/> instance
@@ -51,6 +53,16 @@ namespace Refit
             using var jsonTextReader = new JsonTextReader(reader);
 
             return serializer.Deserialize<T>(jsonTextReader);
+        }
+
+        public string GetFieldNameForProperty(PropertyInfo propertyInfo)
+        {
+            if (propertyInfo is null)
+                throw new ArgumentNullException(nameof(propertyInfo));
+
+            return propertyInfo.GetCustomAttributes<JsonPropertyAttribute>(true)
+                              .Select(a => a.PropertyName)
+                              .FirstOrDefault();
         }
     }
 }

--- a/Refit.Newtonsoft.Json/Refit.Newtonsoft.Json.csproj
+++ b/Refit.Newtonsoft.Json/Refit.Newtonsoft.Json.csproj
@@ -1,0 +1,28 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <Product>Refit Serializer for Newtonsoft.Json ($(TargetFramework))</Product>
+    <Description>Refit Serializers for Newtonsoft.Json</Description>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net461</TargetFrameworks>
+    <GenerateDocumentationFile Condition=" '$(Configuration)' == 'Release' ">true</GenerateDocumentationFile>
+    <RootNamespace>Refit</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies"
+                      Version="1.0.0"
+                      PrivateAssets="All" />
+    <Reference Include="System.Web" />
+    <Reference Include="System.Net.Http" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Refit\Refit.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Refit.Tests/FormValueMultimapTests.cs
+++ b/Refit.Tests/FormValueMultimapTests.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
 
 using Newtonsoft.Json;
 
@@ -328,10 +329,12 @@ namespace Refit.Tests
             public string Foo { get; set; }
 
             [JsonProperty(PropertyName = "b")]
+            [JsonPropertyName("b")]
             public string Bar { get; set; }
 
             [AliasAs("a")]
             [JsonProperty(PropertyName = "z")]
+            [JsonPropertyName("z")]
             public string Baz { get; set; }
 
 

--- a/Refit.Tests/FormValueMultimapTests.cs
+++ b/Refit.Tests/FormValueMultimapTests.cs
@@ -11,7 +11,7 @@ namespace Refit.Tests
 {
     public class FormValueMultimapTests
     {
-        readonly RefitSettings settings = new RefitSettings();
+        readonly RefitSettings settings = new();
 
         [Fact]
         public void EmptyIfNullPassedIn()

--- a/Refit.Tests/GlobalSuppressions.cs
+++ b/Refit.Tests/GlobalSuppressions.cs
@@ -1,0 +1,9 @@
+﻿// This file is used by Code Analysis to maintain SuppressMessage
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given
+// a specific target and scoped to a namespace, type, member, etc.
+
+using System.Diagnostics.CodeAnalysis;
+
+[assembly: SuppressMessage("CodeQuality", "IDE0079:Remove unnecessary suppression", Justification = "<Pending>", Scope = "member", Target = "~T:Refit.Tests.RequestBuilderTests")]
+[assembly: SuppressMessage("CodeQuality", "IDE0079:Remove unnecessary suppression", Justification = "<Pending>", Scope = "member", Target = "~T:Refit.Tests.MultipartTests")]

--- a/Refit.Tests/MethodOverloads.cs
+++ b/Refit.Tests/MethodOverloads.cs
@@ -150,7 +150,7 @@ namespace Refit.Tests
             mockHttp.Expect(HttpMethod.Get, "https://httpbin.org/get")
                 .WithHeaders("X-Refit", "99")
                 .WithQueryString("param", "foo")
-                .Respond("application/json", "{'url': 'https://httpbin.org/get', 'args': {'param': 'foo'}}");
+                .Respond("application/json", "{\"url\": \"https://httpbin.org/get\", \"args\": {\"param\": \"foo\"}}");
 
             var fixture = RestService.For<IUseOverloadedGenericMethods<HttpBinGet, string, int>>("https://httpbin.org/", settings);
 
@@ -173,7 +173,7 @@ namespace Refit.Tests
             mockHttp.Expect(HttpMethod.Get, "https://httpbin.org/get")
                 .WithHeaders("X-Refit", "foo")
                 .WithQueryString("param", "99")
-                .Respond("application/json", "{'url': 'https://httpbin.org/get', 'args': {'param': '99'}}");
+                .Respond("application/json", "{\"url\": \"https://httpbin.org/get\", \"args\": {\"param\": \"99\"}}");
 
             var fixture = RestService.For<IUseOverloadedGenericMethods<HttpBinGet, string, int>>("https://httpbin.org/", settings);
 

--- a/Refit.Tests/MethodOverloads.cs
+++ b/Refit.Tests/MethodOverloads.cs
@@ -69,7 +69,7 @@ namespace Refit.Tests
 
             var resp = await fixture.Get(403);
 
-            Assert.True(!String.IsNullOrWhiteSpace(plainText));
+            Assert.True(!string.IsNullOrWhiteSpace(plainText));
             Assert.Equal(HttpStatusCode.Forbidden, resp.StatusCode);
 
         }

--- a/Refit.Tests/MultipartTests.cs
+++ b/Refit.Tests/MultipartTests.cs
@@ -306,8 +306,16 @@ namespace Refit.Tests
                 RequestAsserts = message =>
                 {
                     Assert.Equal(someHeader, message.Headers.Authorization.ToString());
+
+#if NET5_0
+                    Assert.Single(message.Options);
+                    Assert.Equal(someProperty, ((IDictionary<string, object>)message.Options)["SomeProperty"]);
+#endif
+
+#pragma warning disable CS0618 // Type or member is obsolete
                     Assert.Single(message.Properties);
                     Assert.Equal(someProperty, message.Properties["SomeProperty"]);
+#pragma warning restore CS0618 // Type or member is obsolete
                 },
                 Asserts = async content =>
                 {

--- a/Refit.Tests/MultipartTests.cs
+++ b/Refit.Tests/MultipartTests.cs
@@ -303,7 +303,7 @@ namespace Refit.Tests
 
             var handler = new MockHttpMessageHandler
             {
-                RequestAsserts = async message =>
+                RequestAsserts = message =>
                 {
                     Assert.Equal(someHeader, message.Headers.Authorization.ToString());
                     Assert.Single(message.Properties);
@@ -546,7 +546,7 @@ namespace Refit.Tests
         [InlineData(typeof(XmlContentSerializer), "application/xml")]
         public async Task MultipartUploadShouldWorkWithAnObject(Type contentSerializerType, string mediaType)
         {
-            if (!(Activator.CreateInstance(contentSerializerType) is IContentSerializer serializer))
+            if (Activator.CreateInstance(contentSerializerType) is not IContentSerializer serializer)
             {
                 throw new ArgumentException($"{contentSerializerType.FullName} does not implement {nameof(IContentSerializer)}");
             }
@@ -590,7 +590,7 @@ namespace Refit.Tests
         [InlineData(typeof(XmlContentSerializer), "application/xml")]
         public async Task MultipartUploadShouldWorkWithObjects(Type contentSerializerType, string mediaType)
         {
-            if (!(Activator.CreateInstance(contentSerializerType) is IContentSerializer serializer))
+            if (Activator.CreateInstance(contentSerializerType) is not IContentSerializer serializer)
             {
                 throw new ArgumentException($"{contentSerializerType.FullName} does not implement {nameof(IContentSerializer)}");
             }
@@ -787,7 +787,7 @@ namespace Refit.Tests
         {
             Assert.Throws<ArgumentNullException>(() =>
             {
-                var byteArrayPart = new ByteArrayPart(new byte[0], null, "application/pdf");
+                var byteArrayPart = new ByteArrayPart(Array.Empty<byte>(), null, "application/pdf");
             });
         }
 
@@ -831,7 +831,7 @@ namespace Refit.Tests
             return stream;
         }
 
-        bool StreamsEqual(Stream a, Stream b)
+        static bool StreamsEqual(Stream a, Stream b)
         {
             if (a == null &&
                 b == null)

--- a/Refit.Tests/Refit.Tests.csproj
+++ b/Refit.Tests/Refit.Tests.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="RichardSzalay.MockHttp" Version="6.0.0" />
     <ProjectReference Include="..\InterfaceStubGenerator.App\InterfaceStubGenerator.App.csproj" />
     <ProjectReference Include="..\Refit.HttpClientFactory\Refit.HttpClientFactory.csproj" />
-    <ProjectReference Include="..\Refit\Refit.csproj" />
+    <ProjectReference Include="..\Refit.Newtonsoft.Json\Refit.Newtonsoft.Json.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net461' ">

--- a/Refit.Tests/RefitStubs.Net46.cs
+++ b/Refit.Tests/RefitStubs.Net46.cs
@@ -532,9 +532,9 @@ namespace Refit.Tests
         }
 
         /// <inheritdoc />
-        Task IApiBindPathToObject.GetFoos2(List<int> Values)
+        Task IApiBindPathToObject.GetFoos2(List<int> values)
         {
-            var arguments = new object[] { Values };
+            var arguments = new object[] { values };
             var func = requestBuilder.BuildRestResultFuncForMethod("GetFoos2", new Type[] { typeof(List<int>) });
             return (Task)func(Client, arguments);
         }

--- a/Refit.Tests/RefitStubs.Net46.cs
+++ b/Refit.Tests/RefitStubs.Net46.cs
@@ -1857,6 +1857,7 @@ namespace Refit.Tests
     using global::Refit.Buffers;
     using global::Xunit;
     using JsonSerializer =  global::Newtonsoft.Json.JsonSerializer;
+    using global::System.Text.Json.Serialization;
 
     /// <inheritdoc />
     [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]

--- a/Refit.Tests/RefitStubs.Net5.cs
+++ b/Refit.Tests/RefitStubs.Net5.cs
@@ -532,9 +532,9 @@ namespace Refit.Tests
         }
 
         /// <inheritdoc />
-        Task IApiBindPathToObject.GetFoos2(List<int> Values)
+        Task IApiBindPathToObject.GetFoos2(List<int> values)
         {
-            var arguments = new object[] { Values };
+            var arguments = new object[] { values };
             var func = requestBuilder.BuildRestResultFuncForMethod("GetFoos2", new Type[] { typeof(List<int>) });
             return (Task)func(Client, arguments);
         }

--- a/Refit.Tests/RefitStubs.Net5.cs
+++ b/Refit.Tests/RefitStubs.Net5.cs
@@ -1857,6 +1857,7 @@ namespace Refit.Tests
     using global::Refit.Buffers;
     using global::Xunit;
     using JsonSerializer =  global::Newtonsoft.Json.JsonSerializer;
+    using global::System.Text.Json.Serialization;
 
     /// <inheritdoc />
     [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]

--- a/Refit.Tests/RefitStubs.NetCore2.cs
+++ b/Refit.Tests/RefitStubs.NetCore2.cs
@@ -532,9 +532,9 @@ namespace Refit.Tests
         }
 
         /// <inheritdoc />
-        Task IApiBindPathToObject.GetFoos2(List<int> Values)
+        Task IApiBindPathToObject.GetFoos2(List<int> values)
         {
-            var arguments = new object[] { Values };
+            var arguments = new object[] { values };
             var func = requestBuilder.BuildRestResultFuncForMethod("GetFoos2", new Type[] { typeof(List<int>) });
             return (Task)func(Client, arguments);
         }

--- a/Refit.Tests/RefitStubs.NetCore2.cs
+++ b/Refit.Tests/RefitStubs.NetCore2.cs
@@ -1857,6 +1857,7 @@ namespace Refit.Tests
     using global::Refit.Buffers;
     using global::Xunit;
     using JsonSerializer =  global::Newtonsoft.Json.JsonSerializer;
+    using global::System.Text.Json.Serialization;
 
     /// <inheritdoc />
     [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]

--- a/Refit.Tests/RefitStubs.NetCore3.cs
+++ b/Refit.Tests/RefitStubs.NetCore3.cs
@@ -532,9 +532,9 @@ namespace Refit.Tests
         }
 
         /// <inheritdoc />
-        Task IApiBindPathToObject.GetFoos2(List<int> Values)
+        Task IApiBindPathToObject.GetFoos2(List<int> values)
         {
-            var arguments = new object[] { Values };
+            var arguments = new object[] { values };
             var func = requestBuilder.BuildRestResultFuncForMethod("GetFoos2", new Type[] { typeof(List<int>) });
             return (Task)func(Client, arguments);
         }

--- a/Refit.Tests/RefitStubs.NetCore3.cs
+++ b/Refit.Tests/RefitStubs.NetCore3.cs
@@ -1857,6 +1857,7 @@ namespace Refit.Tests
     using global::Refit.Buffers;
     using global::Xunit;
     using JsonSerializer =  global::Newtonsoft.Json.JsonSerializer;
+    using global::System.Text.Json.Serialization;
 
     /// <inheritdoc />
     [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]

--- a/Refit.Tests/RequestBuilder.cs
+++ b/Refit.Tests/RequestBuilder.cs
@@ -1510,8 +1510,16 @@ namespace Refit.Tests
             var factory = fixture.BuildRequestFactoryForMethod(nameof(IDummyHttpApi.FetchSomeStuffWithDynamicRequestProperty));
             var output = factory(new object[] { 6, someProperty });
 
+#if NET5_0
+            Assert.NotEmpty(output.Options);
+            Assert.Equal(someProperty, ((IDictionary<string, object>)output.Options)["SomeProperty"]);
+#endif
+
+#pragma warning disable CS0618 // Type or member is obsolete
             Assert.NotEmpty(output.Properties);
             Assert.Equal(someProperty, output.Properties["SomeProperty"]);
+#pragma warning restore CS0618 // Type or member is obsolete
+
         }
 
         [Fact]
@@ -1523,9 +1531,17 @@ namespace Refit.Tests
             var factory = fixture.BuildRequestFactoryForMethod(nameof(IDummyHttpApi.FetchSomeStuffWithDynamicRequestPropertyWithoutKey));
             var output = factory(new object[] { 6, someProperty, someOtherProperty });
 
+#if NET5_0
+            Assert.NotEmpty(output.Options);
+            Assert.Equal(someProperty, ((IDictionary<string, object>)output.Options)["someValue"]);
+            Assert.Equal(someOtherProperty, ((IDictionary<string, object>)output.Options)["someOtherValue"]);
+#endif
+
+#pragma warning disable CS0618 // Type or member is obsolete
             Assert.NotEmpty(output.Properties);
             Assert.Equal(someProperty, output.Properties["someValue"]);
             Assert.Equal(someOtherProperty, output.Properties["someOtherValue"]);
+#pragma warning restore CS0618 // Type or member is obsolete
         }
 
         [Fact]
@@ -1537,8 +1553,16 @@ namespace Refit.Tests
             var factory = fixture.BuildRequestFactoryForMethod(nameof(IDummyHttpApi.FetchSomeStuffWithDynamicRequestPropertyWithDuplicateKey));
             var output = factory(new object[] { 6, someProperty, someOtherProperty });
 
+
+#if NET5_0
+            Assert.Single(output.Options);
+            Assert.Equal(someOtherProperty, ((IDictionary<string, object>)output.Options)["SomeProperty"]);
+#endif
+
+#pragma warning disable CS0618 // Type or member is obsolete
             Assert.Single(output.Properties);
             Assert.Equal(someOtherProperty, output.Properties["SomeProperty"]);
+#pragma warning restore CS0618 // Type or member is obsolete
         }
 
         [Fact]

--- a/Refit.Tests/ResponseTests.cs
+++ b/Refit.Tests/ResponseTests.cs
@@ -14,6 +14,7 @@ using Refit.Buffers;
 // for the code gen
 using Xunit;
 using JsonSerializer = Newtonsoft.Json.JsonSerializer;
+using System.Text.Json.Serialization;
 
 namespace Refit.Tests
 {
@@ -23,6 +24,7 @@ namespace Refit.Tests
         public string ShortNameForAlias { get; set; }
 
         [JsonProperty(PropertyName = "FIELD_WE_SHOULD_SHORTEN_WITH_JSON_PROPERTY")]
+        [JsonPropertyName("FIELD_WE_SHOULD_SHORTEN_WITH_JSON_PROPERTY")]
         public string ShortNameForJsonProperty { get; set; }
     }
 
@@ -52,7 +54,7 @@ namespace Refit.Tests
         public async Task JsonPropertyCanBeUsedToAliasFieldNamesInResponses()
         {
             mockHandler.Expect(HttpMethod.Get, "http://api/aliasTest")
-                .Respond("application/json", "{FIELD_WE_SHOULD_SHORTEN_WITH_ALIAS_AS: 'Hello', FIELD_WE_SHOULD_SHORTEN_WITH_JSON_PROPERTY: 'World'}");
+                .Respond("application/json", "{\"FIELD_WE_SHOULD_SHORTEN_WITH_ALIAS_AS\": \"Hello\", \"FIELD_WE_SHOULD_SHORTEN_WITH_JSON_PROPERTY\": \"World\"}");
 
             var result = await fixture.GetTestObject();
 
@@ -68,7 +70,7 @@ namespace Refit.Tests
         {
 
             mockHandler.Expect(HttpMethod.Get, "http://api/aliasTest")
-                .Respond("application/json", "{FIELD_WE_SHOULD_SHORTEN_WITH_ALIAS_AS: 'Hello', FIELD_WE_SHOULD_SHORTEN_WITH_JSON_PROPERTY: 'World'}");
+                .Respond("application/json", "{\"FIELD_WE_SHOULD_SHORTEN_WITH_ALIAS_AS\": \"Hello\", \"FIELD_WE_SHOULD_SHORTEN_WITH_JSON_PROPERTY\": \"World\"}");
 
             var result = await fixture.GetTestObject();
 

--- a/Refit.Tests/RestService.cs
+++ b/Refit.Tests/RestService.cs
@@ -1151,7 +1151,7 @@ namespace Refit.Tests
             };
 
             mockHttp.Expect(HttpMethod.Get, "https://registry.npmjs.org/congruence")
-                    .Respond("application/json", "{ '_id':'congruence', '_rev':'rev' , 'name':'name'}");
+                    .Respond("application/json", "{ \"_id\":\"congruence\", \"_rev\":\"rev\" , \"name\":\"name\"}");
 
 
 
@@ -1374,37 +1374,6 @@ namespace Refit.Tests
         }
 
         [Fact]
-        public async Task ErrorsFromApiReturnErrorContentNonAsync()
-        {
-            var mockHttp = new MockHttpMessageHandler();
-
-            var settings = new RefitSettings
-            {
-                HttpMessageHandlerFactory = () => mockHttp,
-                ContentSerializer = new NewtonsoftJsonContentSerializer(new JsonSerializerSettings() { ContractResolver = new SnakeCasePropertyNamesContractResolver() })
-            };
-
-            mockHttp.Expect(HttpMethod.Post, "https://api.github.com/users")
-                    .Respond(HttpStatusCode.BadRequest, "application/json", "{ 'errors': [ 'error1', 'message' ]}");
-
-
-            var fixture = RestService.For<IGitHubApi>("https://api.github.com", settings);
-
-
-            var result = await Assert.ThrowsAsync<ApiException>(async () => await fixture.CreateUser(new User { Name = "foo" }));
-
-
-#pragma warning disable CS0618 // Ensure that this code continues to be tested until it is removed
-            var errors = result.GetContentAs<ErrorResponse>();
-#pragma warning restore CS0618
-
-            Assert.Contains("error1", errors.Errors);
-            Assert.Contains("message", errors.Errors);
-
-            mockHttp.VerifyNoOutstandingExpectation();
-        }
-
-        [Fact]
         public void NonRefitInterfacesThrowMeaningfulExceptions()
         {
             try
@@ -1444,7 +1413,7 @@ namespace Refit.Tests
             mockHttp.Expect(HttpMethod.Get, "http://httpbin.org/get")
                     .WithHeaders("X-Refit", "99")
                     .WithQueryString("param", "foo")
-                    .Respond("application/json", "{'url': 'http://httpbin.org/get?param=foo', 'args': {'param': 'foo'}, 'headers':{'X-Refit':'99'}}");
+                    .Respond("application/json", "{\"url\": \"http://httpbin.org/get?param=foo\", \"args\": {\"param\": \"foo\"}, \"headers\":{\"X-Refit\":\"99\"}}");
 
 
 
@@ -1494,7 +1463,7 @@ namespace Refit.Tests
 
             mockHttp.Expect(HttpMethod.Get, "https://httpbin.org/get")
                 .WithHeaders("X-Refit", "99")
-                .Respond("application/json", "{'url': 'https://httpbin.org/get?FirstName=John&LastName=Rambo', 'args': {'FirstName': 'John', 'lName': 'Rambo'}}");
+                .Respond("application/json", "{\"url\": \"https://httpbin.org/get?FirstName=John&LastName=Rambo\", \"args\": {\"FirstName\": \"John\", \"lName\": \"Rambo\"}}");
 
             var myParams = new MySimpleQueryParams
             {
@@ -1521,7 +1490,7 @@ namespace Refit.Tests
             };
 
             mockHttp.Expect(HttpMethod.Get, "https://httpbin.org/get")
-                .Respond("application/json", "{'url': 'https://httpbin.org/get?hardcoded=true&FirstName=John&LastName=Rambo&Addr_Zip=9999&Addr_Street=HomeStreet 99&MetaData_Age=99&MetaData_Initials=JR&MetaData_Birthday=10%2F31%2F1918 4%3A21%3A16 PM&Other=12345&Other=10%2F31%2F2017 4%3A21%3A17 PM&Other=696e8653-6671-4484-a65f-9485af95fd3a', 'args': { 'Addr_Street': 'HomeStreet 99', 'Addr_Zip': '9999', 'FirstName': 'John', 'LastName': 'Rambo', 'MetaData_Age': '99', 'MetaData_Birthday': '10/31/1981 4:32:59 PM', 'MetaData_Initials': 'JR', 'Other': ['12345','10/31/2017 4:32:59 PM','60282dd2-f79a-4400-be01-bcb0e86e7bc6'], 'hardcoded': 'true'}}");
+                .Respond("application/json", "{\"url\": \"https://httpbin.org/get?hardcoded=true&FirstName=John&LastName=Rambo&Addr_Zip=9999&Addr_Street=HomeStreet 99&MetaData_Age=99&MetaData_Initials=JR&MetaData_Birthday=10%2F31%2F1918 4%3A21%3A16 PM&Other=12345&Other=10%2F31%2F2017 4%3A21%3A17 PM&Other=696e8653-6671-4484-a65f-9485af95fd3a\", \"args\": { \"Addr_Street\": \"HomeStreet 99\", \"Addr_Zip\": \"9999\", \"FirstName\": \"John\", \"LastName\": \"Rambo\", \"MetaData_Age\": \"99\", \"MetaData_Birthday\": \"10/31/1981 4:32:59 PM\", \"MetaData_Initials\": \"JR\", \"Other\": [\"12345\",\"10/31/2017 4:32:59 PM\",\"60282dd2-f79a-4400-be01-bcb0e86e7bc6\"], \"hardcoded\": \"true\"}}");
 
             var myParams = new MyComplexQueryParams
             {
@@ -1560,7 +1529,7 @@ namespace Refit.Tests
             };
 
             mockHttp.Expect(HttpMethod.Post, "https://httpbin.org/post")
-                .Respond("application/json", "{'url': 'https://httpbin.org/post?hardcoded=true&FirstName=John&LastName=Rambo&Addr_Zip=9999&Addr_Street=HomeStreet 99&MetaData_Age=99&MetaData_Initials=JR&MetaData_Birthday=10%2F31%2F1918 4%3A21%3A16 PM&Other=12345&Other=10%2F31%2F2017 4%3A21%3A17 PM&Other=696e8653-6671-4484-a65f-9485af95fd3a', 'args': { 'Addr_Street': 'HomeStreet 99', 'Addr_Zip': '9999', 'FirstName': 'John', 'LastName': 'Rambo', 'MetaData_Age': '99', 'MetaData_Birthday': '10/31/1981 4:32:59 PM', 'MetaData_Initials': 'JR', 'Other': ['12345','10/31/2017 4:32:59 PM','60282dd2-f79a-4400-be01-bcb0e86e7bc6'], 'hardcoded': 'true'}}");
+                .Respond("application/json", "{\"url\": \"https://httpbin.org/post?hardcoded=true&FirstName=John&LastName=Rambo&Addr_Zip=9999&Addr_Street=HomeStreet 99&MetaData_Age=99&MetaData_Initials=JR&MetaData_Birthday=10%2F31%2F1918 4%3A21%3A16 PM&Other=12345&Other=10%2F31%2F2017 4%3A21%3A17 PM&Other=696e8653-6671-4484-a65f-9485af95fd3a\", \"args\": { \"Addr_Street\": \"HomeStreet 99\", \"Addr_Zip\": \"9999\", \"FirstName\": \"John\", \"LastName\": \"Rambo\", \"MetaData_Age\": \"99\", \"MetaData_Birthday\": \"10/31/1981 4:32:59 PM\", \"MetaData_Initials\": \"JR\", \"Other\": [\"12345\",\"10/31/2017 4:32:59 PM\",\"60282dd2-f79a-4400-be01-bcb0e86e7bc6\"], \"hardcoded\": \"true\"}}");
 
             var myParams = new MyComplexQueryParams
             {
@@ -1682,7 +1651,7 @@ namespace Refit.Tests
             };
 
             mockHttp.Expect(HttpMethod.Get, "https://httpbin.org/get")
-                .Respond("application/json", "{'url': 'https://httpbin.org/get?hardcoded=true&FirstName=John&LastName=Rambo&Address_Zip=9999&Address_Street=HomeStreet 99', 'args': {'Address_Street': 'HomeStreet 99','Address_Zip': '9999','FirstName': 'John','LastName': 'Rambo','hardcoded': 'true'}}");
+                .Respond("application/json", "{\"url\": \"https://httpbin.org/get?hardcoded=true&FirstName=John&LastName=Rambo&Address_Zip=9999&Address_Street=HomeStreet 99\", \"args\": {\"Address_Street\": \"HomeStreet 99\",\"Address_Zip\": \"9999\",\"FirstName\": \"John\",\"LastName\": \"Rambo\",\"hardcoded\": \"true\"}}");
 
             var myParams = new Dictionary<string, object>
             {
@@ -1715,7 +1684,7 @@ namespace Refit.Tests
             };
 
             mockHttp.Expect(HttpMethod.Get, "https://httpbin.org/get")
-                .Respond("application/json", "{'url': 'https://httpbin.org/get?search.FirstName=John&search.LastName=Rambo&search.Addr.Zip=9999&search.Addr.Street=HomeStreet 99', 'args': {'search.Addr.Street': 'HomeStreet 99','search.Addr.Zip': '9999','search.FirstName': 'John','search.LastName': 'Rambo'}}");
+                .Respond("application/json", "{\"url\": \"https://httpbin.org/get?search.FirstName=John&search.LastName=Rambo&search.Addr.Zip=9999&search.Addr.Street=HomeStreet 99\", \"args\": {\"search.Addr.Street\": \"HomeStreet 99\",\"search.Addr.Zip\": \"9999\",\"search.FirstName\": \"John\",\"search.LastName\": \"Rambo\"}}");
 
             var myParams = new MyComplexQueryParams
             {

--- a/Refit.Tests/RestService.cs
+++ b/Refit.Tests/RestService.cs
@@ -78,7 +78,7 @@ namespace Refit.Tests
         Task GetFoos(PathBoundList request);
 
         [Get("/foos2/{values}")]
-        Task GetFoos2(List<int> Values);
+        Task GetFoos2(List<int> values);
 
         [Post("/foos/{request.someProperty}/bar/{request.someProperty2}")]
         Task PostFooBar(PathBoundObject request, [Body]object someObject);

--- a/Refit.Tests/SerializedContentTests.cs
+++ b/Refit.Tests/SerializedContentTests.cs
@@ -17,7 +17,7 @@ namespace Refit.Tests
         [InlineData(typeof(XmlContentSerializer))]
         public async Task WhenARequestRequiresABodyThenItDoesNotDeadlock(Type contentSerializerType)
         {
-            if (!(Activator.CreateInstance(contentSerializerType) is IContentSerializer serializer))
+            if (Activator.CreateInstance(contentSerializerType) is not IContentSerializer serializer)
             {
                 throw new ArgumentException($"{contentSerializerType.FullName} does not implement {nameof(IContentSerializer)}");
             }
@@ -45,7 +45,7 @@ namespace Refit.Tests
         [InlineData(typeof(XmlContentSerializer))]
         public async Task WhenARequestRequiresABodyThenItIsSerialized(Type contentSerializerType)
         {
-            if (!(Activator.CreateInstance(contentSerializerType) is IContentSerializer serializer))
+            if (Activator.CreateInstance(contentSerializerType) is not IContentSerializer serializer)
             {
                 throw new ArgumentException($"{contentSerializerType.FullName} does not implement {nameof(IContentSerializer)}");
             }
@@ -137,10 +137,8 @@ namespace Refit.Tests
             var serializer = new SystemTextJsonContentSerializer();
 
             var json = await serializer.SerializeAsync(model);
-
-            var stream = await json.ReadAsStreamAsync();
-
-            var result = await System.Text.Json.JsonSerializer.DeserializeAsync<TestAliasObject>(stream);
+            
+            var result = await serializer.DeserializeAsync<TestAliasObject>(json);
 
             Assert.NotNull(result);
             Assert.Equal(model.ShortNameForAlias, result.ShortNameForAlias);

--- a/Refit.Tests/SerializedContentTests.cs
+++ b/Refit.Tests/SerializedContentTests.cs
@@ -91,12 +91,12 @@ namespace Refit.Tests
             var settings = new RefitSettings();
 
             Assert.NotNull(settings.ContentSerializer);
-            Assert.IsType<NewtonsoftJsonContentSerializer>(settings.ContentSerializer);
+            Assert.IsType<SystemTextJsonContentSerializer>(settings.ContentSerializer);
 
-            settings = new RefitSettings(new SystemTextJsonContentSerializer());
+            settings = new RefitSettings(new NewtonsoftJsonContentSerializer());
 
             Assert.NotNull(settings.ContentSerializer);
-            Assert.IsType<SystemTextJsonContentSerializer>(settings.ContentSerializer);
+            Assert.IsType<NewtonsoftJsonContentSerializer>(settings.ContentSerializer);
         }
 
         /// <summary>

--- a/Refit.sln
+++ b/Refit.sln
@@ -30,6 +30,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "InterfaceStubGenerator.Buil
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Refit.HttpClientFactory", "Refit.HttpClientFactory\Refit.HttpClientFactory.csproj", "{01AE14AC-88D1-49C4-A612-2F9B2DEB5DEA}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Refit.Newtonsoft.Json", "Refit.Newtonsoft.Json\Refit.Newtonsoft.Json.csproj", "{2210E606-1C91-4EA0-8876-3B2F501F2669}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -138,6 +140,22 @@ Global
 		{01AE14AC-88D1-49C4-A612-2F9B2DEB5DEA}.Release|x64.Build.0 = Release|Any CPU
 		{01AE14AC-88D1-49C4-A612-2F9B2DEB5DEA}.Release|x86.ActiveCfg = Release|Any CPU
 		{01AE14AC-88D1-49C4-A612-2F9B2DEB5DEA}.Release|x86.Build.0 = Release|Any CPU
+		{2210E606-1C91-4EA0-8876-3B2F501F2669}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2210E606-1C91-4EA0-8876-3B2F501F2669}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2210E606-1C91-4EA0-8876-3B2F501F2669}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{2210E606-1C91-4EA0-8876-3B2F501F2669}.Debug|ARM.Build.0 = Debug|Any CPU
+		{2210E606-1C91-4EA0-8876-3B2F501F2669}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{2210E606-1C91-4EA0-8876-3B2F501F2669}.Debug|x64.Build.0 = Debug|Any CPU
+		{2210E606-1C91-4EA0-8876-3B2F501F2669}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{2210E606-1C91-4EA0-8876-3B2F501F2669}.Debug|x86.Build.0 = Debug|Any CPU
+		{2210E606-1C91-4EA0-8876-3B2F501F2669}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2210E606-1C91-4EA0-8876-3B2F501F2669}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2210E606-1C91-4EA0-8876-3B2F501F2669}.Release|ARM.ActiveCfg = Release|Any CPU
+		{2210E606-1C91-4EA0-8876-3B2F501F2669}.Release|ARM.Build.0 = Release|Any CPU
+		{2210E606-1C91-4EA0-8876-3B2F501F2669}.Release|x64.ActiveCfg = Release|Any CPU
+		{2210E606-1C91-4EA0-8876-3B2F501F2669}.Release|x64.Build.0 = Release|Any CPU
+		{2210E606-1C91-4EA0-8876-3B2F501F2669}.Release|x86.ActiveCfg = Release|Any CPU
+		{2210E606-1C91-4EA0-8876-3B2F501F2669}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Refit/CachedRequestBuilderImplementation.cs
+++ b/Refit/CachedRequestBuilderImplementation.cs
@@ -20,7 +20,7 @@ namespace Refit
         }
 
         readonly IRequestBuilder innerBuilder;
-        readonly ConcurrentDictionary<string, Func<HttpClient, object[], object>> methodDictionary = new ConcurrentDictionary<string, Func<HttpClient, object[], object>>();
+        readonly ConcurrentDictionary<string, Func<HttpClient, object[], object>> methodDictionary = new();
 
         public Func<HttpClient, object[], object> BuildRestResultFuncForMethod(string methodName, Type[] parameterTypes = null, Type[] genericArgumentTypes = null)
         {

--- a/Refit/FormValueMultimap.cs
+++ b/Refit/FormValueMultimap.cs
@@ -5,8 +5,6 @@ using System.Linq;
 using System.Reflection;
 using System.Text.Json.Serialization;
 
-using Newtonsoft.Json;
-
 namespace Refit
 {
     /// <summary>
@@ -22,8 +20,14 @@ namespace Refit
 
         readonly IList<KeyValuePair<string, string>> formEntries = new List<KeyValuePair<string, string>>();
 
+        readonly IContentSerializer contentSerializer;
+
         public FormValueMultimap(object source, RefitSettings settings)
         {
+            if (settings is null)
+                throw new ArgumentNullException(nameof(settings));
+            contentSerializer = settings.ContentSerializer;
+
             if (source == null) return;
 
             if (source is IDictionary dictionary)
@@ -120,12 +124,7 @@ namespace Refit
             var name = propertyInfo.GetCustomAttributes<AliasAsAttribute>(true)
                                .Select(a => a.Name)
                                .FirstOrDefault()
-                   ?? propertyInfo.GetCustomAttributes<JsonPropertyAttribute>(true)
-                                  .Select(a => a.PropertyName)
-                                  .FirstOrDefault()
-                   ?? propertyInfo.GetCustomAttributes<JsonPropertyNameAttribute>(true)
-                       .Select(a => a.Name)
-                       .FirstOrDefault()
+                   ?? contentSerializer.GetFieldNameForProperty(propertyInfo)
                    ?? propertyInfo.Name;
 
             var qattrib = propertyInfo.GetCustomAttributes<QueryAttribute>(true)

--- a/Refit/FormValueMultimap.cs
+++ b/Refit/FormValueMultimap.cs
@@ -15,8 +15,7 @@ namespace Refit
     /// same or different values.</remarks>
     class FormValueMultimap : IEnumerable<KeyValuePair<string, string>>
     {
-        static readonly Dictionary<Type, PropertyInfo[]> PropertyCache
-            = new Dictionary<Type, PropertyInfo[]>();
+        static readonly Dictionary<Type, PropertyInfo[]> PropertyCache = new();
 
         readonly IList<KeyValuePair<string, string>> formEntries = new List<KeyValuePair<string, string>>();
 

--- a/Refit/FormValueMultimap.cs
+++ b/Refit/FormValueMultimap.cs
@@ -133,7 +133,7 @@ namespace Refit
             return qattrib ?? name;
         }
 
-        PropertyInfo[] GetProperties(Type type)
+        static PropertyInfo[] GetProperties(Type type)
         {
             return type.GetProperties(BindingFlags.Instance | BindingFlags.Public)
                        .Where(p => p.CanRead && p.GetMethod.IsPublic)

--- a/Refit/JsonContentSerializer.cs
+++ b/Refit/JsonContentSerializer.cs
@@ -1,49 +1,28 @@
 ﻿using System;
 using System.IO;
 using System.Net.Http;
+using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
 
 namespace Refit
 {
-    [Obsolete("Use NewtonsoftJsonContentSerializer instead", false)]
+    [Obsolete("Use NewtonsoftJsonContentSerializer in the Refit.Newtonsoft.Json package instead", true)]
     public class JsonContentSerializer : IContentSerializer
     {
-        readonly Lazy<JsonSerializerSettings> jsonSerializerSettings;
-
-        public JsonContentSerializer() : this(null) { }
-
-        public JsonContentSerializer(JsonSerializerSettings jsonSerializerSettings)
-        {
-            this.jsonSerializerSettings = new Lazy<JsonSerializerSettings>(() =>
-            {
-                if (jsonSerializerSettings == null)
-                {
-                    if (JsonConvert.DefaultSettings == null)
-                    {
-                        return new JsonSerializerSettings();
-                    }
-                    return JsonConvert.DefaultSettings();
-                }
-                return jsonSerializerSettings;
-            });
-        }
-
         public Task<HttpContent> SerializeAsync<T>(T item)
         {
-            var content = new StringContent(JsonConvert.SerializeObject(item, jsonSerializerSettings.Value), Encoding.UTF8, "application/json");
-            return Task.FromResult((HttpContent)content);
+            throw new NotImplementedException();
         }
 
-        public async Task<T> DeserializeAsync<T>(HttpContent content)
+        public Task<T> DeserializeAsync<T>(HttpContent content)
         {
-            var serializer = JsonSerializer.Create(jsonSerializerSettings.Value);
+            throw new NotImplementedException();
+        }
 
-            using var stream = await content.ReadAsStreamAsync().ConfigureAwait(false);
-            using var reader = new StreamReader(stream);
-            using var jsonTextReader = new JsonTextReader(reader);
-            return serializer.Deserialize<T>(jsonTextReader);
+        public string GetFieldNameForProperty(PropertyInfo propertyInfo)
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/Refit/ProblemDetails.cs
+++ b/Refit/ProblemDetails.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Refit
 {
@@ -18,7 +18,7 @@ namespace Refit
         /// Collection of ProblemDetails extensions
         /// </summary>
         [JsonExtensionData]
-        public IDictionary<string, object> Extensions { get; } = new Dictionary<string, object>(StringComparer.Ordinal);
+        public IDictionary<string, object> Extensions { get; set; } = new Dictionary<string, object>(StringComparer.Ordinal);
 
         /// <summary>
         /// A URI reference that identifies the problem type.

--- a/Refit/Refit.csproj
+++ b/Refit/Refit.csproj
@@ -4,11 +4,9 @@
     <Product>Refit ($(TargetFramework))</Product>
     <TargetFrameworks>netstandard2.0;netstandard2.1;net461</TargetFrameworks>
     <GenerateDocumentationFile Condition=" '$(Configuration)' == 'Release' ">true</GenerateDocumentationFile>
-    <DebugType>embedded</DebugType>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="System.Text.Json" Version="5.0.0" />
   </ItemGroup>
   

--- a/Refit/Refit.csproj
+++ b/Refit/Refit.csproj
@@ -7,10 +7,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Text.Json" Version="5.0.0" />
+    <PackageReference Condition="'$(TargetFramework)' != 'net5.0'" Include="System.Text.Json" Version="5.0.0" />
   </ItemGroup>
   
   <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies"
+                  Version="1.0.0"
+                  PrivateAssets="All" />
     <Reference Include="System.Web" />
     <Reference Include="System.Net.Http" />
   </ItemGroup>

--- a/Refit/Refit.csproj
+++ b/Refit/Refit.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Product>Refit ($(TargetFramework))</Product>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net461</TargetFrameworks>
+    <TargetFrameworks>net5.0;netstandard2.0;netstandard2.1;net461</TargetFrameworks>
     <GenerateDocumentationFile Condition=" '$(Configuration)' == 'Release' ">true</GenerateDocumentationFile>
   </PropertyGroup>
 

--- a/Refit/RefitSettings.cs
+++ b/Refit/RefitSettings.cs
@@ -94,8 +94,7 @@ namespace Refit
 
     public class DefaultUrlParameterFormatter : IUrlParameterFormatter
     {
-        static readonly ConcurrentDictionary<Type, ConcurrentDictionary<string, EnumMemberAttribute>> EnumMemberCache
-            = new ConcurrentDictionary<Type, ConcurrentDictionary<string, EnumMemberAttribute>>();
+        static readonly ConcurrentDictionary<Type, ConcurrentDictionary<string, EnumMemberAttribute>> EnumMemberCache = new();
 
         public virtual string Format(object parameterValue, ICustomAttributeProvider attributeProvider, Type type)
         {
@@ -129,7 +128,7 @@ namespace Refit
     public class DefaultFormUrlEncodedParameterFormatter : IFormUrlEncodedParameterFormatter
     {
         static readonly ConcurrentDictionary<Type, ConcurrentDictionary<string, EnumMemberAttribute>> EnumMemberCache
-            = new ConcurrentDictionary<Type, ConcurrentDictionary<string, EnumMemberAttribute>>();
+            = new();
 
         public virtual string Format(object parameterValue, string formatString)
         {

--- a/Refit/RefitSettings.cs
+++ b/Refit/RefitSettings.cs
@@ -7,20 +7,17 @@ using System.Reflection;
 using System.Runtime.Serialization;
 using System.Threading.Tasks;
 
-using Newtonsoft.Json;
-
 namespace Refit
 {
     public class RefitSettings
-    {
-        JsonSerializerSettings jsonSerializerSettings;
+    {       
 
         /// <summary>
         /// Creates a new <see cref="RefitSettings"/> instance with the default parameters
         /// </summary>
         public RefitSettings()
         {
-            ContentSerializer = new NewtonsoftJsonContentSerializer();
+            ContentSerializer = new SystemTextJsonContentSerializer();
             UrlParameterFormatter = new DefaultUrlParameterFormatter();
             FormUrlEncodedParameterFormatter = new DefaultFormUrlEncodedParameterFormatter();
             ExceptionFactory = new DefaultApiExceptionFactory(this).CreateAsync;
@@ -64,17 +61,6 @@ namespace Refit
         /// </summary>
         public Func<HttpResponseMessage, Task<Exception>> ExceptionFactory { get; set; }
 
-        [Obsolete("Set RefitSettings.ContentSerializer = new NewtonsoftJsonContentSerializer(JsonSerializerSettings) instead.", false)]
-        public JsonSerializerSettings JsonSerializerSettings
-        {
-            get => jsonSerializerSettings;
-            set
-            {
-                jsonSerializerSettings = value;
-                ContentSerializer = new JsonContentSerializer(value);
-            }
-        }
-
         public IContentSerializer ContentSerializer { get; set; }
         public IUrlParameterFormatter UrlParameterFormatter { get; set; }
         public IFormUrlEncodedParameterFormatter FormUrlEncodedParameterFormatter { get; set; }
@@ -87,6 +73,13 @@ namespace Refit
         Task<HttpContent> SerializeAsync<T>(T item);
 
         Task<T> DeserializeAsync<T>(HttpContent content);
+
+        /// <summary>
+        /// Calculates what the field name should be for the given property. This may be affected by custom attributes the serializer understands
+        /// </summary>
+        /// <param name="propertyInfo"></param>
+        /// <returns></returns>
+        string GetFieldNameForProperty(PropertyInfo propertyInfo);
     }
 
     public interface IUrlParameterFormatter

--- a/Refit/RequestBuilderImplementation.cs
+++ b/Refit/RequestBuilderImplementation.cs
@@ -95,7 +95,7 @@ namespace Refit
 
                 var isGeneric = genericArgumentTypes?.Length > 0;
 
-                var possibleMethodsList = httpMethods.Where(method => method.MethodInfo.GetParameters().Length == parameterTypes.Count());
+                var possibleMethodsList = httpMethods.Where(method => method.MethodInfo.GetParameters().Length == parameterTypes.Length);
 
                 // If it's a generic method, add that filter
                 if (isGeneric)
@@ -667,7 +667,7 @@ namespace Refit
                     // sure we have an HttpContent object to add them to,
                     // provided the HttpClient will allow it for the method
                     if (ret.Content == null && !BodylessMethods.Contains(ret.Method))
-                        ret.Content = new ByteArrayContent(new byte[0]);
+                        ret.Content = new ByteArrayContent(Array.Empty<byte>());
 
                     foreach (var header in headersToAdd)
                     {
@@ -677,7 +677,11 @@ namespace Refit
 
                 foreach (var property in propertiesToAdd)
                 {
+#if NET5_0
+                    ret.Options.Set(new HttpRequestOptionsKey<object>(property.Key), property.Value);
+#else
                     ret.Properties[property.Key] = property.Value;
+#endif
                 }
 
                 // NB: The URI methods in .NET are dumb. Also, we do this

--- a/Refit/RequestBuilderImplementation.cs
+++ b/Refit/RequestBuilderImplementation.cs
@@ -284,7 +284,7 @@ namespace Refit
             };
         }
 
-        private async Task<T> DeserializeContentAsync<T>(HttpResponseMessage resp, HttpContent content)
+        async Task<T> DeserializeContentAsync<T>(HttpResponseMessage resp, HttpContent content)
         {
             T result;
             if (typeof(T) == typeof(HttpResponseMessage))

--- a/Refit/RestMethodInfo.cs
+++ b/Refit/RestMethodInfo.cs
@@ -38,8 +38,8 @@ namespace Refit
         public bool IsApiResponse { get; }
         public bool ShouldDisposeResponse { get; private set; }
 
-        static readonly Regex ParameterRegex = new Regex(@"{(.*?)}");
-        static readonly HttpMethod PatchMethod = new HttpMethod("PATCH");
+        static readonly Regex ParameterRegex = new(@"{(.*?)}");
+        static readonly HttpMethod PatchMethod = new("PATCH");
 
         public RestMethodInfo(Type targetInterface, MethodInfo methodInfo, RefitSettings refitSettings = null)
         {

--- a/Refit/RestService.cs
+++ b/Refit/RestService.cs
@@ -6,7 +6,7 @@ namespace Refit
 {
     public static class RestService
     {
-        static readonly ConcurrentDictionary<Type, Type> TypeMapping = new ConcurrentDictionary<Type, Type>();
+        static readonly ConcurrentDictionary<Type, Type> TypeMapping = new();
 
         public static T For<T>(HttpClient client, IRequestBuilder<T> builder)
         {
@@ -89,7 +89,7 @@ namespace Refit
 
         static Type GetGeneratedType(Type refitInterfaceType)
         {
-            string typeName = UniqueName.ForType(refitInterfaceType);
+            var typeName = UniqueName.ForType(refitInterfaceType);
 
             var generatedType = Type.GetType(typeName);
 

--- a/Refit/SystemTextJsonContentSerializer.cs
+++ b/Refit/SystemTextJsonContentSerializer.cs
@@ -1,11 +1,15 @@
 ﻿using System;
 using System.Buffers;
+using System.Collections.Generic;
 using System.Diagnostics.Contracts;
+using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using Refit.Buffers;
 
@@ -19,12 +23,21 @@ namespace Refit
         /// <summary>
         /// The JSON serialization options to use
         /// </summary>
-        private readonly JsonSerializerOptions jsonSerializerOptions;
+        readonly JsonSerializerOptions jsonSerializerOptions;
 
         /// <summary>
         /// Creates a new <see cref="SystemTextJsonContentSerializer"/> instance
         /// </summary>
-        public SystemTextJsonContentSerializer() : this(new JsonSerializerOptions()) { }
+        public SystemTextJsonContentSerializer() : this(new JsonSerializerOptions())
+        {
+
+            // Set some defaults
+            // Default to case insensitive property name matching as that's likely the behavior most users expect
+            jsonSerializerOptions.PropertyNameCaseInsensitive = true;
+            jsonSerializerOptions.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
+            jsonSerializerOptions.Converters.Add(new ObjectToInferredTypesConverter());
+            jsonSerializerOptions.Converters.Add(new JsonStringEnumConverter(JsonNamingPolicy.CamelCase));
+        }
 
         /// <summary>
         /// Creates a new <see cref="SystemTextJsonContentSerializer"/> instance with the specified parameters
@@ -105,12 +118,76 @@ namespace Refit
         /// <returns>A <typeparamref name="T"/> item deserialized from the UTF8 bytes within <paramref name="buffer"/></returns>
         [Pure]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static T Deserialize<T>(byte[] buffer, int length, JsonSerializerOptions jsonSerializerOptions)
+        static T Deserialize<T>(byte[] buffer, int length, JsonSerializerOptions jsonSerializerOptions)
         {
             var span = new ReadOnlySpan<byte>(buffer, 0, length);
             var utf8JsonReader = new Utf8JsonReader(span);
 
             return JsonSerializer.Deserialize<T>(ref utf8JsonReader, jsonSerializerOptions);
         }
+
+        public string GetFieldNameForProperty(PropertyInfo propertyInfo)
+        {
+            if (propertyInfo is null)
+                throw new ArgumentNullException(nameof(propertyInfo));
+
+            return propertyInfo.GetCustomAttributes<JsonPropertyNameAttribute>(true)
+                       .Select(a => a.Name)
+                       .FirstOrDefault();
+        }
     }
+
+    // From https://docs.microsoft.com/en-us/dotnet/standard/serialization/system-text-json-converters-how-to?pivots=dotnet-5-0#deserialize-inferred-types-to-object-properties
+    public class ObjectToInferredTypesConverter
+       : JsonConverter<object>
+    {
+        public override object Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options)
+        {
+            if (reader.TokenType == JsonTokenType.True)
+            {
+                return true;
+            }
+
+            if (reader.TokenType == JsonTokenType.False)
+            {
+                return false;
+            }
+
+            if (reader.TokenType == JsonTokenType.Number)
+            {
+                if (reader.TryGetInt64(out long l))
+                {
+                    return l;
+                }
+
+                return reader.GetDouble();
+            }
+
+            if (reader.TokenType == JsonTokenType.String)
+            {
+                if (reader.TryGetDateTime(out DateTime datetime))
+                {
+                    return datetime;
+                }
+
+                return reader.GetString();
+            }
+
+            // Use JsonElement as fallback.
+            // Newtonsoft uses JArray or JObject.
+            using JsonDocument document = JsonDocument.ParseValue(ref reader);
+            return document.RootElement.Clone();
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            object objectToWrite,
+            JsonSerializerOptions options) =>
+                throw new InvalidOperationException("Should not get here.");
+    }
+
 }
+

--- a/Refit/SystemTextJsonContentSerializer.cs
+++ b/Refit/SystemTextJsonContentSerializer.cs
@@ -158,7 +158,7 @@ namespace Refit
 
             if (reader.TokenType == JsonTokenType.Number)
             {
-                if (reader.TryGetInt64(out long l))
+                if (reader.TryGetInt64(out var l))
                 {
                     return l;
                 }
@@ -168,7 +168,7 @@ namespace Refit
 
             if (reader.TokenType == JsonTokenType.String)
             {
-                if (reader.TryGetDateTime(out DateTime datetime))
+                if (reader.TryGetDateTime(out var datetime))
                 {
                     return datetime;
                 }
@@ -178,7 +178,7 @@ namespace Refit
 
             // Use JsonElement as fallback.
             // Newtonsoft uses JArray or JObject.
-            using JsonDocument document = JsonDocument.ParseValue(ref reader);
+            using var document = JsonDocument.ParseValue(ref reader);
             return document.RootElement.Clone();
         }
 

--- a/Refit/ValidationApiException.cs
+++ b/Refit/ValidationApiException.cs
@@ -10,7 +10,7 @@ namespace Refit
     [Serializable]
     public class ValidationApiException : ApiException
     {
-        static readonly JsonSerializerOptions SerializerOptions = new JsonSerializerOptions();
+        static readonly JsonSerializerOptions SerializerOptions = new();
 
         static ValidationApiException()
         {

--- a/Refit/XmlContentSerializer.cs
+++ b/Refit/XmlContentSerializer.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.IO;
+using System.Linq;
 using System.Net.Http;
+using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
 using System.Xml;
@@ -49,6 +51,20 @@ namespace Refit
             using var input = new StringReader(await content.ReadAsStringAsync().ConfigureAwait(false));
             using var reader = XmlReader.Create(input, settings.XmlReaderWriterSettings.ReaderSettings);
             return (T)xmlSerializer.Deserialize(reader);
+        }
+
+        public string GetFieldNameForProperty(PropertyInfo propertyInfo)
+        {
+            if (propertyInfo is null)
+                throw new ArgumentNullException(nameof(propertyInfo));
+
+            return propertyInfo.GetCustomAttributes<XmlElementAttribute>(true)
+                       .Select(a => a.ElementName)
+                       .FirstOrDefault()
+                  ??
+                  propertyInfo.GetCustomAttributes<XmlAttributeAttribute>(true)
+                       .Select(a => a.AttributeName)
+                       .FirstOrDefault();
         }
     }
 

--- a/Refit/XmlContentSerializer.cs
+++ b/Refit/XmlContentSerializer.cs
@@ -15,7 +15,7 @@ namespace Refit
     public class XmlContentSerializer : IContentSerializer
     {
         readonly XmlContentSerializerSettings settings;
-        readonly ConcurrentDictionary<Type, XmlSerializer> serializerCache = new ConcurrentDictionary<Type, XmlSerializer>();
+        readonly ConcurrentDictionary<Type, XmlSerializer> serializerCache = new();
 
         public XmlContentSerializer() : this(new XmlContentSerializerSettings())
         {


### PR DESCRIPTION
Implements and fixes #981

Refit now uses System.Text.Json by default and provides a new package containing support for Newtonsoft.Json.

Todo: Update docs.

@anaisbetts @bennor 