### PR TITLE
Add interface type to HttpMessageRequest.Options

### DIFF
--- a/Refit.Tests/MultipartTests.cs
+++ b/Refit.Tests/MultipartTests.cs
@@ -307,7 +307,7 @@ namespace Refit.Tests
                 {
                     Assert.Equal(someHeader, message.Headers.Authorization.ToString());
 
-#if NET5_0
+#if NET5_0_OR_GREATER
                     Assert.Single(message.Options);
                     Assert.Equal(someProperty, ((IDictionary<string, object>)message.Options)["SomeProperty"]);
 #endif

--- a/Refit.Tests/MultipartTests.cs
+++ b/Refit.Tests/MultipartTests.cs
@@ -308,12 +308,12 @@ namespace Refit.Tests
                     Assert.Equal(someHeader, message.Headers.Authorization.ToString());
 
 #if NET5_0_OR_GREATER
-                    Assert.Single(message.Options);
+                    Assert.Equal(2, message.Options.Count());
                     Assert.Equal(someProperty, ((IDictionary<string, object>)message.Options)["SomeProperty"]);
 #endif
 
 #pragma warning disable CS0618 // Type or member is obsolete
-                    Assert.Single(message.Properties);
+                    Assert.Equal(2, message.Properties.Count);
                     Assert.Equal(someProperty, message.Properties["SomeProperty"]);
 #pragma warning restore CS0618 // Type or member is obsolete
                 },

--- a/Refit.Tests/RequestBuilder.cs
+++ b/Refit.Tests/RequestBuilder.cs
@@ -1831,7 +1831,7 @@ namespace Refit.Tests
             Assert.NotEmpty(output.Properties);
             Assert.Equal(typeof(IContainAandB), output.Properties[HttpRequestMessageOptions.InterfaceType]);
 #pragma warning restore CS0618 // Type or member is obsolete
-
+           
         }
 
         [Fact]

--- a/Refit.Tests/RequestBuilder.cs
+++ b/Refit.Tests/RequestBuilder.cs
@@ -1867,12 +1867,12 @@ namespace Refit.Tests
 
 
 #if NET5_0_OR_GREATER
-            Assert.Single(output.Options);
+            Assert.Equal(2, output.Options.Count());
             Assert.Equal(someOtherProperty, ((IDictionary<string, object>)output.Options)["SomeProperty"]);
 #endif
 
 #pragma warning disable CS0618 // Type or member is obsolete
-            Assert.Single(output.Properties);
+            Assert.Equal(2, output.Properties.Count);
             Assert.Equal(someOtherProperty, output.Properties["SomeProperty"]);
 #pragma warning restore CS0618 // Type or member is obsolete
         }

--- a/Refit.Tests/RequestBuilder.cs
+++ b/Refit.Tests/RequestBuilder.cs
@@ -1802,7 +1802,7 @@ namespace Refit.Tests
             var factory = fixture.BuildRequestFactoryForMethod(nameof(IDummyHttpApi.FetchSomeStuffWithDynamicRequestProperty));
             var output = factory(new object[] { 6, someProperty });
 
-#if NET5_0
+#if NET5_0_OR_GREATER
             Assert.NotEmpty(output.Options);
             Assert.Equal(someProperty, ((IDictionary<string, object>)output.Options)["SomeProperty"]);
 #endif
@@ -1823,7 +1823,7 @@ namespace Refit.Tests
             var factory = fixture.BuildRequestFactoryForMethod(nameof(IDummyHttpApi.FetchSomeStuffWithDynamicRequestPropertyWithoutKey));
             var output = factory(new object[] { 6, someProperty, someOtherProperty });
 
-#if NET5_0
+#if NET5_0_OR_GREATER
             Assert.NotEmpty(output.Options);
             Assert.Equal(someProperty, ((IDictionary<string, object>)output.Options)["someValue"]);
             Assert.Equal(someOtherProperty, ((IDictionary<string, object>)output.Options)["someOtherValue"]);
@@ -1846,7 +1846,7 @@ namespace Refit.Tests
             var output = factory(new object[] { 6, someProperty, someOtherProperty });
 
 
-#if NET5_0
+#if NET5_0_OR_GREATER
             Assert.Single(output.Options);
             Assert.Equal(someOtherProperty, ((IDictionary<string, object>)output.Options)["SomeProperty"]);
 #endif

--- a/Refit.Tests/RequestBuilder.cs
+++ b/Refit.Tests/RequestBuilder.cs
@@ -1815,6 +1815,26 @@ namespace Refit.Tests
         }
 
         [Fact]
