### PR TITLE
Changed the condition of _RefitMSBuildVersionCheck

### DIFF
--- a/Refit/targets/refit.targets
+++ b/Refit/targets/refit.targets
@@ -42,8 +42,8 @@
   </Target>
 
   <Target Name="_RefitMSBuildVersionCheck"
-          Condition=" '$([System.Version]::Parse($(_RefitMSBuildMinVersion)).CompareTo($([System.Version]::Parse($(MSBuildVersion)))))' &gt; '0' "
-     BeforeTargets="ResolveAssemblyReferences;Build;Rebuild" >
+          Condition="!($(MSBuildVersion) >= $(_RefitMSBuildMinVersion))"
+          BeforeTargets="ResolveAssemblyReferences;Build;Rebuild" >
     <Error
         Text = "Projects using Refit cannot build using MSBuild '$(MSBuildVersion)'. MSBuild '$(_RefitMSBuildMinVersion)' or later is required." />
   </Target>


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
[[BUG] Unable to build Refit with MSBuild >= 17.x #1387](https://github.com/reactiveui/refit/issues/1387)



**What is the current behavior?**
Can't evaluate if build versions is OK



**What is the new behavior?**
Changed the logic how they evaluate



**What might this PR break?**
Nothing i suppose


**Please check if the PR fulfills these requirements**
- [ ] ~~Tests for the changes have been added (for bug fixes / features)~~
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~

**Other information**:
Somehow the Condition thinks 1 is bigger than 2, hence the ! (not) infront of the condition. 
Guess I lack some understanding about .target and such.
