### PR TITLE
Generate non-implicit impls for top-level interfaces

### DIFF
--- a/Refit.Tests/InheritedInterfacesApi.cs
+++ b/Refit.Tests/InheritedInterfacesApi.cs
@@ -52,6 +52,24 @@ namespace Refit.Tests
     {
 
     }
+
+    public interface IAmInterfaceEWithNoRefit<T>
+    {
+        public Task DoSomething(T parameter);
+
+        public Task DoSomethingElse();
+    }
+
+    public interface IImplementTheInterfaceAndUseRefit : IAmInterfaceEWithNoRefit<int>
+    {
+#pragma warning disable CS0108 // Member hides inherited member; missing new keyword
+        [Get("/doSomething")]
+        public Task DoSomething(int parameter);
+#pragma warning restore CS0108 // Member hides inherited member; missing new keyword
+
+        [Get("/DoSomethingElse")]
+        public new Task DoSomethingElse();
+    }
 }
 
 namespace Refit.Tests.SeparateNamespaceWithModel

--- a/Refit.Tests/InterfaceStubGenerator.cs
+++ b/Refit.Tests/InterfaceStubGenerator.cs
@@ -175,6 +175,110 @@ namespace Refit.Implementation
 
 
         /// <inheritdoc />
+        public global::System.Threading.Tasks.Task<global::Refit.Tests.User> GetUser(string @userName) 
+        {
+            var ______arguments = new object[] { @userName };
+            var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetUser"", new global::System.Type[] { typeof(string) } );
+            return (global::System.Threading.Tasks.Task<global::Refit.Tests.User>)______func(this.Client, ______arguments);
+        }
+
+        /// <inheritdoc />
+        public global::System.IObservable<global::Refit.Tests.User> GetUserObservable(string @userName) 
+        {
+            var ______arguments = new object[] { @userName };
+            var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetUserObservable"", new global::System.Type[] { typeof(string) } );
+            return (global::System.IObservable<global::Refit.Tests.User>)______func(this.Client, ______arguments);
+        }
+
+        /// <inheritdoc />
+        public global::System.IObservable<global::Refit.Tests.User> GetUserCamelCase(string @userName) 
+        {
+            var ______arguments = new object[] { @userName };
+            var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetUserCamelCase"", new global::System.Type[] { typeof(string) } );
+            return (global::System.IObservable<global::Refit.Tests.User>)______func(this.Client, ______arguments);
+        }
+
+        /// <inheritdoc />
+        public global::System.Threading.Tasks.Task<global::System.Collections.Generic.List<global::Refit.Tests.User>> GetOrgMembers(string @orgName, global::System.Threading.CancellationToken @cancellationToken) 
+        {
+            var ______arguments = new object[] { @orgName, @cancellationToken };
+            var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetOrgMembers"", new global::System.Type[] { typeof(string), typeof(global::System.Threading.CancellationToken) } );
+            return (global::System.Threading.Tasks.Task<global::System.Collections.Generic.List<global::Refit.Tests.User>>)______func(this.Client, ______arguments);
+        }
+
+        /// <inheritdoc />
+        public global::System.Threading.Tasks.Task<global::Refit.Tests.UserSearchResult> FindUsers(string @q) 
+        {
+            var ______arguments = new object[] { @q };
+            var ______func = requestBuilder.BuildRestResultFuncForMethod(""FindUsers"", new global::System.Type[] { typeof(string) } );
+            return (global::System.Threading.Tasks.Task<global::Refit.Tests.UserSearchResult>)______func(this.Client, ______arguments);
+        }
+
+        /// <inheritdoc />
+        public global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage> GetIndex() 
+        {
+            var ______arguments = new object[] {  };
+            var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetIndex"", new global::System.Type[] {  } );
+            return (global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage>)______func(this.Client, ______arguments);
+        }
+
+        /// <inheritdoc />
+        public global::System.IObservable<string> GetIndexObservable() 
+        {
+            var ______arguments = new object[] {  };
+            var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetIndexObservable"", new global::System.Type[] {  } );
+            return (global::System.IObservable<string>)______func(this.Client, ______arguments);
+        }
+
+        /// <inheritdoc />
+        public global::System.Threading.Tasks.Task<global::Refit.Tests.User> NothingToSeeHere() 
+        {
+            var ______arguments = new object[] {  };
+            var ______func = requestBuilder.BuildRestResultFuncForMethod(""NothingToSeeHere"", new global::System.Type[] {  } );
+            return (global::System.Threading.Tasks.Task<global::Refit.Tests.User>)______func(this.Client, ______arguments);
+        }
+
+        /// <inheritdoc />
+        public global::System.Threading.Tasks.Task<global::Refit.ApiResponse<global::Refit.Tests.User>> NothingToSeeHereWithMetadata() 
+        {
+            var ______arguments = new object[] {  };
+            var ______func = requestBuilder.BuildRestResultFuncForMethod(""NothingToSeeHereWithMetadata"", new global::System.Type[] {  } );
+            return (global::System.Threading.Tasks.Task<global::Refit.ApiResponse<global::Refit.Tests.User>>)______func(this.Client, ______arguments);
+        }
+
+        /// <inheritdoc />
+        public global::System.Threading.Tasks.Task<global::Refit.ApiResponse<global::Refit.Tests.User>> GetUserWithMetadata(string @userName) 
+        {
+            var ______arguments = new object[] { @userName };
+            var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetUserWithMetadata"", new global::System.Type[] { typeof(string) } );
+            return (global::System.Threading.Tasks.Task<global::Refit.ApiResponse<global::Refit.Tests.User>>)______func(this.Client, ______arguments);
+        }
+
+        /// <inheritdoc />
+        public global::System.IObservable<global::Refit.ApiResponse<global::Refit.Tests.User>> GetUserObservableWithMetadata(string @userName) 
+        {
+            var ______arguments = new object[] { @userName };
+            var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetUserObservableWithMetadata"", new global::System.Type[] { typeof(string) } );
+            return (global::System.IObservable<global::Refit.ApiResponse<global::Refit.Tests.User>>)______func(this.Client, ______arguments);
+        }
+
+        /// <inheritdoc />
+        public global::System.Threading.Tasks.Task<global::Refit.Tests.User> CreateUser(global::Refit.Tests.User @user) 
+        {
+            var ______arguments = new object[] { @user };
+            var ______func = requestBuilder.BuildRestResultFuncForMethod(""CreateUser"", new global::System.Type[] { typeof(global::Refit.Tests.User) } );
+            return (global::System.Threading.Tasks.Task<global::Refit.Tests.User>)______func(this.Client, ______arguments);
+        }
+
+        /// <inheritdoc />
+        public global::System.Threading.Tasks.Task<global::Refit.ApiResponse<global::Refit.Tests.User>> CreateUserWithMetadata(global::Refit.Tests.User @user) 
+        {
+            var ______arguments = new object[] { @user };
+            var ______func = requestBuilder.BuildRestResultFuncForMethod(""CreateUserWithMetadata"", new global::System.Type[] { typeof(global::Refit.Tests.User) } );
+            return (global::System.Threading.Tasks.Task<global::Refit.ApiResponse<global::Refit.Tests.User>>)______func(this.Client, ______arguments);
+        }
+
+        /// <inheritdoc />
         global::System.Threading.Tasks.Task<global::Refit.Tests.User> global::Refit.Tests.IGitHubApi.GetUser(string @userName) 
         {
             var ______arguments = new object[] { @userName };
@@ -315,6 +419,14 @@ namespace Refit.Implementation
 
 
         /// <inheritdoc />
+        public global::System.Threading.Tasks.Task RefitMethod() 
+        {
+            var ______arguments = new object[] {  };
+            var ______func = requestBuilder.BuildRestResultFuncForMethod(""RefitMethod"", new global::System.Type[] {  } );
+            return (global::System.Threading.Tasks.Task)______func(this.Client, ______arguments);
+        }
+
+        /// <inheritdoc />
         global::System.Threading.Tasks.Task global::Refit.Tests.IGitHubApiDisposable.RefitMethod() 
         {
             var ______arguments = new object[] {  };
@@ -363,6 +475,70 @@ namespace Refit.Implementation
         }
     
 
+
+        /// <inheritdoc />
+        public global::System.Threading.Tasks.Task<global::Refit.Tests.User> GetUser(string @userName) 
+        {
+            var ______arguments = new object[] { @userName };
+            var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetUser"", new global::System.Type[] { typeof(string) } );
+            return (global::System.Threading.Tasks.Task<global::Refit.Tests.User>)______func(this.Client, ______arguments);
+        }
+
+        /// <inheritdoc />
+        public global::System.IObservable<global::Refit.Tests.User> GetUserObservable(string @userName) 
+        {
+            var ______arguments = new object[] { @userName };
+            var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetUserObservable"", new global::System.Type[] { typeof(string) } );
+            return (global::System.IObservable<global::Refit.Tests.User>)______func(this.Client, ______arguments);
+        }
+
+        /// <inheritdoc />
+        public global::System.IObservable<global::Refit.Tests.User> GetUserCamelCase(string @userName) 
+        {
+            var ______arguments = new object[] { @userName };
+            var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetUserCamelCase"", new global::System.Type[] { typeof(string) } );
+            return (global::System.IObservable<global::Refit.Tests.User>)______func(this.Client, ______arguments);
+        }
+
+        /// <inheritdoc />
+        public global::System.Threading.Tasks.Task<global::System.Collections.Generic.List<global::Refit.Tests.User>> GetOrgMembers(string @orgName) 
+        {
+            var ______arguments = new object[] { @orgName };
+            var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetOrgMembers"", new global::System.Type[] { typeof(string) } );
+            return (global::System.Threading.Tasks.Task<global::System.Collections.Generic.List<global::Refit.Tests.User>>)______func(this.Client, ______arguments);
+        }
+
+        /// <inheritdoc />
+        public global::System.Threading.Tasks.Task<global::Refit.Tests.UserSearchResult> FindUsers(string @q) 
+        {
+            var ______arguments = new object[] { @q };
+            var ______func = requestBuilder.BuildRestResultFuncForMethod(""FindUsers"", new global::System.Type[] { typeof(string) } );
+            return (global::System.Threading.Tasks.Task<global::Refit.Tests.UserSearchResult>)______func(this.Client, ______arguments);
+        }
+
+        /// <inheritdoc />
+        public global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage> GetIndex() 
+        {
+            var ______arguments = new object[] {  };
+            var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetIndex"", new global::System.Type[] {  } );
+            return (global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage>)______func(this.Client, ______arguments);
+        }
+
+        /// <inheritdoc />
+        public global::System.IObservable<string> GetIndexObservable() 
+        {
+            var ______arguments = new object[] {  };
+            var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetIndexObservable"", new global::System.Type[] {  } );
+            return (global::System.IObservable<string>)______func(this.Client, ______arguments);
+        }
+
+        /// <inheritdoc />
+        public global::System.Threading.Tasks.Task NothingToSeeHere() 
+        {
+            var ______arguments = new object[] {  };
+            var ______func = requestBuilder.BuildRestResultFuncForMethod(""NothingToSeeHere"", new global::System.Type[] {  } );
+            return (global::System.Threading.Tasks.Task)______func(this.Client, ______arguments);
+        }
 
         /// <inheritdoc />
         global::System.Threading.Tasks.Task<global::Refit.Tests.User> global::Refit.Tests.TestNested.INestedGitHubApi.GetUser(string @userName) 
