### PR TITLE
Add Xml documentation to exposed methods and classes.

### DIFF
--- a/Refit/ApiException.cs
+++ b/Refit/ApiException.cs
@@ -6,19 +6,60 @@ using System.Threading.Tasks;
 
 namespace Refit
 {
-
+    /// <summary>
+    /// Represents an error that occured while sending an API request.
+    /// </summary>
     [Serializable]
     public class ApiException : Exception
     {
+        /// <summary>
+        /// HTTP response status code.
+        /// </summary>
         public HttpStatusCode StatusCode { get; }
+
+        /// <summary>
+        /// The reason phrase which typically is sent by the server together with the status code.
+        /// </summary>
         public string? ReasonPhrase { get; }
+
+        /// <summary>
+        /// HTTP response headers.
+        /// </summary>
         public HttpResponseHeaders Headers { get; }
+
+        /// <summary>
+        /// The HTTP method used to send the request.
+        /// </summary>
         public HttpMethod HttpMethod { get; }
+
+        /// <summary>
+        /// The <see cref="System.Uri"/> used to send the HTTP request.
+        /// </summary>
         public Uri? Uri => RequestMessage.RequestUri;
+
+        /// <summary>
+        /// The HTTP Request message used to send the request.
+        /// </summary>
         public HttpRequestMessage RequestMessage { get; }
+
+        /// <summary>
+        /// HTTP response content headers as defined in RFC 2616.
+        /// </summary>
         public HttpContentHeaders? ContentHeaders { get; private set; }
+
+        /// <summary>
+        /// HTTP Response content as string.
+        /// </summary>
         public string? Content { get; private set; }
+
+        /// <summary>
+        /// Does the response have content?
+        /// </summary>
         public bool HasContent => !string.IsNullOrWhiteSpace(Content);
+
+        /// <summary>
+        /// Refit settings used to send the request.
+        /// </summary>
         public RefitSettings RefitSettings { get; }
 
         protected ApiException(HttpRequestMessage message, HttpMethod httpMethod, string? content, HttpStatusCode statusCode, string? reasonPhrase, HttpResponseHeaders headers, RefitSettings refitSettings, Exception? innerException = null) :
@@ -38,10 +79,24 @@ namespace Refit
             Content = content;
         }
 
+        /// <summary>
+        /// Get the deserialized response content as nullable <typeparamref name="T"/>.
+        /// </summary>
+        /// <typeparam name="T">Type to deserialize the content to</typeparam>
+        /// <returns>The response content deserialized as <typeparamref name="T"/></returns>
         public async Task<T?> GetContentAsAsync<T>() => HasContent ?
                 await RefitSettings.ContentSerializer.FromHttpContentAsync<T>(new StringContent(Content!)).ConfigureAwait(false) :
                 default;
 
+        /// <summary>
+        /// Create an instance of <see cref="ApiException"/>.
+        /// </summary>
+        /// <param name="message">The HTTP Request message used to send the request.</param>
+        /// <param name="httpMethod">The HTTP method used to send the request.</param>
+        /// <param name="response">The HTTP Response message.</param>
+        /// <param name="refitSettings">Refit settings used to sent the request.</param>
+        /// <param name="innerException">Add an inner exception to the <see cref="ApiException"/>.</param>
+        /// <returns>A newly created <see cref="ApiException"/>.</returns>
 #pragma warning disable VSTHRD200 // Use "Async" suffix for async methods
         public static Task<ApiException> Create(HttpRequestMessage message, HttpMethod httpMethod, HttpResponseMessage response, RefitSettings refitSettings, Exception? innerException = null)
 #pragma warning restore VSTHRD200 // Use "Async" suffix for async methods
@@ -50,6 +105,16 @@ namespace Refit
             return Create(exceptionMessage, message, httpMethod, response, refitSettings, innerException);
         }
 
