### PR TITLE
Gate the incremental source generators on LangVersion=preview

### DIFF
--- a/Refit/targets/refit.props
+++ b/Refit/targets/refit.props
@@ -5,7 +5,8 @@
   </ItemGroup>
 
   <Choose>
-    <When Condition="$([MSBuild]::VersionGreaterThanOrEquals($(VisualStudioVersion), '17.0')) AND '$(DesignTimeBuild)' == 'True'">
+    <!-- TODO: Remove the LangVersion restriction once the incremental source generator APIs stabilize (https://github.com/dotnet/roslyn/issues/55848) -->
+    <When Condition="$([MSBuild]::VersionGreaterThanOrEquals($(VisualStudioVersion), '17.0')) AND '$(DesignTimeBuild)' == 'True' AND '$(LangVersion)' == 'preview'">
       <ItemGroup>
         <Analyzer Include="$(MSBuildThisFileDirectory)../../build/analyzers/cs/roslyn40/*.dll" />
       </ItemGroup>


### PR DESCRIPTION
Addresses the issue described in https://github.com/reactiveui/refit/pull/1222#issuecomment-904768658.

This restriction can be removed once https://github.com/dotnet/roslyn/issues/55848 is resolved.