### PR TITLE
Fixes issue #952 - did not write everything to output stream

### DIFF
--- a/Refit.Tests/RefitStubs.Net46.cs
+++ b/Refit.Tests/RefitStubs.Net46.cs
@@ -2542,6 +2542,14 @@ namespace Refit.Tests
             var func = requestBuilder.BuildRestResultFuncForMethod("PostGeneric", new Type[] { typeof(T) }, new Type[] { typeof(T) });
             return (Task)func(Client, arguments);
         }
+
+        /// <inheritdoc />
+        Task IRequestBin.PostBig(BigObject big)
+        {
+            var arguments = new object[] { big };
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostBig", new Type[] { typeof(BigObject) });
+            return (Task)func(Client, arguments);
+        }
     }
 }
 

--- a/Refit.Tests/RefitStubs.Net5.cs
+++ b/Refit.Tests/RefitStubs.Net5.cs
@@ -2542,6 +2542,14 @@ namespace Refit.Tests
             var func = requestBuilder.BuildRestResultFuncForMethod("PostGeneric", new Type[] { typeof(T) }, new Type[] { typeof(T) });
             return (Task)func(Client, arguments);
         }
+
+        /// <inheritdoc />
+        Task IRequestBin.PostBig(BigObject big)
+        {
+            var arguments = new object[] { big };
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostBig", new Type[] { typeof(BigObject) });
+            return (Task)func(Client, arguments);
+        }
     }
 }
 

--- a/Refit.Tests/RefitStubs.NetCore2.cs
+++ b/Refit.Tests/RefitStubs.NetCore2.cs
@@ -2542,6 +2542,14 @@ namespace Refit.Tests
             var func = requestBuilder.BuildRestResultFuncForMethod("PostGeneric", new Type[] { typeof(T) }, new Type[] { typeof(T) });
             return (Task)func(Client, arguments);
         }
+
+        /// <inheritdoc />
+        Task IRequestBin.PostBig(BigObject big)
+        {
+            var arguments = new object[] { big };
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostBig", new Type[] { typeof(BigObject) });
+            return (Task)func(Client, arguments);
+        }
     }
 }
 

--- a/Refit.Tests/RefitStubs.NetCore3.cs
+++ b/Refit.Tests/RefitStubs.NetCore3.cs
@@ -2542,6 +2542,14 @@ namespace Refit.Tests
             var func = requestBuilder.BuildRestResultFuncForMethod("PostGeneric", new Type[] { typeof(T) }, new Type[] { typeof(T) });
             return (Task)func(Client, arguments);
         }
+
+        /// <inheritdoc />
+        Task IRequestBin.PostBig(BigObject big)
+        {
+            var arguments = new object[] { big };
+            var func = requestBuilder.BuildRestResultFuncForMethod("PostBig", new Type[] { typeof(BigObject) });
+            return (Task)func(Client, arguments);
+        }
     }
 }
 

--- a/Refit/Buffers/PooledBufferWriter.Stream.NETStandard21.cs
+++ b/Refit/Buffers/PooledBufferWriter.Stream.NETStandard21.cs
@@ -14,18 +14,17 @@ namespace Refit.Buffers
         private sealed partial class PooledMemoryStream : Stream
         {
             /// <inheritdoc/>
-            public override void CopyTo(Stream destination, int bufferSize)
+            public Task CopyToInternalAsync(Stream destination, CancellationToken cancellationToken)
             {
                 if (pooledBuffer is null) ThrowObjectDisposedException();
 
                 var bytesAvailable = length - position;
-                var spanLength = Math.Min(bytesAvailable, bufferSize);
 
-                var source = pooledBuffer.AsSpan(position, spanLength);
+                var source = pooledBuffer.AsMemory(position, bytesAvailable);
 
                 position += source.Length;
 
-                destination.Write(source);
+                return destination.WriteAsync(source, cancellationToken).AsTask();
             }
 
             /// <inheritdoc/>

--- a/Refit/Buffers/PooledBufferWriter.Stream.NETStandard21.cs
+++ b/Refit/Buffers/PooledBufferWriter.Stream.NETStandard21.cs
@@ -1,4 +1,4 @@
-﻿#if NETSTANDARD2_1
+﻿#if NETSTANDARD2_1 || NET5_0
 
 using System;
 using System.IO;

--- a/Refit/Buffers/PooledBufferWriter.Stream.cs
+++ b/Refit/Buffers/PooledBufferWriter.Stream.cs
@@ -91,9 +91,12 @@ namespace Refit.Buffers
 
                 try
                 {
+#if NETSTANDARD2_1 || NET5_0
+                    return CopyToInternalAsync(destination, cancellationToken);
+#else
                     CopyTo(destination, bufferSize);
-
                     return Task.CompletedTask;
+#endif
                 }
                 catch (OperationCanceledException e)
                 {


### PR DESCRIPTION
Refit might not write everything to the outgoing http stream depending on buffer size and the total amount of data it should sent. This PR fixes that.

Should I also create a PR for 5.2.1, since it's a pretty critical bug, I'd think?

Unsure how to create a good unit/integration test for this - any help would be appreciated.

**Please check if the PR fulfills these requirements**
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)