+        /// <summary>
+        /// Create an instance of <see cref="ApiException"/> with a custom exception message.
+        /// </summary>
+        /// <param name="exceptionMessage">A custom exception message.</param>
+        /// <param name="message">The HTTP Request message used to send the request.</param>
+        /// <param name="httpMethod">The HTTP method used to send the request.</param>
+        /// <param name="response">The HTTP Response message.</param>
+        /// <param name="refitSettings">Refit settings used to sent the request.</param>
+        /// <param name="innerException">Add an inner exception to the <see cref="ApiException"/>.</param>
+        /// <returns>A newly created <see cref="ApiException"/>.</returns>
 #pragma warning disable VSTHRD200 // Use "Async" suffix for async methods
         public static async Task<ApiException> Create(string exceptionMessage, HttpRequestMessage message, HttpMethod httpMethod, HttpResponseMessage response, RefitSettings refitSettings, Exception? innerException = null)
 #pragma warning restore VSTHRD200 // Use "Async" suffix for async methods

--- a/Refit/ApiResponse.cs
+++ b/Refit/ApiResponse.cs
@@ -14,11 +14,23 @@ namespace Refit
         }
     }
 
+    /// <summary>
+    /// Implementation of <see cref="IApiResponse{T}"/> that provides additional functionalities.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
     public sealed class ApiResponse<T> : IApiResponse<T>
     {
         readonly HttpResponseMessage response;
         bool disposed;
 
+        /// <summary>
+        /// Create an instance of <see cref="ApiResponse{T}"/> with type <typeparamref name="T"/>.
+        /// </summary>
+        /// <param name="response">Original HTTP Response message.</param>
+        /// <param name="content">Response content.</param>
+        /// <param name="settings">Refit settings used to send the request.</param>
+        /// <param name="error">The ApiException, if the request failed.</param>
+        /// <exception cref="ArgumentNullException"></exception>
         public ApiResponse(HttpResponseMessage response, T? content, RefitSettings settings, ApiException? error = null)
         {
             this.response = response ?? throw new ArgumentNullException(nameof(response));
@@ -27,16 +39,30 @@ namespace Refit
             Settings = settings;
         }
 
+        /// <summary>
+        /// Deserialized request content as <typeparamref name="T"/>.
+        /// </summary>
         public T? Content { get; }
-        public RefitSettings Settings { get; }
 
+        /// <summary>
+        /// Refit settings used to send the request.
+        /// </summary>
+        public RefitSettings Settings { get; }
+        
         public HttpResponseHeaders Headers => response.Headers;
+        
         public HttpContentHeaders? ContentHeaders => response.Content?.Headers;
+        
         public bool IsSuccessStatusCode => response.IsSuccessStatusCode;
+
         public string? ReasonPhrase => response.ReasonPhrase;
+        
         public HttpRequestMessage? RequestMessage => response.RequestMessage;
+        
         public HttpStatusCode StatusCode => response.StatusCode;
+        
         public Version Version => response.Version;
+        
         public ApiException? Error { get; private set; }
 
 
@@ -45,6 +71,11 @@ namespace Refit
             Dispose(true);
         }
 
+        /// <summary>
+        /// Ensures the request was successful by throwing an exception in case of failure
+        /// </summary>
+        /// <returns>The current <see cref="ApiResponse{T}"/></returns>
+        /// <exception cref="ApiException"></exception>
         public async Task<ApiResponse<T>> EnsureSuccessStatusCodeAsync()
         {
             if (!IsSuccessStatusCode)
@@ -70,20 +101,58 @@ namespace Refit
         }
     }
 
+    /// <inheritdoc/>
     public interface IApiResponse<out T> : IApiResponse
     {
+        /// <summary>
+        /// Deserialized request content as <typeparamref name="T"/>.
+        /// </summary>
         T? Content { get; }
     }
 
