### PR TITLE
(Please) allow developers to inject the MethodInfo as a Property

### DIFF
--- a/Refit.Tests/RequestBuilder.cs
+++ b/Refit.Tests/RequestBuilder.cs
@@ -511,7 +511,7 @@ namespace Refit.Tests
             Assert.Empty(fixture.QueryParameterMap);
             Assert.Null(fixture.BodyParameterInfo);
         }
-        
+
         [Fact]
         public void ParameterMappingWithTheSameIdInAFewPlaces()
         {
@@ -2139,6 +2139,54 @@ namespace Refit.Tests
             Assert.Equal(typeof(IContainAandB), output.Properties[HttpRequestMessageOptions.InterfaceType]);
 #pragma warning restore CS0618 // Type or member is obsolete
 
+        }
+
+        [Fact]
+        public void MethodInfoShouldBeInPropertiesIfInjectMethodInfoAsPropertyTrue()
+        {
+            var fixture = new RequestBuilderImplementation<IContainAandB>(new RefitSettings
+            {
+                InjectMethodInfoAsProperty = true
+            });
+            var factory = fixture.BuildRequestFactoryForMethod(nameof(IContainAandB.Ping));
+            var output = factory(new object[] {  });
+
+            MethodInfo methodInfo;
+#if NET5_0_OR_GREATER
+            Assert.NotEmpty(output.Options);
+            output.Options.TryGetValue(HttpRequestMessageOptions.MethodInfoKey, out methodInfo);
+            Assert.NotNull(methodInfo);
+            Assert.Equal(nameof(IContainAandB.Ping), methodInfo.Name);
+            Assert.Equal(typeof(IAmInterfaceA), methodInfo.DeclaringType);
+#endif
+
+#pragma warning disable CS0618 // Type or member is obsolete
+            Assert.NotEmpty(output.Properties);
+            methodInfo = (MethodInfo)(output.Properties[HttpRequestMessageOptions.MethodInfo]);
+            Assert.NotNull(methodInfo);
+            Assert.Equal(nameof(IContainAandB.Ping), methodInfo.Name);
+            Assert.Equal(typeof(IAmInterfaceA), methodInfo.DeclaringType);
+#pragma warning restore CS0618 // Type or member is obsolete
+        }
+
+        [Fact]
+        public void MethodInfoShouldNotBeInPropertiesIfInjectMethodInfoAsPropertyFalse()
+        {
+            var fixture = new RequestBuilderImplementation<IContainAandB>();
+            var factory = fixture.BuildRequestFactoryForMethod(nameof(IContainAandB.Ping));
+            var output = factory(new object[] {  });
+
+            MethodInfo methodInfo;
+#if NET5_0_OR_GREATER
+            Assert.NotEmpty(output.Options);
+            output.Options.TryGetValue(HttpRequestMessageOptions.MethodInfoKey, out methodInfo);
+            Assert.Null(methodInfo);
+#endif
+
+#pragma warning disable CS0618 // Type or member is obsolete
+            Assert.NotEmpty(output.Properties);
+            Assert.False(output.Properties.ContainsKey(HttpRequestMessageOptions.MethodInfo));
+#pragma warning restore CS0618 // Type or member is obsolete
         }
 
         [Fact]

