### PR TITLE
feat: add startup and performance benchmarks

### DIFF
--- a/Refit.Benchmarks/EndToEndBenchmark.cs
+++ b/Refit.Benchmarks/EndToEndBenchmark.cs
@@ -2,317 +2,316 @@
 using AutoFixture;
 using BenchmarkDotNet.Attributes;
 
-namespace Refit.Benchmarks
+namespace Refit.Benchmarks;
+
+[MemoryDiagnoser]
+public class EndToEndBenchmark
 {
-    [MemoryDiagnoser]
-    public class EndToEndBenchmark
+    private readonly Fixture autoFixture = new();
+    private const string Host = "https://github.com";
+    private SystemTextJsonContentSerializer systemTextJsonContentSerializer;
+    private NewtonsoftJsonContentSerializer newtonsoftJsonContentSerializer;
+    private readonly IDictionary<int, IEnumerable<User>> users =
+        new Dictionary<int, IEnumerable<User>>();
+    private readonly IDictionary<
+        SerializationStrategy,
+        IDictionary<HttpStatusCode, IGitHubService>
+    > refitClient = new Dictionary<
+        SerializationStrategy,
+        IDictionary<HttpStatusCode, IGitHubService>
+    >
     {
-        private readonly Fixture autoFixture = new();
-        private const string Host = "https://github.com";
-        private SystemTextJsonContentSerializer systemTextJsonContentSerializer;
-        private NewtonsoftJsonContentSerializer newtonsoftJsonContentSerializer;
-        private readonly IDictionary<int, IEnumerable<User>> users =
-            new Dictionary<int, IEnumerable<User>>();
-        private readonly IDictionary<
-            SerializationStrategy,
-            IDictionary<HttpStatusCode, IGitHubService>
-        > refitClient = new Dictionary<
-            SerializationStrategy,
-            IDictionary<HttpStatusCode, IGitHubService>
-        >
         {
-            {
-                SerializationStrategy.SystemTextJson,
-                new Dictionary<HttpStatusCode, IGitHubService>()
-            },
-            {
-                SerializationStrategy.NewtonsoftJson,
-                new Dictionary<HttpStatusCode, IGitHubService>()
-            }
-        };
-
-        private readonly IDictionary<HttpVerb, HttpMethod> httpMethod = new Dictionary<
-            HttpVerb,
-            HttpMethod
-        >
+            SerializationStrategy.SystemTextJson,
+            new Dictionary<HttpStatusCode, IGitHubService>()
+        },
         {
-            { HttpVerb.Get, HttpMethod.Get },
-            { HttpVerb.Post, HttpMethod.Post }
-        };
-
-        private const int TenUsers = 10;
-
-        public enum SerializationStrategy
-        {
-            SystemTextJson,
-            NewtonsoftJson
+            SerializationStrategy.NewtonsoftJson,
+            new Dictionary<HttpStatusCode, IGitHubService>()
         }
+    };
 
-        public enum HttpVerb
-        {
-            Get,
-            Post
-        }
+    private readonly IDictionary<HttpVerb, HttpMethod> httpMethod = new Dictionary<
+        HttpVerb,
+        HttpMethod
+    >
+    {
+        { HttpVerb.Get, HttpMethod.Get },
+        { HttpVerb.Post, HttpMethod.Post }
+    };
 
