### PR TITLE
feat: add new PathPrefix attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,29 @@ Search("admin/products");
 >>> "/search/admin/products"
 ```
 
+#### Path prefix
+
+When a group of methods share the same relative URL path prefix, you can use the PathPrefix annotation. When given, the
+path prefix will be concatenated after the base URL and before the relative path as specified in the method's annotation.
+
+```csharp
+[PathPrefix("/resources")]
+public interface IResourcesService
+{
+    [Get("")]
+    Task<List<Resource>> ReadAll();
+
+    [Get("/{key}")]
+    Task<Resource> ReadOne(TKey key);
+}
+
+Get("");
+>>> "/resources"
+
+Get("/123");
+>>> "/resources/123"
+```
+
 ### Dynamic Querystring Parameters
 
 If you specify an `object` as a query parameter, all public properties which are not null are used as query parameters.
@@ -1049,6 +1072,32 @@ public interface IDerivedServiceB : IBaseService
 ```
 
 In this example, the `IDerivedServiceA` interface will expose both the `GetResource` and `DeleteResource` APIs, while `IDerivedServiceB` will expose `GetResource` and `AddResource`.
+
+#### Path prefix
+
+The principle of interface inheritance can be used together with the PathPrefix annotation. Like this:
+
+```csharp
+[PathPrefix("/resources")]
+public interface IBaseResourcesService
+{
+    [Get("")]
+    Task<List<Resource>> ReadAll();
+}
+
+public interface ISpecificResourcesService : IBaseResourcesService
+{
+    [Get("/{key}")]
+    Task<Resource> GetSomethingSpecific(TKey key);
+}
+
+Get("");
+>>> "/resources"
+
+Get("/123");
+>>> "/resources/123"
+```
+
 
 #### Headers inheritance
 

--- a/Refit.Tests/IPathPrefix.cs
+++ b/Refit.Tests/IPathPrefix.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Refit; // InterfaceStubGenerator looks for this
+using Refit.Tests.SeparateNamespaceWithModel;
+
+using static System.Math; // This is here to verify https://github.com/reactiveui/refit/issues/283
+
+namespace Refit.Tests
+{
+    [Headers("User-Agent: Refit Integration Tests")]
+    [PathPrefix("/ping")]
+    public interface IPathPrefix
+    {
+        [Get("/get?result=Ping")]
+        Task<string> Ping();
+    }
+
+    [Headers("User-Agent: Refit Integration Tests")]
+    public interface IInheritingPathPrefix : IPathPrefix
+    {
+        [Get("/get?result=Pang")]
+        Task<string> Pang();
+    }
+
+}

--- a/Refit.Tests/ReflectionHelpersTests.cs
+++ b/Refit.Tests/ReflectionHelpersTests.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using Xunit;
+using Refit;
+
+namespace Refit.Tests
+{
+    public class ReflectionHelpersTests
+    {
+        [Fact]
+        public void NullTargetInterfaceThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => ReflectionHelpers.GetPathPrefixFor(null));
+        }
+
+        [Fact]
+        public void TargetInterfaceHasPathPrefixAttributeReturnsCorrectPathPrefix()
+        {
+            var pathPrefix = ReflectionHelpers.GetPathPrefixFor(typeof(IInterfaceWithPathPrefix));
+            Assert.Equal("/pathPrefix", pathPrefix);
+        }
+
+        [Fact]
+        public void InheritedInterfaceHasPathPrefixAttributeReturnsCorrectPathPrefix()
+        {
+            var pathPrefix = ReflectionHelpers.GetPathPrefixFor(typeof(IInterfaceInheritingPathPrefix));
+            Assert.Equal("/pathPrefix", pathPrefix);
+        }
+
+        [Fact]
+        public void NoPathPrefixAttributeReturnsEmptyString()
+        {
+            var pathPrefix = ReflectionHelpers.GetPathPrefixFor(typeof(IInterfaceWithoutPathPrefix));
+            Assert.Equal(string.Empty, pathPrefix);
+        }
+
+        [PathPrefix("/pathPrefix")]
+        public interface IInterfaceWithPathPrefix { }
+
+        public interface IInterfaceInheritingPathPrefix : IInterfaceWithPathPrefix { }
+
+        public interface IInterfaceWithoutPathPrefix { }
+    }
+}

--- a/Refit.Tests/RestService.cs
+++ b/Refit.Tests/RestService.cs
@@ -1994,6 +1994,40 @@ namespace Refit.Tests
         }
 
         [Fact]
