### PR TITLE
Rethrow for Better Stack Trace

### DIFF
--- a/InterfaceStubGenerator.Shared/InterfaceStubGenerator.cs
+++ b/InterfaceStubGenerator.Shared/InterfaceStubGenerator.cs
@@ -527,8 +527,8 @@ namespace Refit.Implementation
 
                 source.Append(string.Join(", ", list));
             }
-            
-           source.Append(@$") {GenerateConstraints(methodSymbol.TypeParameters, isExplicitInterface)}
+
+            source.Append(@$"){GenerateConstraints(methodSymbol.TypeParameters, isExplicitInterface)}
         {{");
         }
 

--- a/InterfaceStubGenerator.Shared/InterfaceStubGenerator.cs
+++ b/InterfaceStubGenerator.Shared/InterfaceStubGenerator.cs
@@ -411,7 +411,14 @@ namespace Refit.Implementation
             source.Append(@$"
             var ______arguments = new object[] {{ {string.Join(", ", argList)} }};
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""{methodSymbol.Name}"", new global::System.Type[] {{ {string.Join(", ", typeList)} }}{genericString} );
-            return ({methodSymbol.ReturnType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)})______func(this.Client, ______arguments);
+            try
+            {{
+                return ({methodSymbol.ReturnType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)})______func(this.Client, ______arguments);
+            }}
+            catch (global::System.Exception ex)
+            {{
+                throw ex;
+            }}
 ");
 
             WriteMethodClosing(source);

--- a/Refit.Tests/InterfaceStubGenerator.cs
+++ b/Refit.Tests/InterfaceStubGenerator.cs
@@ -204,7 +204,7 @@ namespace Refit.Implementation
 
 
         /// <inheritdoc />
-        public global::System.Threading.Tasks.Task<global::Refit.Tests.User> GetUser(string @userName) 
+        public global::System.Threading.Tasks.Task<global::Refit.Tests.User> GetUser(string @userName)
         {
             var ______arguments = new object[] { @userName };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetUser"", new global::System.Type[] { typeof(string) } );
@@ -212,7 +212,7 @@ namespace Refit.Implementation
         }
 
         /// <inheritdoc />
-        public global::System.IObservable<global::Refit.Tests.User> GetUserObservable(string @userName) 
+        public global::System.IObservable<global::Refit.Tests.User> GetUserObservable(string @userName)
         {
             var ______arguments = new object[] { @userName };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetUserObservable"", new global::System.Type[] { typeof(string) } );
@@ -220,7 +220,7 @@ namespace Refit.Implementation
         }
 
         /// <inheritdoc />
-        public global::System.IObservable<global::Refit.Tests.User> GetUserCamelCase(string @userName) 
+        public global::System.IObservable<global::Refit.Tests.User> GetUserCamelCase(string @userName)
         {
             var ______arguments = new object[] { @userName };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetUserCamelCase"", new global::System.Type[] { typeof(string) } );
@@ -228,7 +228,7 @@ namespace Refit.Implementation
         }
 
         /// <inheritdoc />
-        public global::System.Threading.Tasks.Task<global::System.Collections.Generic.List<global::Refit.Tests.User>> GetOrgMembers(string @orgName, global::System.Threading.CancellationToken @cancellationToken) 
+        public global::System.Threading.Tasks.Task<global::System.Collections.Generic.List<global::Refit.Tests.User>> GetOrgMembers(string @orgName, global::System.Threading.CancellationToken @cancellationToken)
         {
             var ______arguments = new object[] { @orgName, @cancellationToken };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetOrgMembers"", new global::System.Type[] { typeof(string), typeof(global::System.Threading.CancellationToken) } );
@@ -236,7 +236,7 @@ namespace Refit.Implementation
         }
 
         /// <inheritdoc />
-        public global::System.Threading.Tasks.Task<global::Refit.Tests.UserSearchResult> FindUsers(string @q) 
+        public global::System.Threading.Tasks.Task<global::Refit.Tests.UserSearchResult> FindUsers(string @q)
         {
             var ______arguments = new object[] { @q };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""FindUsers"", new global::System.Type[] { typeof(string) } );
@@ -244,7 +244,7 @@ namespace Refit.Implementation
         }
 
         /// <inheritdoc />
-        public global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage> GetIndex() 
+        public global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage> GetIndex()
         {
             var ______arguments = new object[] {  };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetIndex"", new global::System.Type[] {  } );
@@ -252,7 +252,7 @@ namespace Refit.Implementation
         }
 
         /// <inheritdoc />
-        public global::System.IObservable<string> GetIndexObservable() 
+        public global::System.IObservable<string> GetIndexObservable()
         {
             var ______arguments = new object[] {  };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetIndexObservable"", new global::System.Type[] {  } );
@@ -260,7 +260,7 @@ namespace Refit.Implementation
         }
 
         /// <inheritdoc />
-        public global::System.Threading.Tasks.Task<global::Refit.Tests.User> NothingToSeeHere() 
+        public global::System.Threading.Tasks.Task<global::Refit.Tests.User> NothingToSeeHere()
         {
             var ______arguments = new object[] {  };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""NothingToSeeHere"", new global::System.Type[] {  } );
@@ -268,7 +268,7 @@ namespace Refit.Implementation
         }
 
         /// <inheritdoc />
-        public global::System.Threading.Tasks.Task<global::Refit.ApiResponse<global::Refit.Tests.User>> NothingToSeeHereWithMetadata() 
+        public global::System.Threading.Tasks.Task<global::Refit.ApiResponse<global::Refit.Tests.User>> NothingToSeeHereWithMetadata()
         {
             var ______arguments = new object[] {  };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""NothingToSeeHereWithMetadata"", new global::System.Type[] {  } );
@@ -276,7 +276,7 @@ namespace Refit.Implementation
         }
 
         /// <inheritdoc />
-        public global::System.Threading.Tasks.Task<global::Refit.ApiResponse<global::Refit.Tests.User>> GetUserWithMetadata(string @userName) 
+        public global::System.Threading.Tasks.Task<global::Refit.ApiResponse<global::Refit.Tests.User>> GetUserWithMetadata(string @userName)
         {
             var ______arguments = new object[] { @userName };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetUserWithMetadata"", new global::System.Type[] { typeof(string) } );
@@ -284,7 +284,7 @@ namespace Refit.Implementation
         }
 
         /// <inheritdoc />
-        public global::System.IObservable<global::Refit.ApiResponse<global::Refit.Tests.User>> GetUserObservableWithMetadata(string @userName) 
+        public global::System.IObservable<global::Refit.ApiResponse<global::Refit.Tests.User>> GetUserObservableWithMetadata(string @userName)
         {
             var ______arguments = new object[] { @userName };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetUserObservableWithMetadata"", new global::System.Type[] { typeof(string) } );
@@ -292,7 +292,7 @@ namespace Refit.Implementation
         }
 
         /// <inheritdoc />
-        public global::System.Threading.Tasks.Task<global::Refit.Tests.User> CreateUser(global::Refit.Tests.User @user) 
+        public global::System.Threading.Tasks.Task<global::Refit.Tests.User> CreateUser(global::Refit.Tests.User @user)
         {
             var ______arguments = new object[] { @user };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""CreateUser"", new global::System.Type[] { typeof(global::Refit.Tests.User) } );
@@ -300,7 +300,7 @@ namespace Refit.Implementation
         }
 
         /// <inheritdoc />
-        public global::System.Threading.Tasks.Task<global::Refit.ApiResponse<global::Refit.Tests.User>> CreateUserWithMetadata(global::Refit.Tests.User @user) 
+        public global::System.Threading.Tasks.Task<global::Refit.ApiResponse<global::Refit.Tests.User>> CreateUserWithMetadata(global::Refit.Tests.User @user)
         {
             var ______arguments = new object[] { @user };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""CreateUserWithMetadata"", new global::System.Type[] { typeof(global::Refit.Tests.User) } );
@@ -308,7 +308,7 @@ namespace Refit.Implementation
         }
 
         /// <inheritdoc />
-        global::System.Threading.Tasks.Task<global::Refit.Tests.User> global::Refit.Tests.IGitHubApi.GetUser(string @userName) 
+        global::System.Threading.Tasks.Task<global::Refit.Tests.User> global::Refit.Tests.IGitHubApi.GetUser(string @userName)
         {
             var ______arguments = new object[] { @userName };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetUser"", new global::System.Type[] { typeof(string) } );
@@ -316,7 +316,7 @@ namespace Refit.Implementation
         }
 
         /// <inheritdoc />
-        global::System.IObservable<global::Refit.Tests.User> global::Refit.Tests.IGitHubApi.GetUserObservable(string @userName) 
+        global::System.IObservable<global::Refit.Tests.User> global::Refit.Tests.IGitHubApi.GetUserObservable(string @userName)
         {
             var ______arguments = new object[] { @userName };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetUserObservable"", new global::System.Type[] { typeof(string) } );
@@ -324,7 +324,7 @@ namespace Refit.Implementation
         }
 
         /// <inheritdoc />
-        global::System.IObservable<global::Refit.Tests.User> global::Refit.Tests.IGitHubApi.GetUserCamelCase(string @userName) 
+        global::System.IObservable<global::Refit.Tests.User> global::Refit.Tests.IGitHubApi.GetUserCamelCase(string @userName)
         {
             var ______arguments = new object[] { @userName };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetUserCamelCase"", new global::System.Type[] { typeof(string) } );
@@ -332,7 +332,7 @@ namespace Refit.Implementation
         }
 
         /// <inheritdoc />
-        global::System.Threading.Tasks.Task<global::System.Collections.Generic.List<global::Refit.Tests.User>> global::Refit.Tests.IGitHubApi.GetOrgMembers(string @orgName, global::System.Threading.CancellationToken @cancellationToken) 
+        global::System.Threading.Tasks.Task<global::System.Collections.Generic.List<global::Refit.Tests.User>> global::Refit.Tests.IGitHubApi.GetOrgMembers(string @orgName, global::System.Threading.CancellationToken @cancellationToken)
         {
             var ______arguments = new object[] { @orgName, @cancellationToken };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetOrgMembers"", new global::System.Type[] { typeof(string), typeof(global::System.Threading.CancellationToken) } );
@@ -340,7 +340,7 @@ namespace Refit.Implementation
         }
 
         /// <inheritdoc />
