### PR TITLE
Added refit setting to bypass url verification

### DIFF
--- a/Refit/RefitSettings.cs
+++ b/Refit/RefitSettings.cs
@@ -66,7 +66,7 @@ namespace Refit
         public IUrlParameterFormatter UrlParameterFormatter { get; set; }
         public IFormUrlEncodedParameterFormatter FormUrlEncodedParameterFormatter { get; set; }
         public CollectionFormat CollectionFormat { get; set; } = CollectionFormat.RefitParameterFormatter;
-        public bool Buffered { get; set; } = true;
+        public bool Buffered { get; set; } = false;
         public bool BypassUrlVerification { get; set; } = false;
     }
 

--- a/Refit/RefitSettings.cs
+++ b/Refit/RefitSettings.cs
@@ -67,6 +67,7 @@ namespace Refit
         public IFormUrlEncodedParameterFormatter FormUrlEncodedParameterFormatter { get; set; }
         public CollectionFormat CollectionFormat { get; set; } = CollectionFormat.RefitParameterFormatter;
         public bool Buffered { get; set; } = true;
+        public bool BypassUrlVerification { get; set; } = false;
     }
 
     public interface IHttpContentSerializer

--- a/Refit/RestMethodInfo.cs
+++ b/Refit/RestMethodInfo.cs
@@ -64,7 +64,9 @@ namespace Refit
 
             MultipartBoundary = IsMultipart ? methodInfo.GetCustomAttribute<MultipartAttribute>(true)?.BoundaryText ?? new MultipartAttribute().BoundaryText : string.Empty;
 
-            VerifyUrlPathIsSane(RelativePath);
+            if (refitSettings?.BypassUrlVerification != true)
+                VerifyUrlPathIsSane(RelativePath);
+
             DetermineReturnTypeInfo(methodInfo);
             DetermineIfResponseMustBeDisposed();
 


### PR DESCRIPTION
**Feature**
Added a new Refit Setting to allow bypassing of Url verification, specifically for use in a generic class for the Microsoft Dynamics Web API which uses OData.


**What is the current behavior?**
The current behavior enforces the url verification:

`VerifyUrlPathIsSane(RelativePath);`

```
static void VerifyUrlPathIsSane(string relativePath)
        {
            if (relativePath == "")
                return;

            if (!relativePath.StartsWith("/"))
                throw new ArgumentException($"URL path {relativePath} must start with '/' and be of the form '/foo/bar/baz'");
        }
```


**What is the new behavior?**
The new behavior adds an option to bypass this check:

```
if(refitSettings?.BypassUrlVerification != true)
                VerifyUrlPathIsSane(RelativePath);
```



**What might this PR break?**
This PR should have no effect on anything else, as the default behavior without changing this option is the same.
