### PR TITLE
Add IHttpResponseMessageSerializer support

### DIFF
--- a/Refit.Tests/Collections/EnumerableExtended.cs
+++ b/Refit.Tests/Collections/EnumerableExtended.cs
@@ -1,0 +1,22 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+
+namespace Refit.Tests.Collections
+{
+    public class EnumerableExtended<T> : IEnumerable<T>
+    {
+        private readonly IEnumerable<T> items;
+
+        public EnumerableExtended(IEnumerable<T> items, IDictionary<string, string> parameters)
+        {
+            this.items = items;
+            this.Parameters = parameters;
+        }
+
+        public IDictionary<string, string> Parameters { get; }
+
+        public IEnumerator<T> GetEnumerator() => this.items.GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => this.items.GetEnumerator();
+    }
+}

--- a/Refit.Tests/Collections/EnumerableExtensions.cs
+++ b/Refit.Tests/Collections/EnumerableExtensions.cs
@@ -1,0 +1,12 @@
+﻿using System.Collections.Generic;
+
+namespace Refit.Tests.Collections
+{
+    public static class EnumerableExtensions
+    {
+        public static EnumerableExtended<T> Extend<T>(this IEnumerable<T> enumerable, IDictionary<string, string> parameters)
+        {
+            return new EnumerableExtended<T>(enumerable, parameters);
+        }
+    }
+}

--- a/Refit.Tests/CustomContentSerializer.cs
+++ b/Refit.Tests/CustomContentSerializer.cs
@@ -1,0 +1,58 @@
+﻿using System.Linq;
+using System.Net.Http;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Refit.Tests.Collections;
+
+namespace Refit.Tests
+{
+    public class CustomContentSerializer : IHttpResponseMessageSerializer
+    {
+        private readonly IHttpContentSerializer serializer;
+
+        public CustomContentSerializer(IHttpContentSerializer serializer)
+        {
+            this.serializer = serializer;
+        }
+
+        public HttpContent ToHttpContent<T>(T item)
+        {
+            return serializer.ToHttpContent<T>(item);
+        }
+
+        public Task<T> FromHttpContentAsync<T>(HttpContent content, CancellationToken cancellationToken = default)
+        {
+            return FromHttpContentAsync<T>(null, content, cancellationToken);
+        }
+
+        public async Task<T> FromHttpContentAsync<T>(HttpResponseMessage responseMessage, HttpContent content, CancellationToken cancellationToken = default)
+        {
+            var item = await serializer.FromHttpContentAsync<T>(content, cancellationToken).ConfigureAwait(false);
+
+            if (responseMessage != null &&
+                item != null &&
+                item is System.Collections.IEnumerable)
+            {
+                var type = typeof(T);
+
+                if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(System.Collections.Generic.IEnumerable<>))
+                {
+                    var parameters = responseMessage.Headers.ToDictionary(f => f.Key, f => f.Value.FirstOrDefault());
+                    var method = typeof(EnumerableExtensions).GetMethod("Extend", BindingFlags.Public | BindingFlags.Static);
+                    item = (T)method
+                        .MakeGenericMethod(type.GetGenericArguments().First())
+                        .Invoke(null, new object[] { item, parameters });
+                }
+            }
+
+            return item;
+        }
+
+        public string GetFieldNameForProperty(PropertyInfo propertyInfo)
+        {
+            return serializer.GetFieldNameForProperty(propertyInfo);
+        }
+    }
+}

--- a/Refit.Tests/SerializedContentTests.cs
+++ b/Refit.Tests/SerializedContentTests.cs
@@ -162,5 +162,37 @@ namespace Refit.Tests
             Assert.Equal("utf-8", json.Headers.ContentType.CharSet);
             Assert.Equal("application/json", json.Headers.ContentType.MediaType);
         }