-        global::System.Threading.Tasks.Task<global::Refit.Tests.UserSearchResult> global::Refit.Tests.IGitHubApi.FindUsers(string @q) 
+        global::System.Threading.Tasks.Task<global::Refit.Tests.UserSearchResult> global::Refit.Tests.IGitHubApi.FindUsers(string @q)
         {
             var ______arguments = new object[] { @q };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""FindUsers"", new global::System.Type[] { typeof(string) } );
@@ -348,7 +348,7 @@ namespace Refit.Implementation
         }
 
         /// <inheritdoc />
-        global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage> global::Refit.Tests.IGitHubApi.GetIndex() 
+        global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage> global::Refit.Tests.IGitHubApi.GetIndex()
         {
             var ______arguments = new object[] {  };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetIndex"", new global::System.Type[] {  } );
@@ -356,7 +356,7 @@ namespace Refit.Implementation
         }
 
         /// <inheritdoc />
-        global::System.IObservable<string> global::Refit.Tests.IGitHubApi.GetIndexObservable() 
+        global::System.IObservable<string> global::Refit.Tests.IGitHubApi.GetIndexObservable()
         {
             var ______arguments = new object[] {  };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetIndexObservable"", new global::System.Type[] {  } );
@@ -364,7 +364,7 @@ namespace Refit.Implementation
         }
 
         /// <inheritdoc />
-        global::System.Threading.Tasks.Task<global::Refit.Tests.User> global::Refit.Tests.IGitHubApi.NothingToSeeHere() 
+        global::System.Threading.Tasks.Task<global::Refit.Tests.User> global::Refit.Tests.IGitHubApi.NothingToSeeHere()
         {
             var ______arguments = new object[] {  };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""NothingToSeeHere"", new global::System.Type[] {  } );
@@ -372,7 +372,7 @@ namespace Refit.Implementation
         }
 
         /// <inheritdoc />
-        global::System.Threading.Tasks.Task<global::Refit.ApiResponse<global::Refit.Tests.User>> global::Refit.Tests.IGitHubApi.NothingToSeeHereWithMetadata() 
+        global::System.Threading.Tasks.Task<global::Refit.ApiResponse<global::Refit.Tests.User>> global::Refit.Tests.IGitHubApi.NothingToSeeHereWithMetadata()
         {
             var ______arguments = new object[] {  };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""NothingToSeeHereWithMetadata"", new global::System.Type[] {  } );
@@ -380,7 +380,7 @@ namespace Refit.Implementation
         }
 
         /// <inheritdoc />
-        global::System.Threading.Tasks.Task<global::Refit.ApiResponse<global::Refit.Tests.User>> global::Refit.Tests.IGitHubApi.GetUserWithMetadata(string @userName) 
+        global::System.Threading.Tasks.Task<global::Refit.ApiResponse<global::Refit.Tests.User>> global::Refit.Tests.IGitHubApi.GetUserWithMetadata(string @userName)
         {
             var ______arguments = new object[] { @userName };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetUserWithMetadata"", new global::System.Type[] { typeof(string) } );
@@ -388,7 +388,7 @@ namespace Refit.Implementation
         }
 
         /// <inheritdoc />
-        global::System.IObservable<global::Refit.ApiResponse<global::Refit.Tests.User>> global::Refit.Tests.IGitHubApi.GetUserObservableWithMetadata(string @userName) 
+        global::System.IObservable<global::Refit.ApiResponse<global::Refit.Tests.User>> global::Refit.Tests.IGitHubApi.GetUserObservableWithMetadata(string @userName)
         {
             var ______arguments = new object[] { @userName };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetUserObservableWithMetadata"", new global::System.Type[] { typeof(string) } );
@@ -396,7 +396,7 @@ namespace Refit.Implementation
         }
 
         /// <inheritdoc />
-        global::System.Threading.Tasks.Task<global::Refit.Tests.User> global::Refit.Tests.IGitHubApi.CreateUser(global::Refit.Tests.User @user) 
+        global::System.Threading.Tasks.Task<global::Refit.Tests.User> global::Refit.Tests.IGitHubApi.CreateUser(global::Refit.Tests.User @user)
         {
             var ______arguments = new object[] { @user };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""CreateUser"", new global::System.Type[] { typeof(global::Refit.Tests.User) } );
@@ -404,7 +404,7 @@ namespace Refit.Implementation
         }
 
         /// <inheritdoc />
-        global::System.Threading.Tasks.Task<global::Refit.ApiResponse<global::Refit.Tests.User>> global::Refit.Tests.IGitHubApi.CreateUserWithMetadata(global::Refit.Tests.User @user) 
+        global::System.Threading.Tasks.Task<global::Refit.ApiResponse<global::Refit.Tests.User>> global::Refit.Tests.IGitHubApi.CreateUserWithMetadata(global::Refit.Tests.User @user)
         {
             var ______arguments = new object[] { @user };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""CreateUserWithMetadata"", new global::System.Type[] { typeof(global::Refit.Tests.User) } );
@@ -448,7 +448,7 @@ namespace Refit.Implementation
 
 
         /// <inheritdoc />
-        public global::System.Threading.Tasks.Task RefitMethod() 
+        public global::System.Threading.Tasks.Task RefitMethod()
         {
             var ______arguments = new object[] {  };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""RefitMethod"", new global::System.Type[] {  } );
@@ -456,7 +456,7 @@ namespace Refit.Implementation
         }
 
         /// <inheritdoc />
-        global::System.Threading.Tasks.Task global::Refit.Tests.IGitHubApiDisposable.RefitMethod() 
+        global::System.Threading.Tasks.Task global::Refit.Tests.IGitHubApiDisposable.RefitMethod()
         {
             var ______arguments = new object[] {  };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""RefitMethod"", new global::System.Type[] {  } );
@@ -464,7 +464,7 @@ namespace Refit.Implementation
         }
 
         /// <inheritdoc />
-        void global::System.IDisposable.Dispose() 
+        void global::System.IDisposable.Dispose()
         {
                 Client?.Dispose();
         }
@@ -506,7 +506,7 @@ namespace Refit.Implementation
 
 
         /// <inheritdoc />
-        public global::System.Threading.Tasks.Task<global::Refit.Tests.User> GetUser(string @userName) 
+        public global::System.Threading.Tasks.Task<global::Refit.Tests.User> GetUser(string @userName)
         {
             var ______arguments = new object[] { @userName };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetUser"", new global::System.Type[] { typeof(string) } );
@@ -514,7 +514,7 @@ namespace Refit.Implementation
         }
 
         /// <inheritdoc />
-        public global::System.IObservable<global::Refit.Tests.User> GetUserObservable(string @userName) 
+        public global::System.IObservable<global::Refit.Tests.User> GetUserObservable(string @userName)
         {
             var ______arguments = new object[] { @userName };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetUserObservable"", new global::System.Type[] { typeof(string) } );
@@ -522,7 +522,7 @@ namespace Refit.Implementation
         }
 
         /// <inheritdoc />
-        public global::System.IObservable<global::Refit.Tests.User> GetUserCamelCase(string @userName) 
+        public global::System.IObservable<global::Refit.Tests.User> GetUserCamelCase(string @userName)
         {
             var ______arguments = new object[] { @userName };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetUserCamelCase"", new global::System.Type[] { typeof(string) } );
@@ -530,7 +530,7 @@ namespace Refit.Implementation
         }
 
         /// <inheritdoc />
-        public global::System.Threading.Tasks.Task<global::System.Collections.Generic.List<global::Refit.Tests.User>> GetOrgMembers(string @orgName) 
+        public global::System.Threading.Tasks.Task<global::System.Collections.Generic.List<global::Refit.Tests.User>> GetOrgMembers(string @orgName)
         {
             var ______arguments = new object[] { @orgName };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetOrgMembers"", new global::System.Type[] { typeof(string) } );
@@ -538,7 +538,7 @@ namespace Refit.Implementation
         }
 
         /// <inheritdoc />
-        public global::System.Threading.Tasks.Task<global::Refit.Tests.UserSearchResult> FindUsers(string @q) 
+        public global::System.Threading.Tasks.Task<global::Refit.Tests.UserSearchResult> FindUsers(string @q)
         {
             var ______arguments = new object[] { @q };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""FindUsers"", new global::System.Type[] { typeof(string) } );
@@ -546,7 +546,7 @@ namespace Refit.Implementation
         }
 
         /// <inheritdoc />
-        public global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage> GetIndex() 
+        public global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage> GetIndex()
         {
             var ______arguments = new object[] {  };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetIndex"", new global::System.Type[] {  } );
@@ -554,7 +554,7 @@ namespace Refit.Implementation
         }
 
         /// <inheritdoc />
-        public global::System.IObservable<string> GetIndexObservable() 
+        public global::System.IObservable<string> GetIndexObservable()
         {
             var ______arguments = new object[] {  };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetIndexObservable"", new global::System.Type[] {  } );
@@ -562,7 +562,7 @@ namespace Refit.Implementation
         }
 
         /// <inheritdoc />
-        public global::System.Threading.Tasks.Task NothingToSeeHere() 
+        public global::System.Threading.Tasks.Task NothingToSeeHere()
         {
             var ______arguments = new object[] {  };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""NothingToSeeHere"", new global::System.Type[] {  } );
@@ -570,7 +570,7 @@ namespace Refit.Implementation
         }
 
         /// <inheritdoc />
-        global::System.Threading.Tasks.Task<global::Refit.Tests.User> global::Refit.Tests.TestNested.INestedGitHubApi.GetUser(string @userName) 
+        global::System.Threading.Tasks.Task<global::Refit.Tests.User> global::Refit.Tests.TestNested.INestedGitHubApi.GetUser(string @userName)
         {
             var ______arguments = new object[] { @userName };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetUser"", new global::System.Type[] { typeof(string) } );
@@ -578,7 +578,7 @@ namespace Refit.Implementation
         }
 
         /// <inheritdoc />
-        global::System.IObservable<global::Refit.Tests.User> global::Refit.Tests.TestNested.INestedGitHubApi.GetUserObservable(string @userName) 
+        global::System.IObservable<global::Refit.Tests.User> global::Refit.Tests.TestNested.INestedGitHubApi.GetUserObservable(string @userName)
         {
             var ______arguments = new object[] { @userName };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetUserObservable"", new global::System.Type[] { typeof(string) } );
@@ -586,7 +586,7 @@ namespace Refit.Implementation
         }
 
         /// <inheritdoc />
