### PR TITLE
Enchance SystemTextJsonContentSerializer default options

### DIFF
--- a/Refit/SystemTextJsonContentSerializer.cs
+++ b/Refit/SystemTextJsonContentSerializer.cs
@@ -29,15 +29,8 @@ namespace Refit
         /// <summary>
         /// Creates a new <see cref="SystemTextJsonContentSerializer"/> instance
         /// </summary>
-        public SystemTextJsonContentSerializer() : this(new JsonSerializerOptions())
+        public SystemTextJsonContentSerializer() : this(GetDefaultJsonSerializerOptions())
         {
-
-            // Set some defaults
-            // Default to case insensitive property name matching as that's likely the behavior most users expect
-            jsonSerializerOptions.PropertyNameCaseInsensitive = true;
-            jsonSerializerOptions.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
-            jsonSerializerOptions.Converters.Add(new ObjectToInferredTypesConverter());
-            jsonSerializerOptions.Converters.Add(new JsonStringEnumConverter(JsonNamingPolicy.CamelCase));
         }
 
         /// <summary>
@@ -73,6 +66,21 @@ namespace Refit
                        .Select(a => a.Name)
                        .FirstOrDefault();
         }
+
+        /// <summary>
+        /// Creates new <see cref="JsonSerializerOptions"/> and fills it with default parameters
+        /// </summary>
+        public static JsonSerializerOptions GetDefaultJsonSerializerOptions()
+        {
+            var jsonSerializerOptions = new JsonSerializerOptions();
+            // Default to case insensitive property name matching as that's likely the behavior most users expect
+            jsonSerializerOptions.PropertyNameCaseInsensitive = true;
+            jsonSerializerOptions.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
+            jsonSerializerOptions.Converters.Add(new ObjectToInferredTypesConverter());
+            jsonSerializerOptions.Converters.Add(new JsonStringEnumConverter(JsonNamingPolicy.CamelCase));
+
+            return jsonSerializerOptions;
+        }
     }
 
     // From https://docs.microsoft.com/en-us/dotnet/standard/serialization/system-text-json-converters-how-to?pivots=dotnet-5-0#deserialize-inferred-types-to-object-properties
@@ -101,4 +109,3 @@ namespace Refit
     }
 
 }
-

--- a/Refit/SystemTextJsonContentSerializer.cs
+++ b/Refit/SystemTextJsonContentSerializer.cs
@@ -109,3 +109,4 @@ namespace Refit
     }
 
 }
+


### PR DESCRIPTION
**What kind of change does this PR introduce?**
This is a new feature that extends/enhances SystemTextJsonContentSerializer initialization.



**What is the current behavior?**
To enchance a default SystemTextJsonContentSerializer behavior (e.g. add/remove converters) it is required to create a new JsonSerializerOptions instance and initialize it the same way it is initialized in SystemTextJsonContentSerializer constructor (copy/pasting), then additional options can be added.


**What is the new behavior?**
A user can create a JsonSerializerOptions initialized with defaults by calling `SystemTextJsonContentSerializer.GetDefaultJsonSerializerOptions()` extend it and use for SystemTextJsonContentSerializer initialization.


**What might this PR break?**
Not a breaking change.

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

related to #1217