+        public async Task PathPrefixAttributeTest()
+        {
+            var mockHttp = new MockHttpMessageHandler();
+
+            var settings = new RefitSettings { HttpMessageHandlerFactory = () => mockHttp };
+
+            var fixture = RestService.For<IPathPrefix>("https://httpbin.org", settings);
+
+            mockHttp
+                .Expect(HttpMethod.Get, "https://httpbin.org/ping/get")
+                .Respond("application/json", nameof(IPathPrefix.Ping));
+            var resp = await fixture.Ping();
+            Assert.Equal(nameof(IPathPrefix.Ping), resp);
+            mockHttp.VerifyNoOutstandingExpectation();
+        }
+
+        [Fact]
+        public async Task PathPrefixAttributeInheritanceTest()
+        {
+            var mockHttp = new MockHttpMessageHandler();
+
+            var settings = new RefitSettings { HttpMessageHandlerFactory = () => mockHttp };
+
+            var fixture = RestService.For<IInheritingPathPrefix>("https://httpbin.org", settings);
+
+            mockHttp
+                .Expect(HttpMethod.Get, "https://httpbin.org/ping/get")
+                .Respond("application/json", nameof(IInheritingPathPrefix.Pang));
+            var resp = await fixture.Pang();
+            Assert.Equal(nameof(IInheritingPathPrefix.Pang), resp);
+            mockHttp.VerifyNoOutstandingExpectation();
+        }
+
+        [Fact]
         public async Task DictionaryDynamicQueryparametersTest()
         {
             var mockHttp = new MockHttpMessageHandler();

--- a/Refit/Attributes.cs
+++ b/Refit/Attributes.cs
@@ -2,6 +2,23 @@
 
 namespace Refit
 {
+    /// <summary>
+    /// Apply the given path prefix to all requests.
+    /// </summary>
+    /// <remarks>
+    /// When set, this will be used between the base URL and the endpoint's specific path.
+    /// </remarks>
+    [AttributeUsage(AttributeTargets.Interface)]
+    public class PathPrefixAttribute : Attribute
+    {
+        public PathPrefixAttribute(string pathPrefix)
+        {
+            PathPrefix = pathPrefix;
+        }
+
+        public string PathPrefix { get; }
+    }
+
     public abstract class HttpMethodAttribute : Attribute
     {
         public HttpMethodAttribute(string path)

--- a/Refit/ReflectionHelpers.cs
+++ b/Refit/ReflectionHelpers.cs
@@ -1,0 +1,54 @@
+﻿using System.Reflection;
+
+namespace Refit
+{
+    /// <summary>
+    /// Provides utility methods for reflection-based operations.
+    /// </summary>
+    public static class ReflectionHelpers
+    {
+        /// <summary>
+        /// Retrieves the path prefix defined by a <see cref="PathPrefixAttribute"/> on a specified interface or its inherited interfaces.
+        /// </summary>
+        /// <param name="targetInterface">The interface type from which to retrieve the path prefix.</param>
+        /// <returns>
+        /// The path prefix if a <see cref="PathPrefixAttribute"/> is found; otherwise, an empty string.
+        /// </returns>
+        /// <remarks>
+        /// This method first checks the specified interface for the <see cref="PathPrefixAttribute"/>. If not found,
+        /// it then checks each interface inherited by the target interface. If no attribute is found after all checks,
+        /// the method returns an empty string.
+        /// </remarks>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown if <paramref name="targetInterface"/> is null.
+        /// </exception>
+        public static string GetPathPrefixFor(Type targetInterface)
+        {
+            // Manual null check for compatibility with older .NET versions
+            if (targetInterface == null)
+            {
+                throw new ArgumentNullException(nameof(targetInterface));
+            }
+
+            // Check if the attribute is applied to the type T itself
+            var attribute = targetInterface.GetCustomAttribute<PathPrefixAttribute>();
+            if (attribute != null)
+            {
+                return attribute.PathPrefix;
+            }
+
+            // If the attribute is not found on T, check its interfaces
+            foreach (var interfaceType in targetInterface.GetInterfaces())
+            {
+                attribute = interfaceType.GetCustomAttribute<PathPrefixAttribute>();
+                if (attribute != null)
+                {
+                    return attribute.PathPrefix;
+                }
+            }
+
+            // If the attribute is still not found, return empty string
+            return string.Empty;
+        }
+    }
+}

--- a/Refit/RestMethodInfo.cs
+++ b/Refit/RestMethodInfo.cs
@@ -68,7 +68,7 @@ namespace Refit
             var hma = methodInfo.GetCustomAttributes(true).OfType<HttpMethodAttribute>().First();
 
             HttpMethod = hma.Method;
-            RelativePath = hma.Path;
+            RelativePath = ReflectionHelpers.GetPathPrefixFor(targetInterface) + hma.Path;
 
             IsMultipart = methodInfo.GetCustomAttributes(true).OfType<MultipartAttribute>().Any();
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**
When a group of methods share the same relative URL path prefix, you can use the PathPrefix annotation. When given, the path prefix will be concatenated after the base URL and before the relative path as specified in the method's annotation.

**What is the current behavior?**
This is an added feature, so the current behavior is that this is not possible. At the moment, the constructed URL is always a concatenation of the base URL and the method specific relative path.

**What is the new behavior?**
You now have the possibility to define a PathPrefix on interface level. 

**What might this PR break?**
URL construction in RestMethodInfoInternal.RelativePath, although it should and does not break. When a PathPrefix is omitted, it simply will not be used.

**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)