### PR TITLE
BREAKING: Simplify authorization configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -573,7 +573,7 @@ var user = await GetUser("octocat", headers);
 Most APIs need some sort of Authentication. The most common is OAuth Bearer authentication. A header is added to each request of the form: `Authorization: Bearer <token>`. Refit makes it easy to insert your logic to get the token however your app needs, so you don't have to pass a token into each method.
 
 1. Add `[Headers("Authorization: Bearer")]` to the interface or methods which need the token.
-2. Set either `AuthorizationHeaderValueGetter` or `AuthorizationHeaderValueWithParamGetter` in the `RefitSettings` instance. The difference is that the latter one passes the `HttpRequestMessage` into the function in case you need to take action based on the specific request. Refit will call your delegate each time it needs to obtain the token, so it's a good idea for your mechanism to cache the token value for some period within the token lifetime.
+2. Set `AuthorizationHeaderValueGetter` in the `RefitSettings` instance. Refit will call your delegate each time it needs to obtain the token, so it's a good idea for your mechanism to cache the token value for some period within the token lifetime.
 
 #### Reducing header boilerplate with DelegatingHandlers (Authorization headers worked example)
 Although we make provisions for adding dynamic headers at runtime directly in Refit,
@@ -1242,7 +1242,6 @@ RestService.For<ISomeApi>(new HttpClient()
 However, when supplying a custom `HttpClient` instance the following `RefitSettings` properties will not work:
 
 * `AuthorizationHeaderValueGetter`
-* `AuthorizationHeaderValueWithParamGetter`
 * `HttpMessageHandlerFactory`
 
 If you still want to be able to configure the `HtttpClient` instance that `Refit` provides while still making use of the above settings, simply expose the `HttpClient` on the API interface:
@@ -1264,7 +1263,7 @@ Then, after creating the REST service, you can set any `HttpClient` property you
 ```csharp
 SomeApi = RestService.For<ISomeApi>("https://www.someapi.com/api/", new RefitSettings()
 {
-    AuthorizationHeaderValueGetter = () => GetTokenAsync()
+    AuthorizationHeaderValueGetter = (rq, ct) => GetTokenAsync()
 });
 
 SomeApi.Client.Timeout = timeout;

--- a/Refit.HttpClientFactory/HttpClientFactoryExtensions.cs
+++ b/Refit.HttpClientFactory/HttpClientFactoryExtensions.cs
@@ -64,7 +64,7 @@ namespace Refit
                 .ConfigureHttpMessageHandlerBuilder(builder =>
                 {
                     // check to see if user provided custom auth token
-                    if (CreateInnerHandlerIfProvided(builder.Services.GetRequiredService<SettingsFor<T>>().Settings) is {} innerHandler)
+                    if (CreateInnerHandlerIfProvided(builder.Services.GetRequiredService<SettingsFor<T>>().Settings) is { } innerHandler)
                     {
                         builder.PrimaryHandler = innerHandler;
                     }
@@ -115,15 +115,7 @@ namespace Refit
 
                 if (settings.AuthorizationHeaderValueGetter != null)
                 {
-                    innerHandler = new AuthenticatedHttpClientHandler((_, _) => settings.AuthorizationHeaderValueGetter(), innerHandler);
-                }
-                else if (settings.AuthorizationHeaderValueWithParamGetter != null)
-                {
-                    innerHandler = new AuthenticatedHttpClientHandler((request, _) => settings.AuthorizationHeaderValueWithParamGetter(request), innerHandler);
-                }
-                else if (settings.AuthorizationHeaderValueWithCancellationTokenGetter != null)
-                {
-                    innerHandler = new AuthenticatedHttpClientHandler(settings.AuthorizationHeaderValueWithCancellationTokenGetter, innerHandler);
+                    innerHandler = new AuthenticatedHttpClientHandler(settings.AuthorizationHeaderValueGetter, innerHandler);
                 }
             }
 

--- a/Refit.Tests/AuthenticatedClientHandlerTests.cs
+++ b/Refit.Tests/AuthenticatedClientHandlerTests.cs
@@ -68,7 +68,7 @@ namespace Refit.Tests
             var handler = new MockHttpMessageHandler();
             var settings = new RefitSettings()
             {
-                AuthorizationHeaderValueGetter = () => Task.FromResult("tokenValue"),
+                AuthorizationHeaderValueGetter = (_, __) => Task.FromResult("tokenValue"),
                 HttpMessageHandlerFactory = () => handler
             };
 
@@ -91,7 +91,7 @@ namespace Refit.Tests
             var handler = new MockHttpMessageHandler();
             var settings = new RefitSettings()
             {
-                AuthorizationHeaderValueGetter = () => Task.FromResult("tokenValue"),
+                AuthorizationHeaderValueGetter = (_, __) => Task.FromResult("tokenValue"),
                 HttpMessageHandlerFactory = () => handler
             };
 
@@ -114,7 +114,7 @@ namespace Refit.Tests
             var handler = new MockHttpMessageHandler();
             var settings = new RefitSettings()
             {
-                AuthorizationHeaderValueWithParamGetter = (request) => Task.FromResult("tokenValue"),
+                AuthorizationHeaderValueGetter = (request, _) => Task.FromResult("tokenValue"),
                 HttpMessageHandlerFactory = () => handler
             };
 
@@ -293,7 +293,7 @@ namespace Refit.Tests
             var handler = new MockHttpMessageHandler();
             var settings = new RefitSettings()
             {
-                AuthorizationHeaderValueGetter = () => Task.FromResult("tokenValue"),
+                AuthorizationHeaderValueGetter = (_, __) => Task.FromResult("tokenValue"),
                 HttpMessageHandlerFactory = () => handler
             };
 
@@ -316,7 +316,7 @@ namespace Refit.Tests
             var handler = new MockHttpMessageHandler();
             var settings = new RefitSettings()
             {
-                AuthorizationHeaderValueGetter = () => Task.FromResult("tokenValue"),
+                AuthorizationHeaderValueGetter = (_, __) => Task.FromResult("tokenValue"),
                 HttpMessageHandlerFactory = () => handler
             };
 

--- a/Refit/RefitSettings.cs
+++ b/Refit/RefitSettings.cs
@@ -37,7 +37,7 @@ namespace Refit
         /// <param name="formUrlEncodedParameterFormatter">The <see cref="IFormUrlEncodedParameterFormatter"/> instance to use (defaults to <see cref="DefaultFormUrlEncodedParameterFormatter"/>)</param>
         /// <param name="injectMethodInfoAsProperty">Controls injecting the <see cref="MethodInfo"/> of the method on the Refit client interface that was invoked into the HttpRequestMessage.Options (defaults to false)</param>
 #else
-                /// <summary>
+        /// <summary>
         /// Creates a new <see cref="RefitSettings"/> instance with the specified parameters
         /// </summary>
         /// <param name="contentSerializer">The <see cref="IHttpContentSerializer"/> instance to use</param>
@@ -61,17 +61,7 @@ namespace Refit
         /// <summary>
         /// Supply a function to provide the Authorization header. Does not work if you supply an HttpClient instance.
         /// </summary>
-        public Func<Task<string>>? AuthorizationHeaderValueGetter { get; set; }
-
-        /// <summary>
-        /// Supply a function to provide the Authorization header. Does not work if you supply an HttpClient instance.
-        /// </summary>
-        public Func<HttpRequestMessage, Task<string>>? AuthorizationHeaderValueWithParamGetter { get; set; }
-
-        /// <summary>
-        /// Supply a function to provide the Authorization header. Does not work if you supply an HttpClient instance.
-        /// </summary>
-        public Func<HttpRequestMessage, CancellationToken, Task<string>>? AuthorizationHeaderValueWithCancellationTokenGetter { get; set; }
+        public Func<HttpRequestMessage, CancellationToken, Task<string>>? AuthorizationHeaderValueGetter { get; set; }
 
         /// <summary>
         /// Supply a custom inner HttpMessageHandler. Does not work if you supply an HttpClient instance.
@@ -113,7 +103,7 @@ namespace Refit
         /// Optional Key-Value pairs, which are displayed in the property <see cref="HttpRequestMessage.Options"/> or <see cref="HttpRequestMessage.Properties"/>. 
         /// </summary>
         public Dictionary<string, object> HttpRequestMessageOptions { get; set; }
-        
+
 #if NET6_0_OR_GREATER
         /// <summary>
         /// Controls injecting the <see cref="MethodInfo"/> of the method on the Refit client interface that was invoked into the HttpRequestMessage.Options (defaults to false)

--- a/Refit/RestService.cs
+++ b/Refit/RestService.cs
@@ -149,15 +149,7 @@ namespace Refit
 
                 if (settings.AuthorizationHeaderValueGetter != null)
                 {
-                    innerHandler = new AuthenticatedHttpClientHandler((_, _) => settings.AuthorizationHeaderValueGetter(), innerHandler);
-                }
-                else if (settings.AuthorizationHeaderValueWithParamGetter != null)
-                {
-                    innerHandler = new AuthenticatedHttpClientHandler((request, _) => settings.AuthorizationHeaderValueWithParamGetter(request), innerHandler);
-                }
-                else if (settings.AuthorizationHeaderValueWithCancellationTokenGetter != null)
-                {
-                    innerHandler = new AuthenticatedHttpClientHandler(settings.AuthorizationHeaderValueWithCancellationTokenGetter, innerHandler);
+                    innerHandler = new AuthenticatedHttpClientHandler(settings.AuthorizationHeaderValueGetter, innerHandler);
                 }
             }
 


### PR DESCRIPTION
In order to maintain backwards compatibility, we now are ending up with three separate fetchers that do the same thing. Let's instead simplify since we're doing a breaking change anyways, and that this will be pretty straightforward for developers to deal with

**What kind of change does this PR introduce?**
API design change

**What is the current behavior?**
Three separate properties to configure the same thing

**What is the new behavior?**
One property for the same thing

**What might this PR break?**
Developers will need some find-replaces to fix it

**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
