### PR TITLE
Issue 1671: Add MemberNotNullWhen attribute for Content property in IApiResponse<T>

### DIFF
--- a/Refit/ApiResponse.cs
+++ b/Refit/ApiResponse.cs
@@ -29,7 +29,7 @@ namespace Refit
     /// Implementation of <see cref="IApiResponse{T}"/> that provides additional functionalities.
     /// </summary>
     /// <typeparam name="T"></typeparam>
-    public sealed class ApiResponse<T> : IApiResponse<T>
+    public sealed class ApiResponse<T> : IApiResponse<T>, IApiResponse
     {
         readonly HttpResponseMessage response;
         bool disposed;

--- a/Refit/ApiResponse.cs
+++ b/Refit/ApiResponse.cs
@@ -60,6 +60,8 @@ namespace Refit
         /// </summary>
         public T? Content { get; }
 
+        object? IApiResponse.Content => Content;
+
         /// <summary>
         /// Refit settings used to send the request.
         /// </summary>
@@ -158,13 +160,19 @@ namespace Refit
     }
 
     /// <inheritdoc/>
-    public interface IApiResponse<out T> : IApiResponseBase
+    public interface IApiResponse<out T> : IApiResponse
     {
         /// <summary>
         /// Deserialized request content as <typeparamref name="T"/>.
         /// </summary>
-        T? Content { get; }
+        new T? Content { get; }
+    }
 
+    /// <summary>
+    /// Base interface used to represent an API response.
+    /// </summary>
+    public interface IApiResponse : IDisposable
+    {
         /// <summary>
         /// Indicates whether the request was successful.
         /// </summary>
@@ -174,25 +182,12 @@ namespace Refit
         [MemberNotNullWhen(true, nameof(Content))]
 #endif
         bool IsSuccessStatusCode { get; }
-    }
 
-    public interface IApiResponse : IApiResponseBase
-    {
         /// <summary>
-        /// Indicates whether the request was successful.
+        /// Deserialized request content as an object.
         /// </summary>
-#if NET6_0_OR_GREATER
-        [MemberNotNullWhen(true, nameof(ContentHeaders))]
-        [MemberNotNullWhen(false, nameof(Error))]
-#endif
-        bool IsSuccessStatusCode { get; }
-    }
+        object? Content { get; }
 
-    /// <summary>
-    /// Base interface used to represent an API response.
-    /// </summary>
-    public interface IApiResponseBase : IDisposable
-    {
         /// <summary>
         /// HTTP response headers.
         /// </summary>

--- a/Refit/ApiResponse.cs
+++ b/Refit/ApiResponse.cs
@@ -131,18 +131,40 @@ namespace Refit
     }
 
     /// <inheritdoc/>
-    public interface IApiResponse<out T> : IApiResponse
+    public interface IApiResponse<out T> : IApiResponseBase
     {
         /// <summary>
         /// Deserialized request content as <typeparamref name="T"/>.
         /// </summary>
         T? Content { get; }
+
+        /// <summary>
+        /// Indicates whether the request was successful.
+        /// </summary>
+#if NET6_0_OR_GREATER
+        [MemberNotNullWhen(true, nameof(ContentHeaders))]
+        [MemberNotNullWhen(false, nameof(Error))]
+        [MemberNotNullWhen(true, nameof(Content))]
+#endif
+        bool IsSuccessStatusCode { get; }
+    }
+
+    public interface IApiResponse : IApiResponseBase
+    {
+        /// <summary>
+        /// Indicates whether the request was successful.
+        /// </summary>
+#if NET6_0_OR_GREATER
+        [MemberNotNullWhen(true, nameof(ContentHeaders))]
+        [MemberNotNullWhen(false, nameof(Error))]
+#endif
+        bool IsSuccessStatusCode { get; }
     }
 
     /// <summary>
     /// Base interface used to represent an API response.
     /// </summary>
-    public interface IApiResponse : IDisposable
+    public interface IApiResponseBase : IDisposable
     {
         /// <summary>
         /// HTTP response headers.
@@ -153,15 +175,6 @@ namespace Refit
         /// HTTP response content headers as defined in RFC 2616.
         /// </summary>
         HttpContentHeaders? ContentHeaders { get; }
-
-        /// <summary>
-        /// Indicates whether the request was successful.
-        /// </summary>
-#if NET6_0_OR_GREATER
-        [MemberNotNullWhen(true, nameof(ContentHeaders))]
-        [MemberNotNullWhen(false, nameof(Error))]
-#endif
-        bool IsSuccessStatusCode { get; }
 
         /// <summary>
         /// HTTP response status code.


### PR DESCRIPTION
Potential fix for https://github.com/reactiveui/refit/issues/1671

An alternative way:
`new bool IsSuccessStatusCode { get; }` property in the `IApiResponse<T>` interface with all 3 attributes above

