### PR TITLE
chore: remove unused using statements

### DIFF
--- a/Refit.Benchmarks/EndToEndBenchmark.cs
+++ b/Refit.Benchmarks/EndToEndBenchmark.cs
@@ -1,9 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Net;
-using System.Net.Http;
-using System.Threading.Tasks;
+﻿using System.Net;
+
 using AutoFixture;
 using BenchmarkDotNet.Attributes;
 

--- a/Refit.Benchmarks/IGitHubService.cs
+++ b/Refit.Benchmarks/IGitHubService.cs
@@ -1,12 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Net.Http;
-
-using Refit;
-using System.Threading.Tasks;
-
-namespace Refit.Benchmarks
+﻿namespace Refit.Benchmarks
 {
     public interface IGitHubService
     {

--- a/Refit.Benchmarks/Program.cs
+++ b/Refit.Benchmarks/Program.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-using BenchmarkDotNet.Running;
+﻿using BenchmarkDotNet.Running;
 
 namespace Refit.Benchmarks
 {

--- a/Refit.Benchmarks/StaticFileHttpResponseHandler.cs
+++ b/Refit.Benchmarks/StaticFileHttpResponseHandler.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.IO;
-using System.Net;
-using System.Net.Http;
-using System.Threading;
-using System.Threading.Tasks;
+﻿using System.Net;
 
 namespace Refit.Benchmarks
 {

--- a/Refit/AnonymousDisposable.cs
+++ b/Refit/AnonymousDisposable.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Refit
+﻿namespace Refit
 {
     sealed class AnonymousDisposable : IDisposable
     {

--- a/Refit/ApiException.cs
+++ b/Refit/ApiException.cs
@@ -1,8 +1,6 @@
-﻿using System;
-using System.Net;
+﻿using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
-using System.Threading.Tasks;
 
 namespace Refit
 {

--- a/Refit/ApiResponse.cs
+++ b/Refit/ApiResponse.cs
@@ -1,9 +1,7 @@
-﻿using System;
-using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
-using System.Threading.Tasks;
 
 namespace Refit
 {

--- a/Refit/Attributes.cs
+++ b/Refit/Attributes.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Net.Http;
+﻿using System.Net.Http;
 
 namespace Refit
 {

--- a/Refit/AuthenticatedHttpClientHandler.cs
+++ b/Refit/AuthenticatedHttpClientHandler.cs
@@ -1,8 +1,5 @@
-﻿using System;
-using System.Net.Http;
+﻿using System.Net.Http;
 using System.Net.Http.Headers;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Refit
 {

--- a/Refit/Buffers/PooledBufferWriter.Stream.cs
+++ b/Refit/Buffers/PooledBufferWriter.Stream.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Buffers;
-using System.IO;
-using System.Threading;
-using System.Threading.Tasks;
+﻿using System.Buffers;
 
 #nullable enable
 

--- a/Refit/Buffers/PooledBufferWriter.ThrowExceptions.cs
+++ b/Refit/Buffers/PooledBufferWriter.ThrowExceptions.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
 
 namespace Refit.Buffers
 {

--- a/Refit/Buffers/PooledBufferWriter.cs
+++ b/Refit/Buffers/PooledBufferWriter.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Buffers;
-using System.IO;
+﻿using System.Buffers;
 using System.Runtime.CompilerServices;
 
 namespace Refit.Buffers

--- a/Refit/CachedRequestBuilderImplementation.cs
+++ b/Refit/CachedRequestBuilderImplementation.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Concurrent;
-using System.Linq;
+﻿using System.Collections.Concurrent;
 using System.Net.Http;
 
 namespace Refit

--- a/Refit/CloseGenericMethodKey.cs
+++ b/Refit/CloseGenericMethodKey.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Linq;
-using System.Reflection;
+﻿using System.Reflection;
 
 namespace Refit
 {

--- a/Refit/FormValueMultimap.cs
+++ b/Refit/FormValueMultimap.cs
@@ -1,9 +1,5 @@
-﻿using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Collections;
 using System.Reflection;
-using System.Text.Json.Serialization;
 
 namespace Refit
 {

--- a/Refit/HttpContentExtensions.cs
+++ b/Refit/HttpContentExtensions.cs
@@ -1,11 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Net.Http;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
+﻿using System.Net.Http;
 
 namespace Refit
 {

--- a/Refit/JsonContentSerializer.cs
+++ b/Refit/JsonContentSerializer.cs
@@ -1,10 +1,5 @@
-﻿using System;
-using System.IO;
-using System.Net.Http;
+﻿using System.Net.Http;
 using System.Reflection;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Refit
 {

--- a/Refit/MultipartItem.cs
+++ b/Refit/MultipartItem.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.IO;
-using System.Net.Http;
+﻿using System.Net.Http;
 using System.Net.Http.Headers;
 
 namespace Refit

--- a/Refit/NameValueCollection.cs
+++ b/Refit/NameValueCollection.cs
@@ -1,7 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-
-namespace System.Collections.Specialized
+﻿namespace System.Collections.Specialized
 {
     class NameValueCollection : Dictionary<string, string>
     {

--- a/Refit/ProblemDetails.cs
+++ b/Refit/ProblemDetails.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
+﻿using System.Text.Json.Serialization;
 
 namespace Refit
 {

--- a/Refit/PushStreamContent.cs
+++ b/Refit/PushStreamContent.cs
@@ -21,10 +21,7 @@
 
 using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
-using System.IO;
 using System.Net.Http.Headers;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace System.Net.Http
 {

--- a/Refit/RefitSettings.cs
+++ b/Refit/RefitSettings.cs
@@ -1,13 +1,8 @@
-﻿using System;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
+﻿using System.Collections.Concurrent;
 using System.Globalization;
-using System.Linq;
 using System.Net.Http;
 using System.Reflection;
 using System.Runtime.Serialization;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Refit
 {
@@ -86,7 +81,7 @@ namespace Refit
         public bool Buffered { get; set; } = false;
 
         /// <summary>
-        /// Optional Key-Value pairs, which are displayed in the property <see cref="HttpRequestMessage.Options"/> or <see cref="HttpRequestMessage.Properties"/>. 
+        /// Optional Key-Value pairs, which are displayed in the property <see cref="HttpRequestMessage.Options"/> or <see cref="HttpRequestMessage.Properties"/>.
         /// </summary>
         public Dictionary<string, object> HttpRequestMessageOptions { get; set; }
     }

--- a/Refit/RequestBuilder.cs
+++ b/Refit/RequestBuilder.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Net.Http;
+﻿using System.Net.Http;
 
 namespace Refit
 {

--- a/Refit/RequestBuilderFactory.cs
+++ b/Refit/RequestBuilderFactory.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Refit
+﻿namespace Refit
 {
     interface IRequestBuilderFactory
     {

--- a/Refit/RequestBuilderImplementation.TaskToObservable.cs
+++ b/Refit/RequestBuilderImplementation.TaskToObservable.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Threading;
-using System.Threading.Tasks;
-
-namespace Refit
+﻿namespace Refit
 {
     partial class RequestBuilderImplementation
     {

--- a/Refit/RequestBuilderImplementation.cs
+++ b/Refit/RequestBuilderImplementation.cs
@@ -1,16 +1,9 @@
-﻿using System;
-using System.Collections;
+﻿using System.Collections;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.ComponentModel.Design;
-using System.IO;
-using System.Linq;
 using System.Net.Http;
 using System.Reflection;
 using System.Text;
 using System.Text.RegularExpressions;
-using System.Threading;
-using System.Threading.Tasks;
 using System.Web;
 
 namespace Refit
@@ -753,7 +746,7 @@ namespace Refit
 #else
                 ret.Properties[HttpRequestMessageOptions.InterfaceType] = TargetType;
                 ret.Properties[HttpRequestMessageOptions.RestMethodInfo] = restMethod.ToRestMethodInfo();
-#endif                
+#endif
 
                 // NB: The URI methods in .NET are dumb. Also, we do this
                 // UriBuilder business so that we preserve any hardcoded query

--- a/Refit/RestMethodInfo.cs
+++ b/Refit/RestMethodInfo.cs
@@ -1,13 +1,7 @@
-﻿using System;
-using System.Net.Http;
-using System.Collections.Generic;
+﻿using System.Net.Http;
 using System.Diagnostics;
-using System.IO;
-using System.Linq;
 using System.Reflection;
-using System.Threading.Tasks;
 using System.Text.RegularExpressions;
-using System.Threading;
 
 // Enable support for C# 9 record types
 #if NETSTANDARD2_1 || !NET6_0_OR_GREATER

--- a/Refit/RestMethodParameterInfo.cs
+++ b/Refit/RestMethodParameterInfo.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Reflection;
+﻿using System.Reflection;
 
 namespace Refit
 {

--- a/Refit/RestService.cs
+++ b/Refit/RestService.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Concurrent;
+﻿using System.Collections.Concurrent;
 using System.Net.Http;
 
 namespace Refit

--- a/Refit/SystemTextJsonContentSerializer.cs
+++ b/Refit/SystemTextJsonContentSerializer.cs
@@ -1,18 +1,8 @@
-﻿using System;
-using System.Buffers;
-using System.Diagnostics.Contracts;
-using System.Linq;
-using System.Net.Http;
-using System.Net.Http.Headers;
+﻿using System.Net.Http;
 using System.Net.Http.Json;
 using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using System.Threading;
-using System.Threading.Tasks;
-using Refit.Buffers;
 
 namespace Refit
 {

--- a/Refit/UniqueName.cs
+++ b/Refit/UniqueName.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Refit
+﻿namespace Refit
 {
     class UniqueName
     {

--- a/Refit/ValidationApiException.cs
+++ b/Refit/ValidationApiException.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Text.Json;
-using System.Threading.Tasks;
+﻿using System.Text.Json;
 
 namespace Refit
 {


### PR DESCRIPTION
Remove unused using statements. Haven't done this to all the projects as it would cause the tests to fail.

See https://github.com/reactiveui/refit/pull/1596 & https://github.com/reactiveui/refit/issues/1602