### PR TITLE
Change the condition to check the MSBuild version

### DIFF
--- a/Refit/targets/refit.targets
+++ b/Refit/targets/refit.targets
@@ -14,7 +14,7 @@
 
 
   <Target Name="_RefitMSBuildVersionCheck"
-          Condition=" '$([System.Version]::Parse($(_RefitMSBuildMinVersion)).CompareTo($([System.Version]::Parse($(MSBuildVersion)))))' &gt;= '0' "
+          Condition=" '$([System.Version]::Parse($(_RefitMSBuildMinVersion)).CompareTo($([System.Version]::Parse($(MSBuildVersion)))))' &gt; '0' "
      BeforeTargets="ResolveAssemblyReferences;Build;Rebuild">
     <Error
         Text = "Projects using Refit cannot build using MSBuild '$(MSBuildVersion)'. MSBuild '$(_RefitMSBuildMinVersion)' or later is required." />


### PR DESCRIPTION
No error, if the current version is equals the RefitMSBuildMinVersion

Fix the issue #1037

**What kind of change does this PR introduce?**
Allow to compile with the minimum MSBuild version (currently 16.8.0)

**What is the current behavior?**
Only a version bigger than the minimal version is allowed.

**What is the new behavior?**
The minimal version is allowed.

**What might this PR break?**
Nothing
