### PR TITLE
[WIP] Make XmlContentSerializers serializerCache static

### DIFF
--- a/Refit/XmlContentSerializer.cs
+++ b/Refit/XmlContentSerializer.cs
@@ -24,7 +24,7 @@ namespace Refit
         }
 
         readonly XmlContentSerializerSettings settings;
-        static readonly ConcurrentDictionary<TypeSettingsCacheEntry, XmlSerializer> serializerCache = new();
+        static readonly ConcurrentDictionary<XmlContentTypeSettingsCacheEntry, XmlSerializer> serializerCache = new();
 
         public XmlContentSerializer() : this(new XmlContentSerializerSettings())
         {
@@ -40,7 +40,7 @@ namespace Refit
             if (item is null) throw new ArgumentNullException(nameof(item));
 
             
-            var xmlSerializer = serializerCache.GetOrAdd(new TypeSettingsCacheEntry{ Type = item.GetType(), Settings = settings}, t => new XmlSerializer(t.Type, t.Settings.XmlAttributeOverrides));
+            var xmlSerializer = serializerCache.GetOrAdd(new XmlContentTypeSettingsCacheEntry{ Type = item.GetType(), Settings = settings}, t => new XmlSerializer(t.Type, t.Settings.XmlAttributeOverrides));
 
             using var stream = new MemoryStream();
             using var writer = XmlWriter.Create(stream, settings.XmlReaderWriterSettings.WriterSettings);
@@ -53,7 +53,7 @@ namespace Refit
 
         public async Task<T?> FromHttpContentAsync<T>(HttpContent content, CancellationToken cancellationToken = default)
         {
-            var xmlSerializer = serializerCache.GetOrAdd(new TypeSettingsCacheEntry { Type = typeof(T), Settings = settings } , t => new XmlSerializer(
+            var xmlSerializer = serializerCache.GetOrAdd(new XmlContentTypeSettingsCacheEntry { Type = typeof(T), Settings = settings } , t => new XmlSerializer(
                 t.Type,
                 t.Settings.XmlAttributeOverrides,
                 Array.Empty<Type>(),

--- a/Refit/XmlContentSerializer.cs
+++ b/Refit/XmlContentSerializer.cs
@@ -16,7 +16,7 @@ namespace Refit
     public class XmlContentSerializer : IHttpContentSerializer
     {
         readonly XmlContentSerializerSettings settings;
-        readonly ConcurrentDictionary<Type, XmlSerializer> serializerCache = new();
+        static readonly ConcurrentDictionary<Type, XmlSerializer> serializerCache = new();
 
         public XmlContentSerializer() : this(new XmlContentSerializerSettings())
         {


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Bug Fix



**What is the current behavior?**

XmlSerializers do not actually get cached in the ConcurrentDictionary because the XmlContentSerializer is constantly getting new'ed up resulting in a new cache with a single XmlSerializer entry per request.

See issue #1118 


**What might this PR break?**
Applications where one wants to instantiate XmlContentSerializer several times in the same application on the same Type with different XmlContentSerializerSettings.
e.g [typeof(MyType)+ default configuration] + [typeof(MyType) + custom configuration] 


**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