+
+        [Theory]
+        [InlineData("param1", "test")]
+        public async Task WhenAResponseHasHeadersThenAppendHeadersToResult(string headerName, string headerValue)
+        {
+            var users = new[]
+            {
+                new User
+                {
+                    Name = "Wile E. Coyote",
+                    CreatedAt = new DateTime(1949, 9, 16).ToString(),
+                    Company = "ACME",
+                },
+            };
+
+            var serializer = new CustomContentSerializer(new SystemTextJsonContentSerializer());
+
+            var json = serializer.ToHttpContent(users);
+
+            var responseMessage = new HttpResponseMessage(HttpStatusCode.OK);
+            responseMessage.Headers.Add(headerName, headerValue);
+
+            var result = await serializer.FromHttpContentAsync<System.Collections.Generic.IEnumerable<User>>(responseMessage, json);
+
+            Assert.NotNull(result);
+            Assert.IsType<Collections.EnumerableExtended<User>>(result);
+
+            var extended = (Collections.EnumerableExtended<User>)result;
+
+            Assert.NotEmpty(extended.Parameters);
+            Assert.Contains(headerName, extended.Parameters);
+        }
     }
 }

--- a/Refit/RefitSettings.cs
+++ b/Refit/RefitSettings.cs
@@ -83,6 +83,11 @@ namespace Refit
         string? GetFieldNameForProperty(PropertyInfo propertyInfo);
     }
 
+    public interface IHttpResponseMessageSerializer : IHttpContentSerializer
+    {
+        Task<T?> FromHttpContentAsync<T>(HttpResponseMessage response, HttpContent content, CancellationToken cancellationToken = default);
+    }
+
     public interface IUrlParameterFormatter
     {
         string? Format(object? value, ICustomAttributeProvider attributeProvider, Type type);

--- a/Refit/RequestBuilderImplementation.cs
+++ b/Refit/RequestBuilderImplementation.cs
@@ -341,7 +341,16 @@ namespace Refit
             }
             else
             {
-                result = await serializer.FromHttpContentAsync<T>(content, cancellationToken).ConfigureAwait(false);
+                var responseSerializer = serializer as IHttpResponseMessageSerializer;
+
+                if (responseSerializer != null)
+                {
+                    result = await responseSerializer.FromHttpContentAsync<T>(resp, content, cancellationToken).ConfigureAwait(false);
+                }
+                else
+                {
+                    result = await serializer.FromHttpContentAsync<T>(content, cancellationToken).ConfigureAwait(false);
+                }
             }
             return result;
         }


### PR DESCRIPTION
Necessity:

I work with pagination, and page information is received through the header link.
The FromHttpContentAsync method of the IHttpContentSerializer interfaces does not have access to the response header so that you can customize and retrieve the information.

Solution:

Create an interface that extends from IHttpContentSerializer and allows access to the HttpResponseMessage.

````
public interface IHttpResponseMessageSerializer : IHttpContentSerializer
{
	Task<T?> FromHttpContentAsync<T>(HttpResponseMessage response, HttpContent content, CancellationToken cancellationToken = default);
}
````

Change the DeserializeContentAsync method in the RequestBuilderImplementation class, so if the configured serializer is an IHttpResponseMessageSerializer, it calls the method informing the HttpResponseMessage

````
async Task<T?> DeserializeContentAsync<T>(HttpResponseMessage resp, HttpContent content, CancellationToken cancellationToken)
{
	T? result;
	if (typeof(T) == typeof(HttpResponseMessage))
	{
		result = (T)(object)resp;
	}
	else if (typeof(T) == typeof(HttpContent))
	{
		result = (T)(object)content;
	}
	else if (typeof(T) == typeof(Stream))
	{
		var stream = (object)await content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
		result = (T)stream;
	}
	else if (typeof(T) == typeof(string))
	{
		using var stream = await content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
		using var reader = new StreamReader(stream);
		var str = (object)await reader.ReadToEndAsync().ConfigureAwait(false);
		result = (T)str;
	}
	else
	{
		var responseSerializer = serializer as IHttpResponseMessageSerializer;

		if (responseSerializer != null)
		{
			result = await responseSerializer.FromHttpContentAsync<T>(resp, content, cancellationToken).ConfigureAwait(false);
		}
		else
		{
			result = await serializer.FromHttpContentAsync<T>(content, cancellationToken).ConfigureAwait(false);
		}
	}
	return result;
}

````