-        global::System.IObservable<global::Refit.Tests.User> global::Refit.Tests.TestNested.INestedGitHubApi.GetUserCamelCase(string @userName) 
+        global::System.IObservable<global::Refit.Tests.User> global::Refit.Tests.TestNested.INestedGitHubApi.GetUserCamelCase(string @userName)
         {
             var ______arguments = new object[] { @userName };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetUserCamelCase"", new global::System.Type[] { typeof(string) } );
@@ -594,7 +594,7 @@ namespace Refit.Implementation
         }
 
         /// <inheritdoc />
-        global::System.Threading.Tasks.Task<global::System.Collections.Generic.List<global::Refit.Tests.User>> global::Refit.Tests.TestNested.INestedGitHubApi.GetOrgMembers(string @orgName) 
+        global::System.Threading.Tasks.Task<global::System.Collections.Generic.List<global::Refit.Tests.User>> global::Refit.Tests.TestNested.INestedGitHubApi.GetOrgMembers(string @orgName)
         {
             var ______arguments = new object[] { @orgName };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetOrgMembers"", new global::System.Type[] { typeof(string) } );
@@ -602,7 +602,7 @@ namespace Refit.Implementation
         }
 
         /// <inheritdoc />
-        global::System.Threading.Tasks.Task<global::Refit.Tests.UserSearchResult> global::Refit.Tests.TestNested.INestedGitHubApi.FindUsers(string @q) 
+        global::System.Threading.Tasks.Task<global::Refit.Tests.UserSearchResult> global::Refit.Tests.TestNested.INestedGitHubApi.FindUsers(string @q)
         {
             var ______arguments = new object[] { @q };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""FindUsers"", new global::System.Type[] { typeof(string) } );
@@ -610,7 +610,7 @@ namespace Refit.Implementation
         }
 
         /// <inheritdoc />
-        global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage> global::Refit.Tests.TestNested.INestedGitHubApi.GetIndex() 
+        global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage> global::Refit.Tests.TestNested.INestedGitHubApi.GetIndex()
         {
             var ______arguments = new object[] {  };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetIndex"", new global::System.Type[] {  } );
@@ -618,7 +618,7 @@ namespace Refit.Implementation
         }
 
         /// <inheritdoc />
-        global::System.IObservable<string> global::Refit.Tests.TestNested.INestedGitHubApi.GetIndexObservable() 
+        global::System.IObservable<string> global::Refit.Tests.TestNested.INestedGitHubApi.GetIndexObservable()
         {
             var ______arguments = new object[] {  };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetIndexObservable"", new global::System.Type[] {  } );
@@ -626,7 +626,7 @@ namespace Refit.Implementation
         }
 
         /// <inheritdoc />
-        global::System.Threading.Tasks.Task global::Refit.Tests.TestNested.INestedGitHubApi.NothingToSeeHere() 
+        global::System.Threading.Tasks.Task global::Refit.Tests.TestNested.INestedGitHubApi.NothingToSeeHere()
         {
             var ______arguments = new object[] {  };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""NothingToSeeHere"", new global::System.Type[] {  } );
@@ -750,7 +750,7 @@ namespace Refit.Implementation
 
 
         /// <inheritdoc />
-        public global::System.Threading.Tasks.Task GetRoot() 
+        public global::System.Threading.Tasks.Task GetRoot()
         {
             var ______arguments = new object[] {  };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetRoot"", new global::System.Type[] {  } );
@@ -758,7 +758,7 @@ namespace Refit.Implementation
         }
 
         /// <inheritdoc />
-        public global::System.Threading.Tasks.Task PostRoot() 
+        public global::System.Threading.Tasks.Task PostRoot()
         {
             var ______arguments = new object[] {  };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""PostRoot"", new global::System.Type[] {  } );
@@ -766,7 +766,7 @@ namespace Refit.Implementation
         }
 
         /// <inheritdoc />
-        global::System.Threading.Tasks.Task global::IServiceWithoutNamespace.GetRoot() 
+        global::System.Threading.Tasks.Task global::IServiceWithoutNamespace.GetRoot()
         {
             var ______arguments = new object[] {  };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetRoot"", new global::System.Type[] {  } );
@@ -774,7 +774,7 @@ namespace Refit.Implementation
         }
 
         /// <inheritdoc />
-        global::System.Threading.Tasks.Task global::IServiceWithoutNamespace.PostRoot() 
+        global::System.Threading.Tasks.Task global::IServiceWithoutNamespace.PostRoot()
         {
             var ______arguments = new object[] {  };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""PostRoot"", new global::System.Type[] {  } );

--- a/Refit.Tests/InterfaceStubGenerator.cs
+++ b/Refit.Tests/InterfaceStubGenerator.cs
@@ -208,7 +208,14 @@ namespace Refit.Implementation
         {
             var ______arguments = new object[] { @userName };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetUser"", new global::System.Type[] { typeof(string) } );
-            return (global::System.Threading.Tasks.Task<global::Refit.Tests.User>)______func(this.Client, ______arguments);
+            try
+            {
+                return (global::System.Threading.Tasks.Task<global::Refit.Tests.User>)______func(this.Client, ______arguments);
+            }
+            catch (global::System.Exception ex)
+            {
+                throw ex;
+            }
         }
 
         /// <inheritdoc />
@@ -216,7 +223,14 @@ namespace Refit.Implementation
         {
             var ______arguments = new object[] { @userName };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetUserObservable"", new global::System.Type[] { typeof(string) } );
-            return (global::System.IObservable<global::Refit.Tests.User>)______func(this.Client, ______arguments);
+            try
+            {
+                return (global::System.IObservable<global::Refit.Tests.User>)______func(this.Client, ______arguments);
+            }
+            catch (global::System.Exception ex)
+            {
+                throw ex;
+            }
         }
 
         /// <inheritdoc />
@@ -224,7 +238,14 @@ namespace Refit.Implementation
         {
             var ______arguments = new object[] { @userName };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetUserCamelCase"", new global::System.Type[] { typeof(string) } );
-            return (global::System.IObservable<global::Refit.Tests.User>)______func(this.Client, ______arguments);
+            try
+            {
+                return (global::System.IObservable<global::Refit.Tests.User>)______func(this.Client, ______arguments);
+            }
+            catch (global::System.Exception ex)
+            {
+                throw ex;
+            }
         }
 
         /// <inheritdoc />
@@ -232,7 +253,14 @@ namespace Refit.Implementation
         {
             var ______arguments = new object[] { @orgName, @cancellationToken };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetOrgMembers"", new global::System.Type[] { typeof(string), typeof(global::System.Threading.CancellationToken) } );
-            return (global::System.Threading.Tasks.Task<global::System.Collections.Generic.List<global::Refit.Tests.User>>)______func(this.Client, ______arguments);
+            try
+            {
+                return (global::System.Threading.Tasks.Task<global::System.Collections.Generic.List<global::Refit.Tests.User>>)______func(this.Client, ______arguments);
+            }
+            catch (global::System.Exception ex)
+            {
+                throw ex;
+            }
         }
 
         /// <inheritdoc />
@@ -240,7 +268,14 @@ namespace Refit.Implementation
         {
             var ______arguments = new object[] { @q };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""FindUsers"", new global::System.Type[] { typeof(string) } );
-            return (global::System.Threading.Tasks.Task<global::Refit.Tests.UserSearchResult>)______func(this.Client, ______arguments);
+            try
+            {
+                return (global::System.Threading.Tasks.Task<global::Refit.Tests.UserSearchResult>)______func(this.Client, ______arguments);
+            }
+            catch (global::System.Exception ex)
+            {
+                throw ex;
+            }
         }
 
         /// <inheritdoc />
@@ -248,7 +283,14 @@ namespace Refit.Implementation
         {
             var ______arguments = new object[] {  };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetIndex"", new global::System.Type[] {  } );
-            return (global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage>)______func(this.Client, ______arguments);
+            try
+            {
+                return (global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage>)______func(this.Client, ______arguments);
+            }
+            catch (global::System.Exception ex)
+            {
+                throw ex;
+            }
         }
 
         /// <inheritdoc />
@@ -256,7 +298,14 @@ namespace Refit.Implementation
         {
             var ______arguments = new object[] {  };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetIndexObservable"", new global::System.Type[] {  } );
-            return (global::System.IObservable<string>)______func(this.Client, ______arguments);
+            try
+            {
+                return (global::System.IObservable<string>)______func(this.Client, ______arguments);
+            }
+            catch (global::System.Exception ex)
+            {
+                throw ex;
+            }
         }
 
         /// <inheritdoc />
@@ -264,7 +313,14 @@ namespace Refit.Implementation
         {
             var ______arguments = new object[] {  };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""NothingToSeeHere"", new global::System.Type[] {  } );
-            return (global::System.Threading.Tasks.Task<global::Refit.Tests.User>)______func(this.Client, ______arguments);
+            try
+            {
+                return (global::System.Threading.Tasks.Task<global::Refit.Tests.User>)______func(this.Client, ______arguments);
+            }
+            catch (global::System.Exception ex)
+            {
+                throw ex;
+            }
         }
 
         /// <inheritdoc />
@@ -272,7 +328,14 @@ namespace Refit.Implementation
         {
             var ______arguments = new object[] {  };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""NothingToSeeHereWithMetadata"", new global::System.Type[] {  } );
-            return (global::System.Threading.Tasks.Task<global::Refit.ApiResponse<global::Refit.Tests.User>>)______func(this.Client, ______arguments);
+            try
+            {
+                return (global::System.Threading.Tasks.Task<global::Refit.ApiResponse<global::Refit.Tests.User>>)______func(this.Client, ______arguments);
+            }
+            catch (global::System.Exception ex)
+            {
+                throw ex;
+            }
         }
 
         /// <inheritdoc />
@@ -280,7 +343,14 @@ namespace Refit.Implementation
         {
             var ______arguments = new object[] { @userName };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetUserWithMetadata"", new global::System.Type[] { typeof(string) } );
-            return (global::System.Threading.Tasks.Task<global::Refit.ApiResponse<global::Refit.Tests.User>>)______func(this.Client, ______arguments);
+            try
+            {
+                return (global::System.Threading.Tasks.Task<global::Refit.ApiResponse<global::Refit.Tests.User>>)______func(this.Client, ______arguments);
+            }
+            catch (global::System.Exception ex)
+            {
+                throw ex;
+            }
         }
 
         /// <inheritdoc />
