### PR TITLE
Fixed the wrong API call in Readme.md used with dotnet DI

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ var octocat = await gitHubApi.GetUser("octocat");
 ```
 .NET Core supports registering via HttpClientFactory
 ```csharp
-services.AddRefitClient<IGitHubApi>("https://api.github.com");
+services
+    .AddRefitClient<IGitHubApi>()
+    .ConfigureHttpClient(c => c.BaseAddress = new Uri("https://api.github.com"));
 ```
 
 #Table of Contents


### PR DESCRIPTION
**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
This is a Readme update that seems to have an error or maybe just not updated after API change.
The API described in Readme does not seem to exist and not even used in the same readme further.


**What is the current behavior?**
<!-- You can also link to an open issue here. -->
Not applicable


**What is the new behavior?**
<!-- If this is a feature change -->
Not applicable


**What might this PR break?**
Nothing, it's just readme update


**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

