### PR TITLE
Added MemberNotNullWhen in IApiResponse

### DIFF
--- a/Refit/ApiResponse.cs
+++ b/Refit/ApiResponse.cs
@@ -134,6 +134,9 @@ namespace Refit
         /// <summary>
         /// Indicates whether the request was successful.
         /// </summary>
+#if NET5_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.MemberNotNullWhen(false, nameof(Error))]
+#endif
         bool IsSuccessStatusCode { get; }
 
         /// <summary>


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
Better experience in development when using 


**What is the current behavior?**

N/A


**What is the new behavior?**

It's just change the developer experience, avoiding using `!` operator when is not required.


**What might this PR break?**

Nothing


**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

With that change, if I am in the .NET 5 or higher after the if statement, compiler will know that `response.Error` is not null and I dont need to use `response.Error!`
```csharp
var response = api.GetSomething();
if (!response.IsSuccessStatusCode)
{
    //....
}

_logger.LogError(response.Error, "Message");
```