+    /// <summary>
+    /// Base interface used to represent an API response.
+    /// </summary>
     public interface IApiResponse : IDisposable
     {
+        /// <summary>
+        /// HTTP response headers.
+        /// </summary>
         HttpResponseHeaders Headers { get; }
+
+        /// <summary>
+        /// HTTP response content headers as defined in RFC 2616.
+        /// </summary>
         HttpContentHeaders? ContentHeaders { get; }
+
+        /// <summary>
+        /// Indicates whether the request was successful.
+        /// </summary>
         bool IsSuccessStatusCode { get; }
-        string? ReasonPhrase { get; }
-        HttpRequestMessage? RequestMessage { get; }
+
+        /// <summary>
+        /// HTTP response status code.
+        /// </summary>
         HttpStatusCode StatusCode { get; }
+
+        /// <summary>
+        /// The reason phrase which typically is sent by the server together with the status code.
+        /// </summary>
+        string? ReasonPhrase { get; }
+
+        /// <summary>
+        /// The HTTP Request message which led to this response.
+        /// </summary>
+        HttpRequestMessage? RequestMessage { get; }
+
+        /// <summary>
+        /// HTTP Message version.
+        /// </summary>
         Version Version { get; }
+
+        /// <summary>
+        /// The <see cref="ApiException"/> object in case of unsuccessful response.
+        /// </summary>
         ApiException? Error { get; }
     }
 }

--- a/Refit/Attributes.cs
+++ b/Refit/Attributes.cs
@@ -19,6 +19,9 @@ namespace Refit
         }
     }
 
+    /// <summary>
+    /// Send the request with HTTP method 'GET'.
+    /// </summary>
     [AttributeUsage(AttributeTargets.Method)]
     public class GetAttribute : HttpMethodAttribute
     {
@@ -30,6 +33,9 @@ namespace Refit
         }
     }
 
+    /// <summary>
+    /// Send the request with HTTP method 'POST'.
+    /// </summary>
     [AttributeUsage(AttributeTargets.Method)]
     public class PostAttribute : HttpMethodAttribute
     {
@@ -41,6 +47,9 @@ namespace Refit
         }
     }
 
+    /// <summary>
+    /// Send the request with HTTP method 'PUT'.
+    /// </summary>
     [AttributeUsage(AttributeTargets.Method)]
     public class PutAttribute : HttpMethodAttribute
     {
@@ -52,6 +61,9 @@ namespace Refit
         }
     }
 
+    /// <summary>
+    /// Send the request with HTTP method 'DELETE'.
+    /// </summary>
     [AttributeUsage(AttributeTargets.Method)]
     public class DeleteAttribute : HttpMethodAttribute
     {
@@ -63,6 +75,9 @@ namespace Refit
         }
     }
 
+    /// <summary>
+    /// Send the request with HTTP method 'PATCH'.
+    /// </summary>
     [AttributeUsage(AttributeTargets.Method)]
     public class PatchAttribute : HttpMethodAttribute
     {
@@ -74,6 +89,9 @@ namespace Refit
         }
     }
 
+    /// <summary>
+    /// Send the request with HTTP method 'OPTION'.
+    /// </summary>
     [AttributeUsage(AttributeTargets.Method)]
     public class OptionsAttribute : HttpMethodAttribute
     {
@@ -85,6 +103,9 @@ namespace Refit
         }
     }
 
+    /// <summary>
+    /// Send the request with HTTP method 'HEAD'.
+    /// </summary>
     [AttributeUsage(AttributeTargets.Method)]
     public class HeadAttribute : HttpMethodAttribute
     {
@@ -96,6 +117,12 @@ namespace Refit
         }
     }
 
+    /// <summary>
+    /// Send the request as multipart.
+    /// </summary>
+    /// <remarks>
+    /// Currently, multipart methods only support the following parameter types: <see cref="string"/>, <see cref="byte"/> array, <see cref="System.IO.Stream"/>, <see cref="System.IO.FileInfo"/>.
+    /// </remarks>
     [AttributeUsage(AttributeTargets.Method)]
     public class MultipartAttribute : Attribute
     {
@@ -132,6 +159,17 @@ namespace Refit
         Serialized
     }
 
