### PR TITLE
Refit interface methods that return Task<IApiResponse> assign ApiException to the IApiResponse.Error property on error

### DIFF
--- a/README.md
+++ b/README.md
@@ -1135,10 +1135,10 @@ public class HomeController : Controller
 ```
 
 ### Handling exceptions
-Refit has different exception handling behavior depending on if your Refit interface methods return `Task<T>` or if they return `Task<ApiResponse<T>>`.
+Refit has different exception handling behavior depending on if your Refit interface methods return `Task<T>` or if they return `Task<IApiResponse>`, `Task<IApiResponse<T>>`, or `Task<ApiResponse<T>>`.
 
-#### When returning `Task<ApiResponse<T>>`
-Refit traps any `ApiException` raised by the `ExceptionFactory` when processing the response and any errors that occur when attempting to deserialize the response to `Task<ApiResponse<T>>` and populates the exception into the `Error` property on `ApiResponse<T>` without throwing the exception.
+#### When returning `Task<IApiResponse>`, `Task<IApiResponse<T>>`, or `Task<ApiResponse<T>>`
+Refit traps any `ApiException` raised by the `ExceptionFactory` when processing the response, and any errors that occur when attempting to deserialize the response to `ApiResponse<T>`, and populates the exception into the `Error` property on `ApiResponse<T>` without throwing the exception.
 
 You can then decide what to do like so:
 

--- a/Refit.Tests/ResponseTests.cs
+++ b/Refit.Tests/ResponseTests.cs
@@ -51,6 +51,9 @@ namespace Refit.Tests
 
             [Get("/GetApiResponseTestObject")]
             Task<ApiResponse<TestAliasObject>> GetApiResponseTestObject();
+
+            [Get("/GetIApiResponse")]
+            Task<IApiResponse> GetIApiResponse();
         }
 
         [Fact]
@@ -243,6 +246,26 @@ namespace Refit.Tests
                 .Respond(req => expectedResponse);
 
             var apiResponse = await fixture.GetApiResponseTestObject();
+
+            Assert.NotNull(apiResponse);
+            Assert.NotNull(apiResponse.Error);
+            Assert.NotNull(apiResponse.Error.Content);
+            Assert.Equal("Hello world", apiResponse.Error.Content);
+        }
+
+        [Fact]
+        public async Task BadRequestWithStringContent_ShouldReturnIApiResponse()
+        {
+            var expectedResponse = new HttpResponseMessage(HttpStatusCode.BadRequest)
+            {
+                Content = new StringContent("Hello world")
+            };
+            expectedResponse.Content.Headers.Clear();
+
+            mockHandler.Expect(HttpMethod.Get, $"http://api/{nameof(fixture.GetIApiResponse)}")
+                .Respond(req => expectedResponse);
+
+            var apiResponse = await fixture.GetIApiResponse();
 
             Assert.NotNull(apiResponse);
             Assert.NotNull(apiResponse.Error);

--- a/Refit/RestMethodInfo.cs
+++ b/Refit/RestMethodInfo.cs
@@ -126,9 +126,9 @@ namespace Refit
             CancellationToken = ctParams.FirstOrDefault();
 
             IsApiResponse = ReturnResultType!.GetTypeInfo().IsGenericType &&
-                            (ReturnResultType!.GetGenericTypeDefinition() == typeof(ApiResponse<>)
-                             || ReturnResultType.GetGenericTypeDefinition()  == typeof(IApiResponse<>)
-                             || ReturnResultType == typeof(IApiResponse));
+                              (ReturnResultType!.GetGenericTypeDefinition() == typeof(ApiResponse<>)
+                              || ReturnResultType.GetGenericTypeDefinition()  == typeof(IApiResponse<>))
+                            || ReturnResultType == typeof(IApiResponse);
         }
 
         private ISet<int> BuildHeaderCollectionParameterMap(List<ParameterInfo> parameterList)


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
Bug fix

**What is the current behavior?**
Refit interface methods that return `Task<IApiResponse>` _throw_ `ApiException` on error, rather than assigning it to the `IApiResponse.Error` property (like what happens for `Task<IApiResponse<T>>` or `Task<ApiResponse<T>>`). See #1289 for more details.

**What is the new behavior?**
Refit interface methods that return `Task<IApiResponse>` will assign `ApiException` to the `IApiResponse.Error` property on error rather than throw it.

**What might this PR break?**
Consumers that rely on the old undocumented behavior of `ApiException` being thrown from Refit interface methods that return `Task<IApiResponse>`.

**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