-        [GlobalSetup]
-        public Task SetupAsync()
-        {
-            systemTextJsonContentSerializer = new SystemTextJsonContentSerializer();
-            refitClient[SerializationStrategy.SystemTextJson][HttpStatusCode.OK] =
-                RestService.For<IGitHubService>(
-                    Host,
-                    new RefitSettings(systemTextJsonContentSerializer)
-                    {
-                        HttpMessageHandlerFactory = () =>
-                            new StaticFileHttpResponseHandler(
-                                "system-text-json-10-users.json",
-                                HttpStatusCode.OK
-                            )
-                    }
-                );
-            refitClient[SerializationStrategy.SystemTextJson][HttpStatusCode.InternalServerError] =
-                RestService.For<IGitHubService>(
-                    Host,
-                    new RefitSettings(systemTextJsonContentSerializer)
-                    {
-                        HttpMessageHandlerFactory = () =>
-                            new StaticFileHttpResponseHandler(
-                                "system-text-json-10-users.json",
-                                HttpStatusCode.InternalServerError
-                            )
-                    }
-                );
+    private const int TenUsers = 10;
 
-            newtonsoftJsonContentSerializer = new NewtonsoftJsonContentSerializer();
-            refitClient[SerializationStrategy.NewtonsoftJson][HttpStatusCode.OK] =
-                RestService.For<IGitHubService>(
-                    Host,
-                    new RefitSettings(newtonsoftJsonContentSerializer)
-                    {
-                        HttpMessageHandlerFactory = () =>
-                            new StaticFileHttpResponseHandler(
-                                "newtonsoft-json-10-users.json",
-                                System.Net.HttpStatusCode.OK
-                            )
-                    }
-                );
-            refitClient[SerializationStrategy.NewtonsoftJson][HttpStatusCode.InternalServerError] =
-                RestService.For<IGitHubService>(
-                    Host,
-                    new RefitSettings(newtonsoftJsonContentSerializer)
-                    {
-                        HttpMessageHandlerFactory = () =>
-                            new StaticFileHttpResponseHandler(
-                                "newtonsoft-json-10-users.json",
-                                System.Net.HttpStatusCode.InternalServerError
-                            )
-                    }
-                );
+    public enum SerializationStrategy
+    {
+        SystemTextJson,
+        NewtonsoftJson
+    }
 
-            users[TenUsers] = autoFixture.CreateMany<User>(TenUsers);
+    public enum HttpVerb
+    {
+        Get,
+        Post
+    }
 
-            return Task.CompletedTask;
-        }
-
-        /*
-         * Each [Benchmark] tests one return type that Refit allows and is parameterized to test different, serializers, and http methods, and status codes
-         */
-
-        [Params(HttpStatusCode.OK, HttpStatusCode.InternalServerError)]
-        public HttpStatusCode HttpStatusCode { get; set; }
-
-        [Params(TenUsers)]
-        public int ModelCount { get; set; }
-
-        [ParamsAllValues]
-        public HttpVerb Verb { get; set; }
-
-        [ParamsAllValues]
-        public SerializationStrategy Serializer { get; set; }
-
-        [Benchmark]
-        public async Task Task_Async()
-        {
-            try
-            {
-                switch (Verb)
+    [GlobalSetup]
+    public Task SetupAsync()
+    {
+        systemTextJsonContentSerializer = new SystemTextJsonContentSerializer();
+        refitClient[SerializationStrategy.SystemTextJson][HttpStatusCode.OK] =
+            RestService.For<IGitHubService>(
+                Host,
+                new RefitSettings(systemTextJsonContentSerializer)
                 {
-                    case HttpVerb.Get:
-                        await refitClient[Serializer][HttpStatusCode].GetUsersTaskAsync();
-                        break;
-                    case HttpVerb.Post:
-                        await refitClient[Serializer]
-                            [HttpStatusCode]
-                            .PostUsersTaskAsync(users[ModelCount]);
-                        break;
-                    default:
-                        throw new ArgumentOutOfRangeException(nameof(Verb));
+                    HttpMessageHandlerFactory = () =>
+                        new StaticFileHttpResponseHandler(
+                            "system-text-json-10-users.json",
+                            HttpStatusCode.OK
+                        )
                 }
-            }
-            catch
-            {
-                //swallow
-            }
-        }
-
-        [Benchmark]
-        public async Task<string> TaskString_Async()
-        {
-            try
-            {
-                switch (Verb)
+            );
+        refitClient[SerializationStrategy.SystemTextJson][HttpStatusCode.InternalServerError] =
+            RestService.For<IGitHubService>(
+                Host,
+                new RefitSettings(systemTextJsonContentSerializer)
                 {
-                    case HttpVerb.Get:
-                        return await refitClient[Serializer]
-                            [HttpStatusCode]
-                            .GetUsersTaskStringAsync();
-                    case HttpVerb.Post:
-                        return await refitClient[Serializer]
-                            [HttpStatusCode]
-                            .PostUsersTaskStringAsync(users[ModelCount]);
-                    default:
-                        throw new ArgumentOutOfRangeException(nameof(Verb));
+                    HttpMessageHandlerFactory = () =>
+                        new StaticFileHttpResponseHandler(
+                            "system-text-json-10-users.json",
+                            HttpStatusCode.InternalServerError
+                        )
                 }
-            }
-            catch
-            {
-                //swallow
-            }
+            );
 
-            return default;
-        }
-
-        [Benchmark]
-        public async Task<Stream> TaskStream_Async()
-        {
-            try
-            {
-                switch (Verb)
+        newtonsoftJsonContentSerializer = new NewtonsoftJsonContentSerializer();
+        refitClient[SerializationStrategy.NewtonsoftJson][HttpStatusCode.OK] =
+            RestService.For<IGitHubService>(
+                Host,
+                new RefitSettings(newtonsoftJsonContentSerializer)
                 {
-                    case HttpVerb.Get:
-                        return await refitClient[Serializer]
-                            [HttpStatusCode]
-                            .GetUsersTaskStreamAsync();
-                    case HttpVerb.Post:
-                        return await refitClient[Serializer]
-                            [HttpStatusCode]
-                            .PostUsersTaskStreamAsync(users[ModelCount]);
-                    default:
-                        throw new ArgumentOutOfRangeException(nameof(Verb));
+                    HttpMessageHandlerFactory = () =>
+                        new StaticFileHttpResponseHandler(
+                            "newtonsoft-json-10-users.json",
+                            System.Net.HttpStatusCode.OK
+                        )
                 }
-            }
-            catch
-            {
-                //swallow
-            }
-
-            return default;
-        }
-
-        [Benchmark]
-        public async Task<HttpContent> TaskHttpContent_Async()
-        {
-            try
-            {
-                switch (Verb)
+            );
+        refitClient[SerializationStrategy.NewtonsoftJson][HttpStatusCode.InternalServerError] =
+            RestService.For<IGitHubService>(
+                Host,
+                new RefitSettings(newtonsoftJsonContentSerializer)
                 {
-                    case HttpVerb.Get:
-                        return await refitClient[Serializer]
-                            [HttpStatusCode]
-                            .GetUsersTaskHttpContentAsync();
-                    case HttpVerb.Post:
-                        return await refitClient[Serializer]
-                            [HttpStatusCode]
-                            .PostUsersTaskHttpContentAsync(users[ModelCount]);
-                    default:
-                        throw new ArgumentOutOfRangeException(nameof(Verb));
+                    HttpMessageHandlerFactory = () =>
+                        new StaticFileHttpResponseHandler(
+                            "newtonsoft-json-10-users.json",
+                            System.Net.HttpStatusCode.InternalServerError
+                        )
                 }
-            }
-            catch
+            );
+
+        users[TenUsers] = autoFixture.CreateMany<User>(TenUsers);
+
+        return Task.CompletedTask;
+    }
+
+    /*
+     * Each [Benchmark] tests one return type that Refit allows and is parameterized to test different, serializers, and http methods, and status codes
+     */
+
+    [Params(HttpStatusCode.OK, HttpStatusCode.InternalServerError)]
+    public HttpStatusCode HttpStatusCode { get; set; }
+
+    [Params(TenUsers)]
+    public int ModelCount { get; set; }
+
+    [ParamsAllValues]
+    public HttpVerb Verb { get; set; }
+
+    [ParamsAllValues]
+    public SerializationStrategy Serializer { get; set; }
+
+    [Benchmark]
+    public async Task Task_Async()
+    {
+        try
+        {
+            switch (Verb)
             {
-                //swallow
+                case HttpVerb.Get:
+                    await refitClient[Serializer][HttpStatusCode].GetUsersTaskAsync();
+                    break;
+                case HttpVerb.Post:
+                    await refitClient[Serializer]
+                        [HttpStatusCode]
+                        .PostUsersTaskAsync(users[ModelCount]);
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(Verb));
             }
-
-            return default;
         }
+        catch
+        {
+            //swallow
+        }
+    }
 