+        public void InterfaceTypeShouldBeInProperties()
+        {
+            var someProperty = new object();
+            var fixture = new RequestBuilderImplementation<IContainAandB>();
+            var factory = fixture.BuildRequestFactoryForMethod(nameof(IContainAandB.Ping));
+            var output = factory(new object[] {  });
+
+#if NET5_0_OR_GREATER
+            Assert.NotEmpty(output.Options);
+            Assert.Equal(typeof(IContainAandB), ((IDictionary<string, object>)output.Options)[HttpRequestMessageOptions.InterfaceType]);
+#endif
+
+#pragma warning disable CS0618 // Type or member is obsolete
+            Assert.NotEmpty(output.Properties);
+            Assert.Equal(typeof(IContainAandB), output.Properties[HttpRequestMessageOptions.InterfaceType]);
+#pragma warning restore CS0618 // Type or member is obsolete
+
+        }
+
+        [Fact]
         public void DynamicRequestPropertiesWithDefaultKeysShouldBeInProperties()
         {
             var someProperty = new object();

--- a/Refit/Buffers/PooledBufferWriter.Stream.NETStandard21.cs
+++ b/Refit/Buffers/PooledBufferWriter.Stream.NETStandard21.cs
@@ -1,4 +1,4 @@
-﻿#if NETSTANDARD2_1 || NET5_0
+﻿#if NETSTANDARD2_1 || NET5_0_OR_GREATER
 
 using System;
 using System.IO;

--- a/Refit/Buffers/PooledBufferWriter.Stream.cs
+++ b/Refit/Buffers/PooledBufferWriter.Stream.cs
@@ -91,7 +91,7 @@ namespace Refit.Buffers
 
                 try
                 {
-#if NETSTANDARD2_1 || NET5_0
+#if NETSTANDARD2_1 || NET5_0_OR_GREATER
                     return CopyToInternalAsync(destination, cancellationToken);
 #else
                     CopyTo(destination, bufferSize);

--- a/Refit/HttpContentExtensions.cs
+++ b/Refit/HttpContentExtensions.cs
@@ -9,7 +9,7 @@ using System.Threading.Tasks;
 
 namespace Refit
 {
-#if !NET5_0
+#if !NET5_0_OR_GREATER
     static class HttpContentExtensions
     {
 #pragma warning disable IDE0079 // Remove unnecessary suppression

--- a/Refit/HttpRequestMessageProperties.cs
+++ b/Refit/HttpRequestMessageProperties.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Refit
+{
+    /// <summary>
+    /// Contains Refit-defined properties on the HttpRequestMessage.Properties/Options
+    /// </summary>
+    public static class HttpRequestMessageOptions
+    {
+        /// <summary>
+        /// Returns the <see cref="System.Type"/> of the top-level interface where the method was called from
+        /// </summary>
+        public static string InterfaceType { get; } = "Refit.InterfaceType";
+    }
+}

--- a/Refit/RequestBuilderImplementation.cs
+++ b/Refit/RequestBuilderImplementation.cs
@@ -719,6 +719,15 @@ namespace Refit
 #endif
                 }
 
+                // Always add the top-level type of the interface to the properties               
+#if NET5_0_OR_GREATER
+                ret.Options.Set(new HttpRequestOptionsKey<Type>(HttpRequestMessageOptions.InterfaceType), TargetType);
+#else
+                ret.Properties[HttpRequestMessageOptions.InterfaceType] = TargetType;
+#endif
+
+                ;
+
                 // NB: The URI methods in .NET are dumb. Also, we do this
                 // UriBuilder business so that we preserve any hardcoded query
                 // parameters as well as add the parameterized ones.

--- a/Refit/RequestBuilderImplementation.cs
+++ b/Refit/RequestBuilderImplementation.cs
@@ -712,7 +712,7 @@ namespace Refit
 
                 foreach (var property in propertiesToAdd)
                 {
-#if NET5_0
+#if NET5_0_OR_GREATER
                     ret.Options.Set(new HttpRequestOptionsKey<object?>(property.Key), property.Value);
 #else
                     ret.Properties[property.Key] = property.Value;

--- a/Refit/SystemTextJsonContentSerializer.cs
+++ b/Refit/SystemTextJsonContentSerializer.cs
@@ -98,7 +98,7 @@ namespace Refit
 
             try
             {
-#if NET5_0
+#if NET5_0_OR_GREATER
                 var utf8Length = await stream.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
 #else
                 var utf8Length = await stream.ReadAsync(buffer, 0, buffer.Length, cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
This adds the target interface type to the HttpMessageRequest so that a Delegating Handler can take action based on what the interface is.

Allows #1036 to be implemented using a delegating handler.