### PR TITLE
Really Buffered JsonContent when buffered is set

### DIFF
--- a/Refit.Tests/RequestBuilder.cs
+++ b/Refit.Tests/RequestBuilder.cs
@@ -104,7 +104,7 @@ namespace Refit.Tests
         Task<string> FetchSomeStuffWithDynamicRequestPropertyWithoutKey(int id, [Property] object someValue, [Property("")] object someOtherValue);
 
         [Post("/foo/{id}")]
-        Task<bool> OhYeahValueTypes(int id, [Body] int whatever);
+        Task<bool> OhYeahValueTypes(int id, [Body(buffered: true)] int whatever);
 
         [Post("/foo/{id}")]
         Task<bool> OhYeahValueTypesUnbuffered(int id, [Body(buffered: false)] int whatever);

--- a/Refit/RefitSettings.cs
+++ b/Refit/RefitSettings.cs
@@ -66,7 +66,7 @@ namespace Refit
         public IUrlParameterFormatter UrlParameterFormatter { get; set; }
         public IFormUrlEncodedParameterFormatter FormUrlEncodedParameterFormatter { get; set; }
         public CollectionFormat CollectionFormat { get; set; } = CollectionFormat.RefitParameterFormatter;
-        public bool Buffered { get; set; } = true;
+        public bool Buffered { get; set; } = false;
     }
 
     public interface IHttpContentSerializer

--- a/Refit/RequestBuilderImplementation.cs
+++ b/Refit/RequestBuilderImplementation.cs
@@ -248,6 +248,11 @@ namespace Refit
                 var disposeResponse = true;
                 try
                 {
+                    //Load the data into buffer when body should be buffered.
+                    if (restMethod.BodyParameterInfo?.Item2 ?? false && (rq.Content != null))
+                    {
+                        await rq.Content!.LoadIntoBufferAsync().ConfigureAwait(false);
+                    }
                     resp = await client.SendAsync(rq, HttpCompletionOption.ResponseHeadersRead, ct).ConfigureAwait(false);
                     content = resp.Content ?? new StringContent(string.Empty);
                     Exception? e = null;

--- a/Refit/RestMethodInfo.cs
+++ b/Refit/RestMethodInfo.cs
@@ -372,7 +372,7 @@ namespace Refit
 
             if (refParams.Count == 1)
             {
-                return Tuple.Create(BodySerializationMethod.Serialized, false, parameterList.IndexOf(refParams[0]));
+                return Tuple.Create(BodySerializationMethod.Serialized, RefitSettings.Buffered, parameterList.IndexOf(refParams[0]));
             }
 
             return null;


### PR DESCRIPTION
**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
If fixes the bug #1099.

**What is the current behavior?**
<!-- You can also link to an open issue here. -->
When the body is serialized (with JsonContent), the data is not buffered because the JsonContent doesn't implement the `TryComputeLength` method (https://github.com/dotnet/runtime/blob/9c3fc566eb916434f8bfe6974e4ddc21ba6e7ff6/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/JsonContent.cs#L55)

The settings `RefitSettings.Buffered` is only used when the `Body` attribute is set without the property `Buffered` defined and has no effect when the `Body` attribute missing. The buffering is always disabled when the attribute is missing.

**What is the new behavior?**
<!-- If this is a feature change -->
The request content is buffered, if the buffering is active.

The `RefitSettings.Buffered` is by default equals to false, and have effect even if the Body property is missing.

**What might this PR break?**
The `RefitSettings.Buffered` have now false as default value, so the attribute `Body` is without buffering by default.
If `RefitSettings.Buffered` is explicitely set to true, all the body are buffered even if the Body attribute is missing.

Some users can belived they buffered and it was not the case, so with this fix the memory usage can increase.

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features) => not done. Hard to find how to test it but all the current tests are not broken.
- [ X] Docs have been added / updated (for bug fixes / features) => The doc was incorrect. "By default, Refit streams the body content without buffering it." It was not totally true.

**Other information**:
The use of  `PushStreamContent` (https://github.com/reactiveui/refit/blob/64d91012c64057ea0fc6c3cb308bf3468a392973/Refit/RequestBuilderImplementation.cs#L576) when buffering is disabled is maybe useless when it is a `JsonContent` because it already streams the data. I didn't change this because I don't know Refit enough well to know the other implication.