-        [Benchmark]
-        public async Task<HttpResponseMessage> TaskHttpResponseMessage_Async()
+    [Benchmark]
+    public async Task<string> TaskString_Async()
+    {
+        try
         {
             switch (Verb)
             {
                 case HttpVerb.Get:
                     return await refitClient[Serializer]
                         [HttpStatusCode]
-                        .GetUsersTaskHttpResponseMessageAsync();
+                        .GetUsersTaskStringAsync();
                 case HttpVerb.Post:
                     return await refitClient[Serializer]
                         [HttpStatusCode]
-                        .PostUsersTaskHttpResponseMessageAsync(users[ModelCount]);
+                        .PostUsersTaskStringAsync(users[ModelCount]);
                 default:
                     throw new ArgumentOutOfRangeException(nameof(Verb));
             }
         }
-
-        [Benchmark]
-        public IObservable<HttpResponseMessage> ObservableHttpResponseMessage()
+        catch
         {
-            switch (Verb)
-            {
-                case HttpVerb.Get:
-                    return refitClient[Serializer]
-                        [HttpStatusCode]
-                        .GetUsersObservableHttpResponseMessage();
-                case HttpVerb.Post:
-                    return refitClient[Serializer]
-                        [HttpStatusCode]
-                        .PostUsersObservableHttpResponseMessage(users[ModelCount]);
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(Verb));
-            }
+            //swallow
         }
 
