### PR TITLE
fix: load content into buffer for void return methods

### DIFF
--- a/Refit/RequestBuilderImplementation.cs
+++ b/Refit/RequestBuilderImplementation.cs
@@ -248,8 +248,8 @@ namespace Refit
                 var disposeResponse = true;
                 try
                 {
-                    //Load the data into buffer when body should be buffered.
-                    if (restMethod.BodyParameterInfo?.Item2 ?? false && (rq.Content != null))
+                    // Load the data into buffer when body should be buffered.
+                    if (IsBodyBuffered(restMethod, rq))
                     {
                         await rq.Content!.LoadIntoBufferAsync().ConfigureAwait(false);
                     }
@@ -874,6 +874,11 @@ namespace Refit
                     ct = paramList.OfType<CancellationToken>().FirstOrDefault();
                 }
 
+                // Load the data into buffer when body should be buffered.
+                if (IsBodyBuffered(restMethod, rq))
+                {
+                    await rq.Content!.LoadIntoBufferAsync().ConfigureAwait(false);
+                }
                 using var resp = await client.SendAsync(rq, ct).ConfigureAwait(false);
 
                 var exception = await settings.ExceptionFactory(resp).ConfigureAwait(false);
@@ -882,6 +887,11 @@ namespace Refit
                     throw exception;
                 }
             };
+        }
+
+        private static bool IsBodyBuffered(RestMethodInfo restMethod, HttpRequestMessage? request)
+        {
+            return (restMethod.BodyParameterInfo?.Item2 ?? false) && (request?.Content != null);
         }
 
         static bool DoNotConvertToQueryMap(object? value)


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

It fixes another code path related to the bug detailed in #1099.

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

When a Refit interface method returns `Task` rather than `Task<T>`, the `[Body(buffered: true)]` attribute is ignored.

**What is the new behavior?**
<!-- If this is a feature change -->

Now void return interface methods will correctly buffer body content when specified in the Refit interface method signature.

**What might this PR break?**

It could break how POST/PUT bodies are serialized in requests.

**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~ -- I believe the docs are already correct for how to use `buffered: true`.

**Other information**:

