### PR TITLE
Support returning api response in case of deserialization exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -1131,8 +1131,43 @@ public class HomeController : Controller
 ```
 
 ### Handling exceptions
+Refit has different exception handling behavior depending on if your Refit interface methods return `Task<T>` or if they return `Task<ApiResponse<T>>`.
 
-To encapsulate any exceptions that may come from a service, you can catch an `ApiException` which contains request- and response information. Refit also supports the catching of validation exceptions that are thrown by a service implementing the RFC 7807 specification for problem details due to bad requests. For specific information on the problem details of the validation exception, simply catch `ValidationApiException`:
+#### When returning `Task<ApiResponse<T>>`
+Refit traps any `ApiException` raised by the `ExceptionFactory` when processing the response and any errors that occur when attempting to deserialize the response to `Task<ApiResponse<T>>` and populates the exception into the `Error` property on `ApiResponse<T>` without throwing the exception.
+
+You can then decide what to do like so:
+
+    var response = await _myRefitClient.GetSomeStuff();
+    if(response.IsSuccess)
+    {
+       //do your thing
+    }
+    else
+    {
+       _logger.LogError(response.Error, response.Error.Content);
+    }
+
+
+#### When returning `Task<T>`
+Refit throws any `ApiException` raised by the `ExceptionFactory` when processing the response and any errors that occur when attempting to deserialize the response to `Task<T>`.
+
+```csharp
+// ...
+try
+{
+   var result = await awesomeApi.GetFooAsync("bar");
+}
+catch (ApiException exception)
+{
+   //exception handling
+}
+// ...
+```
+
+Refit can also throw `ValidationApiException` instead which in addition to the information present on `ApiException` also contains `ProblemDetails` when the service implements the [RFC 7807](https://tools.ietf.org/html/rfc7807) specification for problem details and the response content type is `application/problem+json`
+
+For specific information on the problem details of the validation exception, simply catch `ValidationApiException`:
 
 ```csharp
 // ...
@@ -1155,7 +1190,7 @@ catch (ApiException exception)
 // ...
 ```
 
-You can also override default exceptions behavior by providing custom exception factory in `RefitSettings`. For example, you can suppress all exceptions with the following:
+You can also override default exceptions behavior that are raised by the `ExceptionFactory` when processing the result by providing a custom exception factory in `RefitSettings`. For example, you can suppress all exceptions with the following:
 
 ```csharp
 var nullTask = Task.FromResult<Exception>(null);
@@ -1165,3 +1200,5 @@ var gitHubApi = RestService.For<IGitHubApi>("https://api.github.com",
         ExceptionFactory = httpResponse => nullTask;
     });
 ```
+
+Note that exceptions raised when attempting to deserialize the response are not affected by this.

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ services
 * [Handling exceptions](#handling-exceptions)
   * [When returning Task<ApiResponse<T>>](#when-returning-taskapiresponset)
   * [When returning Task<T>](#when-returning-taskt)
+  * [Providing a custom ExceptionFactory](#providing-a-custom-exceptionfactory)
 
 ### Where does this work?
 
@@ -1191,6 +1192,8 @@ catch (ApiException exception)
 }
 // ...
 ```
+
+#### Providing a custom `ExceptionFactory`
 
 You can also override default exceptions behavior that are raised by the `ExceptionFactory` when processing the result by providing a custom exception factory in `RefitSettings`. For example, you can suppress all exceptions with the following:
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ services
 * [Default Interface Methods](#default-interface-methods)
 * [Using HttpClientFactory](#using-httpclientfactory)
 * [Handling exceptions](#handling-exceptions)
+  * [When returning Task<ApiResponse<T>>](#when-returning-taskapiresponset)
+  * [When returning Task<T>](#when-returning-taskt)
 
 ### Where does this work?
 

--- a/README.md
+++ b/README.md
@@ -1142,7 +1142,7 @@ Refit traps any `ApiException` raised by the `ExceptionFactory` when processing 
 You can then decide what to do like so:
 
     var response = await _myRefitClient.GetSomeStuff();
-    if(response.IsSuccess)
+    if(response.IsSuccessStatusCode)
     {
        //do your thing
     }

--- a/Refit.Tests/ResponseTests.cs
+++ b/Refit.Tests/ResponseTests.cs
@@ -49,7 +49,7 @@ namespace Refit.Tests
             [Get("/aliasTest")]
             Task<TestAliasObject> GetTestObject();
 
-            [Get("/aliasTest")]
+            [Get("/GetApiResponseTestObject")]
             Task<ApiResponse<TestAliasObject>> GetApiResponseTestObject();
         }
 
@@ -135,6 +135,9 @@ namespace Refit.Tests
 
             expectedResponse.Content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/problem+json");
             mockHandler.Expect(HttpMethod.Get, "http://api/aliasTest")
+                .Respond(req => expectedResponse);
+
+            mockHandler.Expect(HttpMethod.Get, "http://api/soloyolo")
                 .Respond(req => expectedResponse);
 
             var actualException = await Assert.ThrowsAsync<ValidationApiException>(() => fixture.GetTestObject());
@@ -236,7 +239,7 @@ namespace Refit.Tests
             };
             expectedResponse.Content.Headers.Clear();
 
-            mockHandler.Expect(HttpMethod.Get, "http://api/aliasTest")
+            mockHandler.Expect(HttpMethod.Get, $"http://api/{nameof(fixture.GetApiResponseTestObject)}")
                 .Respond(req => expectedResponse);
 
             var apiResponse = await fixture.GetApiResponseTestObject();
@@ -303,7 +306,7 @@ namespace Refit.Tests
             };
             expectedResponse.Content.Headers.Clear();
 
-            mockHandler.Expect(HttpMethod.Get, "http://api/aliasTest")
+            mockHandler.Expect(HttpMethod.Get, $"http://api/{nameof(fixture.GetApiResponseTestObject)}")
                 .Respond(req => expectedResponse);
 
             var apiResponse = await fixture.GetApiResponseTestObject();
@@ -361,7 +364,7 @@ namespace Refit.Tests
             };
             expectedResponse.Content.Headers.Clear();
 
-            mockHandler.Expect(HttpMethod.Get, "http://api/aliasTest")
+            mockHandler.Expect(HttpMethod.Get, $"http://api/{nameof(fixture.GetApiResponseTestObject)}")
                 .Respond(req => expectedResponse);
 
             var apiResponse = await newtonSoftFixture.GetApiResponseTestObject();

--- a/Refit/RequestBuilderImplementation.cs
+++ b/Refit/RequestBuilderImplementation.cs
@@ -274,10 +274,10 @@ namespace Refit
                                 ? await DeserializeContentAsync<TBody>(resp, content, ct).ConfigureAwait(false)
                                 : default;
                         }
-                        catch (ApiException ex)
+                        catch (Exception ex)
                         {
                             //if an error occured while attempting to deserialize return the wrapped ApiException
-                            e = ex;
+                            e = await ApiException.Create("An error occured deserializing the response.", resp.RequestMessage!, resp.RequestMessage!.Method, resp, settings, ex);
                         }
 
                         return ApiResponse.Create<T, TBody>(resp, body, settings, e as ApiException);
@@ -288,7 +288,16 @@ namespace Refit
                         throw e;
                     }
                     else
-                        return await DeserializeContentAsync<T>(resp, content, ct).ConfigureAwait(false);
+                    {
+                        try
+                        {
+                            return await DeserializeContentAsync<T>(resp, content, ct).ConfigureAwait(false);
+                        }
+                        catch (Exception ex)
+                        {
+                            throw await ApiException.Create("An error occured deserializing the response.", resp.RequestMessage!, resp.RequestMessage!.Method, resp, settings, ex);
+                        }
+                    }
                 }
                 finally
                 {
@@ -306,42 +315,35 @@ namespace Refit
 
         async Task<T?> DeserializeContentAsync<T>(HttpResponseMessage resp, HttpContent content, CancellationToken cancellationToken)
         {
-            try
+            T? result;
+            if (typeof(T) == typeof(HttpResponseMessage))
             {
-                T? result;
-                if (typeof(T) == typeof(HttpResponseMessage))
-                {
-                    // NB: This double-casting manual-boxing hate crime is the only way to make
-                    // this work without a 'class' generic constraint. It could blow up at runtime
-                    // and would be A Bad Idea if we hadn't already vetted the return type.
-                    result = (T)(object)resp;
-                }
-                else if (typeof(T) == typeof(HttpContent))
-                {
-                    result = (T)(object)content;
-                }
-                else if (typeof(T) == typeof(Stream))
-                {
-                    var stream = (object)await content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
-                    result = (T)stream;
-                }
-                else if (typeof(T) == typeof(string))
-                {
-                    using var stream = await content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
-                    using var reader = new StreamReader(stream);
-                    var str = (object)await reader.ReadToEndAsync().ConfigureAwait(false);
-                    result = (T)str;
-                }
-                else
-                {
-                    result = await serializer.FromHttpContentAsync<T>(content, cancellationToken).ConfigureAwait(false);
-                }
-                return result;
+                // NB: This double-casting manual-boxing hate crime is the only way to make
+                // this work without a 'class' generic constraint. It could blow up at runtime
+                // and would be A Bad Idea if we hadn't already vetted the return type.
+                result = (T)(object)resp;
             }
-            catch(Exception ex) // wrap the exception as an ApiException
+            else if (typeof(T) == typeof(HttpContent))
             {
-                throw await ApiException.Create("An error occured deserializing the response.", resp.RequestMessage!, resp.RequestMessage!.Method, resp, settings, ex);
+                result = (T)(object)content;
             }
+            else if (typeof(T) == typeof(Stream))
+            {
+                var stream = (object)await content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+                result = (T)stream;
+            }
+            else if (typeof(T) == typeof(string))
+            {
+                using var stream = await content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+                using var reader = new StreamReader(stream);
+                var str = (object)await reader.ReadToEndAsync().ConfigureAwait(false);
+                result = (T)str;
+            }
+            else
+            {
+                result = await serializer.FromHttpContentAsync<T>(content, cancellationToken).ConfigureAwait(false);
+            }
+            return result;
         }
 
         List<KeyValuePair<string, object?>> BuildQueryMap(object? @object, string? delimiter = null, RestMethodParameterInfo? parameterInfo = null)


### PR DESCRIPTION
**What kind of change does this PR introduce?**
This is a bug fix for #1160 and #1017 - ApiResponse<T> wasn't trapping exceptions that occurred while attempting to deserialize the response, which violated the expectations of the ApiResponse<T> programming model.


**What is the current behavior?**
The current behavior is that an ApiResponse<T> will throw a Refit.ApiException if an exception is thrown while attempting to deserialize the response.



**What is the new behavior?**
The deserialization exception is properly wrapped by a Refit.ApiException and returned in the ApiResponse<T>



**What might this PR break?**
I've added tests for this and ensured the existing tests for the non ApiResponse<T> case still pass. If callers knew about the current behavior and had explicit try/catch blocks those will no longer be invoked anymore. Though, all callers will almost certainly have existing exception handling logic for the ApiResponse<T> which should pick up the deserialization exceptions now too. I, for one, didn't realize the library behaved as it does at present and expected every and all exception to come back via ApiResponse.Error.

**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