-        [Benchmark]
-        public async Task<List<User>> TaskT_Async()
-        {
-            try
-            {
-                switch (Verb)
-                {
-                    case HttpVerb.Get:
-                        return await refitClient[Serializer][HttpStatusCode].GetUsersTaskTAsync();
-                    case HttpVerb.Post:
-                        return await refitClient[Serializer]
-                            [HttpStatusCode]
-                            .PostUsersTaskTAsync(users[ModelCount]);
-                    default:
-                        throw new ArgumentOutOfRangeException(nameof(Verb));
-                }
-            }
-            catch
-            {
-                //swallow
-            }
+        return default;
+    }
 
-            return default;
-        }
-
-        [Benchmark]
-        public async Task<ApiResponse<List<User>>> TaskApiResponseT_Async()
+    [Benchmark]
+    public async Task<Stream> TaskStream_Async()
+    {
+        try
         {
             switch (Verb)
             {
                 case HttpVerb.Get:
                     return await refitClient[Serializer]
                         [HttpStatusCode]
-                        .GetUsersTaskApiResponseTAsync();
+                        .GetUsersTaskStreamAsync();
                 case HttpVerb.Post:
                     return await refitClient[Serializer]
                         [HttpStatusCode]
-                        .PostUsersTaskApiResponseTAsync(users[ModelCount]);
+                        .PostUsersTaskStreamAsync(users[ModelCount]);
                 default:
                     throw new ArgumentOutOfRangeException(nameof(Verb));
             }
+        }
+        catch
+        {
+            //swallow
+        }
+
+        return default;
+    }
+
+    [Benchmark]
+    public async Task<HttpContent> TaskHttpContent_Async()
+    {
+        try
+        {
+            switch (Verb)
+            {
+                case HttpVerb.Get:
+                    return await refitClient[Serializer]
+                        [HttpStatusCode]
+                        .GetUsersTaskHttpContentAsync();
+                case HttpVerb.Post:
+                    return await refitClient[Serializer]
+                        [HttpStatusCode]
+                        .PostUsersTaskHttpContentAsync(users[ModelCount]);
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(Verb));
+            }
+        }
+        catch
+        {
+            //swallow
+        }
+
+        return default;
+    }
+
+    [Benchmark]
+    public async Task<HttpResponseMessage> TaskHttpResponseMessage_Async()
+    {
+        switch (Verb)
+        {
+            case HttpVerb.Get:
+                return await refitClient[Serializer]
+                    [HttpStatusCode]
+                    .GetUsersTaskHttpResponseMessageAsync();
+            case HttpVerb.Post:
+                return await refitClient[Serializer]
+                    [HttpStatusCode]
+                    .PostUsersTaskHttpResponseMessageAsync(users[ModelCount]);
+            default:
+                throw new ArgumentOutOfRangeException(nameof(Verb));
+        }
+    }
+
+    [Benchmark]
+    public IObservable<HttpResponseMessage> ObservableHttpResponseMessage()
+    {
+        switch (Verb)
+        {
+            case HttpVerb.Get:
+                return refitClient[Serializer]
+                    [HttpStatusCode]
+                    .GetUsersObservableHttpResponseMessage();
+            case HttpVerb.Post:
+                return refitClient[Serializer]
+                    [HttpStatusCode]
+                    .PostUsersObservableHttpResponseMessage(users[ModelCount]);
+            default:
+                throw new ArgumentOutOfRangeException(nameof(Verb));
+        }
+    }
+
+    [Benchmark]
+    public async Task<List<User>> TaskT_Async()
+    {
+        try
+        {
+            switch (Verb)
+            {
+                case HttpVerb.Get:
+                    return await refitClient[Serializer][HttpStatusCode].GetUsersTaskTAsync();
+                case HttpVerb.Post:
+                    return await refitClient[Serializer]
+                        [HttpStatusCode]
+                        .PostUsersTaskTAsync(users[ModelCount]);
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(Verb));
+            }
+        }
+        catch
+        {
+            //swallow
+        }
+
+        return default;
+    }
+
+    [Benchmark]
+    public async Task<ApiResponse<List<User>>> TaskApiResponseT_Async()
+    {
+        switch (Verb)
+        {
+            case HttpVerb.Get:
+                return await refitClient[Serializer]
+                    [HttpStatusCode]
+                    .GetUsersTaskApiResponseTAsync();
+            case HttpVerb.Post:
+                return await refitClient[Serializer]
+                    [HttpStatusCode]
+                    .PostUsersTaskApiResponseTAsync(users[ModelCount]);
+            default:
+                throw new ArgumentOutOfRangeException(nameof(Verb));
         }
     }
 }