+    /// <summary>
+    /// Set a parameter to be sent as the HTTP request's body.
+    /// </summary>
+    /// <remarks>
+    /// There are four behaviors when sending a parameter as the request body:<br/>
+    /// - If the type is/implements <see cref="System.IO.Stream"/>, the content will be streamed via <see cref="StreamContent"/>.<br/>
+    /// - If the type is <see cref="string"/>, it will be used directly as the content unless <c>[Body(BodySerializationMethod.Json)]</c> is set
+    /// which will send it as a <see cref="StringContent"/>.<br/>
+    /// - If the parameter has the attribute <c>[Body(BodySerializationMethod.UrlEncoded)]</c>, the content will be URL-encoded.<br/>
+    /// - For all other types, the object will be serialized using the content serializer specified in the request's <see cref="RefitSettings"/>.
+    /// </remarks>
     [AttributeUsage(AttributeTargets.Parameter)]
     public class BodyAttribute : Attribute
     {
@@ -161,6 +199,9 @@ namespace Refit
         public BodySerializationMethod SerializationMethod { get; protected set; } = BodySerializationMethod.Default;
     }
 
+    /// <summary>
+    /// Override the key that will be sent in the query string.
+    /// </summary>
     [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Property)]
     public class AliasAsAttribute : Attribute
     {
@@ -185,7 +226,7 @@ namespace Refit
     }
 
     /// <summary>
-    /// Allows you provide a Dictionary of headers to be added to the request.
+    /// Allows you to provide a Dictionary of headers to be added to the request.
     /// </summary>
     [AttributeUsage(AttributeTargets.Parameter)]
     public class HeaderCollectionAttribute : Attribute
@@ -193,6 +234,9 @@ namespace Refit
 
     }
 
+    /// <summary>
+    /// Add multiple headers to the request.
+    /// </summary>
     [AttributeUsage(AttributeTargets.Interface | AttributeTargets.Method)]
     public class HeadersAttribute : Attribute
     {
@@ -204,6 +248,9 @@ namespace Refit
         public string[] Headers { get; }
     }
 
+    /// <summary>
+    /// Add a header to the request.
+    /// </summary>
     [AttributeUsage(AttributeTargets.Parameter)]
     public class HeaderAttribute : Attribute
     {
@@ -236,6 +283,12 @@ namespace Refit
         public string? Key { get; }
     }
 
+    /// <summary>
+    /// Add the Authorize header to the request with the value of the associated parameter.
+    /// </summary>
+    /// <remarks>
+    /// Default authorization scheme: Bearer
+    /// </remarks>
     [AttributeUsage(AttributeTargets.Parameter)]
     public class AuthorizeAttribute : Attribute
     {
@@ -247,8 +300,10 @@ namespace Refit
         public string Scheme { get; }
     }
 
+    /// <summary>
+    /// Associated value will be added to the request Uri as query-string, using a delimiter to split the values. (default: '.')
+    /// </summary>
     [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Property)] // Property is to allow for form url encoded data
-
     public class QueryAttribute : Attribute
     {
         CollectionFormat? collectionFormat;
@@ -332,7 +387,6 @@ namespace Refit
     }
 
     [AttributeUsage(AttributeTargets.Method)]
-
     public class QueryUriFormatAttribute : Attribute
     {
         public QueryUriFormatAttribute(UriFormat uriFormat)

--- a/Refit/Attributes.cs
+++ b/Refit/Attributes.cs
@@ -135,6 +135,9 @@ namespace Refit
 
     }
 
+    /// <summary>
+    /// Defines methods to serialize HTTP requests' bodies.
+    /// </summary>
     public enum BodySerializationMethod
     {
         /// <summary>

--- a/Refit/MultipartItem.cs
+++ b/Refit/MultipartItem.cs
@@ -38,6 +38,9 @@ namespace Refit
         protected abstract HttpContent CreateContent();
     }
 
+    /// <summary>
+    /// Allows the use of a generic <see cref="Stream"/> in a multipart form body.
+    /// </summary>
     public class StreamPart : MultipartItem
     {
         public StreamPart(Stream value, string fileName, string? contentType = null, string? name = null) :
@@ -54,6 +57,9 @@ namespace Refit
         }
     }
 