@@ -288,7 +358,14 @@ namespace Refit.Implementation
         {
             var ______arguments = new object[] { @userName };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetUserObservableWithMetadata"", new global::System.Type[] { typeof(string) } );
-            return (global::System.IObservable<global::Refit.ApiResponse<global::Refit.Tests.User>>)______func(this.Client, ______arguments);
+            try
+            {
+                return (global::System.IObservable<global::Refit.ApiResponse<global::Refit.Tests.User>>)______func(this.Client, ______arguments);
+            }
+            catch (global::System.Exception ex)
+            {
+                throw ex;
+            }
         }
 
         /// <inheritdoc />
@@ -296,7 +373,14 @@ namespace Refit.Implementation
         {
             var ______arguments = new object[] { @user };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""CreateUser"", new global::System.Type[] { typeof(global::Refit.Tests.User) } );
-            return (global::System.Threading.Tasks.Task<global::Refit.Tests.User>)______func(this.Client, ______arguments);
+            try
+            {
+                return (global::System.Threading.Tasks.Task<global::Refit.Tests.User>)______func(this.Client, ______arguments);
+            }
+            catch (global::System.Exception ex)
+            {
+                throw ex;
+            }
         }
 
         /// <inheritdoc />
@@ -304,7 +388,14 @@ namespace Refit.Implementation
         {
             var ______arguments = new object[] { @user };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""CreateUserWithMetadata"", new global::System.Type[] { typeof(global::Refit.Tests.User) } );
-            return (global::System.Threading.Tasks.Task<global::Refit.ApiResponse<global::Refit.Tests.User>>)______func(this.Client, ______arguments);
+            try
+            {
+                return (global::System.Threading.Tasks.Task<global::Refit.ApiResponse<global::Refit.Tests.User>>)______func(this.Client, ______arguments);
+            }
+            catch (global::System.Exception ex)
+            {
+                throw ex;
+            }
         }
 
         /// <inheritdoc />
@@ -312,7 +403,14 @@ namespace Refit.Implementation
         {
             var ______arguments = new object[] { @userName };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetUser"", new global::System.Type[] { typeof(string) } );
-            return (global::System.Threading.Tasks.Task<global::Refit.Tests.User>)______func(this.Client, ______arguments);
+            try
+            {
+                return (global::System.Threading.Tasks.Task<global::Refit.Tests.User>)______func(this.Client, ______arguments);
+            }
+            catch (global::System.Exception ex)
+            {
+                throw ex;
+            }
         }
 
         /// <inheritdoc />
@@ -320,7 +418,14 @@ namespace Refit.Implementation
         {
             var ______arguments = new object[] { @userName };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetUserObservable"", new global::System.Type[] { typeof(string) } );
-            return (global::System.IObservable<global::Refit.Tests.User>)______func(this.Client, ______arguments);
+            try
+            {
+                return (global::System.IObservable<global::Refit.Tests.User>)______func(this.Client, ______arguments);
+            }
+            catch (global::System.Exception ex)
+            {
+                throw ex;
+            }
         }
 
         /// <inheritdoc />
@@ -328,7 +433,14 @@ namespace Refit.Implementation
         {
             var ______arguments = new object[] { @userName };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetUserCamelCase"", new global::System.Type[] { typeof(string) } );
-            return (global::System.IObservable<global::Refit.Tests.User>)______func(this.Client, ______arguments);
+            try
+            {
+                return (global::System.IObservable<global::Refit.Tests.User>)______func(this.Client, ______arguments);
+            }
+            catch (global::System.Exception ex)
+            {
+                throw ex;
+            }
         }
 
         /// <inheritdoc />
@@ -336,7 +448,14 @@ namespace Refit.Implementation
         {
             var ______arguments = new object[] { @orgName, @cancellationToken };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetOrgMembers"", new global::System.Type[] { typeof(string), typeof(global::System.Threading.CancellationToken) } );
-            return (global::System.Threading.Tasks.Task<global::System.Collections.Generic.List<global::Refit.Tests.User>>)______func(this.Client, ______arguments);
+            try
+            {
+                return (global::System.Threading.Tasks.Task<global::System.Collections.Generic.List<global::Refit.Tests.User>>)______func(this.Client, ______arguments);
+            }
+            catch (global::System.Exception ex)
+            {
+                throw ex;
+            }
         }
 
         /// <inheritdoc />
@@ -344,7 +463,14 @@ namespace Refit.Implementation
         {
             var ______arguments = new object[] { @q };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""FindUsers"", new global::System.Type[] { typeof(string) } );
-            return (global::System.Threading.Tasks.Task<global::Refit.Tests.UserSearchResult>)______func(this.Client, ______arguments);
+            try
+            {
+                return (global::System.Threading.Tasks.Task<global::Refit.Tests.UserSearchResult>)______func(this.Client, ______arguments);
+            }
+            catch (global::System.Exception ex)
+            {
+                throw ex;
+            }
         }
 
         /// <inheritdoc />
@@ -352,7 +478,14 @@ namespace Refit.Implementation
         {
             var ______arguments = new object[] {  };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetIndex"", new global::System.Type[] {  } );
-            return (global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage>)______func(this.Client, ______arguments);
+            try
+            {
+                return (global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage>)______func(this.Client, ______arguments);
+            }
+            catch (global::System.Exception ex)
+            {
+                throw ex;
+            }
         }
 
         /// <inheritdoc />
@@ -360,7 +493,14 @@ namespace Refit.Implementation
         {
             var ______arguments = new object[] {  };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetIndexObservable"", new global::System.Type[] {  } );
-            return (global::System.IObservable<string>)______func(this.Client, ______arguments);
+            try
+            {
+                return (global::System.IObservable<string>)______func(this.Client, ______arguments);
+            }
+            catch (global::System.Exception ex)
+            {
+                throw ex;
+            }
         }
 
         /// <inheritdoc />
@@ -368,7 +508,14 @@ namespace Refit.Implementation
         {
             var ______arguments = new object[] {  };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""NothingToSeeHere"", new global::System.Type[] {  } );
-            return (global::System.Threading.Tasks.Task<global::Refit.Tests.User>)______func(this.Client, ______arguments);
+            try
+            {
+                return (global::System.Threading.Tasks.Task<global::Refit.Tests.User>)______func(this.Client, ______arguments);
+            }
+            catch (global::System.Exception ex)
+            {
+                throw ex;
+            }
         }
 
         /// <inheritdoc />
@@ -376,7 +523,14 @@ namespace Refit.Implementation
         {
             var ______arguments = new object[] {  };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""NothingToSeeHereWithMetadata"", new global::System.Type[] {  } );
-            return (global::System.Threading.Tasks.Task<global::Refit.ApiResponse<global::Refit.Tests.User>>)______func(this.Client, ______arguments);
+            try
+            {
+                return (global::System.Threading.Tasks.Task<global::Refit.ApiResponse<global::Refit.Tests.User>>)______func(this.Client, ______arguments);
+            }
+            catch (global::System.Exception ex)
+            {
+                throw ex;
+            }
         }
 
         /// <inheritdoc />
@@ -384,7 +538,14 @@ namespace Refit.Implementation
         {
             var ______arguments = new object[] { @userName };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetUserWithMetadata"", new global::System.Type[] { typeof(string) } );
-            return (global::System.Threading.Tasks.Task<global::Refit.ApiResponse<global::Refit.Tests.User>>)______func(this.Client, ______arguments);
+            try
+            {
+                return (global::System.Threading.Tasks.Task<global::Refit.ApiResponse<global::Refit.Tests.User>>)______func(this.Client, ______arguments);
+            }
+            catch (global::System.Exception ex)
+            {
+                throw ex;
+            }
         }
 
         /// <inheritdoc />
@@ -392,7 +553,14 @@ namespace Refit.Implementation
         {
             var ______arguments = new object[] { @userName };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetUserObservableWithMetadata"", new global::System.Type[] { typeof(string) } );
-            return (global::System.IObservable<global::Refit.ApiResponse<global::Refit.Tests.User>>)______func(this.Client, ______arguments);
+            try
+            {
+                return (global::System.IObservable<global::Refit.ApiResponse<global::Refit.Tests.User>>)______func(this.Client, ______arguments);
+            }
+            catch (global::System.Exception ex)
+            {
+                throw ex;
+            }
         }
 
         /// <inheritdoc />
@@ -400,7 +568,14 @@ namespace Refit.Implementation
         {
             var ______arguments = new object[] { @user };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""CreateUser"", new global::System.Type[] { typeof(global::Refit.Tests.User) } );
-            return (global::System.Threading.Tasks.Task<global::Refit.Tests.User>)______func(this.Client, ______arguments);
+            try
+            {
+                return (global::System.Threading.Tasks.Task<global::Refit.Tests.User>)______func(this.Client, ______arguments);
+            }
+            catch (global::System.Exception ex)
+            {
+                throw ex;
+            }
         }
 
         /// <inheritdoc />
@@ -408,7 +583,14 @@ namespace Refit.Implementation
         {
             var ______arguments = new object[] { @user };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""CreateUserWithMetadata"", new global::System.Type[] { typeof(global::Refit.Tests.User) } );
-            return (global::System.Threading.Tasks.Task<global::Refit.ApiResponse<global::Refit.Tests.User>>)______func(this.Client, ______arguments);
+            try
+            {
+                return (global::System.Threading.Tasks.Task<global::Refit.ApiResponse<global::Refit.Tests.User>>)______func(this.Client, ______arguments);
+            }
+            catch (global::System.Exception ex)
+            {
+                throw ex;
+            }
         }
     }
     }
@@ -452,7 +634,14 @@ namespace Refit.Implementation
         {
             var ______arguments = new object[] {  };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""RefitMethod"", new global::System.Type[] {  } );
-            return (global::System.Threading.Tasks.Task)______func(this.Client, ______arguments);
+            try
+            {
+                return (global::System.Threading.Tasks.Task)______func(this.Client, ______arguments);
+            }
+            catch (global::System.Exception ex)
+            {
+                throw ex;
+            }
         }
 
         /// <inheritdoc />
@@ -460,7 +649,14 @@ namespace Refit.Implementation
         {
             var ______arguments = new object[] {  };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""RefitMethod"", new global::System.Type[] {  } );
-            return (global::System.Threading.Tasks.Task)______func(this.Client, ______arguments);
+            try
+            {
+                return (global::System.Threading.Tasks.Task)______func(this.Client, ______arguments);
+            }
+            catch (global::System.Exception ex)
+            {
+                throw ex;
+            }
         }
 
         /// <inheritdoc />
