### PR TITLE
feat: WIP optimize url creation

### DIFF
--- a/Refit.Tests/API/ApiApprovalTests.Refit.DotNet6_0.verified.txt
+++ b/Refit.Tests/API/ApiApprovalTests.Refit.DotNet6_0.verified.txt
@@ -393,6 +393,11 @@ namespace Refit
         public System.Net.Http.HttpContent ToHttpContent<T>(T item) { }
         public static System.Text.Json.JsonSerializerOptions GetDefaultJsonSerializerOptions() { }
     }
+    public class UnreachableException : System.Exception
+    {
+        public UnreachableException() { }
+        public UnreachableException(string message) { }
+    }
     [System.Serializable]
     public class ValidationApiException : Refit.ApiException
     {

--- a/Refit.Tests/API/ApiApprovalTests.Refit.DotNet8_0.verified.txt
+++ b/Refit.Tests/API/ApiApprovalTests.Refit.DotNet8_0.verified.txt
@@ -393,6 +393,11 @@ namespace Refit
         public System.Net.Http.HttpContent ToHttpContent<T>(T item) { }
         public static System.Text.Json.JsonSerializerOptions GetDefaultJsonSerializerOptions() { }
     }
+    public class UnreachableException : System.Exception
+    {
+        public UnreachableException() { }
+        public UnreachableException(string message) { }
+    }
     [System.Serializable]
     public class ValidationApiException : Refit.ApiException
     {

--- a/Refit/UnreachableException.cs
+++ b/Refit/UnreachableException.cs
@@ -1,0 +1,21 @@
+﻿namespace Refit;
+
+/// <summary>
+/// The exception that is thrown when the program executes an instruction that was thought to be unreachable.
+/// </summary>
+public class UnreachableException : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="UnreachableException"/> class with a specified error message.
+    /// </summary>
+    /// <param name="message">Specified error message.</param>
+    public UnreachableException(string message) : base(message){}
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="UnreachableException"/> class with the default error message.
+    /// </summary>
+    public UnreachableException()
+    {}
+}
+
+


### PR DESCRIPTION
WIP; Uses the first call to determine the substitutions for the URL.

- This might be a "breaking change" as the url conversion is done later on and in bulk, in addition to calling `UrlParameterFormatter.Format` on the same value if it appears several times in the URL.
    - If this is an issue I can use a `ValueListBuilder` to preserve the order of operations and to cache values,
- `ParameterFragment` is my messy attempt to create a tagged union.
  - Instead of having a `string Value` property it could be an index and count representing the reevant area in the original url.
- Uses `ValueStringBuilder` I'll need to rebase this after #1719 is merged.
- This would ideally be done in the source generator.
- Could do with some benchmarks, especially for startup times.