### PR TITLE
Adds named httpclient support

### DIFF
--- a/Refit.HttpClientFactory/HttpClientFactoryExtensions.cs
+++ b/Refit.HttpClientFactory/HttpClientFactoryExtensions.cs
@@ -6,6 +6,8 @@ using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Http;
 
+using Refit.HttpClientFactory;
+
 namespace Refit
 {
     public static class HttpClientFactoryExtensions
@@ -55,6 +57,7 @@ namespace Refit
         {
             services.AddSingleton(provider => new SettingsFor<T>(settingsAction?.Invoke(provider)));
             services.AddSingleton(provider => RequestBuilder.ForType<T>(provider.GetRequiredService<SettingsFor<T>>().Settings));
+            services.AddScoped<IRefitHttpClientFactory, RefitHttpClientFactory>();
 
             return services
                 .AddHttpClient(name ?? UniqueName.ForType<T>())
@@ -66,7 +69,7 @@ namespace Refit
                         builder.PrimaryHandler = innerHandler;
                     }
                 })
-                .AddTypedClient((client, serviceProvider) => RestService.For<T>(client, serviceProvider.GetService<IRequestBuilder<T>>()!));
+                .AddTypedClient((client, serviceProvider) => RestService.For(client, serviceProvider.GetService<IRequestBuilder<T>>()!));
         }
 
         /// <summary>

--- a/Refit.HttpClientFactory/HttpClientFactoryExtensions.cs
+++ b/Refit.HttpClientFactory/HttpClientFactoryExtensions.cs
@@ -41,13 +41,23 @@ namespace Refit
         /// <param name="services">container</param>
         /// <param name="settingsAction">Optional. Action to configure refit settings.  This method is called once and only once, avoid using any scoped dependencies that maybe be disposed automatically.</param>
         /// <returns></returns>
-        public static IHttpClientBuilder AddRefitClient<T>(this IServiceCollection services, Func<IServiceProvider, RefitSettings?>? settingsAction) where T : class
+        public static IHttpClientBuilder AddRefitClient<T>(this IServiceCollection services, Func<IServiceProvider, RefitSettings?>? settingsAction) where T : class => AddRefitClient<T>(services, null, settingsAction);
+
+        /// <summary>
+        /// Adds a Refit client to the DI container
+        /// </summary>
+        /// <typeparam name="T">Type of the Refit interface</typeparam>
+        /// <param name="services">container</param>
+        /// <param name="name">Named http client</param>
+        /// <param name="settingsAction">Optional. Action to configure refit settings.  This method is called once and only once, avoid using any scoped dependencies that maybe be disposed automatically.</param>
+        /// <returns></returns>
+        public static IHttpClientBuilder AddRefitClient<T>(this IServiceCollection services, string? name, Func<IServiceProvider, RefitSettings?>? settingsAction) where T : class
         {
             services.AddSingleton(provider => new SettingsFor<T>(settingsAction?.Invoke(provider)));
             services.AddSingleton(provider => RequestBuilder.ForType<T>(provider.GetRequiredService<SettingsFor<T>>().Settings));
 
             return services
-                .AddHttpClient(UniqueName.ForType<T>())
+                .AddHttpClient(name ?? UniqueName.ForType<T>())
                 .ConfigureHttpMessageHandlerBuilder(builder =>
                 {
                     // check to see if user provided custom auth token

--- a/Refit.HttpClientFactory/IRefitHttpClientFactory.cs
+++ b/Refit.HttpClientFactory/IRefitHttpClientFactory.cs
@@ -1,0 +1,6 @@
+﻿namespace Refit.HttpClientFactory;
+
+public interface IRefitHttpClientFactory
+{
+    T CreateClient<T>(string? name);
+}

--- a/Refit.HttpClientFactory/RefitHttpClientFactory.cs
+++ b/Refit.HttpClientFactory/RefitHttpClientFactory.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Net.Http;
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Refit.HttpClientFactory;
+
+internal class RefitHttpClientFactory : IRefitHttpClientFactory
+{
+    public RefitHttpClientFactory(IHttpClientFactory httpClientFactory, IServiceProvider serviceProvider)
+    {
+        HttpClientFactory = httpClientFactory;
+        ServiceProvider = serviceProvider;
+    }
+
+    private IHttpClientFactory HttpClientFactory { get; }
+
+    private IServiceProvider ServiceProvider { get; }
+
+    public T CreateClient<T>(string? name)
+    {
+        var client = HttpClientFactory.CreateClient(name ?? UniqueName.ForType<T>());
+        return RestService.For(client, ServiceProvider.GetRequiredService<IRequestBuilder<T>>());
+    }
+}


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
Makes it possible to set a custom name to the HTTP Client factory



**What is the current behavior?**
You can't use the same interface to point at multiple environments for example.



**What is the new behavior?**
You can use custom names to the same interface but with different environment/handlers.



**What might this PR break?**
In the original implementation `UniqueName.ForType<T>()` was used as the client's name, so if a custom name is used it might break somewhere, tho I've looked and not found any other references for this other than tests.


**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