--- a/Refit.Benchmarks/IGitHubService.cs
+++ b/Refit.Benchmarks/IGitHubService.cs
@@ -1,77 +1,76 @@
-﻿namespace Refit.Benchmarks
+﻿namespace Refit.Benchmarks;
+
+public interface IGitHubService
 {
-    public interface IGitHubService
-    {
-        //Task - throws
-        [Get("/users")]
-        public Task GetUsersTaskAsync();
+    //Task - throws
+    [Get("/users")]
+    public Task GetUsersTaskAsync();
 
-        [Post("/users")]
-        public Task PostUsersTaskAsync([Body] IEnumerable<User> users);
+    [Post("/users")]
+    public Task PostUsersTaskAsync([Body] IEnumerable<User> users);
 
-        //Task<string> - throws
-        [Get("/users")]
-        public Task<string> GetUsersTaskStringAsync();
+    //Task<string> - throws
+    [Get("/users")]
+    public Task<string> GetUsersTaskStringAsync();
 
-        [Post("/users")]
-        public Task<string> PostUsersTaskStringAsync([Body] IEnumerable<User> users);
+    [Post("/users")]
+    public Task<string> PostUsersTaskStringAsync([Body] IEnumerable<User> users);
 
-        //Task<Stream> - throws
-        [Get("/users")]
-        public Task<Stream> GetUsersTaskStreamAsync();
+    //Task<Stream> - throws
+    [Get("/users")]
+    public Task<Stream> GetUsersTaskStreamAsync();
 
-        [Post("/users")]
-        public Task<Stream> PostUsersTaskStreamAsync([Body] IEnumerable<User> users);
+    [Post("/users")]
+    public Task<Stream> PostUsersTaskStreamAsync([Body] IEnumerable<User> users);
 
-        //Task<HttpContent> - throws
-        [Get("/users")]
-        public Task<HttpContent> GetUsersTaskHttpContentAsync();
+    //Task<HttpContent> - throws
+    [Get("/users")]
+    public Task<HttpContent> GetUsersTaskHttpContentAsync();
 
-        [Post("/users")]
-        public Task<HttpContent> PostUsersTaskHttpContentAsync([Body] IEnumerable<User> users);
+    [Post("/users")]
+    public Task<HttpContent> PostUsersTaskHttpContentAsync([Body] IEnumerable<User> users);
 
-        //Task<HttpResponseMessage>
-        [Get("/users")]
-        public Task<HttpResponseMessage> GetUsersTaskHttpResponseMessageAsync();
+    //Task<HttpResponseMessage>
+    [Get("/users")]
+    public Task<HttpResponseMessage> GetUsersTaskHttpResponseMessageAsync();
 
-        [Post("/users")]
-        public Task<HttpResponseMessage> PostUsersTaskHttpResponseMessageAsync(
-            [Body] IEnumerable<User> users
-        );
+    [Post("/users")]
+    public Task<HttpResponseMessage> PostUsersTaskHttpResponseMessageAsync(
+        [Body] IEnumerable<User> users
+    );
 
-        //IObservable<HttpResponseMessage>
-        [Get("/users")]
-        public IObservable<HttpResponseMessage> GetUsersObservableHttpResponseMessage();
+    //IObservable<HttpResponseMessage>
+    [Get("/users")]
+    public IObservable<HttpResponseMessage> GetUsersObservableHttpResponseMessage();
 
-        [Post("/users")]
-        public IObservable<HttpResponseMessage> PostUsersObservableHttpResponseMessage(
-            [Body] IEnumerable<User> users
-        );
+    [Post("/users")]
+    public IObservable<HttpResponseMessage> PostUsersObservableHttpResponseMessage(
+        [Body] IEnumerable<User> users
+    );
 
-        //Task<<T>> - throws
-        [Get("/users")]
-        public Task<List<User>> GetUsersTaskTAsync();
+    //Task<<T>> - throws
+    [Get("/users")]
+    public Task<List<User>> GetUsersTaskTAsync();
 
-        [Post("/users")]
-        public Task<List<User>> PostUsersTaskTAsync([Body] IEnumerable<User> users);
+    [Post("/users")]
+    public Task<List<User>> PostUsersTaskTAsync([Body] IEnumerable<User> users);
 
-        //Task<ApiResponse<T>>
-        [Get("/users")]
-        public Task<ApiResponse<List<User>>> GetUsersTaskApiResponseTAsync();
+    //Task<ApiResponse<T>>
+    [Get("/users")]
+    public Task<ApiResponse<List<User>>> GetUsersTaskApiResponseTAsync();
 
-        [Post("/users")]
-        public Task<ApiResponse<List<User>>> PostUsersTaskApiResponseTAsync(
-            [Body] IEnumerable<User> users
-        );
-    }
+    [Post("/users")]
+    public Task<ApiResponse<List<User>>> PostUsersTaskApiResponseTAsync(
+        [Body] IEnumerable<User> users
+    );
+}
 
