### PR TITLE
Fixed a bug in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -806,8 +806,8 @@ Note: in .NET 5 `HttpRequestMessage.Properties` has been marked `Obsolete` and R
 #### Support for Polly and Polly.Context
 
 Because Refit supports `HttpClientFactory` it is possible to configure Polly policies on your HttpClient.
-If your policy makes use of `Polly.Context` this can be passed via Refit by adding `[Property("PollyExecutionContext")] Polly.Context context`
-as behind the scenes `Polly.Context` is simply stored in `HttpRequestMessage.Properties` under the key `PollyExecutionContext` and is of type `Polly.Context`
+If your policy makes use of `Polly.Context` this can be passed via Refit by adding `[Property("PolicyExecutionContext")] Polly.Context context`
+as behind the scenes `Polly.Context` is simply stored in `HttpRequestMessage.Properties` under the key `PolicyExecutionContext` and is of type `Polly.Context`. It's only recommended to pass the `Polly.Context` this way if your use case requires that the `Polly.Context` be initialized with dynamic content only known at runtime. If your `Polly.Context` only requires the same content every time (e.g an `ILogger` that you want to use to log from inside your policies) a cleaner approach is to inject the `Polly.Context` via a `DelegatingHandler` as described in [#801](https://github.com/reactiveui/refit/issues/801#issuecomment-1137318526)
 
 #### Target Interface Type
 


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
A bug report came in via an old issue https://github.com/reactiveui/refit/issues/801 that highlighted a bug in the docs. I've fixed the doc bug and added some guidance on how better to support a common use case and outlined in what case it's appropriate to pass the `Polly.Context` via the `[Property]` attribute.

**What is the current behavior?**
see https://github.com/reactiveui/refit/issues/801 

**What is the new behavior?**
Docs are fixed :)

**What might this PR break?**
Nothing - it's only updating documentation.

**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)