### PR TITLE
Add RestMethodInfo in HttpRequestMessage (Options or Properties)

### DIFF
--- a/Refit.Tests/RequestBuilder.cs
+++ b/Refit.Tests/RequestBuilder.cs
@@ -2142,6 +2142,26 @@ namespace Refit.Tests
         }
 
         [Fact]
+        public void RestMethodInfoShouldBeInProperties()
+        {
+            var someProperty = new object();
+            var fixture = new RequestBuilderImplementation<IContainAandB>();
+            var factory = fixture.BuildRequestFactoryForMethod(nameof(IContainAandB.Ping));
+            var output = factory(new object[] { });
+
+#if NET5_0_OR_GREATER
+            Assert.NotEmpty(output.Options);
+            Assert.True(output.Options.TryGetValue(new HttpRequestOptionsKey<RestMethodInfo>(HttpRequestMessageOptions.RestMethodInfo), out var restMethodInfo));
+#else
+            Assert.NotEmpty(output.Properties);
+            Assert.True(output.Properties.TryGetValue(HttpRequestMessageOptions.RestMethodInfo, out var restMethodInfoObj));
+            Assert.IsType<RestMethodInfo>(restMethodInfoObj);
+            var restMethodInfo = restMethodInfoObj as RestMethodInfo;
+#endif
+            Assert.Equal(nameof(IContainAandB.Ping), restMethodInfo.Name);
+        }
+
+        [Fact]
         public void DynamicRequestPropertiesWithDefaultKeysShouldBeInProperties()
         {
             var someProperty = new object();

--- a/Refit/HttpRequestMessageProperties.cs
+++ b/Refit/HttpRequestMessageProperties.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Refit
+﻿namespace Refit
 {
     /// <summary>
     /// Contains Refit-defined properties on the HttpRequestMessage.Properties/Options
@@ -15,5 +9,10 @@ namespace Refit
         /// Returns the <see cref="System.Type"/> of the top-level interface where the method was called from
         /// </summary>
         public static string InterfaceType { get; } = "Refit.InterfaceType";
+
+        /// <summary>
+        /// Returns the <see cref="Refit.RestMethodInfo"/> of the top-level interface
+        /// </summary>
+        public static string RestMethodInfo { get; } = "Refit.RestMethodInfo";
     }
 }

--- a/Refit/RequestBuilderImplementation.cs
+++ b/Refit/RequestBuilderImplementation.cs
@@ -736,11 +736,11 @@ namespace Refit
                 // Always add the top-level type of the interface to the properties
 #if NET5_0_OR_GREATER
                 ret.Options.Set(new HttpRequestOptionsKey<Type>(HttpRequestMessageOptions.InterfaceType), TargetType);
+                ret.Options.Set(new HttpRequestOptionsKey<RestMethodInfo>(HttpRequestMessageOptions.RestMethodInfo), restMethod);
 #else
                 ret.Properties[HttpRequestMessageOptions.InterfaceType] = TargetType;
-#endif
-
-                ;
+                ret.Properties[HttpRequestMessageOptions.RestMethodInfo] = restMethod;
+#endif                
 
                 // NB: The URI methods in .NET are dumb. Also, we do this
                 // UriBuilder business so that we preserve any hardcoded query


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Feature

**What is the current behavior?**
No RestMethodInfo is available in the HttpMessageHandler

**What is the new behavior?**
RestMethodInfo is now available in the HttpMessageHandler. Parameter-Name: `RestMethodInfo { get; } = "Refit.RestMethodInfo";`

**What might this PR break?**
Nothing


**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

