### PR TITLE
feat: add husky to run csharpier

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,18 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "husky": {
+      "version": "0.6.3",
+      "commands": [
+        "husky"
+      ]
+    },
+    "csharpier": {
+      "version": "0.26.3",
+      "commands": [
+        "dotnet-csharpier"
+      ]
+    }
+  }
+}

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,5 @@
+#!/bin/sh
+# shellcheck source=/dev/null
+. "$(dirname "$0")/_/husky.sh"
+
+dotnet husky run

--- a/.husky/task-runner.json
+++ b/.husky/task-runner.json
@@ -1,0 +1,16 @@
+{
+   "tasks": [
+     {
+       "name": "Run csharpier",
+       "command": "dotnet",
+       "args": [
+         "csharpier",
+         "${staged}"
+       ],
+       "include": [
+         "**/*.cs"
+       ]
+     }
+   ]
+ }
+ 

--- a/Refit/Refit.csproj
+++ b/Refit/Refit.csproj
@@ -8,6 +8,12 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <Target Name="husky" BeforeTargets="Restore;CollectPackageReferences" Condition="'$(HUSKY)' != 0">
+   <Exec Command="dotnet tool restore"  StandardOutputImportance="Low" StandardErrorImportance="High"/>
+   <Exec Command="dotnet husky install" StandardOutputImportance="Low" StandardErrorImportance="High"
+         WorkingDirectory="../" />  <!--Update this to the relative path to your project root dir -->
+  </Target>
+
   <ItemGroup>
     <PackageReference Include="System.Text.Json" Version="8.0.0" />
     <PackageReference Include="System.Net.Http.Json" Version="8.0.0" />


### PR DESCRIPTION
Added husky to run a pre commit hook to run csharpier. The changes to csproj should install the required dotnet tools for husky.

I could add a lint step to the pipeline to run `dotnet format` and `csharpier check`.

Shamelessly copied from mapperly 😅

See #1617