### PR TITLE
feat: allow custom formatting querystring keys in objects

### DIFF
--- a/Refit.Tests/RequestBuilder.cs
+++ b/Refit.Tests/RequestBuilder.cs
@@ -376,6 +376,29 @@ namespace Refit.Tests
         }
 
         [Fact]
+        public void PostWithCustomQueryParameterKeyFormatterHasCorrectQuerystring()
+        {
+            var settings = new RefitSettings() {
+                UrlParameterKeyFormatter = new TestUrlParameterKeyFormatter()
+            };
+            var fixture = new RequestBuilderImplementation<IDummyHttpApi>(settings);
+
+            var factory = fixture.BuildRequestFactoryForMethod(nameof(IDummyHttpApi.PostWithComplexTypeQuery));
+
+            var param = new ComplexQueryObject
+            {
+                TestAlias1 = "one",
+                TestAlias2 = "two"
+            };
+
+            var output = factory(new object[] { param });
+
+            var uri = new Uri(new Uri("http://api"), output.RequestUri);
+
+            Assert.Equal("/foo?test-query-alias=one&testalias2=two", uri.PathAndQuery);
+        }
+
+        [Fact]
         public void PostWithObjectQueryParameterWithEnumList_Multi()
         {
             var fixture = new RequestBuilderImplementation<IDummyHttpApi>();
@@ -1520,6 +1543,21 @@ namespace Refit.Tests
             }
 
             return base.Format(parameterValue, attributeProvider, type);
+        }
+    }
+
+    public class TestUrlLowercaseParameterKeyFormatter : IUrlParameterKeyFormatter
+    {
+        readonly string constantParameterOutput;
+
+        public TestUrlLowercaseParameterKeyFormatter(string constantOutput)
+        {
+            constantParameterOutput = constantOutput;
+        }
+
+        public string Format(object key, ICustomAttributeProvider attributeProvider, Type type)
+        {
+            return constantParameterOutput;
         }
     }
 

--- a/Refit.Tests/RequestBuilder.cs
+++ b/Refit.Tests/RequestBuilder.cs
@@ -376,7 +376,30 @@ namespace Refit.Tests
         }
 
         [Fact]
