### PR TITLE
Change folder path to avoid implicit NuGet inclusions

### DIFF
--- a/Refit/Refit.csproj
+++ b/Refit/Refit.csproj
@@ -28,12 +28,12 @@
     <None Include="targets\refit.targets" PackagePath="build\netstandard2.0" Pack="true" />
 
     <None Include="..\InterfaceStubGenerator.Roslyn38\bin\$(Configuration)\netstandard2.0\InterfaceStubGeneratorV1.dll"
-          PackagePath="analyzers\cs\roslyn38"
+          PackagePath="build\analyzers\roslyn38"
           Pack="true"
           Visible="false" />
 
     <None Include="..\InterfaceStubGenerator.Roslyn40\bin\$(Configuration)\netstandard2.0\InterfaceStubGeneratorV2.dll"
-          PackagePath="analyzers\cs\roslyn40"
+          PackagePath="build\analyzers\roslyn40"
           Pack="true"
           Visible="false" />
   </ItemGroup>

--- a/Refit/targets/refit.props
+++ b/Refit/targets/refit.props
@@ -7,12 +7,12 @@
   <Choose>
     <When Condition="$([MSBuild]::VersionGreaterThanOrEquals($(VisualStudioVersion), '17.0')) AND '$(DesignTimeBuild)' == 'True'">
       <ItemGroup>
-        <Analyzer Include="$(MSBuildThisFileDirectory)../../analyzers/cs/roslyn40/*.dll" />
+        <Analyzer Include="$(MSBuildThisFileDirectory)../../build/analyzers/cs/roslyn40/*.dll" />
       </ItemGroup>
     </When>
     <Otherwise>
       <ItemGroup>
-        <Analyzer Include="$(MSBuildThisFileDirectory)../../analyzers/cs/roslyn38/*.dll" />
+        <Analyzer Include="$(MSBuildThisFileDirectory)../../build/analyzers/cs/roslyn38/*.dll" />
       </ItemGroup>
     </Otherwise>
   </Choose>


### PR DESCRIPTION
@Mike-E-angelo I'm hoping we can use something like this PR to avoid needing to move these files completely outside the `analyzers` folder.

Fixes https://github.com/reactiveui/refit/pull/1216#issuecomment-902132236