### PR TITLE
feat: fix existing query values bug

### DIFF
--- a/Refit.Tests/RequestBuilder.cs
+++ b/Refit.Tests/RequestBuilder.cs
@@ -2531,7 +2531,7 @@ namespace Refit.Tests
 
             var uri = new Uri(new Uri("http://api"), output.RequestUri);
 
-            Assert.Equal("/query?q2=value2&q1=value1", uri.PathAndQuery);
+            Assert.Equal("/query?q1=value1&q2=value2", uri.PathAndQuery);
         }
 
         [Fact]

--- a/Refit/RequestBuilderImplementation.cs
+++ b/Refit/RequestBuilderImplementation.cs
@@ -980,17 +980,7 @@ namespace Refit
                 // UriBuilder business so that we preserve any hardcoded query
                 // parameters as well as add the parameterized ones.
                 var uri = new UriBuilder(new Uri(new Uri("http://api"), urlTarget));
-                var query = HttpUtility.ParseQueryString(uri.Query ?? "");
-                foreach (var key in query.AllKeys)
-                {
-                    if (!string.IsNullOrWhiteSpace(key))
-                    {
-                        queryParamsToAdd.Insert(
-                            0,
-                            new KeyValuePair<string, string?>(key, query[key])
-                        );
-                    }
-                }
+                ParseExistingQueryString(uri, queryParamsToAdd);
 
                 if (queryParamsToAdd.Count != 0)
                 {
@@ -1097,6 +1087,25 @@ namespace Refit
                     yield return string.Join(delimiter, formattedValues);
 
                     break;
+            }
+        }
+
+        static void ParseExistingQueryString(UriBuilder uri, List<KeyValuePair<string, string?>> queryParamsToAdd)
+        {
+            if (string.IsNullOrEmpty(uri.Query))
+                return;
+
+            var query = HttpUtility.ParseQueryString(uri.Query);
+            var index = 0;
+            foreach (var key in query.AllKeys)
+            {
+                if (!string.IsNullOrWhiteSpace(key))
+                {
+                    queryParamsToAdd.Insert(
+                        index++,
+                        new KeyValuePair<string, string?>(key, query[key])
+                    );
+                }
             }
         }
 


### PR DESCRIPTION
Closes #1732 
Fixes a bug where existing query parameters would have their positions reversed #1732

- Extracted logic into a method
- If the existing `Query` is empty we early return
  - This early return prevents the allocation of an empty 300 byte `NameValueCollection`
- Otherwise the query is parsed with each key pair added
  - There might be room for improvement here by using a linq `Select` method. `Select` would know the length of the collection and `InsertRange` would be able to bulk copy the values. This could only be done if we know for certain that the key can't be empty and `Where` is not required.


### Before
| Method                   | Mean      | Error     | StdDev    | Gen0   | Gen1   | Allocated |
|------------------------- |----------:|----------:|----------:|-------:|-------:|----------:|
| ConstantRouteAsync       |  2.606 us | 0.0251 us | 0.0235 us | 0.7668 | 0.0038 |   7.06 KB |
| DynamicRouteAsync        |  3.306 us | 0.0589 us | 0.0550 us | 0.8087 |      - |   7.45 KB |
| ComplexDynamicRouteAsync |  4.635 us | 0.0730 us | 0.0683 us | 0.8926 | 0.0076 |   8.27 KB |
| ObjectRequestAsync       |  5.169 us | 0.0992 us | 0.0974 us | 0.9766 | 0.0076 |   8.99 KB |
| ComplexRequestAsync      | 13.306 us | 0.1515 us | 0.1343 us | 1.6479 |      - |  15.24 KB |

### Query changes
| Method                   | Mean      | Error     | StdDev    | Gen0   | Gen1   | Allocated |
|------------------------- |----------:|----------:|----------:|----|-------:|----------:|
| ConstantRouteAsync       |  2.696 us | 0.0302 us | 0.0236 us | 0.7362 | 0.0038 |   6.77 KB |
| DynamicRouteAsync        |  3.369 us | 0.0666 us | 0.0684 us | 0.7782 |      - |   7.16 KB |
| ComplexDynamicRouteAsync |  4.529 us | 0.0412 us | 0.0344 us | 0.8621 |      - |   7.97 KB |
| ObjectRequestAsync       |  5.061 us | 0.0476 us | 0.0445 us | 0.9384 | 0.0076 |   8.69 KB |
| ComplexRequestAsync      | 13.274 us | 0.1464 us | 0.1222 us | 1.6174 | 0.0153 |  14.94 KB |