@@ -510,7 +706,14 @@ namespace Refit.Implementation
         {
             var ______arguments = new object[] { @userName };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetUser"", new global::System.Type[] { typeof(string) } );
-            return (global::System.Threading.Tasks.Task<global::Refit.Tests.User>)______func(this.Client, ______arguments);
+            try
+            {
+                return (global::System.Threading.Tasks.Task<global::Refit.Tests.User>)______func(this.Client, ______arguments);
+            }
+            catch (global::System.Exception ex)
+            {
+                throw ex;
+            }
         }
 
         /// <inheritdoc />
@@ -518,7 +721,14 @@ namespace Refit.Implementation
         {
             var ______arguments = new object[] { @userName };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetUserObservable"", new global::System.Type[] { typeof(string) } );
-            return (global::System.IObservable<global::Refit.Tests.User>)______func(this.Client, ______arguments);
+            try
+            {
+                return (global::System.IObservable<global::Refit.Tests.User>)______func(this.Client, ______arguments);
+            }
+            catch (global::System.Exception ex)
+            {
+                throw ex;
+            }
         }
 
         /// <inheritdoc />
@@ -526,7 +736,14 @@ namespace Refit.Implementation
         {
             var ______arguments = new object[] { @userName };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetUserCamelCase"", new global::System.Type[] { typeof(string) } );
-            return (global::System.IObservable<global::Refit.Tests.User>)______func(this.Client, ______arguments);
+            try
+            {
+                return (global::System.IObservable<global::Refit.Tests.User>)______func(this.Client, ______arguments);
+            }
+            catch (global::System.Exception ex)
+            {
+                throw ex;
+            }
         }
 
         /// <inheritdoc />
@@ -534,7 +751,14 @@ namespace Refit.Implementation
         {
             var ______arguments = new object[] { @orgName };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetOrgMembers"", new global::System.Type[] { typeof(string) } );
-            return (global::System.Threading.Tasks.Task<global::System.Collections.Generic.List<global::Refit.Tests.User>>)______func(this.Client, ______arguments);
+            try
+            {
+                return (global::System.Threading.Tasks.Task<global::System.Collections.Generic.List<global::Refit.Tests.User>>)______func(this.Client, ______arguments);
+            }
+            catch (global::System.Exception ex)
+            {
+                throw ex;
+            }
         }
 
         /// <inheritdoc />
@@ -542,7 +766,14 @@ namespace Refit.Implementation
         {
             var ______arguments = new object[] { @q };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""FindUsers"", new global::System.Type[] { typeof(string) } );
-            return (global::System.Threading.Tasks.Task<global::Refit.Tests.UserSearchResult>)______func(this.Client, ______arguments);
+            try
+            {
+                return (global::System.Threading.Tasks.Task<global::Refit.Tests.UserSearchResult>)______func(this.Client, ______arguments);
+            }
+            catch (global::System.Exception ex)
+            {
+                throw ex;
+            }
         }
 
         /// <inheritdoc />
@@ -550,7 +781,14 @@ namespace Refit.Implementation
         {
             var ______arguments = new object[] {  };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetIndex"", new global::System.Type[] {  } );
-            return (global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage>)______func(this.Client, ______arguments);
+            try
+            {
+                return (global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage>)______func(this.Client, ______arguments);
+            }
+            catch (global::System.Exception ex)
+            {
+                throw ex;
+            }
         }
 
         /// <inheritdoc />
@@ -558,7 +796,14 @@ namespace Refit.Implementation
         {
             var ______arguments = new object[] {  };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetIndexObservable"", new global::System.Type[] {  } );
-            return (global::System.IObservable<string>)______func(this.Client, ______arguments);
+            try
+            {
+                return (global::System.IObservable<string>)______func(this.Client, ______arguments);
+            }
+            catch (global::System.Exception ex)
+            {
+                throw ex;
+            }
         }
 
         /// <inheritdoc />
@@ -566,7 +811,14 @@ namespace Refit.Implementation
         {
             var ______arguments = new object[] {  };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""NothingToSeeHere"", new global::System.Type[] {  } );
-            return (global::System.Threading.Tasks.Task)______func(this.Client, ______arguments);
+            try
+            {
+                return (global::System.Threading.Tasks.Task)______func(this.Client, ______arguments);
+            }
+            catch (global::System.Exception ex)
+            {
+                throw ex;
+            }
         }
 
         /// <inheritdoc />
@@ -574,7 +826,14 @@ namespace Refit.Implementation
         {
             var ______arguments = new object[] { @userName };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetUser"", new global::System.Type[] { typeof(string) } );
-            return (global::System.Threading.Tasks.Task<global::Refit.Tests.User>)______func(this.Client, ______arguments);
+            try
+            {
+                return (global::System.Threading.Tasks.Task<global::Refit.Tests.User>)______func(this.Client, ______arguments);
+            }
+            catch (global::System.Exception ex)
+            {
+                throw ex;
+            }
         }
 
         /// <inheritdoc />
@@ -582,7 +841,14 @@ namespace Refit.Implementation
         {
             var ______arguments = new object[] { @userName };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetUserObservable"", new global::System.Type[] { typeof(string) } );
-            return (global::System.IObservable<global::Refit.Tests.User>)______func(this.Client, ______arguments);
+            try
+            {
+                return (global::System.IObservable<global::Refit.Tests.User>)______func(this.Client, ______arguments);
+            }
+            catch (global::System.Exception ex)
+            {
+                throw ex;
+            }
         }
 
         /// <inheritdoc />
@@ -590,7 +856,14 @@ namespace Refit.Implementation
         {
             var ______arguments = new object[] { @userName };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetUserCamelCase"", new global::System.Type[] { typeof(string) } );
-            return (global::System.IObservable<global::Refit.Tests.User>)______func(this.Client, ______arguments);
+            try
+            {
+                return (global::System.IObservable<global::Refit.Tests.User>)______func(this.Client, ______arguments);
+            }
+            catch (global::System.Exception ex)
+            {
+                throw ex;
+            }
         }
 
         /// <inheritdoc />
@@ -598,7 +871,14 @@ namespace Refit.Implementation
         {
             var ______arguments = new object[] { @orgName };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetOrgMembers"", new global::System.Type[] { typeof(string) } );
-            return (global::System.Threading.Tasks.Task<global::System.Collections.Generic.List<global::Refit.Tests.User>>)______func(this.Client, ______arguments);
+            try
+            {
+                return (global::System.Threading.Tasks.Task<global::System.Collections.Generic.List<global::Refit.Tests.User>>)______func(this.Client, ______arguments);
+            }
+            catch (global::System.Exception ex)
+            {
+                throw ex;
+            }
         }
 
         /// <inheritdoc />
@@ -606,7 +886,14 @@ namespace Refit.Implementation
         {
             var ______arguments = new object[] { @q };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""FindUsers"", new global::System.Type[] { typeof(string) } );
-            return (global::System.Threading.Tasks.Task<global::Refit.Tests.UserSearchResult>)______func(this.Client, ______arguments);
+            try
+            {
+                return (global::System.Threading.Tasks.Task<global::Refit.Tests.UserSearchResult>)______func(this.Client, ______arguments);
+            }
+            catch (global::System.Exception ex)
+            {
+                throw ex;
+            }
         }
 
         /// <inheritdoc />
@@ -614,7 +901,14 @@ namespace Refit.Implementation
         {
             var ______arguments = new object[] {  };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetIndex"", new global::System.Type[] {  } );
-            return (global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage>)______func(this.Client, ______arguments);
+            try
+            {
+                return (global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage>)______func(this.Client, ______arguments);
+            }
+            catch (global::System.Exception ex)
+            {
+                throw ex;
+            }
         }
 
         /// <inheritdoc />
@@ -622,7 +916,14 @@ namespace Refit.Implementation
         {
             var ______arguments = new object[] {  };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetIndexObservable"", new global::System.Type[] {  } );
-            return (global::System.IObservable<string>)______func(this.Client, ______arguments);
+            try
+            {
+                return (global::System.IObservable<string>)______func(this.Client, ______arguments);
+            }
+            catch (global::System.Exception ex)
+            {
+                throw ex;
+            }
         }
 
         /// <inheritdoc />
@@ -630,7 +931,14 @@ namespace Refit.Implementation
         {
             var ______arguments = new object[] {  };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""NothingToSeeHere"", new global::System.Type[] {  } );
-            return (global::System.Threading.Tasks.Task)______func(this.Client, ______arguments);
+            try
+            {
+                return (global::System.Threading.Tasks.Task)______func(this.Client, ______arguments);
+            }
+            catch (global::System.Exception ex)
+            {
+                throw ex;
+            }
         }
     }
     }
@@ -754,7 +1062,14 @@ namespace Refit.Implementation
         {
             var ______arguments = new object[] {  };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetRoot"", new global::System.Type[] {  } );
-            return (global::System.Threading.Tasks.Task)______func(this.Client, ______arguments);
+            try
+            {
+                return (global::System.Threading.Tasks.Task)______func(this.Client, ______arguments);
+            }
+            catch (global::System.Exception ex)
+            {
+                throw ex;
+            }
         }
 
         /// <inheritdoc />
@@ -762,7 +1077,14 @@ namespace Refit.Implementation
         {
             var ______arguments = new object[] {  };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""PostRoot"", new global::System.Type[] {  } );
-            return (global::System.Threading.Tasks.Task)______func(this.Client, ______arguments);
+            try
+            {
+                return (global::System.Threading.Tasks.Task)______func(this.Client, ______arguments);
+            }
+            catch (global::System.Exception ex)
+            {
+                throw ex;
+            }
         }
 
         /// <inheritdoc />
@@ -770,7 +1092,14 @@ namespace Refit.Implementation
         {
             var ______arguments = new object[] {  };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetRoot"", new global::System.Type[] {  } );
-            return (global::System.Threading.Tasks.Task)______func(this.Client, ______arguments);
+            try
+            {
+                return (global::System.Threading.Tasks.Task)______func(this.Client, ______arguments);
+            }
+            catch (global::System.Exception ex)
+            {
+                throw ex;
+            }
         }
 
         /// <inheritdoc />
@@ -778,7 +1107,14 @@ namespace Refit.Implementation
         {
             var ______arguments = new object[] {  };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""PostRoot"", new global::System.Type[] {  } );
