### PR TITLE
Added methods to support creating RefitSettings using the service provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -790,17 +790,17 @@ There may be times when you want to know what the target interface type is of th
 have a derived interface that implements a common base like this:
 
 ```csharp
-public interface IGetAPI<TEntity> 
+public interface IGetAPI<TEntity>
 {
     [Get("/{key}")]
     Task<TEntity> Get(long key);
 }
 
-public interface IUsersAPI : IGetAPI<User> 
+public interface IUsersAPI : IGetAPI<User>
 {
 }
 
-public interface IOrdersAPI : IGetAPI<Order> 
+public interface IOrdersAPI : IGetAPI<Order>
 {
 }
 ```
@@ -1099,6 +1099,14 @@ services.AddRefitClient<IWebApi>(settings)
         // Add additional IHttpClientBuilder chained methods as required here:
         // .AddHttpMessageHandler<MyHandler>()
         // .SetHandlerLifetime(TimeSpan.FromMinutes(2));
+
+// or injected from the container
+services.AddRefitClient<IWebApi>(provider => new RefitSettings() { /* configure settings */ })
+        .ConfigureHttpClient(c => c.BaseAddress = new Uri("https://api.example.com"));
+        // Add additional IHttpClientBuilder chained methods as required here:
+        // .AddHttpMessageHandler<MyHandler>()
+        // .SetHandlerLifetime(TimeSpan.FromMinutes(2));
+
 ```
 Note that some of the properties of `RefitSettings` will be ignored because the `HttpClient` and `HttpClientHandlers` will be managed by the `HttpClientFactory` instead of Refit.
 

--- a/Refit.HttpClientFactory/HttpClientFactoryExtensions.cs
+++ b/Refit.HttpClientFactory/HttpClientFactoryExtensions.cs
@@ -1,7 +1,10 @@
 ﻿using System;
+using System.Linq;
 using System.Net.Http;
+using System.Reflection;
 
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Http;
 
 namespace Refit
 {
@@ -16,37 +19,7 @@ namespace Refit
         /// <returns></returns>
         public static IHttpClientBuilder AddRefitClient<T>(this IServiceCollection services, RefitSettings? settings = null) where T : class
         {
-            services.AddSingleton(provider => RequestBuilder.ForType<T>(settings));
-
-            return services.AddHttpClient(UniqueName.ForType<T>())
-                           .ConfigureHttpMessageHandlerBuilder(builder =>
-                           {
-                               // check to see if user provided custom auth token
-                               HttpMessageHandler? innerHandler = null;
-                               if (settings != null)
-                               {
-                                   if (settings.HttpMessageHandlerFactory != null)
-                                   {
-                                       innerHandler = settings.HttpMessageHandlerFactory();
-                                   }
-
-                                   if (settings.AuthorizationHeaderValueGetter != null)
-                                   {
-                                       innerHandler = new AuthenticatedHttpClientHandler(settings.AuthorizationHeaderValueGetter, innerHandler);
-                                   }
-                                   else if (settings.AuthorizationHeaderValueWithParamGetter != null)
-                                   {
-                                       innerHandler = new AuthenticatedParameterizedHttpClientHandler(settings.AuthorizationHeaderValueWithParamGetter, innerHandler);
-                                   }
-                               }
-
-                               if(innerHandler != null)
-                               {
-                                   builder.PrimaryHandler = innerHandler;
-                               }    
-
-                           })
-                           .AddTypedClient((client, serviceProvider) => RestService.For<T>(client, serviceProvider.GetService<IRequestBuilder<T>>()!));
+            return AddRefitClient<T>(services, _ => settings);
         }
 
         /// <summary>
@@ -58,35 +31,86 @@ namespace Refit
         /// <returns></returns>
         public static IHttpClientBuilder AddRefitClient(this IServiceCollection services, Type refitInterfaceType, RefitSettings? settings = null)
         {
-            return services.AddHttpClient(UniqueName.ForType(refitInterfaceType))
-                            .ConfigureHttpMessageHandlerBuilder(builder =>
-                            {
-                                // check to see if user provided custom auth token
-                                HttpMessageHandler? innerHandler = null;
-                                if (settings != null)
-                                {
-                                    if (settings.HttpMessageHandlerFactory != null)
-                                    {
-                                        innerHandler = settings.HttpMessageHandlerFactory();
-                                    }
+            return AddRefitClient(services, refitInterfaceType, _ => settings);
+        }
 
-                                    if (settings.AuthorizationHeaderValueGetter != null)
-                                    {
-                                        innerHandler = new AuthenticatedHttpClientHandler(settings.AuthorizationHeaderValueGetter, innerHandler);
-                                    }
-                                    else if (settings.AuthorizationHeaderValueWithParamGetter != null)
-                                    {
-                                        innerHandler = new AuthenticatedParameterizedHttpClientHandler(settings.AuthorizationHeaderValueWithParamGetter, innerHandler);
-                                    }
-                                }
+        /// <summary>
+        /// Adds a Refit client to the DI container
+        /// </summary>
+        /// <typeparam name="T">Type of the Refit interface</typeparam>
+        /// <param name="services">container</param>
+        /// <param name="settingsAction">Optional. Action to configure refit settings.  This method is called once and only once, avoid using any scoped dependencies that maybe be disposed automatically.</param>
+        /// <returns></returns>
+        public static IHttpClientBuilder AddRefitClient<T>(this IServiceCollection services, Func<IServiceProvider, RefitSettings?>? settingsAction) where T : class
+        {
+            services.AddSingleton(provider => new SettingsFor<T>(settingsAction?.Invoke(provider)));
+            services.AddSingleton(provider => RequestBuilder.ForType<T>(provider.GetRequiredService<SettingsFor<T>>().Settings));
 
-                                if (innerHandler != null)
-                                {
-                                    builder.PrimaryHandler = innerHandler;
-                                }
+            return services
+                .AddHttpClient(UniqueName.ForType<T>())
+                .ConfigureHttpMessageHandlerBuilder(builder =>
+                {
+                    // check to see if user provided custom auth token
+                    if (CreateInnerHandlerIfProvided(builder.Services.GetRequiredService<SettingsFor<T>>().Settings) is {} innerHandler)
+                    {
+                        builder.PrimaryHandler = innerHandler;
+                    }
+                })
+                .AddTypedClient((client, serviceProvider) => RestService.For<T>(client, serviceProvider.GetService<IRequestBuilder<T>>()!));
+        }
 
-                            })
-                           .AddTypedClient(refitInterfaceType, (client, serviceProvider) => RestService.For(refitInterfaceType, client, settings));
+        /// <summary>
+        /// Adds a Refit client to the DI container
+        /// </summary>
+        /// <param name="services">container</param>
+        /// <param name="refitInterfaceType">Type of the Refit interface</param>
+        /// <param name="settingsAction">Optional. Action to configure refit settings.  This method is called once and only once, avoid using any scoped dependencies that maybe be disposed automatically.</param>
+        /// <returns></returns>
+        public static IHttpClientBuilder AddRefitClient(this IServiceCollection services, Type refitInterfaceType, Func<IServiceProvider, RefitSettings?>? settingsAction)
+        {
+            var settingsType = typeof(SettingsFor<>).MakeGenericType(refitInterfaceType);
+            var requestBuilderType = typeof(IRequestBuilder<>).MakeGenericType(refitInterfaceType);
+            services.AddSingleton(settingsType, provider => Activator.CreateInstance(typeof(SettingsFor<>).MakeGenericType(refitInterfaceType)!, settingsAction?.Invoke(provider))!);
+            services.AddSingleton(requestBuilderType, provider => RequestBuilderGenericForTypeMethod.MakeGenericMethod(refitInterfaceType).Invoke(null, new object?[] { ((ISettingsFor)provider.GetRequiredService(settingsType)).Settings })!);
+
+            return services
+                .AddHttpClient(UniqueName.ForType(refitInterfaceType))
+                .ConfigureHttpMessageHandlerBuilder(builder =>
+                {
+                    // check to see if user provided custom auth token
+                    if (CreateInnerHandlerIfProvided(((ISettingsFor)builder.Services.GetRequiredService(settingsType)).Settings) is { } innerHandler)
+                    {
+                        builder.PrimaryHandler = innerHandler;
+                    }
+                })
+                .AddTypedClient(refitInterfaceType, (client, serviceProvider) => RestService.For(refitInterfaceType, client, (IRequestBuilder)serviceProvider.GetRequiredService(requestBuilderType)));
+        }
+
+        private static readonly MethodInfo RequestBuilderGenericForTypeMethod = typeof(RequestBuilder)
+            .GetMethods(BindingFlags.Public | BindingFlags.Static)
+            .Single(z => z.IsGenericMethodDefinition && z.GetParameters().Length == 1);
+
+        static HttpMessageHandler? CreateInnerHandlerIfProvided(RefitSettings? settings)
+        {
+            HttpMessageHandler? innerHandler = null;
+            if (settings != null)
+            {
+                if (settings.HttpMessageHandlerFactory != null)
+                {
+                    innerHandler = settings.HttpMessageHandlerFactory();
+                }
+
+                if (settings.AuthorizationHeaderValueGetter != null)
+                {
+                    innerHandler = new AuthenticatedHttpClientHandler(settings.AuthorizationHeaderValueGetter, innerHandler);
+                }
+                else if (settings.AuthorizationHeaderValueWithParamGetter != null)
+                {
+                    innerHandler = new AuthenticatedParameterizedHttpClientHandler(settings.AuthorizationHeaderValueWithParamGetter, innerHandler);
+                }
+            }
+
+            return innerHandler;
         }
 
         static IHttpClientBuilder AddTypedClient(this IHttpClientBuilder builder, Type type, Func<HttpClient, IServiceProvider, object> factory)

--- a/Refit.HttpClientFactory/SettingsFor.cs
+++ b/Refit.HttpClientFactory/SettingsFor.cs
@@ -1,0 +1,13 @@
+﻿namespace Refit
+{
+    public interface ISettingsFor
+    {
+        RefitSettings? Settings { get;  }
+    }
+
+    public class SettingsFor<T> : ISettingsFor
+    {
+        public SettingsFor(RefitSettings? settings) => Settings = settings;
+        public RefitSettings? Settings { get;  }
+    }
+}

--- a/Refit.Tests/HttpClientFactoryExtensionsTests.cs
+++ b/Refit.Tests/HttpClientFactoryExtensionsTests.cs
@@ -1,18 +1,21 @@
-﻿namespace Refit.Tests
+﻿
+using Microsoft.Extensions.Options;
+
+namespace Refit.Tests
 {
     using Microsoft.Extensions.DependencyInjection;
+
+    using System.Text.Json;
     using Xunit;
 
     public class HttpClientFactoryExtensionsTests
     {
         class User
         {
-
         }
 
         class Role
         {
-
         }
 
         [Fact]
@@ -24,6 +27,99 @@
             var roleClientName = services.AddRefitClient<IBoringCrudApi<Role, string>>().Name;
 
             Assert.NotEqual(userClientName, roleClientName);
+        }
+
+        [Fact]
+        public void HttpClientServicesAreAddedCorrectlyGivenGenericArgument()
+        {
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddRefitClient<IFooWithOtherAttribute>();
+            Assert.Contains(serviceCollection, z => z.ServiceType == typeof(SettingsFor<IFooWithOtherAttribute>));
+            Assert.Contains(serviceCollection, z => z.ServiceType == typeof(IRequestBuilder<IFooWithOtherAttribute>));
+        }
+
+        [Fact]
+        public void HttpClientServicesAreAddedCorrectlyGivenTypeArgument()
+        {
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddRefitClient(typeof(IFooWithOtherAttribute));
+            Assert.Contains(serviceCollection, z => z.ServiceType == typeof(SettingsFor<IFooWithOtherAttribute>));
+            Assert.Contains(serviceCollection, z => z.ServiceType == typeof(IRequestBuilder<IFooWithOtherAttribute>));
+        }
+
+        [Fact]
+        public void HttpClientReturnsClientGivenGenericArgument()
+        {
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddRefitClient<IFooWithOtherAttribute>();
+            var serviceProvider = serviceCollection.BuildServiceProvider();
+            Assert.NotNull(serviceProvider.GetService<IFooWithOtherAttribute>());
+        }
+
+        [Fact]
+        public void HttpClientReturnsClientGivenTypeArgument()
+        {
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddRefitClient(typeof(IFooWithOtherAttribute));
+            var serviceProvider = serviceCollection.BuildServiceProvider();
+            Assert.NotNull(serviceProvider.GetService<IFooWithOtherAttribute>());
+        }
+
+        [Fact]
+        public void HttpClientSettingsAreInjectableGivenGenericArgument()
+        {
+            var serviceCollection = new ServiceCollection()
+                .Configure<ClientOptions>(o => o.Serializer = new SystemTextJsonContentSerializer(new JsonSerializerOptions()));
+            serviceCollection.AddRefitClient<IFooWithOtherAttribute>(_ => new RefitSettings() {ContentSerializer = _.GetRequiredService<IOptions<ClientOptions>>().Value.Serializer});
+            var serviceProvider = serviceCollection.BuildServiceProvider();
+            Assert.Same(
+                serviceProvider.GetRequiredService<IOptions<ClientOptions>>().Value.Serializer,
+                serviceProvider.GetRequiredService<SettingsFor<IFooWithOtherAttribute>>().Settings!.ContentSerializer
+            );
+        }
+
+        [Fact]
+        public void HttpClientSettingsAreInjectableGivenTypeArgument()
+        {
+            var serviceCollection = new ServiceCollection()
+                .Configure<ClientOptions>(o => o.Serializer = new SystemTextJsonContentSerializer(new JsonSerializerOptions()));
+            serviceCollection.AddRefitClient(typeof(IFooWithOtherAttribute), _ => new RefitSettings() {ContentSerializer = _.GetRequiredService<IOptions<ClientOptions>>().Value.Serializer});
+            var serviceProvider = serviceCollection.BuildServiceProvider();
+            Assert.Same(
+                serviceProvider.GetRequiredService<IOptions<ClientOptions>>().Value.Serializer,
+                serviceProvider.GetRequiredService<SettingsFor<IFooWithOtherAttribute>>().Settings!.ContentSerializer
+            );
+        }
+
+        [Fact]
+        public void HttpClientSettingsCanBeProvidedStaticallyGivenGenericArgument()
+        {
+            var contentSerializer = new SystemTextJsonContentSerializer(new JsonSerializerOptions());
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddRefitClient<IFooWithOtherAttribute>(new RefitSettings() {ContentSerializer = contentSerializer });
+            var serviceProvider = serviceCollection.BuildServiceProvider();
+            Assert.Same(
+                contentSerializer,
+                serviceProvider.GetRequiredService<SettingsFor<IFooWithOtherAttribute>>().Settings!.ContentSerializer
+            );
+        }
+
+        [Fact]
+        public void HttpClientSettingsCanBeProvidedStaticallyGivenTypeArgument()
+        {
+            var contentSerializer = new SystemTextJsonContentSerializer(new JsonSerializerOptions());
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddRefitClient<IFooWithOtherAttribute>(new RefitSettings() {ContentSerializer = contentSerializer });
+            var serviceProvider = serviceCollection.BuildServiceProvider();
+            Assert.Same(
+                contentSerializer,
+                serviceProvider.GetRequiredService<SettingsFor<IFooWithOtherAttribute>>().Settings!.ContentSerializer
+            );
+        }
+
+        class ClientOptions
+        {
+            public SystemTextJsonContentSerializer Serializer { get; set; }
         }
     }
 }


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
Feature

**What is the current behavior?**
Currently it is not possible to influence refit settings using other services in the `IServiceProvider` and everything must be know ahead of time.  This isn't always ideal or possible.

**What is the new behavior?**
Two new overloads have been added to `AddRefitClient` that take `Func<IServiceProvider, RefitSettings?>? settingsAction`.  This is resolved as a singleton when requesting the other related services.


**What might this PR break?**
Hopefully nothing!  Unit tests have been added that cover the new functionality as well as the existing functionality, ensuring that all the services are registered as expected, and the typed service client can properly be resolved.


**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:
Fixes: #903