--- a/Refit/HttpRequestMessageProperties.cs
+++ b/Refit/HttpRequestMessageProperties.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System.Reflection;
 
 namespace Refit
 {
@@ -15,5 +11,25 @@ namespace Refit
         /// Returns the <see cref="System.Type"/> of the top-level interface where the method was called from
         /// </summary>
         public static string InterfaceType { get; } = "Refit.InterfaceType";
+
+#if NET5_0_OR_GREATER
+        /// <summary>
+        /// A typed key to access the <see cref="System.Type"/> of the top-level interface where the method was called from
+        /// on the <see cref="System.Net.Http.HttpRequestMessage.Options"/>.
+        /// </summary>
+        public static System.Net.Http.HttpRequestOptionsKey<System.Type> InterfaceTypeKey { get; } = new(InterfaceType);
+#endif
+
+        /// <summary>
+        /// Returns the <see cref="System.Reflection.MethodInfo"/> of the method that was called
+        /// </summary>
+        public static string MethodInfo { get; } = "Refit.MethodInfo";
+
+#if NET5_0_OR_GREATER
+        /// <summary>
+        /// A typed key to access the <see cref="System.Reflection.MethodInfo"/> of the method that was called
+        /// </summary>
+        public static System.Net.Http.HttpRequestOptionsKey<MethodInfo> MethodInfoKey { get; } = new(MethodInfo);
+#endif
     }
 }

--- a/Refit/RefitSettings.cs
+++ b/Refit/RefitSettings.cs
@@ -26,21 +26,35 @@ namespace Refit
             ExceptionFactory = new DefaultApiExceptionFactory(this).CreateAsync;
         }
 
+
+#if NET5_0_OR_GREATER
         /// <summary>
         /// Creates a new <see cref="RefitSettings"/> instance with the specified parameters
         /// </summary>
         /// <param name="contentSerializer">The <see cref="IHttpContentSerializer"/> instance to use</param>
         /// <param name="urlParameterFormatter">The <see cref="IUrlParameterFormatter"/> instance to use (defaults to <see cref="DefaultUrlParameterFormatter"/>)</param>
         /// <param name="formUrlEncodedParameterFormatter">The <see cref="IFormUrlEncodedParameterFormatter"/> instance to use (defaults to <see cref="DefaultFormUrlEncodedParameterFormatter"/>)</param>
+        /// <param name="injectMethodInfoAsProperty">Controls injecting the <see cref="MethodInfo"/> of the method on the Refit client interface that was invoked into the HttpRequestMessage.Options (defaults to false)</param>
+#else
+                /// <summary>
+        /// Creates a new <see cref="RefitSettings"/> instance with the specified parameters
+        /// </summary>
+        /// <param name="contentSerializer">The <see cref="IHttpContentSerializer"/> instance to use</param>
+        /// <param name="urlParameterFormatter">The <see cref="IUrlParameterFormatter"/> instance to use (defaults to <see cref="DefaultUrlParameterFormatter"/>)</param>
+        /// <param name="formUrlEncodedParameterFormatter">The <see cref="IFormUrlEncodedParameterFormatter"/> instance to use (defaults to <see cref="DefaultFormUrlEncodedParameterFormatter"/>)</param>
+        /// <param name="injectMethodInfoAsProperty">Controls injecting the <see cref="MethodInfo"/> of the method on the Refit client interface that was invoked into the HttpRequestMessage.Properties (defaults to false)</param>
+#endif
         public RefitSettings(
             IHttpContentSerializer contentSerializer,
             IUrlParameterFormatter? urlParameterFormatter = null,
-            IFormUrlEncodedParameterFormatter? formUrlEncodedParameterFormatter = null)
+            IFormUrlEncodedParameterFormatter? formUrlEncodedParameterFormatter = null,
+            bool injectMethodInfoAsProperty = false)
         {
             ContentSerializer = contentSerializer ?? throw new ArgumentNullException(nameof(contentSerializer), "The content serializer can't be null");
             UrlParameterFormatter = urlParameterFormatter ?? new DefaultUrlParameterFormatter();
             FormUrlEncodedParameterFormatter = formUrlEncodedParameterFormatter ?? new DefaultFormUrlEncodedParameterFormatter();
             ExceptionFactory = new DefaultApiExceptionFactory(this).CreateAsync;
+            InjectMethodInfoAsProperty = injectMethodInfoAsProperty;
         }
 
         /// <summary>
@@ -88,6 +102,17 @@ namespace Refit
         /// Sets the default behavior when sending a request's body content. (defaults to false, request body is not streamed to the server)
         /// </summary>
         public bool Buffered { get; set; } = false;
