### PR TITLE
Update output filenames to end in .g.cs to indicate they're generated.

### DIFF
--- a/InterfaceStubGenerator.Core/InterfaceStubGenerator.cs
+++ b/InterfaceStubGenerator.Core/InterfaceStubGenerator.cs
@@ -70,7 +70,7 @@ namespace {refitInternalNamespace}
 
 
             // add the attribute text
-            context.AddSource("PreserveAttribute", SourceText.From(attributeText, Encoding.UTF8));
+            context.AddSource("PreserveAttribute.g.cs", SourceText.From(attributeText, Encoding.UTF8));
 
             if (context.SyntaxReceiver is not SyntaxReceiver receiver)
                 return;
@@ -109,7 +109,7 @@ namespace Refit.Implementation
 }}
 #pragma warning restore
 ";
-            context.AddSource("Generated", SourceText.From(generatedClassText, Encoding.UTF8));
+            context.AddSource("Generated.g.cs", SourceText.From(generatedClassText, Encoding.UTF8));
 
             compilation = compilation.AddSyntaxTrees(CSharpSyntaxTree.ParseText(SourceText.From(generatedClassText, Encoding.UTF8), options));
 
@@ -174,7 +174,7 @@ namespace Refit.Implementation
                 }
                 keyCount[keyName] = value;
 
-                context.AddSource($"{keyName}_refit.cs", SourceText.From(classSource, Encoding.UTF8));
+                context.AddSource($"{keyName}.g.cs", SourceText.From(classSource, Encoding.UTF8));
             }           
 
         }

--- a/Refit.Tests/InterfaceStubGenerator.cs
+++ b/Refit.Tests/InterfaceStubGenerator.cs
@@ -623,11 +623,11 @@ namespace Refit.Implementation
                     Sources =
                     {
                         input,                        
-                        (@"InterfaceStubGenerator.Core\Refit.Generator.InterfaceStubGenerator\PreserveAttribute.cs", SourceText.From(output1, Encoding.UTF8)),
-                        (@"InterfaceStubGenerator.Core\Refit.Generator.InterfaceStubGenerator\Generated.cs", SourceText.From(output1_5, Encoding.UTF8)),
-                        (@"InterfaceStubGenerator.Core\Refit.Generator.InterfaceStubGenerator\IGitHubApi_refit.cs", SourceText.From(output2, Encoding.UTF8)),
-                        (@"InterfaceStubGenerator.Core\Refit.Generator.InterfaceStubGenerator\IGitHubApiDisposable_refit.cs", SourceText.From(output3, Encoding.UTF8)),
-                        (@"InterfaceStubGenerator.Core\Refit.Generator.InterfaceStubGenerator\INestedGitHubApi_refit.cs", SourceText.From(output4, Encoding.UTF8)),
+                        (@"InterfaceStubGenerator.Core\Refit.Generator.InterfaceStubGenerator\PreserveAttribute.g.cs", SourceText.From(output1, Encoding.UTF8)),
+                        (@"InterfaceStubGenerator.Core\Refit.Generator.InterfaceStubGenerator\Generated.g.cs", SourceText.From(output1_5, Encoding.UTF8)),
+                        (@"InterfaceStubGenerator.Core\Refit.Generator.InterfaceStubGenerator\IGitHubApi.g.cs", SourceText.From(output2, Encoding.UTF8)),
+                        (@"InterfaceStubGenerator.Core\Refit.Generator.InterfaceStubGenerator\IGitHubApiDisposable.g.cs", SourceText.From(output3, Encoding.UTF8)),
+                        (@"InterfaceStubGenerator.Core\Refit.Generator.InterfaceStubGenerator\INestedGitHubApi.g.cs", SourceText.From(output4, Encoding.UTF8)),
                     },
                 },
             }.RunAsync();
@@ -757,9 +757,9 @@ namespace Refit.Implementation
                     Sources =
                     {
                         input,
-                        (@"InterfaceStubGenerator.Core\Refit.Generator.InterfaceStubGenerator\PreserveAttribute.cs", SourceText.From(output1, Encoding.UTF8)),
-                        (@"InterfaceStubGenerator.Core\Refit.Generator.InterfaceStubGenerator\Generated.cs", SourceText.From(output1_5, Encoding.UTF8)),
-                        (@"InterfaceStubGenerator.Core\Refit.Generator.InterfaceStubGenerator\IServiceWithoutNamespace_refit.cs", SourceText.From(output2, Encoding.UTF8)),
+                        (@"InterfaceStubGenerator.Core\Refit.Generator.InterfaceStubGenerator\PreserveAttribute.g.cs", SourceText.From(output1, Encoding.UTF8)),
+                        (@"InterfaceStubGenerator.Core\Refit.Generator.InterfaceStubGenerator\Generated.g.cs", SourceText.From(output1_5, Encoding.UTF8)),
+                        (@"InterfaceStubGenerator.Core\Refit.Generator.InterfaceStubGenerator\IServiceWithoutNamespace.g.cs", SourceText.From(output2, Encoding.UTF8)),
                     },
                 },
             }.RunAsync();


### PR DESCRIPTION
Fixes #1066 