@@ -529,6 +705,22 @@ namespace Refit.Implementation
         }
     
 
+
+        /// <inheritdoc />
+        public global::System.Threading.Tasks.Task GetRoot() 
+        {
+            var ______arguments = new object[] {  };
+            var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetRoot"", new global::System.Type[] {  } );
+            return (global::System.Threading.Tasks.Task)______func(this.Client, ______arguments);
+        }
+
+        /// <inheritdoc />
+        public global::System.Threading.Tasks.Task PostRoot() 
+        {
+            var ______arguments = new object[] {  };
+            var ______func = requestBuilder.BuildRestResultFuncForMethod(""PostRoot"", new global::System.Type[] {  } );
+            return (global::System.Threading.Tasks.Task)______func(this.Client, ______arguments);
+        }
 
         /// <inheritdoc />
         global::System.Threading.Tasks.Task global::IServiceWithoutNamespace.GetRoot() 

--- a/Refit.Tests/RestService.cs
+++ b/Refit.Tests/RestService.cs
@@ -1802,6 +1802,44 @@ namespace Refit.Tests
             mockHttp.VerifyNoOutstandingExpectation();
         }
 
+
+        [Fact]
+        public async Task InheritedInterfaceWithoutRefitInBaseMethodsTest()
+        {
+            var mockHttp = new MockHttpMessageHandler();
+
+            var settings = new RefitSettings
+            {
+                HttpMessageHandlerFactory = () => mockHttp
+            };
+
+            var fixture = RestService.For<IImplementTheInterfaceAndUseRefit>("https://httpbin.org", settings);
+
+            mockHttp.Expect(HttpMethod.Get, "https://httpbin.org/doSomething")
+                    .WithQueryString("parameter", "4")
+                    .Respond("application/json", nameof(IImplementTheInterfaceAndUseRefit.DoSomething));
+
+            await fixture.DoSomething(4);
+            mockHttp.VerifyNoOutstandingExpectation();
+
+
+
+
+            mockHttp.Expect(HttpMethod.Get, "https://httpbin.org/DoSomethingElse")
+                .Respond("application/json", nameof(IImplementTheInterfaceAndUseRefit.DoSomethingElse));
+            await fixture.DoSomethingElse();
+            mockHttp.VerifyNoOutstandingExpectation();
+
+
+            mockHttp.Expect(HttpMethod.Get, "https://httpbin.org/DoSomethingElse")
+    .Respond("application/json", nameof(IImplementTheInterfaceAndUseRefit.DoSomethingElse));
+            await ((IAmInterfaceEWithNoRefit<int>)fixture).DoSomethingElse();
+            mockHttp.VerifyNoOutstandingExpectation();
+
+
+            Assert.Throws<InvalidOperationException>(() => RestService.For<IAmInterfaceEWithNoRefit<int>>("https://httpbin.org"));
+        }
+
         [Fact]
         public async Task DictionaryDynamicQueryparametersTest()
         {


### PR DESCRIPTION
Fixes #1061 for cases when the top-level interface declares refit methods and the base interfaces don't.

Does not handle a case where there's three or more interfaces, and a base interface adds the Refit attributes from something it derives from. 