+
+#if NET5_0_OR_GREATER
+        /// <summary>
+        /// Controls injecting the <see cref="MethodInfo"/> of the method on the Refit client interface that was invoked into the HttpRequestMessage.Options (defaults to false)
+        /// </summary>
+#else
+        /// <summary>
+        /// Controls injecting the <see cref="MethodInfo"/> of the method on the Refit client interface that was invoked into the HttpRequestMessage.Properties (defaults to false)
+        /// </summary>
+#endif
+        public bool InjectMethodInfoAsProperty { get; set; } = false;
     }
 
     /// <summary>

--- a/Refit/RequestBuilderImplementation.cs
+++ b/Refit/RequestBuilderImplementation.cs
@@ -733,11 +733,20 @@ namespace Refit
 #endif
                 }
 
-                // Always add the top-level type of the interface to the properties
+                // Always add the top-level type of the interface to the options/properties and include the MethodInfo if the developer has opted-in to that behavior
 #if NET5_0_OR_GREATER
-                ret.Options.Set(new HttpRequestOptionsKey<Type>(HttpRequestMessageOptions.InterfaceType), TargetType);
+                ret.Options.Set(HttpRequestMessageOptions.InterfaceTypeKey, TargetType);
+                if (settings.InjectMethodInfoAsProperty)
+                {
+                    ret.Options.Set(HttpRequestMessageOptions.MethodInfoKey, restMethod.MethodInfo);
+                }
 #else
                 ret.Properties[HttpRequestMessageOptions.InterfaceType] = TargetType;
+                if (settings.InjectMethodInfoAsProperty)
+                {
+                    ret.Properties[HttpRequestMessageOptions.MethodInfo] = restMethod.MethodInfo;
+                }
+
 #endif
 
                 ;


### PR DESCRIPTION
**What kind of change does this PR introduce?**
A feature to make the `MethodInfo` of the method on the Refit client interface invoked available to handlers via the `HttpRequestMessage.Options` / `HttpRequestMessage.Properties`.

This behavior is **opt-in** via the `RefitSettings`
```csharp
services.AddRefitClient<ISomeAPI>(provider => new RefitSettings
            {
                InjectMethodInfoAsProperty = true
            })
        .ConfigureHttpClient(c => c.BaseAddress = new Uri("https://api.example.com"));
```


**What is the current behavior?**
People either can't do what they want or are implementing workarounds by polluting their interfaces. 

https://github.com/reactiveui/refit/pull/1180
https://github.com/reactiveui/refit/pull/1219
https://github.com/reactiveui/refit/pull/1317

https://github.com/reactiveui/refit/issues/1150
https://github.com/reactiveui/refit/issues/1156

**What is the new behavior?**
New behavior is `RefitSettings.InjectMethodInfoAsProperty` defaults to `false` so Refit as a library remains (mostly) unopinionated about the contents of `HttpRequestMessage.Options`/`HttpRequestMessage.Properties`, however if set to `true` it will inject the `MethodInfo` into  `HttpRequestMessage.Options`/`HttpRequestMessage.Properties` under the key `Refit.MethodInfo`.

**What might this PR break?**
Nothing, the behavior is opt-in, so it has to explicitly be enabled giving the developer the chance to consider if there might be any implications for their codebase if the full `MethodInfo` were to be populated into and to put any mitigations necessary should they require it if they do wish to take advantage of the functionality. 

**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:
I know previously it has been stated that it would be acceptable if we store the method name as a string, but I for one just don't feel comfortable relying on something as critical as an integration point between two systems containing some "stringly typed" behavior when it **could** be strongly typed. Once someone introduces an overloaded method then all bets are off and it wouldn't surprise me to see that cause a potentially nasty production incident for someone somewhere, and/or future support issues.

I believe this implementation is a good half-way point between simplicity, safety, and usability and sincerely hope we can get this merged.