### PR TITLE
chore: remove generated whitespace

### DIFF
--- a/InterfaceStubGenerator.Shared/InterfaceStubGenerator.cs
+++ b/InterfaceStubGenerator.Shared/InterfaceStubGenerator.cs
@@ -357,7 +357,7 @@ namespace Refit.Implementation
             Client = client;
             this.requestBuilder = requestBuilder;
         }}
-    
+
 "
             );
             // Get any other methods on the refit interfaces. We'll need to generate something for them and warn

--- a/Refit.Tests/InterfaceStubGenerator.cs
+++ b/Refit.Tests/InterfaceStubGenerator.cs
@@ -207,7 +207,7 @@ namespace Refit.Implementation
             Client = client;
             this.requestBuilder = requestBuilder;
         }
-    
+
 
 
         /// <inheritdoc />
@@ -634,7 +634,7 @@ namespace Refit.Implementation
             Client = client;
             this.requestBuilder = requestBuilder;
         }
-    
+
 
 
         /// <inheritdoc />
@@ -707,7 +707,7 @@ namespace Refit.Implementation
             Client = client;
             this.requestBuilder = requestBuilder;
         }
-    
+
 
 
         /// <inheritdoc />
@@ -1067,7 +1067,7 @@ namespace Refit.Implementation
             Client = client;
             this.requestBuilder = requestBuilder;
         }
-    
+
 
 
         /// <inheritdoc />


### PR DESCRIPTION
Removed a generated chunk of whitespace from `InterfaceStubGeneratorV2` and updated the corresponding tests.

Super nitpicky but it was causing issues with my editor when adding an incremental generator.