-    public class User
-    {
-        public int Id { get; set; }
-        public string Name { get; set; }
-        public string Bio { get; set; }
-        public int Followers { get; set; }
-        public int Following { get; set; }
-        public string Url { get; set; }
-    }
+public class User
+{
+    public int Id { get; set; }
+    public string Name { get; set; }
+    public string Bio { get; set; }
+    public int Followers { get; set; }
+    public int Following { get; set; }
+    public string Url { get; set; }
 }

--- a/Refit.Benchmarks/IPerformanceApi.cs
+++ b/Refit.Benchmarks/IPerformanceApi.cs
@@ -1,0 +1,28 @@
+﻿namespace Refit.Benchmarks;
+
+public interface IPerformanceApi
+{
+    [Get("/users")]
+    public Task<string> ConstantRoute();
+
+    [Get("/users/{id}")]
+    public Task<string> DynamicRoute(int id);
+
+    [Get("/users/{id}/{user}/{status}")]
+    public Task<string> ComplexDynamicRoute(int id, string user, string status);
+
+    [Get("/users/{request.someProperty}")]
+    public Task<string> ObjectRequest(PathBoundObject request);
+
+    [Post("/users/{id}/{request.someProperty}")]
+    [Headers("User-Agent: Awesome Octocat App", "X-Emoji: :smile_cat:")]
+    public Task<string> ComplexRequest(int id, PathBoundObject request, [Query(CollectionFormat.Multi)]int[] queries);
+}
+
+public class PathBoundObject
+{
+    public string SomeProperty { get; set; }
+
+    [Query]
+    public string SomeQuery { get; set; }
+}

--- a/Refit.Benchmarks/IPerformanceService.cs
+++ b/Refit.Benchmarks/IPerformanceService.cs
@@ -1,6 +1,6 @@
 ﻿namespace Refit.Benchmarks;
 
