### PR TITLE
Switch to Roslyn component versioning

### DIFF
--- a/Refit/Refit.csproj
+++ b/Refit/Refit.csproj
@@ -28,12 +28,12 @@
     <None Include="targets\refit.targets" PackagePath="build\netstandard2.0" Pack="true" />
 
     <None Include="..\InterfaceStubGenerator.Roslyn38\bin\$(Configuration)\netstandard2.0\InterfaceStubGeneratorV1.dll"
-          PackagePath="build\analyzers\roslyn38"
+          PackagePath="analyzers\dotnet\roslyn3.8\cs"
           Pack="true"
           Visible="false" />
 
     <None Include="..\InterfaceStubGenerator.Roslyn40\bin\$(Configuration)\netstandard2.0\InterfaceStubGeneratorV2.dll"
-          PackagePath="build\analyzers\roslyn40"
+          PackagePath="analyzers\dotnet\roslyn4.0\cs"
           Pack="true"
           Visible="false" />
   </ItemGroup>

--- a/Refit/targets/refit.props
+++ b/Refit/targets/refit.props
@@ -4,18 +4,4 @@
     <CompilerVisibleProperty Include="RefitInternalNamespace" />
   </ItemGroup>
 
-  <Choose>
-    <!-- TODO: Remove the LangVersion restriction once the incremental source generator APIs stabilize (https://github.com/dotnet/roslyn/issues/55848) -->
-    <When Condition="$([MSBuild]::VersionGreaterThanOrEquals($(VisualStudioVersion), '17.0')) AND '$(DesignTimeBuild)' == 'True' AND '$(LangVersion)' == 'preview'">
-      <ItemGroup>
-        <Analyzer Include="$(MSBuildThisFileDirectory)../../build/analyzers/cs/roslyn40/*.dll" />
-      </ItemGroup>
-    </When>
-    <Otherwise>
-      <ItemGroup>
-        <Analyzer Include="$(MSBuildThisFileDirectory)../../build/analyzers/cs/roslyn38/*.dll" />
-      </ItemGroup>
-    </Otherwise>
-  </Choose>
-
 </Project>

--- a/Refit/targets/refit.targets
+++ b/Refit/targets/refit.targets
@@ -12,6 +12,34 @@
     
   </PropertyGroup>
 
+  <Target Name="_RefitGatherAnalyzers">
+    <ItemGroup>
+      <_RefitAnalyzer Include="@(Analyzer)" Condition="'%(Analyzer.NuGetPackageId)' == 'Refit'" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="_RefitAnalyzerMultiTargeting" 
+          Condition="'$(SupportsRoslynComponentVersioning)' != 'true'" 
+          AfterTargets="ResolvePackageDependenciesForBuild;ResolveNuGetPackageAssets"
+          DependsOnTargets="_RefitGatherAnalyzers">
+
+    <ItemGroup>
+      <!-- Remove our analyzers targeting roslyn4.x -->
+      <Analyzer Remove="@(_RefitAnalyzer)"
+                Condition="$([System.String]::Copy('%(_RefitAnalyzer.Identity)').IndexOf('roslyn4')) &gt;= 0"/>
+    </ItemGroup>
+  </Target>
+
+  <Target Name="_RefitRemoveAnalyzers" 
+          Condition="'$(DisableRefitSourceGenerator)' == 'true'"
+          AfterTargets="ResolvePackageDependenciesForBuild;ResolveNuGetPackageAssets"
+          DependsOnTargets="_RefitGatherAnalyzers">
+
+    <!-- Remove all our analyzers -->
+    <ItemGroup>
+      <Analyzer Remove="@(_RefitAnalyzer)" />
+    </ItemGroup>
+  </Target>
 
   <Target Name="_RefitMSBuildVersionCheck"
           Condition=" '$([System.Version]::Parse($(_RefitMSBuildMinVersion)).CompareTo($([System.Version]::Parse($(MSBuildVersion)))))' &gt; '0' "


### PR DESCRIPTION
* Use Roslyn 3.8 assemblies for .NET SDK prior to 6.0 RC 2 (where [component versioning](https://github.com/dotnet/sdk/issues/20355) was added)
* Use matching Roslyn version for 6.0 RC 2 and newer
* Allow users to disable the source generator by setting `DisableRefitSourceGenerator` to true (derived from [MultiTargetRoslynComponent.targets](https://github.com/dotnet/runtime/blob/main/eng/MultiTargetRoslynComponent.targets.template))

Closes #1244