### PR TITLE
.NET7.0+ AOT supported

### DIFF
--- a/InterfaceStubGenerator.Shared/InterfaceStubGenerator.cs
+++ b/InterfaceStubGenerator.Shared/InterfaceStubGenerator.cs
@@ -247,6 +247,13 @@ namespace Refit.Implementation
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
     internal static partial class Generated
     {{
+#if NET5_0_OR_GREATER
+        [System.Runtime.CompilerServices.ModuleInitializer]
+        [System.Diagnostics.CodeAnalysis.DynamicDependency(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All, typeof(global::Refit.Implementation.Generated))]
+        public static void Initialize()
+        {{
+        }}
+#endif
     }}
 }}
 #pragma warning restore

--- a/Refit.Tests/InterfaceStubGenerator.cs
+++ b/Refit.Tests/InterfaceStubGenerator.cs
@@ -181,6 +181,13 @@ namespace Refit.Implementation
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
     internal static partial class Generated
     {
+#if NET5_0_OR_GREATER
+        [System.Runtime.CompilerServices.ModuleInitializer]
+        [System.Diagnostics.CodeAnalysis.DynamicDependency(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All, typeof(global::Refit.Implementation.Generated))]
+        public static void Initialize()
+        {
+        }
+#endif
     }
 }
 #pragma warning restore
@@ -1105,6 +1112,13 @@ namespace Refit.Implementation
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
     internal static partial class Generated
     {
+#if NET5_0_OR_GREATER
+        [System.Runtime.CompilerServices.ModuleInitializer]
+        [System.Diagnostics.CodeAnalysis.DynamicDependency(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All, typeof(global::Refit.Implementation.Generated))]
+        public static void Initialize()
+        {
+        }
+#endif
     }
 }
 #pragma warning restore


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
This is an implementation complement to #1389, which enables `Generated.g` codes to be preserved during trimming, thereby supporting AOT publish of .NET 7.0 or later versions.This implementation has been used in the [WebApiClient](https://github.com/dotnetcore/WebApiClient) project and is valid for .NET versions 5.0 to 9.0 and is safe.


**What is the current behavior?**
<!-- You can also link to an open issue here. -->
`<TrimMode>full</TrimMode>` is the default behavior of .NET8. Once `<PublishAot>true</PublishAot>` is turned on, all the code currently generated in `Generated.g` will be trimmed, causing AOT publishing to fail.


**What is the new behavior?**
<!-- If this is a feature change -->
Cleverly use [ModuleInitializerAttribute](https://learn.microsoft.com/zh-cn/dotnet/csharp/language-reference/proposals/csharp-9.0/module-initializers) in combination with [DynamicDependencyAttribute](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.codeanalysis.dynamicdependencyattribute?view=net-8.0) to prevent the code of `Generated.g` from being trimmed.


**What might this PR break?**
This PR is non-destructive, but requires the target project to be .NET 5 or above to take effect.


**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

