### PR TITLE
Add MemberNotNullWhen attribute to IsSuccessStatusCode

### DIFF
--- a/Refit/ApiResponse.cs
+++ b/Refit/ApiResponse.cs
@@ -56,6 +56,7 @@ namespace Refit
         
 #if NET5_0_OR_GREATER
         [MemberNotNullWhen(true, nameof(Content))]
+        [MemberNotNullWhen(true, nameof(ContentHeaders))]
         [MemberNotNullWhen(false, nameof(Error))]
 #endif
         public bool IsSuccessStatusCode => response.IsSuccessStatusCode;

--- a/Refit/ApiResponse.cs
+++ b/Refit/ApiResponse.cs
@@ -53,6 +53,10 @@ namespace Refit
         
         public HttpContentHeaders? ContentHeaders => response.Content?.Headers;
         
+#if NET5_0_OR_GREATER
+        [MemberNotNullWhen(true, nameof(Content))]
+        [MemberNotNullWhen(false, nameof(Error))]
+#endif
         public bool IsSuccessStatusCode => response.IsSuccessStatusCode;
 
         public string? ReasonPhrase => response.ReasonPhrase;

--- a/Refit/ApiResponse.cs
+++ b/Refit/ApiResponse.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Improve support for nullable reference types.


**What is the current behavior?**
<!-- You can also link to an open issue here. -->
See [this github issue](https://github.com/reactiveui/refit/issues/1302) for more details


**What is the new behavior?**
<!-- If this is a feature change -->
Improved support for nullable reference types.


**What might this PR break?**
If it is possible for `Content` to be null when  `IsSuccessStatusCode == true`  or if  it is possible for `Error` to be null when `IsSuccessStatusCode` == false, this can lead to the compiler to believe the property is not null while in reality it is.


**Please check if the PR fulfills these requirements**
- [ N/A ] Tests for the changes have been added (for bug fixes / features)
- [ N/A ] Docs have been added / updated (for bug fixes / features)

**Other information**:
I don't believe this change can be unit tested, I've manually tested the new behaviour which worked as expected.