-            return (global::System.Threading.Tasks.Task)______func(this.Client, ______arguments);
+            try
+            {
+                return (global::System.Threading.Tasks.Task)______func(this.Client, ______arguments);
+            }
+            catch (global::System.Exception ex)
+            {
+                throw ex;
+            }
         }
     }
     }

--- a/Refit.Tests/InterfaceStubGenerator.cs
+++ b/Refit.Tests/InterfaceStubGenerator.cs
@@ -204,13 +204,13 @@ namespace Refit.Implementation
 
 
         /// <inheritdoc />
-        public global::System.Threading.Tasks.Task<global::Refit.Tests.User> GetUser(string @userName)
+        public async global::System.Threading.Tasks.Task<global::Refit.Tests.User> GetUser(string @userName)
         {
             var ______arguments = new object[] { @userName };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetUser"", new global::System.Type[] { typeof(string) } );
             try
             {
-                return (global::System.Threading.Tasks.Task<global::Refit.Tests.User>)______func(this.Client, ______arguments);
+                return await ((global::System.Threading.Tasks.Task<global::Refit.Tests.User>)______func(this.Client, ______arguments)).ConfigureAwait(false);
             }
             catch (global::System.Exception ex)
             {
@@ -249,13 +249,13 @@ namespace Refit.Implementation
         }
 
         /// <inheritdoc />
-        public global::System.Threading.Tasks.Task<global::System.Collections.Generic.List<global::Refit.Tests.User>> GetOrgMembers(string @orgName, global::System.Threading.CancellationToken @cancellationToken)
+        public async global::System.Threading.Tasks.Task<global::System.Collections.Generic.List<global::Refit.Tests.User>> GetOrgMembers(string @orgName, global::System.Threading.CancellationToken @cancellationToken)
         {
             var ______arguments = new object[] { @orgName, @cancellationToken };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetOrgMembers"", new global::System.Type[] { typeof(string), typeof(global::System.Threading.CancellationToken) } );
             try
             {
-                return (global::System.Threading.Tasks.Task<global::System.Collections.Generic.List<global::Refit.Tests.User>>)______func(this.Client, ______arguments);
+                return await ((global::System.Threading.Tasks.Task<global::System.Collections.Generic.List<global::Refit.Tests.User>>)______func(this.Client, ______arguments)).ConfigureAwait(false);
             }
             catch (global::System.Exception ex)
             {
@@ -264,13 +264,13 @@ namespace Refit.Implementation
         }
 
         /// <inheritdoc />
-        public global::System.Threading.Tasks.Task<global::Refit.Tests.UserSearchResult> FindUsers(string @q)
+        public async global::System.Threading.Tasks.Task<global::Refit.Tests.UserSearchResult> FindUsers(string @q)
         {
             var ______arguments = new object[] { @q };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""FindUsers"", new global::System.Type[] { typeof(string) } );
             try
             {
-                return (global::System.Threading.Tasks.Task<global::Refit.Tests.UserSearchResult>)______func(this.Client, ______arguments);
+                return await ((global::System.Threading.Tasks.Task<global::Refit.Tests.UserSearchResult>)______func(this.Client, ______arguments)).ConfigureAwait(false);
             }
             catch (global::System.Exception ex)
             {
@@ -279,13 +279,13 @@ namespace Refit.Implementation
         }
 
         /// <inheritdoc />
-        public global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage> GetIndex()
+        public async global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage> GetIndex()
         {
             var ______arguments = new object[] {  };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetIndex"", new global::System.Type[] {  } );
             try
             {
-                return (global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage>)______func(this.Client, ______arguments);
+                return await ((global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage>)______func(this.Client, ______arguments)).ConfigureAwait(false);
             }
             catch (global::System.Exception ex)
             {
@@ -309,13 +309,13 @@ namespace Refit.Implementation
         }
 
         /// <inheritdoc />
-        public global::System.Threading.Tasks.Task<global::Refit.Tests.User> NothingToSeeHere()
+        public async global::System.Threading.Tasks.Task<global::Refit.Tests.User> NothingToSeeHere()
         {
             var ______arguments = new object[] {  };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""NothingToSeeHere"", new global::System.Type[] {  } );
             try
             {
-                return (global::System.Threading.Tasks.Task<global::Refit.Tests.User>)______func(this.Client, ______arguments);
+                return await ((global::System.Threading.Tasks.Task<global::Refit.Tests.User>)______func(this.Client, ______arguments)).ConfigureAwait(false);
             }
             catch (global::System.Exception ex)
             {
@@ -324,13 +324,13 @@ namespace Refit.Implementation
         }
 
         /// <inheritdoc />
-        public global::System.Threading.Tasks.Task<global::Refit.ApiResponse<global::Refit.Tests.User>> NothingToSeeHereWithMetadata()
+        public async global::System.Threading.Tasks.Task<global::Refit.ApiResponse<global::Refit.Tests.User>> NothingToSeeHereWithMetadata()
         {
             var ______arguments = new object[] {  };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""NothingToSeeHereWithMetadata"", new global::System.Type[] {  } );
             try
             {
-                return (global::System.Threading.Tasks.Task<global::Refit.ApiResponse<global::Refit.Tests.User>>)______func(this.Client, ______arguments);
+                return await ((global::System.Threading.Tasks.Task<global::Refit.ApiResponse<global::Refit.Tests.User>>)______func(this.Client, ______arguments)).ConfigureAwait(false);
             }
             catch (global::System.Exception ex)
             {
@@ -339,13 +339,13 @@ namespace Refit.Implementation
         }
 
         /// <inheritdoc />
-        public global::System.Threading.Tasks.Task<global::Refit.ApiResponse<global::Refit.Tests.User>> GetUserWithMetadata(string @userName)
+        public async global::System.Threading.Tasks.Task<global::Refit.ApiResponse<global::Refit.Tests.User>> GetUserWithMetadata(string @userName)
         {
             var ______arguments = new object[] { @userName };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetUserWithMetadata"", new global::System.Type[] { typeof(string) } );
             try
             {
-                return (global::System.Threading.Tasks.Task<global::Refit.ApiResponse<global::Refit.Tests.User>>)______func(this.Client, ______arguments);
+                return await ((global::System.Threading.Tasks.Task<global::Refit.ApiResponse<global::Refit.Tests.User>>)______func(this.Client, ______arguments)).ConfigureAwait(false);
             }
             catch (global::System.Exception ex)
             {
@@ -369,13 +369,13 @@ namespace Refit.Implementation
         }
 
         /// <inheritdoc />
-        public global::System.Threading.Tasks.Task<global::Refit.Tests.User> CreateUser(global::Refit.Tests.User @user)
+        public async global::System.Threading.Tasks.Task<global::Refit.Tests.User> CreateUser(global::Refit.Tests.User @user)
         {
             var ______arguments = new object[] { @user };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""CreateUser"", new global::System.Type[] { typeof(global::Refit.Tests.User) } );
             try
             {
-                return (global::System.Threading.Tasks.Task<global::Refit.Tests.User>)______func(this.Client, ______arguments);
+                return await ((global::System.Threading.Tasks.Task<global::Refit.Tests.User>)______func(this.Client, ______arguments)).ConfigureAwait(false);
             }
             catch (global::System.Exception ex)
             {
@@ -384,13 +384,13 @@ namespace Refit.Implementation
         }
 
         /// <inheritdoc />
-        public global::System.Threading.Tasks.Task<global::Refit.ApiResponse<global::Refit.Tests.User>> CreateUserWithMetadata(global::Refit.Tests.User @user)
+        public async global::System.Threading.Tasks.Task<global::Refit.ApiResponse<global::Refit.Tests.User>> CreateUserWithMetadata(global::Refit.Tests.User @user)
         {
             var ______arguments = new object[] { @user };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""CreateUserWithMetadata"", new global::System.Type[] { typeof(global::Refit.Tests.User) } );
             try
             {
-                return (global::System.Threading.Tasks.Task<global::Refit.ApiResponse<global::Refit.Tests.User>>)______func(this.Client, ______arguments);
+                return await ((global::System.Threading.Tasks.Task<global::Refit.ApiResponse<global::Refit.Tests.User>>)______func(this.Client, ______arguments)).ConfigureAwait(false);
             }
             catch (global::System.Exception ex)
             {
@@ -399,13 +399,13 @@ namespace Refit.Implementation
         }
 
         /// <inheritdoc />
-        global::System.Threading.Tasks.Task<global::Refit.Tests.User> global::Refit.Tests.IGitHubApi.GetUser(string @userName)
+        async global::System.Threading.Tasks.Task<global::Refit.Tests.User> global::Refit.Tests.IGitHubApi.GetUser(string @userName)
         {
             var ______arguments = new object[] { @userName };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetUser"", new global::System.Type[] { typeof(string) } );
             try
             {
-                return (global::System.Threading.Tasks.Task<global::Refit.Tests.User>)______func(this.Client, ______arguments);
+                return await ((global::System.Threading.Tasks.Task<global::Refit.Tests.User>)______func(this.Client, ______arguments)).ConfigureAwait(false);
             }
             catch (global::System.Exception ex)
             {
@@ -444,13 +444,13 @@ namespace Refit.Implementation
         }
 
         /// <inheritdoc />
-        global::System.Threading.Tasks.Task<global::System.Collections.Generic.List<global::Refit.Tests.User>> global::Refit.Tests.IGitHubApi.GetOrgMembers(string @orgName, global::System.Threading.CancellationToken @cancellationToken)
+        async global::System.Threading.Tasks.Task<global::System.Collections.Generic.List<global::Refit.Tests.User>> global::Refit.Tests.IGitHubApi.GetOrgMembers(string @orgName, global::System.Threading.CancellationToken @cancellationToken)
         {
             var ______arguments = new object[] { @orgName, @cancellationToken };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetOrgMembers"", new global::System.Type[] { typeof(string), typeof(global::System.Threading.CancellationToken) } );
             try
             {
-                return (global::System.Threading.Tasks.Task<global::System.Collections.Generic.List<global::Refit.Tests.User>>)______func(this.Client, ______arguments);
+                return await ((global::System.Threading.Tasks.Task<global::System.Collections.Generic.List<global::Refit.Tests.User>>)______func(this.Client, ______arguments)).ConfigureAwait(false);
             }
             catch (global::System.Exception ex)
             {
@@ -459,13 +459,13 @@ namespace Refit.Implementation
         }
 
         /// <inheritdoc />
-        global::System.Threading.Tasks.Task<global::Refit.Tests.UserSearchResult> global::Refit.Tests.IGitHubApi.FindUsers(string @q)
+        async global::System.Threading.Tasks.Task<global::Refit.Tests.UserSearchResult> global::Refit.Tests.IGitHubApi.FindUsers(string @q)
         {
             var ______arguments = new object[] { @q };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""FindUsers"", new global::System.Type[] { typeof(string) } );
             try
             {
-                return (global::System.Threading.Tasks.Task<global::Refit.Tests.UserSearchResult>)______func(this.Client, ______arguments);
+                return await ((global::System.Threading.Tasks.Task<global::Refit.Tests.UserSearchResult>)______func(this.Client, ______arguments)).ConfigureAwait(false);
             }
             catch (global::System.Exception ex)
             {
@@ -474,13 +474,13 @@ namespace Refit.Implementation
         }
 
         /// <inheritdoc />
-        global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage> global::Refit.Tests.IGitHubApi.GetIndex()
+        async global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage> global::Refit.Tests.IGitHubApi.GetIndex()
         {
             var ______arguments = new object[] {  };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetIndex"", new global::System.Type[] {  } );
             try
             {
-                return (global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage>)______func(this.Client, ______arguments);
+                return await ((global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage>)______func(this.Client, ______arguments)).ConfigureAwait(false);
             }
             catch (global::System.Exception ex)
             {
@@ -504,13 +504,13 @@ namespace Refit.Implementation
         }
 
         /// <inheritdoc />
-        global::System.Threading.Tasks.Task<global::Refit.Tests.User> global::Refit.Tests.IGitHubApi.NothingToSeeHere()
+        async global::System.Threading.Tasks.Task<global::Refit.Tests.User> global::Refit.Tests.IGitHubApi.NothingToSeeHere()
         {
             var ______arguments = new object[] {  };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""NothingToSeeHere"", new global::System.Type[] {  } );
             try
             {
-                return (global::System.Threading.Tasks.Task<global::Refit.Tests.User>)______func(this.Client, ______arguments);
+                return await ((global::System.Threading.Tasks.Task<global::Refit.Tests.User>)______func(this.Client, ______arguments)).ConfigureAwait(false);
             }
             catch (global::System.Exception ex)
             {
@@ -519,13 +519,13 @@ namespace Refit.Implementation
         }
 
         /// <inheritdoc />
-        global::System.Threading.Tasks.Task<global::Refit.ApiResponse<global::Refit.Tests.User>> global::Refit.Tests.IGitHubApi.NothingToSeeHereWithMetadata()
+        async global::System.Threading.Tasks.Task<global::Refit.ApiResponse<global::Refit.Tests.User>> global::Refit.Tests.IGitHubApi.NothingToSeeHereWithMetadata()
         {
             var ______arguments = new object[] {  };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""NothingToSeeHereWithMetadata"", new global::System.Type[] {  } );
             try
             {
-                return (global::System.Threading.Tasks.Task<global::Refit.ApiResponse<global::Refit.Tests.User>>)______func(this.Client, ______arguments);
+                return await ((global::System.Threading.Tasks.Task<global::Refit.ApiResponse<global::Refit.Tests.User>>)______func(this.Client, ______arguments)).ConfigureAwait(false);
             }
             catch (global::System.Exception ex)
             {
@@ -534,13 +534,13 @@ namespace Refit.Implementation
         }
 
         /// <inheritdoc />
-        global::System.Threading.Tasks.Task<global::Refit.ApiResponse<global::Refit.Tests.User>> global::Refit.Tests.IGitHubApi.GetUserWithMetadata(string @userName)
+        async global::System.Threading.Tasks.Task<global::Refit.ApiResponse<global::Refit.Tests.User>> global::Refit.Tests.IGitHubApi.GetUserWithMetadata(string @userName)
         {
             var ______arguments = new object[] { @userName };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetUserWithMetadata"", new global::System.Type[] { typeof(string) } );
             try
             {
-                return (global::System.Threading.Tasks.Task<global::Refit.ApiResponse<global::Refit.Tests.User>>)______func(this.Client, ______arguments);
+                return await ((global::System.Threading.Tasks.Task<global::Refit.ApiResponse<global::Refit.Tests.User>>)______func(this.Client, ______arguments)).ConfigureAwait(false);
             }
             catch (global::System.Exception ex)
             {
@@ -564,13 +564,13 @@ namespace Refit.Implementation
         }
 
         /// <inheritdoc />
-        global::System.Threading.Tasks.Task<global::Refit.Tests.User> global::Refit.Tests.IGitHubApi.CreateUser(global::Refit.Tests.User @user)
+        async global::System.Threading.Tasks.Task<global::Refit.Tests.User> global::Refit.Tests.IGitHubApi.CreateUser(global::Refit.Tests.User @user)
         {
             var ______arguments = new object[] { @user };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""CreateUser"", new global::System.Type[] { typeof(global::Refit.Tests.User) } );
             try
             {
-                return (global::System.Threading.Tasks.Task<global::Refit.Tests.User>)______func(this.Client, ______arguments);
+                return await ((global::System.Threading.Tasks.Task<global::Refit.Tests.User>)______func(this.Client, ______arguments)).ConfigureAwait(false);
             }
             catch (global::System.Exception ex)
             {
@@ -579,13 +579,13 @@ namespace Refit.Implementation
         }
 
         /// <inheritdoc />