-public interface IPerformanceApi
+public interface IPerformanceService
 {
     [Get("/users")]
     public Task<string> ConstantRoute();

--- a/Refit.Benchmarks/PerformanceBenchmark.cs
+++ b/Refit.Benchmarks/PerformanceBenchmark.cs
@@ -1,0 +1,48 @@
+﻿using System.Net;
+using BenchmarkDotNet.Attributes;
+
+namespace Refit.Benchmarks;
+
+[MemoryDiagnoser]
+public class PerformanceBenchmark
+{
+    private IPerformanceApi? service;
+
+    private const string Host = "https://github.com";
+    private SystemTextJsonContentSerializer systemTextJsonContentSerializer;
+
+    [GlobalSetup]
+    public Task SetupAsync()
+    {
+        systemTextJsonContentSerializer = new SystemTextJsonContentSerializer();
+        service =
+            RestService.For<IPerformanceApi>(
+                Host,
+                new RefitSettings(systemTextJsonContentSerializer)
+                {
+                    HttpMessageHandlerFactory = () =>
+                        new StaticValueHttpResponseHandler(
+                            "Ok",
+                            HttpStatusCode.OK
+                        )
+                }
+            );
+
+        return Task.CompletedTask;
+    }
+
+    [Benchmark]
+    public async Task<string> ConstantRouteAsync() => await service.ConstantRoute();
+
+    [Benchmark]
+    public async Task<string> DynamicRouteAsync() => await service.DynamicRoute(101);
+
+    [Benchmark]
+    public async Task<string> ComplexDynamicRouteAsync() => await service.ComplexDynamicRoute(101, "tom", "yCxv");
+
+    [Benchmark]
+    public async Task<string> ObjectRequestAsync() => await service.ObjectRequest(new PathBoundObject(){SomeProperty = "myProperty", SomeQuery = "myQuery"});
+
+    [Benchmark]
+    public async Task<string> ComplexRequestAsync() => await service.ComplexRequest(101, new PathBoundObject(){SomeProperty = "myProperty", SomeQuery = "myQuery"}, [1,2,3,4,5,6]);
+}

--- a/Refit.Benchmarks/PerformanceBenchmark.cs
+++ b/Refit.Benchmarks/PerformanceBenchmark.cs
@@ -6,7 +6,7 @@ namespace Refit.Benchmarks;
 [MemoryDiagnoser]
 public class PerformanceBenchmark
 {
-    private IPerformanceApi? service;
+    private IPerformanceService? service;
 
     private const string Host = "https://github.com";
     private SystemTextJsonContentSerializer systemTextJsonContentSerializer;
@@ -16,7 +16,7 @@ public class PerformanceBenchmark
     {
         systemTextJsonContentSerializer = new SystemTextJsonContentSerializer();
         service =
-            RestService.For<IPerformanceApi>(
+            RestService.For<IPerformanceService>(
                 Host,
                 new RefitSettings(systemTextJsonContentSerializer)
                 {

--- a/Refit.Benchmarks/Program.cs
+++ b/Refit.Benchmarks/Program.cs
@@ -1,19 +1,13 @@
 ﻿using BenchmarkDotNet.Running;
+using Refit.Benchmarks;
 
-namespace Refit.Benchmarks
+if (args is { Length: > 0 })
 {
-    class Program
-    {
-        static void Main(string[] args)
-        {
-            if (args != null && args.Length > 0)
-            {
-                BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
-            }
-            else
-            {
-                BenchmarkRunner.Run<EndToEndBenchmark>();
-            }
-        }
-    }
+    BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+}
+else
+{
+    BenchmarkRunner.Run<EndToEndBenchmark>();
+    // BenchmarkRunner.Run<StartupBenchmark>();
+    // BenchmarkRunner.Run<PerformanceBenchmarks>();
 }

--- a/Refit.Benchmarks/StartupBenchmark.cs
+++ b/Refit.Benchmarks/StartupBenchmark.cs
@@ -1,0 +1,36 @@
+﻿using System.Net;
+using BenchmarkDotNet.Attributes;
+
+namespace Refit.Benchmarks;
+
+[MemoryDiagnoser]
+public class StartupBenchmark
+{
+    private const string Host = "https://github.com";
+    private readonly RefitSettings settings = new RefitSettings()
+    {
+        HttpMessageHandlerFactory = () =>
+            new StaticValueHttpResponseHandler(
+                "Ok",
+                HttpStatusCode.OK
+            )
+    };
+
+    [Benchmark]
+    public IPerformanceApi CreateService() => RestService.For<IPerformanceApi>(Host, settings);
+
+    [Benchmark]
+    public async Task<string> ConstantRouteAsync()
+    {
+        var service = RestService.For<IPerformanceApi>(Host, settings);
+        return await service.ConstantRoute();
+    }
+
+
+    [Benchmark]
+    public async Task<string> ComplexRequestAsync()
+    {
+        var service = RestService.For<IPerformanceApi>(Host, settings);
+        return await service.ObjectRequest(new PathBoundObject(){SomeProperty = "myProperty", SomeQuery = "myQuery"});
+    }
+}

--- a/Refit.Benchmarks/StartupBenchmark.cs
+++ b/Refit.Benchmarks/StartupBenchmark.cs
@@ -6,6 +6,7 @@ namespace Refit.Benchmarks;
 [MemoryDiagnoser]
 public class StartupBenchmark
 {
+    private IPerformanceService initialisedService;
     private const string Host = "https://github.com";
     private readonly RefitSettings settings = new RefitSettings()
     {
@@ -16,21 +17,33 @@ public class StartupBenchmark
             )
     };
 
+
+    [IterationSetup(Targets = [nameof(FirstCallConstantRouteAsync), nameof(FirstCallComplexRequestAsync)])]
+    public void Setup()
+    {
+        initialisedService = RestService.For<IPerformanceService>(Host, settings);
+    }
+
     [Benchmark]
-    public IPerformanceApi CreateService() => RestService.For<IPerformanceApi>(Host, settings);
+    public IPerformanceService CreateService() => RestService.For<IPerformanceService>(Host, settings);
+
+    [Benchmark]
+    public async Task<string> FirstCallConstantRouteAsync() => await initialisedService.ConstantRoute();
 
     [Benchmark]
     public async Task<string> ConstantRouteAsync()
     {
-        var service = RestService.For<IPerformanceApi>(Host, settings);
+        var service = RestService.For<IPerformanceService>(Host, settings);
         return await service.ConstantRoute();
     }
 
+    [Benchmark]
+    public async Task<string> FirstCallComplexRequestAsync() => await initialisedService.ObjectRequest(new PathBoundObject(){SomeProperty = "myProperty", SomeQuery = "myQuery"});
 
     [Benchmark]
     public async Task<string> ComplexRequestAsync()
     {
-        var service = RestService.For<IPerformanceApi>(Host, settings);
+        var service = RestService.For<IPerformanceService>(Host, settings);
         return await service.ObjectRequest(new PathBoundObject(){SomeProperty = "myProperty", SomeQuery = "myQuery"});
     }
 }

--- a/Refit.Benchmarks/StaticFileHttpResponseHandler.cs
+++ b/Refit.Benchmarks/StaticFileHttpResponseHandler.cs
@@ -1,14 +1,14 @@
 ﻿using System.Net;
 
-namespace Refit.Benchmarks
-{
-    public class StaticFileHttpResponseHandler : HttpMessageHandler
-    {
-        private readonly HttpStatusCode responseCode;
-        private readonly string responsePayload;
+namespace Refit.Benchmarks;
 
-        public StaticFileHttpResponseHandler(string fileName, HttpStatusCode responseCode)
-        {
+public class StaticFileHttpResponseHandler : HttpMessageHandler
+{
+    private readonly HttpStatusCode responseCode;
+    private readonly string responsePayload;
+
+    public StaticFileHttpResponseHandler(string fileName, HttpStatusCode responseCode)
+    {
             if (string.IsNullOrEmpty(fileName))
                 throw new ArgumentNullException(nameof(fileName));
 
@@ -17,11 +17,11 @@ namespace Refit.Benchmarks
             this.responseCode = responseCode;
         }
 
-        protected override Task<HttpResponseMessage> SendAsync(
-            HttpRequestMessage request,
-            CancellationToken cancellationToken
-        )
-        {
+    protected override Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken
+    )
+    {
             return Task.FromResult(
                 new HttpResponseMessage(responseCode)
                 {
@@ -30,5 +30,4 @@ namespace Refit.Benchmarks
                 }
             );
         }
-    }
 }

--- a/Refit.Benchmarks/StaticValueHttpResponseHandler.cs
+++ b/Refit.Benchmarks/StaticValueHttpResponseHandler.cs
@@ -1,0 +1,20 @@
+﻿using System.Net;
+
+namespace Refit.Benchmarks;
+
+public class StaticValueHttpResponseHandler (string response, HttpStatusCode code) : HttpMessageHandler
+{
+    protected override Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken
+    )
+    {
+            return Task.FromResult(
+                new HttpResponseMessage(code)
+                {
+                    RequestMessage = request,
+                    Content = new StringContent(response)
+                }
+            );
+        }
+}


### PR DESCRIPTION
- Used file scoped namespaces and simplified `Program.cs`
- Added `PerformanceBenchmark` to measure the speed to create and make the average request.
- `StartupBenchmark` measures Refit api creation and call time.
  - Measures: Service creation time, service creation and first call, just first call.
  - Not sure if its worth having the first call benchmarks as they have contradictory results. Why does `FirstCallComplexRequestAsync` use less memory than repeated calls? I might be missing something.

### Performance
| Method                   | Mean      | Error     | StdDev    | Gen0   | Gen1   | Allocated |
|------------------------- |----------:|----------:|----------:|-------:|-------:|----------:|
| ConstantRouteAsync       |  2.940 us | 0.0587 us | 0.0897 us | 0.7744 | 0.0038 |   7.13 KB |
| DynamicRouteAsync        |  3.569 us | 0.0696 us | 0.0905 us | 0.8163 |      - |   7.52 KB |
| ComplexDynamicRouteAsync |  5.022 us | 0.0953 us | 0.1539 us | 0.9003 | 0.0076 |   8.34 KB |
| ObjectRequestAsync       |  5.556 us | 0.0978 us | 0.0817 us | 1.0071 |      - |   9.28 KB |
| ComplexRequestAsync      | 14.040 us | 0.2503 us | 0.2090 us | 1.7090 |      - |  15.86 KB |

### Startup
| Method                       | Job        | InvocationCount | UnrollFactor | Mean     | Error    | StdDev   | Median   | Gen0   | Gen1   | Allocated |
|----------------------------- |----------- |---------------- |------------- |---------:|---------:|---------:|---------:|-------:|-------:|----------:|
| CreateService                | DefaultJob | Default         | 16           | 49.34 us | 0.980 us | 2.733 us | 48.27 us | 5.2490 | 0.1831 |  48.44 KB |
| ConstantRouteAsync           | DefaultJob | Default         | 16           | 52.29 us | 1.023 us | 1.050 us | 52.36 us | 6.1035 | 0.2441 |  57.16 KB |
| ComplexRequestAsync          | DefaultJob | Default         | 16           | 56.78 us | 1.103 us | 1.354 us | 56.49 us | 6.3477 | 0.2441 |  59.34 KB |
| FirstCallConstantRouteAsync  | Job-SUVBDY | 1               | 1            | 43.62 us | 1.434 us | 4.091 us | 42.05 us |      - |      - |   9.87 KB |
| FirstCallComplexRequestAsync | Job-SUVBDY | 1               | 1            | 63.88 us | 1.262 us | 1.640 us | 63.40 us |      - |      - |  13.07 KB |