+    /// <summary>
+    /// Allows the use of a <see cref="byte"/> array in a multipart form body.
+    /// </summary>
     public class ByteArrayPart : MultipartItem
     {
         public ByteArrayPart(byte[] value, string fileName, string? contentType = null, string? name = null) :
@@ -70,6 +76,9 @@ namespace Refit
         }
     }
 
+    /// <summary>
+    /// Allows the use of a <see cref="FileInfo"/> object in a multipart form body.
+    /// </summary>
     public class FileInfoPart : MultipartItem
     {
         public FileInfoPart(FileInfo value, string fileName, string? contentType = null, string? name = null) :

--- a/Refit/RefitSettings.cs
+++ b/Refit/RefitSettings.cs
@@ -10,9 +10,11 @@ using System.Threading.Tasks;
 
 namespace Refit
 {
+    /// <summary>
+    /// Defines various parameters on how Refit should work.
+    /// </summary>
     public class RefitSettings
-    {       
-
+    {
         /// <summary>
         /// Creates a new <see cref="RefitSettings"/> instance with the default parameters
         /// </summary>
@@ -62,13 +64,35 @@ namespace Refit
         /// </summary>
         public Func<HttpResponseMessage, Task<Exception?>> ExceptionFactory { get; set; }
 
+        /// <summary>
+        /// Defines how requests' content should be serialized. (defaults to <see cref="SystemTextJsonContentSerializer"/>)
+        /// </summary>
         public IHttpContentSerializer ContentSerializer { get; set; }
+
+        /// <summary>
+        /// The <see cref="IUrlParameterFormatter"/> instance to use (defaults to <see cref="DefaultUrlParameterFormatter"/>)
+        /// </summary>
         public IUrlParameterFormatter UrlParameterFormatter { get; set; }
+
+        /// <summary>
+        /// The <see cref="IFormUrlEncodedParameterFormatter"/> instance to use (defaults to <see cref="DefaultFormUrlEncodedParameterFormatter"/>)
+        /// </summary>
         public IFormUrlEncodedParameterFormatter FormUrlEncodedParameterFormatter { get; set; }
+
+        /// <summary>
+        /// Sets the default collection format to use. (defaults to <see cref="CollectionFormat.RefitParameterFormatter"/>)
+        /// </summary>
         public CollectionFormat CollectionFormat { get; set; } = CollectionFormat.RefitParameterFormatter;
+
+        /// <summary>
+        /// Sets the default behavior when sending a request's body content. (defaults to false, request body is not streamed to the server)
+        /// </summary>
         public bool Buffered { get; set; } = false;
     }
 
+    /// <summary>
+    /// Provides content serialization to <see cref="HttpContent"/>.
+    /// </summary>
     public interface IHttpContentSerializer
     {
         HttpContent ToHttpContent<T>(T item);
@@ -83,16 +107,25 @@ namespace Refit
         string? GetFieldNameForProperty(PropertyInfo propertyInfo);
     }
 
+    /// <summary>
+    /// Provides Url parameter formatting.
+    /// </summary>
     public interface IUrlParameterFormatter
     {
         string? Format(object? value, ICustomAttributeProvider attributeProvider, Type type);
     }
 
+    /// <summary>
+    /// Provides form Url-encoded parameter formatting.
+    /// </summary>
     public interface IFormUrlEncodedParameterFormatter
     {
         string? Format(object? value, string? formatString);
     }
 
+    /// <summary>
+    /// Default Url parameter formater.
+    /// </summary>
     public class DefaultUrlParameterFormatter : IUrlParameterFormatter
     {
         static readonly ConcurrentDictionary<Type, ConcurrentDictionary<string, EnumMemberAttribute?>> EnumMemberCache = new();
@@ -128,6 +161,9 @@ namespace Refit
         }
     }
 
+    /// <summary>
+    /// Default form Url-encoded parameter formatter.
+    /// </summary>
     public class DefaultFormUrlEncodedParameterFormatter : IFormUrlEncodedParameterFormatter
     {
         static readonly ConcurrentDictionary<Type, ConcurrentDictionary<string, EnumMemberAttribute?>> EnumMemberCache
@@ -155,6 +191,9 @@ namespace Refit
         }
     }
 
+    /// <summary>
+    /// Default Api exception factory.
+    /// </summary>
     public class DefaultApiExceptionFactory
     {
         static readonly Task<Exception?> NullTask = Task.FromResult<Exception?>(null);

--- a/Refit/RefitSettings.cs
+++ b/Refit/RefitSettings.cs
@@ -95,15 +95,28 @@ namespace Refit
     /// </summary>
     public interface IHttpContentSerializer
     {
+        /// <summary>
+        /// Serializes an object of type <typeparamref name="T"/> to <see cref="HttpContent"/>
+        /// </summary>
+        /// <typeparam name="T">Type of the object to serialize from.</typeparam>
+        /// <param name="item">Object to serialize.</param>
+        /// <returns><see cref="HttpContent"/> that contains the serialized <typeparamref name="T"/> object.</returns>
         HttpContent ToHttpContent<T>(T item);
 
+        /// <summary>
+        /// Deserializes an object of type <typeparamref name="T"/> from an <see cref="HttpContent"/> object.
+        /// </summary>
+        /// <typeparam name="T">Type of the object to serialize to.</typeparam>
+        /// <param name="content">HttpContent object to deserialize.</param>
+        /// <param name="cancellationToken">CancellationToken to abort the deserialization.</param>
+        /// <returns>The deserialized object of type <typeparamref name="T"/>.</returns>
         Task<T?> FromHttpContentAsync<T>(HttpContent content, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Calculates what the field name should be for the given property. This may be affected by custom attributes the serializer understands
         /// </summary>
-        /// <param name="propertyInfo"></param>
-        /// <returns></returns>
+        /// <param name="propertyInfo">A PropertyInfo object.</param>
+        /// <returns>The calculated field name.</returns>
         string? GetFieldNameForProperty(PropertyInfo propertyInfo);
     }
 

--- a/Refit/RestService.cs
+++ b/Refit/RestService.cs
@@ -8,11 +8,25 @@ namespace Refit
     {
         static readonly ConcurrentDictionary<Type, Type> TypeMapping = new();
 
+        /// <summary>
+        /// Generate a Refit implementation of the specified interface.
+        /// </summary>
+        /// <typeparam name="T">Interface to create the implementation for.</typeparam>
+        /// <param name="client">The <see cref="HttpClient"/> the implementation will use to send requests.</param>
+        /// <param name="builder"><see cref="IRequestBuilder"/> to use to build requests.</param>
+        /// <returns>An instance that implements <typeparamref name="T"/>.</returns>
         public static T For<T>(HttpClient client, IRequestBuilder<T> builder)
         {
-            return (T)For(typeof(T), client, builder);            
+            return (T)For(typeof(T), client, builder);
         }
 
+        /// <summary>
+        /// Generate a Refit implementation of the specified interface.
+        /// </summary>
+        /// <typeparam name="T">Interface to create the implementation for.</typeparam>
+        /// <param name="client">The <see cref="HttpClient"/> the implementation will use to send requests.</param>
+        /// <param name="settings"><see cref="RefitSettings"/> to use to configure the HttpClient.</param>
+        /// <returns>An instance that implements <typeparamref name="T"/>.</returns>
         public static T For<T>(HttpClient client, RefitSettings? settings)
         {
             var requestBuilder = RequestBuilder.ForType<T>(settings);
@@ -20,8 +34,21 @@ namespace Refit
             return For(client, requestBuilder);
         }
 
+        /// <summary>
+        /// Generate a Refit implementation of the specified interface.
+        /// </summary>
+        /// <typeparam name="T">Interface to create the implementation for.</typeparam>
+        /// <param name="client">The <see cref="HttpClient"/> the implementation will use to send requests.</param>
+        /// <returns>An instance that implements <typeparamref name="T"/>.</returns>
         public static T For<T>(HttpClient client) => For<T>(client, (RefitSettings?)null);
 
+        /// <summary>
+        /// Generate a Refit implementation of the specified interface.
+        /// </summary>
+        /// <typeparam name="T">Interface to create the implementation for.</typeparam>
+        /// <param name="hostUrl">Base address the implementation will use.</param>
+        /// <param name="settings"><see cref="RefitSettings"/> to use to configure the HttpClient.</param>
+        /// <returns>An instance that implements <typeparamref name="T"/>.</returns>
         public static T For<T>(string hostUrl, RefitSettings? settings)
         {
             var client = CreateHttpClient(hostUrl, settings);
@@ -29,8 +56,21 @@ namespace Refit
             return For<T>(client, settings);
         }
 
+        /// <summary>
+        /// Generate a Refit implementation of the specified interface.
+        /// </summary>
+        /// <typeparam name="T">Interface to create the implementation for.</typeparam>
+        /// <param name="hostUrl">Base address the implementation will use.</param>
+        /// <returns>An instance that implements <typeparamref name="T"/>.</returns>
         public static T For<T>(string hostUrl) => For<T>(hostUrl, null);
 
+        /// <summary>
+        /// Generate a Refit implementation of the specified interface.
+        /// </summary>
+        /// <param name="refitInterfaceType">Interface to create the implementation for.</param>
+        /// <param name="client">The <see cref="HttpClient"/> the implementation will use to send requests.</param>
+        /// <param name="builder"><see cref="IRequestBuilder"/> to use to build requests.</param>
+        /// <returns>An instance that implements <paramref name="refitInterfaceType"/>.</returns>
         public static object For(Type refitInterfaceType, HttpClient client, IRequestBuilder builder)
         {
             var generatedType = TypeMapping.GetOrAdd(refitInterfaceType, GetGeneratedType(refitInterfaceType));
@@ -38,6 +78,13 @@ namespace Refit
             return Activator.CreateInstance(generatedType, client, builder)!;
         }
 
+        /// <summary>
+        /// Generate a Refit implementation of the specified interface.
+        /// </summary>
+        /// <param name="refitInterfaceType">Interface to create the implementation for.</param>
+        /// <param name="client">The <see cref="HttpClient"/> the implementation will use to send requests.</param>
+        /// <param name="settings"><see cref="RefitSettings"/> to use to configure the HttpClient.</param>
+        /// <returns>An instance that implements <paramref name="refitInterfaceType"/>.</returns>
         public static object For(Type refitInterfaceType, HttpClient client, RefitSettings? settings)
         {
             var requestBuilder = RequestBuilder.ForType(refitInterfaceType, settings);
@@ -45,8 +92,21 @@ namespace Refit
             return For(refitInterfaceType, client, requestBuilder);
         }
 
+        /// <summary>
+        /// Generate a Refit implementation of the specified interface.
+        /// </summary>
+        /// <param name="refitInterfaceType">Interface to create the implementation for.</param>
+        /// <param name="client">The <see cref="HttpClient"/> the implementation will use to send requests.</param>
+        /// <returns>An instance that implements <paramref name="refitInterfaceType"/>.</returns>
         public static object For(Type refitInterfaceType, HttpClient client) => For(refitInterfaceType, client, (RefitSettings?)null);
 
+        /// <summary>
+        /// Generate a Refit implementation of the specified interface.
+        /// </summary>
+        /// <param name="refitInterfaceType">Interface to create the implementation for.</param>
+        /// <param name="hostUrl">Base address the implementation will use.</param>
+        /// <param name="settings"><see cref="RefitSettings"/> to use to configure the HttpClient.</param>
+        /// <returns>An instance that implements <paramref name="refitInterfaceType"/>.</returns>
         public static object For(Type refitInterfaceType, string hostUrl, RefitSettings? settings)
         {
             var client = CreateHttpClient(hostUrl, settings);
@@ -54,8 +114,21 @@ namespace Refit
             return For(refitInterfaceType, client, settings);
         }
 
+        /// <summary>
+        /// Generate a Refit implementation of the specified interface.
+        /// </summary>
+        /// <param name="refitInterfaceType">Interface to create the implementation for.</param>
+        /// <param name="hostUrl">Base address the implementation will use.</param>
+        /// <returns>An instance that implements <paramref name="refitInterfaceType"/>.</returns>
         public static object For(Type refitInterfaceType, string hostUrl) => For(refitInterfaceType, hostUrl, null);             
 
+        /// <summary>
+        /// Create an <see cref="HttpClient"/> with <paramref name="hostUrl"/> as the base address.
+        /// </summary>
+        /// <param name="hostUrl">Base address.</param>
+        /// <param name="settings"><see cref="RefitSettings"/> to use to configure the HttpClient.</param>
+        /// <returns>A <see cref="HttpClient"/> with the various parameters provided.</returns>
+        /// <exception cref="ArgumentException"></exception>
         public static HttpClient CreateHttpClient(string hostUrl, RefitSettings? settings)
         {
             if (string.IsNullOrWhiteSpace(hostUrl))

--- a/Refit/XmlContentSerializer.cs
+++ b/Refit/XmlContentSerializer.cs
@@ -12,7 +12,9 @@ using System.Xml.Serialization;
 
 namespace Refit
 {
-
+    /// <summary>
+    /// A <see langword="class"/> implementing <see cref="IHttpContentSerializer"/> which provides Xml content serialization.
+    /// </summary>
     public class XmlContentSerializer : IHttpContentSerializer
     {
         readonly XmlContentSerializerSettings settings;
@@ -27,6 +29,13 @@ namespace Refit
             this.settings = settings ?? throw new ArgumentNullException(nameof(settings));
         }
 
+        /// <summary>
+        /// Serialize object of type <typeparamref name="T"/> to a <see cref="HttpContent"/> with Xml.
+        /// </summary>
+        /// <typeparam name="T">Type of the object to serialize from.</typeparam>
+        /// <param name="item">Object to serialize.</param>
+        /// <returns><see cref="HttpContent"/> that contains the serialized <typeparamref name="T"/> object in Xml.</returns>
+        /// <exception cref="ArgumentNullException"></exception>
         public HttpContent ToHttpContent<T>(T item)
         {
             if (item is null) throw new ArgumentNullException(nameof(item));
@@ -42,6 +51,13 @@ namespace Refit
             return content;
         }
 
+        /// <summary>
+        /// Deserializes an object of type <typeparamref name="T"/> from a <see cref="HttpContent"/> object that contains Xml content.
+        /// </summary>
+        /// <typeparam name="T">Type of the object to deserialize to.</typeparam>
+        /// <param name="content">HttpContent object with Xml content to deserialize.</param>
+        /// <param name="cancellationToken">CancellationToken to abort the deserialization.</param>
+        /// <returns>The deserialized object of type <typeparamref name="T"/>.</returns>
         public async Task<T?> FromHttpContentAsync<T>(HttpContent content, CancellationToken cancellationToken = default)
         {
             var xmlSerializer = serializerCache.GetOrAdd(typeof(T), t => new XmlSerializer(
@@ -58,6 +74,7 @@ namespace Refit
             return (T?)xmlSerializer.Deserialize(reader);
         }
 
+        /// <inheritdoc/>
         public string? GetFieldNameForProperty(PropertyInfo propertyInfo)
         {
             if (propertyInfo is null)


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Xml Docs on publicly exposed classes and methods.


**What is the current behavior?**
<!-- You can also link to an open issue here. -->
Most of the classes and methods you would use when using Refit have no Xml docs. Related issue: https://github.com/reactiveui/refit/issues/1274

**What is the new behavior?**
<!-- If this is a feature change -->
Developers using the library will now see comments when typing a class or method name, hovering over them, etc.


**What might this PR break?**
I can't see how adding comments could break something so nothing afaik.


**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features). Checked but doesn't apply to this PR.
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:

Let me know if I have missed something or if you see a comment that should be worded differently/is wrong !