-        global::System.Threading.Tasks.Task<global::Refit.ApiResponse<global::Refit.Tests.User>> global::Refit.Tests.IGitHubApi.CreateUserWithMetadata(global::Refit.Tests.User @user)
+        async global::System.Threading.Tasks.Task<global::Refit.ApiResponse<global::Refit.Tests.User>> global::Refit.Tests.IGitHubApi.CreateUserWithMetadata(global::Refit.Tests.User @user)
         {
             var ______arguments = new object[] { @user };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""CreateUserWithMetadata"", new global::System.Type[] { typeof(global::Refit.Tests.User) } );
             try
             {
-                return (global::System.Threading.Tasks.Task<global::Refit.ApiResponse<global::Refit.Tests.User>>)______func(this.Client, ______arguments);
+                return await ((global::System.Threading.Tasks.Task<global::Refit.ApiResponse<global::Refit.Tests.User>>)______func(this.Client, ______arguments)).ConfigureAwait(false);
             }
             catch (global::System.Exception ex)
             {
@@ -630,13 +630,13 @@ namespace Refit.Implementation
 
 
         /// <inheritdoc />
-        public global::System.Threading.Tasks.Task RefitMethod()
+        public async global::System.Threading.Tasks.Task RefitMethod()
         {
             var ______arguments = new object[] {  };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""RefitMethod"", new global::System.Type[] {  } );
             try
             {
-                return (global::System.Threading.Tasks.Task)______func(this.Client, ______arguments);
+                await ((global::System.Threading.Tasks.Task)______func(this.Client, ______arguments)).ConfigureAwait(false);
             }
             catch (global::System.Exception ex)
             {
@@ -645,13 +645,13 @@ namespace Refit.Implementation
         }
 
         /// <inheritdoc />
-        global::System.Threading.Tasks.Task global::Refit.Tests.IGitHubApiDisposable.RefitMethod()
+        async global::System.Threading.Tasks.Task global::Refit.Tests.IGitHubApiDisposable.RefitMethod()
         {
             var ______arguments = new object[] {  };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""RefitMethod"", new global::System.Type[] {  } );
             try
             {
-                return (global::System.Threading.Tasks.Task)______func(this.Client, ______arguments);
+                await ((global::System.Threading.Tasks.Task)______func(this.Client, ______arguments)).ConfigureAwait(false);
             }
             catch (global::System.Exception ex)
             {
@@ -702,13 +702,13 @@ namespace Refit.Implementation
 
 
         /// <inheritdoc />
-        public global::System.Threading.Tasks.Task<global::Refit.Tests.User> GetUser(string @userName)
+        public async global::System.Threading.Tasks.Task<global::Refit.Tests.User> GetUser(string @userName)
         {
             var ______arguments = new object[] { @userName };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetUser"", new global::System.Type[] { typeof(string) } );
             try
             {
-                return (global::System.Threading.Tasks.Task<global::Refit.Tests.User>)______func(this.Client, ______arguments);
+                return await ((global::System.Threading.Tasks.Task<global::Refit.Tests.User>)______func(this.Client, ______arguments)).ConfigureAwait(false);
             }
             catch (global::System.Exception ex)
             {
@@ -747,13 +747,13 @@ namespace Refit.Implementation
         }
 
         /// <inheritdoc />
-        public global::System.Threading.Tasks.Task<global::System.Collections.Generic.List<global::Refit.Tests.User>> GetOrgMembers(string @orgName)
+        public async global::System.Threading.Tasks.Task<global::System.Collections.Generic.List<global::Refit.Tests.User>> GetOrgMembers(string @orgName)
         {
             var ______arguments = new object[] { @orgName };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetOrgMembers"", new global::System.Type[] { typeof(string) } );
             try
             {
-                return (global::System.Threading.Tasks.Task<global::System.Collections.Generic.List<global::Refit.Tests.User>>)______func(this.Client, ______arguments);
+                return await ((global::System.Threading.Tasks.Task<global::System.Collections.Generic.List<global::Refit.Tests.User>>)______func(this.Client, ______arguments)).ConfigureAwait(false);
             }
             catch (global::System.Exception ex)
             {
@@ -762,13 +762,13 @@ namespace Refit.Implementation
         }
 
         /// <inheritdoc />
-        public global::System.Threading.Tasks.Task<global::Refit.Tests.UserSearchResult> FindUsers(string @q)
+        public async global::System.Threading.Tasks.Task<global::Refit.Tests.UserSearchResult> FindUsers(string @q)
         {
             var ______arguments = new object[] { @q };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""FindUsers"", new global::System.Type[] { typeof(string) } );
             try
             {
-                return (global::System.Threading.Tasks.Task<global::Refit.Tests.UserSearchResult>)______func(this.Client, ______arguments);
+                return await ((global::System.Threading.Tasks.Task<global::Refit.Tests.UserSearchResult>)______func(this.Client, ______arguments)).ConfigureAwait(false);
             }
             catch (global::System.Exception ex)
             {
@@ -777,13 +777,13 @@ namespace Refit.Implementation
         }
 
         /// <inheritdoc />
-        public global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage> GetIndex()
+        public async global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage> GetIndex()
         {
             var ______arguments = new object[] {  };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetIndex"", new global::System.Type[] {  } );
             try
             {
-                return (global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage>)______func(this.Client, ______arguments);
+                return await ((global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage>)______func(this.Client, ______arguments)).ConfigureAwait(false);
             }
             catch (global::System.Exception ex)
             {
@@ -807,13 +807,13 @@ namespace Refit.Implementation
         }
 
         /// <inheritdoc />
-        public global::System.Threading.Tasks.Task NothingToSeeHere()
+        public async global::System.Threading.Tasks.Task NothingToSeeHere()
         {
             var ______arguments = new object[] {  };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""NothingToSeeHere"", new global::System.Type[] {  } );
             try
             {
-                return (global::System.Threading.Tasks.Task)______func(this.Client, ______arguments);
+                await ((global::System.Threading.Tasks.Task)______func(this.Client, ______arguments)).ConfigureAwait(false);
             }
             catch (global::System.Exception ex)
             {
@@ -822,13 +822,13 @@ namespace Refit.Implementation
         }
 
         /// <inheritdoc />
-        global::System.Threading.Tasks.Task<global::Refit.Tests.User> global::Refit.Tests.TestNested.INestedGitHubApi.GetUser(string @userName)
+        async global::System.Threading.Tasks.Task<global::Refit.Tests.User> global::Refit.Tests.TestNested.INestedGitHubApi.GetUser(string @userName)
         {
             var ______arguments = new object[] { @userName };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetUser"", new global::System.Type[] { typeof(string) } );
             try
             {
-                return (global::System.Threading.Tasks.Task<global::Refit.Tests.User>)______func(this.Client, ______arguments);
+                return await ((global::System.Threading.Tasks.Task<global::Refit.Tests.User>)______func(this.Client, ______arguments)).ConfigureAwait(false);
             }
             catch (global::System.Exception ex)
             {
@@ -867,13 +867,13 @@ namespace Refit.Implementation
         }
 
         /// <inheritdoc />
-        global::System.Threading.Tasks.Task<global::System.Collections.Generic.List<global::Refit.Tests.User>> global::Refit.Tests.TestNested.INestedGitHubApi.GetOrgMembers(string @orgName)
+        async global::System.Threading.Tasks.Task<global::System.Collections.Generic.List<global::Refit.Tests.User>> global::Refit.Tests.TestNested.INestedGitHubApi.GetOrgMembers(string @orgName)
         {
             var ______arguments = new object[] { @orgName };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetOrgMembers"", new global::System.Type[] { typeof(string) } );
             try
             {
-                return (global::System.Threading.Tasks.Task<global::System.Collections.Generic.List<global::Refit.Tests.User>>)______func(this.Client, ______arguments);
+                return await ((global::System.Threading.Tasks.Task<global::System.Collections.Generic.List<global::Refit.Tests.User>>)______func(this.Client, ______arguments)).ConfigureAwait(false);
             }
             catch (global::System.Exception ex)
             {
@@ -882,13 +882,13 @@ namespace Refit.Implementation
         }
 
         /// <inheritdoc />
-        global::System.Threading.Tasks.Task<global::Refit.Tests.UserSearchResult> global::Refit.Tests.TestNested.INestedGitHubApi.FindUsers(string @q)
+        async global::System.Threading.Tasks.Task<global::Refit.Tests.UserSearchResult> global::Refit.Tests.TestNested.INestedGitHubApi.FindUsers(string @q)
         {
             var ______arguments = new object[] { @q };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""FindUsers"", new global::System.Type[] { typeof(string) } );
             try
             {
-                return (global::System.Threading.Tasks.Task<global::Refit.Tests.UserSearchResult>)______func(this.Client, ______arguments);
+                return await ((global::System.Threading.Tasks.Task<global::Refit.Tests.UserSearchResult>)______func(this.Client, ______arguments)).ConfigureAwait(false);
             }
             catch (global::System.Exception ex)
             {
@@ -897,13 +897,13 @@ namespace Refit.Implementation
         }
 
         /// <inheritdoc />
-        global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage> global::Refit.Tests.TestNested.INestedGitHubApi.GetIndex()
+        async global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage> global::Refit.Tests.TestNested.INestedGitHubApi.GetIndex()
         {
             var ______arguments = new object[] {  };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetIndex"", new global::System.Type[] {  } );
             try
             {
-                return (global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage>)______func(this.Client, ______arguments);
+                return await ((global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage>)______func(this.Client, ______arguments)).ConfigureAwait(false);
             }
             catch (global::System.Exception ex)
             {
@@ -927,13 +927,13 @@ namespace Refit.Implementation
         }
 
         /// <inheritdoc />
-        global::System.Threading.Tasks.Task global::Refit.Tests.TestNested.INestedGitHubApi.NothingToSeeHere()
+        async global::System.Threading.Tasks.Task global::Refit.Tests.TestNested.INestedGitHubApi.NothingToSeeHere()
         {
             var ______arguments = new object[] {  };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""NothingToSeeHere"", new global::System.Type[] {  } );
             try
             {
-                return (global::System.Threading.Tasks.Task)______func(this.Client, ______arguments);
+                await ((global::System.Threading.Tasks.Task)______func(this.Client, ______arguments)).ConfigureAwait(false);
             }
             catch (global::System.Exception ex)
             {
@@ -1058,13 +1058,13 @@ namespace Refit.Implementation
 
 
         /// <inheritdoc />
-        public global::System.Threading.Tasks.Task GetRoot()
+        public async global::System.Threading.Tasks.Task GetRoot()
         {
             var ______arguments = new object[] {  };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetRoot"", new global::System.Type[] {  } );
             try
             {
-                return (global::System.Threading.Tasks.Task)______func(this.Client, ______arguments);
+                await ((global::System.Threading.Tasks.Task)______func(this.Client, ______arguments)).ConfigureAwait(false);
             }
             catch (global::System.Exception ex)
             {
@@ -1073,13 +1073,13 @@ namespace Refit.Implementation
         }
 
         /// <inheritdoc />
-        public global::System.Threading.Tasks.Task PostRoot()
+        public async global::System.Threading.Tasks.Task PostRoot()
         {
             var ______arguments = new object[] {  };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""PostRoot"", new global::System.Type[] {  } );
             try
             {
-                return (global::System.Threading.Tasks.Task)______func(this.Client, ______arguments);
+                await ((global::System.Threading.Tasks.Task)______func(this.Client, ______arguments)).ConfigureAwait(false);
             }
             catch (global::System.Exception ex)
             {
@@ -1088,13 +1088,13 @@ namespace Refit.Implementation
         }
 
         /// <inheritdoc />
-        global::System.Threading.Tasks.Task global::IServiceWithoutNamespace.GetRoot()
+        async global::System.Threading.Tasks.Task global::IServiceWithoutNamespace.GetRoot()
         {
             var ______arguments = new object[] {  };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetRoot"", new global::System.Type[] {  } );
             try
             {
-                return (global::System.Threading.Tasks.Task)______func(this.Client, ______arguments);
+                await ((global::System.Threading.Tasks.Task)______func(this.Client, ______arguments)).ConfigureAwait(false);
             }
             catch (global::System.Exception ex)
             {
@@ -1103,13 +1103,13 @@ namespace Refit.Implementation
         }
 
         /// <inheritdoc />
-        global::System.Threading.Tasks.Task global::IServiceWithoutNamespace.PostRoot()
+        async global::System.Threading.Tasks.Task global::IServiceWithoutNamespace.PostRoot()
         {
             var ______arguments = new object[] {  };
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""PostRoot"", new global::System.Type[] {  } );
             try
             {
-                return (global::System.Threading.Tasks.Task)______func(this.Client, ______arguments);
+                await ((global::System.Threading.Tasks.Task)______func(this.Client, ______arguments)).ConfigureAwait(false);
             }
             catch (global::System.Exception ex)
             {

--- a/Refit.Tests/RestService.cs
+++ b/Refit.Tests/RestService.cs
@@ -1071,8 +1071,9 @@ namespace Refit.Tests
             var fixture = RestService.For<IGitHubApi>("https://api.github.com", settings);
 
 
+            var result = await Assert.ThrowsAsync<TaskCanceledException>(async () => await fixture.GetOrgMembers("github", cts.Token));
 
-            await Assert.ThrowsAsync<TaskCanceledException>(async () => await fixture.GetOrgMembers("github", cts.Token));
+            AssertFirstLineContains(nameof(IGitHubApi.GetOrgMembers), result.StackTrace);
         }
 
 
@@ -1532,6 +1533,7 @@ namespace Refit.Tests
 
             var result = await Assert.ThrowsAsync<ApiException>(async () => await fixture.CreateUser(new User { Name = "foo" }));
 
+            AssertFirstLineContains(nameof(IGitHubApi.CreateUser), result.StackTrace);
 
             var errors = await result.GetContentAsAsync<ErrorResponse>();
 
@@ -1647,7 +1649,9 @@ namespace Refit.Tests
             var fixture = RestService.For<IGitHubApi>(client);
 
             // We should get an InvalidOperationException if we call a method without a base address set
-            await Assert.ThrowsAsync<InvalidOperationException>(async () => await fixture.GetUser(null));
+            var result = await Assert.ThrowsAsync<InvalidOperationException>(async () => await fixture.GetUser(null));
+
+            AssertFirstLineContains(nameof(IGitHubApi.GetUser), result.StackTrace);
         }
 
         [Fact]
@@ -2164,6 +2168,13 @@ namespace Refit.Tests
             }
 
             return stream;
+        }
+
+        public void AssertFirstLineContains(string expectedSubstring, string actualString)
+        {
+            var eolIndex = actualString.IndexOf('\n');
+            var firstLine = eolIndex < 0 ? actualString : actualString.Substring(0, eolIndex);
+            Assert.Contains(expectedSubstring, firstLine);
         }
     }
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Enhancement

**What is the current behavior?**
`ApiException` call stack starts with something like:
```text
   at Refit.RequestBuilderImplementation.<>c__DisplayClass14_0`2.<<BuildCancellableTaskFuncForMethod>b__0>d.MoveNext()
```

**What is the new behavior?**
`ApiException` call stack starts with something like:
```text
   at Refit.Implementation.Generated.RefitTestsIGitHubApi.<global::Refit-Tests-IGitHubApi-CreateUser>d__29.MoveNext()
```

Useful for observability to know which request method failed.

**What might this PR break?**
Folks that depend on the existing stack trace.

**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:
👋 