-        public void PostWithCustomUrlParameterKeyFormatterHasCorrectQuerystring()
+        public void PostWithCustomUrlParameterKeyFormatterShouldFormatNonAliasedComplexQueryObjectKeys()
+        {
+            var settings = new RefitSettings()
+            {
+                UrlParameterKeyFormatter = new TestUrlLowercaseParameterKeyFormatter()
+            };
+            var fixture = new RequestBuilderImplementation<IDummyHttpApi>(settings);
+
+            var factory = fixture.BuildRequestFactoryForMethod(nameof(IDummyHttpApi.PostWithComplexTypeQuery));
+
+            var param = new ComplexQueryObject
+            {
+                TestAlias2 = "two"
+            };
+
+            var output = factory(new object[] { param });
+
+            var uri = new Uri(new Uri("http://api"), output.RequestUri);
+
+            Assert.Equal("/foo?testalias2=two", uri.PathAndQuery);
+        }
+
+        [Fact]
+        public void PostWithCustomUrlParameterKeyFormatterShould_Not_FormatAliasedComplexQueryObjectKeys()
         {
             var settings = new RefitSettings()
             {

--- a/Refit.Tests/RequestBuilder.cs
+++ b/Refit.Tests/RequestBuilder.cs
@@ -234,19 +234,19 @@ namespace Refit.Tests
         Task ManyComplexTypes(Dictionary<int, string> theData, [Body] Dictionary<int, string> theData1);
 
         [Post("/foo")]
-        Task PostWithDictionaryQuery([Query]Dictionary<int, string> theData);
+        Task PostWithDictionaryQuery([Query] Dictionary<int, string> theData);
 
         [Post("/foo")]
-        Task PostWithComplexTypeQuery([Query]ComplexQueryObject queryParams);
+        Task PostWithComplexTypeQuery([Query] ComplexQueryObject queryParams);
 
         [Post("/foo")]
         Task ImpliedComplexQueryType(ComplexQueryObject queryParams, [Body] Dictionary<int, string> theData1);
 
         [Get("/api/{id}")]
-        Task MultipleQueryAttributes(int id, [Query]string text = null, [Query]int? optionalId = null, [Query(CollectionFormat = CollectionFormat.Multi)]string[] filters = null);
+        Task MultipleQueryAttributes(int id, [Query] string text = null, [Query] int? optionalId = null, [Query(CollectionFormat = CollectionFormat.Multi)] string[] filters = null);
 
         [Get("/api/{id}")]
-        Task NullableValues(int id, string text = null, int? optionalId = null, [Query(CollectionFormat = CollectionFormat.Multi)]string[] filters = null);
+        Task NullableValues(int id, string text = null, int? optionalId = null, [Query(CollectionFormat = CollectionFormat.Multi)] string[] filters = null);
 
         [Get("/api/{id}")]
         Task IEnumerableThrowingError([Query(CollectionFormat.Multi)] IEnumerable<string> values);
@@ -376,10 +376,11 @@ namespace Refit.Tests
         }
 
         [Fact]
-        public void PostWithCustomQueryParameterKeyFormatterHasCorrectQuerystring()
+        public void PostWithCustomUrlParameterKeyFormatterHasCorrectQuerystring()
         {
-            var settings = new RefitSettings() {
-                UrlParameterKeyFormatter = new TestUrlParameterKeyFormatter()
+            var settings = new RefitSettings()
+            {
+                UrlParameterKeyFormatter = new TestUrlLowercaseParameterKeyFormatter()
             };
             var fixture = new RequestBuilderImplementation<IDummyHttpApi>(settings);
 
@@ -534,7 +535,7 @@ namespace Refit.Tests
             Assert.Empty(fixture.QueryParameterMap);
             Assert.Null(fixture.BodyParameterInfo);
         }
-        
+
         [Fact]
         public void ParameterMappingWithTheSameIdInAFewPlaces()
         {
@@ -1222,7 +1223,7 @@ namespace Refit.Tests
         Task<string> FetchSomeStuffWithCustomHeader(int id, [Header("X-Emoji")] string custom);
 
         [Get("/foo/bar/{id}")]
-        Task<string> FetchSomeStuffWithPathMemberInCustomHeader([Header("X-PathMember")]int id, [Header("X-Emoji")] string custom);
+        Task<string> FetchSomeStuffWithPathMemberInCustomHeader([Header("X-PathMember")] int id, [Header("X-Emoji")] string custom);
 
         [Post("/foo/bar/{id}")]
         Task<string> PostSomeStuffWithCustomHeader(int id, [Body] object body, [Header("X-Emoji")] string emoji);
@@ -1325,19 +1326,19 @@ namespace Refit.Tests
         Task QueryWithExplicitParameters(string param1, string param2);
 
         [Get("/query")]
-        Task QueryWithArrayFormattedAsMulti([Query(CollectionFormat.Multi)]int[] numbers);
+        Task QueryWithArrayFormattedAsMulti([Query(CollectionFormat.Multi)] int[] numbers);
 
         [Get("/query")]
-        Task QueryWithArrayFormattedAsCsv([Query(CollectionFormat.Csv)]int[] numbers);
+        Task QueryWithArrayFormattedAsCsv([Query(CollectionFormat.Csv)] int[] numbers);
 
         [Get("/query")]
-        Task QueryWithArrayFormattedAsSsv([Query(CollectionFormat.Ssv)]int[] numbers);
+        Task QueryWithArrayFormattedAsSsv([Query(CollectionFormat.Ssv)] int[] numbers);
 
         [Get("/query")]
-        Task QueryWithArrayFormattedAsTsv([Query(CollectionFormat.Tsv)]int[] numbers);
+        Task QueryWithArrayFormattedAsTsv([Query(CollectionFormat.Tsv)] int[] numbers);
 
         [Get("/query")]
-        Task QueryWithArrayFormattedAsPipes([Query(CollectionFormat.Pipes)]int[] numbers);
+        Task QueryWithArrayFormattedAsPipes([Query(CollectionFormat.Pipes)] int[] numbers);
 
         [Get("/foo")]
         Task ComplexQueryObjectWithDictionary([Query] ComplexQueryObject query);
@@ -1352,19 +1353,19 @@ namespace Refit.Tests
         Task QueryWithDictionaryWithNumericKey([Query] IDictionary<int, string> query);
 
         [Get("/query")]
-        Task QueryWithEnumerableFormattedAsMulti([Query(CollectionFormat.Multi)]IEnumerable<string> lines);
+        Task QueryWithEnumerableFormattedAsMulti([Query(CollectionFormat.Multi)] IEnumerable<string> lines);
 
         [Get("/query")]
-        Task QueryWithEnumerableFormattedAsCsv([Query(CollectionFormat.Csv)]IEnumerable<string> lines);
+        Task QueryWithEnumerableFormattedAsCsv([Query(CollectionFormat.Csv)] IEnumerable<string> lines);
 
         [Get("/query")]
-        Task QueryWithEnumerableFormattedAsSsv([Query(CollectionFormat.Ssv)]IEnumerable<string> lines);
+        Task QueryWithEnumerableFormattedAsSsv([Query(CollectionFormat.Ssv)] IEnumerable<string> lines);
 
         [Get("/query")]
-        Task QueryWithEnumerableFormattedAsTsv([Query(CollectionFormat.Tsv)]IEnumerable<string> lines);
+        Task QueryWithEnumerableFormattedAsTsv([Query(CollectionFormat.Tsv)] IEnumerable<string> lines);
 
         [Get("/query")]
-        Task QueryWithEnumerableFormattedAsPipes([Query(CollectionFormat.Pipes)]IEnumerable<string> lines);
+        Task QueryWithEnumerableFormattedAsPipes([Query(CollectionFormat.Pipes)] IEnumerable<string> lines);
 
         [Get("/query")]
         Task QueryWithObjectWithPrivateGetters(Person person);
@@ -1380,7 +1381,7 @@ namespace Refit.Tests
         Task QueryWithTypeWithEnum(TypeFooWithEnumMember foo);
 
         [Get("/api/{id}")]
-        Task QueryWithOptionalParameters(int id, [Query]string text = null, [Query]int? optionalId = null, [Query(CollectionFormat = CollectionFormat.Multi)]string[] filters = null);
+        Task QueryWithOptionalParameters(int id, [Query] string text = null, [Query] int? optionalId = null, [Query(CollectionFormat = CollectionFormat.Multi)] string[] filters = null);
 
         [Delete("/api/bar")]
         Task ClearWithEnumMember([Query] FooWithEnumMember foo);
@@ -1403,13 +1404,13 @@ namespace Refit.Tests
 
 
         [Post("/foo")]
-        Task PostWithComplexTypeQuery([Query]ComplexQueryObject queryParams);
+        Task PostWithComplexTypeQuery([Query] ComplexQueryObject queryParams);
 
         [Get("/foo")]
-        Task ComplexTypeQueryWithInnerCollection([Query]ComplexQueryObject queryParams);
+        Task ComplexTypeQueryWithInnerCollection([Query] ComplexQueryObject queryParams);
 
         [Get("/api/{obj.someProperty}")]
-        Task QueryWithOptionalParametersPathBoundObject(PathBoundObject obj, [Query]string text = null, [Query]int? optionalId = null, [Query(CollectionFormat = CollectionFormat.Multi)]string[] filters = null);
+        Task QueryWithOptionalParametersPathBoundObject(PathBoundObject obj, [Query] string text = null, [Query] int? optionalId = null, [Query(CollectionFormat = CollectionFormat.Multi)] string[] filters = null);
 
         [Headers("Accept:application/json", "X-API-V: 125")]
         [Get("/api/someModule/deviceList?controlId={control_id}")]
@@ -1548,16 +1549,9 @@ namespace Refit.Tests
 
     public class TestUrlLowercaseParameterKeyFormatter : IUrlParameterKeyFormatter
     {
-        readonly string constantParameterOutput;
-
-        public TestUrlLowercaseParameterKeyFormatter(string constantOutput)
+        public string Format(string key)
         {
-            constantParameterOutput = constantOutput;
-        }
-
-        public string Format(object key, ICustomAttributeProvider attributeProvider, Type type)
-        {
-            return constantParameterOutput;
+            return key.ToLowerInvariant();
         }
     }
 
@@ -2165,7 +2159,7 @@ namespace Refit.Tests
             var someProperty = new object();
             var fixture = new RequestBuilderImplementation<IContainAandB>();
             var factory = fixture.BuildRequestFactoryForMethod(nameof(IContainAandB.Ping));
-            var output = factory(new object[] {  });
+            var output = factory(new object[] { });
 
 #if NET5_0_OR_GREATER
             Assert.NotEmpty(output.Options);
@@ -2908,7 +2902,7 @@ namespace Refit.Tests
                 {
                     task.Wait();
                 }
-                catch(AggregateException e) when (e.InnerException is TaskCanceledException)
+                catch (AggregateException e) when (e.InnerException is TaskCanceledException)
                 {
 
                 }

--- a/Refit.Tests/RequestBuilder.cs
+++ b/Refit.Tests/RequestBuilder.cs
@@ -380,7 +380,7 @@ namespace Refit.Tests
         {
             var settings = new RefitSettings()
             {
-                UrlParameterKeyFormatter = new TestUrlLowercaseParameterKeyFormatter()
+                UrlParameterKeyFormatter = new TestUrlParameterKeyFormatterUsesLowercaseExceptAliased()
             };
             var fixture = new RequestBuilderImplementation<IDummyHttpApi>(settings);
 
@@ -399,11 +399,11 @@ namespace Refit.Tests
         }
 
         [Fact]
-        public void PostWithCustomUrlParameterKeyFormatterShould_Not_FormatAliasedComplexQueryObjectKeys()
+        public void PostWithCustomUrlParameterKeyFormatterThatInheritsDefaultFormatterShould_Not_FormatAliasedComplexQueryObjectKeys()
         {
             var settings = new RefitSettings()
             {
-                UrlParameterKeyFormatter = new TestUrlLowercaseParameterKeyFormatter()
+                UrlParameterKeyFormatter = new TestUrlParameterKeyFormatterUsesLowercaseExceptAliased()
             };
             var fixture = new RequestBuilderImplementation<IDummyHttpApi>(settings);
 
@@ -1570,10 +1570,18 @@ namespace Refit.Tests
         }
     }
 
-    public class TestUrlLowercaseParameterKeyFormatter : IUrlParameterKeyFormatter
+    public class TestUrlParameterKeyFormatterUsesLowercaseExceptAliased : DefaultUrlParameterKeyFormatter
     {
-        public string Format(string key)
+        public override string Format(string key, ICustomAttributeProvider attributeProvider)
         {
+            var baseKey = base.Format(key, attributeProvider);
+            var isAliased = baseKey != key;
+
+            if (isAliased) 
+            {
+                return baseKey;
+            }
+
             return key.ToLowerInvariant();
         }
     }

--- a/Refit/RefitSettings.cs
+++ b/Refit/RefitSettings.cs
@@ -11,7 +11,7 @@ using System.Threading.Tasks;
 namespace Refit
 {
     public class RefitSettings
-    {       
+    {
 
         /// <summary>
         /// Creates a new <see cref="RefitSettings"/> instance with the default parameters
@@ -20,6 +20,7 @@ namespace Refit
         {
             ContentSerializer = new SystemTextJsonContentSerializer();
             UrlParameterFormatter = new DefaultUrlParameterFormatter();
+            UrlParameterKeyFormatter = new DefaultUrlParameterKeyFormatter();
             FormUrlEncodedParameterFormatter = new DefaultFormUrlEncodedParameterFormatter();
             ExceptionFactory = new DefaultApiExceptionFactory(this).CreateAsync;
         }
@@ -30,13 +31,16 @@ namespace Refit
         /// <param name="contentSerializer">The <see cref="IHttpContentSerializer"/> instance to use</param>
         /// <param name="urlParameterFormatter">The <see cref="IUrlParameterFormatter"/> instance to use (defaults to <see cref="DefaultUrlParameterFormatter"/>)</param>
         /// <param name="formUrlEncodedParameterFormatter">The <see cref="IFormUrlEncodedParameterFormatter"/> instance to use (defaults to <see cref="DefaultFormUrlEncodedParameterFormatter"/>)</param>
+        /// /// <param name="urlParameterKeyFormatter">The <see cref="IUrlParameterKeyFormatter"/> instance to use to format query key names (defaults to <see cref="DefaultUrlParameterKeyFormatter"/> which passes through original names)</param>
         public RefitSettings(
             IHttpContentSerializer contentSerializer,
             IUrlParameterFormatter? urlParameterFormatter = null,
-            IFormUrlEncodedParameterFormatter? formUrlEncodedParameterFormatter = null)
+            IFormUrlEncodedParameterFormatter? formUrlEncodedParameterFormatter = null,
+            IUrlParameterKeyFormatter? urlParameterKeyFormatter = null)
         {
             ContentSerializer = contentSerializer ?? throw new ArgumentNullException(nameof(contentSerializer), "The content serializer can't be null");
             UrlParameterFormatter = urlParameterFormatter ?? new DefaultUrlParameterFormatter();
+            UrlParameterKeyFormatter = urlParameterKeyFormatter ?? new DefaultUrlParameterKeyFormatter();
             FormUrlEncodedParameterFormatter = formUrlEncodedParameterFormatter ?? new DefaultFormUrlEncodedParameterFormatter();
             ExceptionFactory = new DefaultApiExceptionFactory(this).CreateAsync;
         }
@@ -64,6 +68,7 @@ namespace Refit
 
         public IHttpContentSerializer ContentSerializer { get; set; }
         public IUrlParameterFormatter UrlParameterFormatter { get; set; }
+        public IUrlParameterKeyFormatter UrlParameterKeyFormatter { get; set; }
         public IFormUrlEncodedParameterFormatter FormUrlEncodedParameterFormatter { get; set; }
         public CollectionFormat CollectionFormat { get; set; } = CollectionFormat.RefitParameterFormatter;
         public bool Buffered { get; set; } = false;
@@ -86,6 +91,13 @@ namespace Refit
     public interface IUrlParameterFormatter
     {
         string? Format(object? value, ICustomAttributeProvider attributeProvider, Type type);
+    }
+
+    /// <summary>
+    /// Formats the key name of URL query parameters (e.g. `TestProperty1=true` => `test_property_1=true`).
+    /// </summary>
+    public interface IUrlParameterKeyFormatter {
+        string? Format(string key);
     }
 
     public interface IFormUrlEncodedParameterFormatter
@@ -125,6 +137,14 @@ namespace Refit
                                            ? "{0}"
                                            : $"{{0:{formatString}}}",
                                        enummember?.Value ?? parameterValue);
+        }
+    }
+
+    public class DefaultUrlParameterKeyFormatter : IUrlParameterKeyFormatter
+    {
+        public string? Format(string key)
+        {
+            return key;
         }
     }
 

--- a/Refit/RefitSettings.cs
+++ b/Refit/RefitSettings.cs
@@ -31,7 +31,7 @@ namespace Refit
         /// <param name="contentSerializer">The <see cref="IHttpContentSerializer"/> instance to use</param>
         /// <param name="urlParameterFormatter">The <see cref="IUrlParameterFormatter"/> instance to use (defaults to <see cref="DefaultUrlParameterFormatter"/>)</param>
         /// <param name="formUrlEncodedParameterFormatter">The <see cref="IFormUrlEncodedParameterFormatter"/> instance to use (defaults to <see cref="DefaultFormUrlEncodedParameterFormatter"/>)</param>
-        /// /// <param name="urlParameterKeyFormatter">The <see cref="IUrlParameterKeyFormatter"/> instance to use to format query key names (defaults to <see cref="DefaultUrlParameterKeyFormatter"/> which passes through original names)</param>
+        /// /// <param name="urlParameterKeyFormatter">The <see cref="IUrlParameterKeyFormatter"/> instance to use to format query key names (defaults to <see cref="DefaultUrlParameterKeyFormatter"/>)</param>
         public RefitSettings(
             IHttpContentSerializer contentSerializer,
             IUrlParameterFormatter? urlParameterFormatter = null,
@@ -96,8 +96,9 @@ namespace Refit
     /// <summary>
     /// Formats the key name of URL query parameters (e.g. `TestProperty1=true` => `test_property_1=true`).
     /// </summary>
-    public interface IUrlParameterKeyFormatter {
-        string? Format(string key);
+    public interface IUrlParameterKeyFormatter
+    {
+        string? Format(string key, ICustomAttributeProvider attributeProvider);
     }
 
     public interface IFormUrlEncodedParameterFormatter
@@ -142,9 +143,19 @@ namespace Refit
 
     public class DefaultUrlParameterKeyFormatter : IUrlParameterKeyFormatter
     {
-        public string? Format(string key)
+        public virtual string? Format(string key, ICustomAttributeProvider attributeProvider)
         {
-            return key;
+            var aliasAs = attributeProvider.GetCustomAttributes(typeof(AliasAsAttribute), true)
+                .OfType<AliasAsAttribute>()
+                .FirstOrDefault()?.Name;
+            if (aliasAs != null)
+            {
+                return aliasAs;
+            }
+            else
+            {
+                return key;
+            }
         }
     }
 

--- a/Refit/RequestBuilderImplementation.cs
+++ b/Refit/RequestBuilderImplementation.cs
@@ -378,17 +378,7 @@ namespace Refit
                     }
                 }
 
-                var key = propertyInfo.Name;
-
-                var aliasAttribute = propertyInfo.GetCustomAttribute<AliasAsAttribute>();
-                if (aliasAttribute != null)
-                {
-                    key = aliasAttribute.Name;
-                }
-                else
-                {
-                    key = settings.UrlParameterKeyFormatter.Format(key);
-                }
+                var key = settings.UrlParameterKeyFormatter.Format(propertyInfo.Name, propertyInfo);
 
                 // Look to see if the property has a Query attribute, and if so, format it accordingly
                 var queryAttribute = propertyInfo.GetCustomAttribute<QueryAttribute>();

--- a/Refit/RequestBuilderImplementation.cs
+++ b/Refit/RequestBuilderImplementation.cs
@@ -382,8 +382,13 @@ namespace Refit
 
                 var aliasAttribute = propertyInfo.GetCustomAttribute<AliasAsAttribute>();
                 if (aliasAttribute != null)
+                {
                     key = aliasAttribute.Name;
-
+                }
+                else
+                {
+                    key = settings.UrlParameterKeyFormatter.Format(key);
+                }
 
                 // Look to see if the property has a Query attribute, and if so, format it accordingly
                 var queryAttribute = propertyInfo.GetCustomAttribute<QueryAttribute>();
@@ -445,7 +450,7 @@ namespace Refit
                 var keyType = key.GetType();
                 var formattedKey = settings.UrlParameterFormatter.Format(key, keyType, keyType);
 
-                if(string.IsNullOrWhiteSpace(formattedKey)) // blank keys can't be put in the query string
+                if (string.IsNullOrWhiteSpace(formattedKey)) // blank keys can't be put in the query string
                 {
                     continue;
                 }


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Closes #1258 I believe! This adds the ability to customize the key handling when using complex objects. It encapsulates the default handling of looking at `[AliasAs]` and allows consumers to override or extend this behavior.

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

The current behavior will serialize property names in querystrings as their object property names by default. If `[AliasAs]` is used, it uses that name instead.

**What is the new behavior?**
<!-- If this is a feature change -->

The logic that performed the default behavior is now encapsulated into a `UrlParameterKeyFormatter` to stay consistent with the other `UrlParameterFormatter` class.

_Update:_ I noticed `BuildQueryMap` against a dictionary formats keys using `UrlParameterFormatter.Format`. It may be useful then to consolidate my impl with that or switch that to this. But that is a change in behavior since it might be looking at `Query` or enum attributes right now.

I think there is _slight_ responsibility differences between these:

```c#
var keyType = key.GetType();
var formattedKey = settings.UrlParameterFormatter.Format(key, keyType, keyType);
```

vs.

```c#
var key = settings.UrlParameterKeyFormatter.Format(propertyInfo.Name, propertyInfo);
```

By delegating to a _specific_ key handler, the consumer can know it's a query string key. With the dictionary approach, the consumer doesn't know if the value being passed is meant to be a key or a value.

I'd propose then either:

1. Introducing a `FormatKey` method onto `IUrlParameterFormatter`
2. Changing the dictionary approach to call the new key formatter (breaking change)
3. Add another intermediate step to call key formatter on the _return value_ (`formattedKey`) of the dictionary value formatter

Like so:

```c#
var keyType = key.GetType();
var keyValueFormatted = settings.UrlParameterFormatter.Format(key, keyType, keyType);
var formattedKey = settings.UrlParameterKeyFormatter.Format(keyFormattedValue, keyType);
```

But I am not positive. It's inconsistent at the moment which would be confusing I expect.

**What might this PR break?**

As-is, this will not have any breaking changes and is backwards-compatible. See above for some other approaches though.

**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:

