### PR TITLE
feat: optimize `RestMethodInfo`, reduce dictionary allocations and li…

### DIFF
--- a/Refit.Tests/RequestBuilder.cs
+++ b/Refit.Tests/RequestBuilder.cs
@@ -1062,8 +1062,8 @@ namespace Refit.Tests
             Assert.Equal("1", fixture.Headers["Api-Version"]);
 
             Assert.Equal(4, fixture.Headers.Count);
-            Assert.Equal(1, fixture.HeaderCollectionParameterMap.Count);
-            Assert.True(fixture.HeaderCollectionParameterMap.Contains(1));
+            Assert.True(fixture.HasHeaderCollection);
+            Assert.True(fixture.HeaderCollectionAt(1));
         }
 
         [Theory]
@@ -1085,8 +1085,8 @@ namespace Refit.Tests
             Assert.NotNull(fixture.BodyParameterInfo);
             Assert.Null(fixture.AuthorizeParameterInfo);
 
-            Assert.Equal(1, fixture.HeaderCollectionParameterMap.Count);
-            Assert.True(fixture.HeaderCollectionParameterMap.Contains(2));
+            Assert.True(fixture.HasHeaderCollection);
+            Assert.True(fixture.HeaderCollectionAt(2));
         }
 
         [Theory]
@@ -1110,8 +1110,8 @@ namespace Refit.Tests
             Assert.Null(fixture.BodyParameterInfo);
             Assert.Null(fixture.AuthorizeParameterInfo);
 
-            Assert.Equal(1, fixture.HeaderCollectionParameterMap.Count);
-            Assert.True(fixture.HeaderCollectionParameterMap.Contains(1));
+            Assert.True(fixture.HasHeaderCollection);
+            Assert.True(fixture.HeaderCollectionAt(1));
         }
 
         [Theory]
@@ -1141,8 +1141,8 @@ namespace Refit.Tests
             Assert.NotNull(fixture.BodyParameterInfo);
             Assert.Null(fixture.AuthorizeParameterInfo);
 
-            Assert.Equal(1, fixture.HeaderCollectionParameterMap.Count);
-            Assert.True(fixture.HeaderCollectionParameterMap.Contains(1));
+            Assert.True(fixture.HasHeaderCollection);
+            Assert.True(fixture.HeaderCollectionAt(1));
             Assert.Equal(2, fixture.BodyParameterInfo.Item3);
         }
 
@@ -1168,8 +1168,8 @@ namespace Refit.Tests
             Assert.Null(fixture.BodyParameterInfo);
 
             Assert.NotNull(fixture.AuthorizeParameterInfo);
-            Assert.Equal(1, fixture.HeaderCollectionParameterMap.Count);
-            Assert.True(fixture.HeaderCollectionParameterMap.Contains(2));
+            Assert.True(fixture.HasHeaderCollection);
+            Assert.True(fixture.HeaderCollectionAt(2));
         }
 
         [Theory]
@@ -1195,8 +1195,8 @@ namespace Refit.Tests
 
             Assert.Single(fixture.HeaderParameterMap);
             Assert.Equal("Authorization", fixture.HeaderParameterMap[1]);
-            Assert.Equal(1, fixture.HeaderCollectionParameterMap.Count);
-            Assert.True(fixture.HeaderCollectionParameterMap.Contains(2));
+            Assert.True(fixture.HasHeaderCollection);
+            Assert.True(fixture.HeaderCollectionAt(2));
 
             input = typeof(IRestMethodInfoTests);
             fixture = new RestMethodInfoInternal(
@@ -1220,8 +1220,8 @@ namespace Refit.Tests
 
             Assert.Single(fixture.HeaderParameterMap);
             Assert.Equal("Authorization", fixture.HeaderParameterMap[2]);
-            Assert.Equal(1, fixture.HeaderCollectionParameterMap.Count);
-            Assert.True(fixture.HeaderCollectionParameterMap.Contains(1));
+            Assert.True(fixture.HasHeaderCollection);
+            Assert.True(fixture.HeaderCollectionAt(1));
         }
 
         [Theory]
@@ -1253,8 +1253,8 @@ namespace Refit.Tests
 
             Assert.Single(fixture.HeaderParameterMap);
             Assert.Equal("X-PathMember", fixture.HeaderParameterMap[0]);
-            Assert.Equal(1, fixture.HeaderCollectionParameterMap.Count);
-            Assert.True(fixture.HeaderCollectionParameterMap.Contains(1));
+            Assert.True(fixture.HasHeaderCollection);
+            Assert.True(fixture.HeaderCollectionAt(1));
         }
 
         [Theory]
@@ -1274,8 +1274,8 @@ namespace Refit.Tests
             Assert.Null(fixture.BodyParameterInfo);
 
             Assert.Equal("baz", fixture.QueryParameterMap[2]);
-            Assert.Equal(1, fixture.HeaderCollectionParameterMap.Count);
-            Assert.True(fixture.HeaderCollectionParameterMap.Contains(1));
+            Assert.True(fixture.HasHeaderCollection);
+            Assert.True(fixture.HeaderCollectionAt(1));
         }
 
         [Theory]
@@ -1321,8 +1321,8 @@ namespace Refit.Tests
 
             Assert.Single(fixture.PropertyParameterMap);
 
-            Assert.Equal(1, fixture.HeaderCollectionParameterMap.Count);
-            Assert.True(fixture.HeaderCollectionParameterMap.Contains(0));
+            Assert.True(fixture.HasHeaderCollection);
+            Assert.True(fixture.HeaderCollectionAt(0));
         }
 
         [Theory]
@@ -1393,7 +1393,7 @@ namespace Refit.Tests
             Assert.Empty(fixture.HeaderParameterMap);
             Assert.NotNull(fixture.BodyParameterInfo);
             Assert.Null(fixture.AuthorizeParameterInfo);
-            Assert.Empty(fixture.HeaderCollectionParameterMap);
+            Assert.False(fixture.HasHeaderCollection);
 
             Assert.Equal("SomeProperty", fixture.PropertyParameterMap[2]);
         }
@@ -1420,7 +1420,7 @@ namespace Refit.Tests
             Assert.Empty(fixture.HeaderParameterMap);
             Assert.NotNull(fixture.BodyParameterInfo);
             Assert.Null(fixture.AuthorizeParameterInfo);
-            Assert.Empty(fixture.HeaderCollectionParameterMap);
+            Assert.False(fixture.HasHeaderCollection);
 
             Assert.Equal("SomeProperty", fixture.PropertyParameterMap[2]);
             Assert.Equal("SomeOtherProperty", fixture.PropertyParameterMap[3]);
@@ -1449,7 +1449,7 @@ namespace Refit.Tests
             Assert.Empty(fixture.HeaderParameterMap);
             Assert.Null(fixture.BodyParameterInfo);
             Assert.Null(fixture.AuthorizeParameterInfo);
-            Assert.Empty(fixture.HeaderCollectionParameterMap);
+            Assert.False(fixture.HasHeaderCollection);
 
             Assert.Equal("SomeProperty", fixture.PropertyParameterMap[1]);
         }
@@ -1477,7 +1477,7 @@ namespace Refit.Tests
             Assert.Empty(fixture.HeaderParameterMap);
             Assert.NotNull(fixture.BodyParameterInfo);
             Assert.Null(fixture.AuthorizeParameterInfo);
-            Assert.Empty(fixture.HeaderCollectionParameterMap);
+            Assert.False(fixture.HasHeaderCollection);
 
             Assert.Equal("SomeProperty", fixture.PropertyParameterMap[1]);
             Assert.Equal(2, fixture.BodyParameterInfo.Item3);

--- a/Refit/EnumerableExtensions.cs
+++ b/Refit/EnumerableExtensions.cs
@@ -19,6 +19,13 @@ internal static class EnumerableExtensions
     }
 }
 
+internal static class EmptyDictionary<TKey, TValue>
+{
+    private static Dictionary<TKey, TValue> Value = new Dictionary<TKey, TValue>();
+
+    internal static Dictionary<TKey, TValue> Get() => Value;
+}
+
 internal enum EnumerablePeek
 {
     Empty,

--- a/Refit/RequestBuilderImplementation.cs
+++ b/Refit/RequestBuilderImplementation.cs
@@ -689,8 +689,8 @@ namespace Refit
                                                 Uri.EscapeDataString(
                                                     settings.UrlParameterFormatter.Format(
                                                         s,
-                                                        restMethod.ParameterInfoMap[i],
-                                                        restMethod.ParameterInfoMap[i].ParameterType
+                                                        restMethod.ParameterInfoArray[i],
+                                                        restMethod.ParameterInfoArray[i].ParameterType
                                                     ) ?? string.Empty
                                                 )
                                         )
@@ -702,8 +702,8 @@ namespace Refit
                                 replacement = Uri.EscapeDataString(
                                     settings.UrlParameterFormatter.Format(
                                         param,
-                                        restMethod.ParameterInfoMap[i],
-                                        restMethod.ParameterInfoMap[i].ParameterType
+                                        restMethod.ParameterInfoArray[i],
+                                        restMethod.ParameterInfoArray[i].ParameterType
                                     ) ?? string.Empty
                                 );
                             }
@@ -738,7 +738,7 @@ namespace Refit
                     }
 
                     //if header collection, add to request headers
-                    if (restMethod.HeaderCollectionParameterMap.Contains(i))
+                    if (restMethod.HeaderCollectionAt(i))
                     {
                         if (param is IDictionary<string, string> headerCollection)
                         {
@@ -776,7 +776,7 @@ namespace Refit
                     // or if is an object bound to the path add any non-path bound properties to query string
                     // or if it's an object with a query attribute
                     var queryAttribute = restMethod
-                        .ParameterInfoMap[i]
+                        .ParameterInfoArray[i]
                         .GetCustomAttribute<QueryAttribute>();
                     if (
                         !restMethod.IsMultipart
@@ -897,7 +897,7 @@ namespace Refit
                 queryParamsToAdd.AddRange(
                     ParseQueryParameter(
                         param,
-                        restMethod.ParameterInfoMap[i],
+                        restMethod.ParameterInfoArray[i],
                         restMethod.QueryParameterMap[i],
                         attr
                     )
@@ -913,7 +913,7 @@ namespace Refit
                     queryParamsToAdd.AddRange(
                         ParseQueryParameter(
                             kvp.Value,
-                            restMethod.ParameterInfoMap[i],
+                            restMethod.ParameterInfoArray[i],
                             path,
                             attr
                         )


### PR DESCRIPTION
- Changed `ParameterInfoMap` to `ParameterInfoArray`.
   - Not sure why refit was using a dictionary as an array?
- Changed `Headers`, `HeaderParameterMap`, `PropertyParameterMap`, `QueryParameterMap`, `AttachmentNameMap` to only allocate a dictionary when needed.
   - Sharing a mutable `Empty` dictionary is a little risky but I dont see why we'd ever want to mutate the collection.
- Addded `EmptyDictionary<TKey, TValue>.get()` to create static empty dictionaries. I would prefer to use `ImmutableDictionary.Empty` and change `Dictionary` to `IReadOnlyDictionary` but they aren't available in . Net Framework.
   - This is a little messy but It saves 72 bytes per dictionary instance.
- `bodyParamEnumerable` and `authorizeParamsEnumerable` now use a tuple instead of an anonymous class.
- Used an integer `HeaderCollectionParameterIndex` instead of the hashset `HeaderCollectionParameterMap`
   - Another strange one, refit explicitly prevents adding more than 1 item to the hashset, it seemed a little redundant :smile:.

We could probably get away with using arrays instead of `Dictionary<int, TSomething>` they would use less memory in most cases and would have faster lookups for smaller numbers.

Saves 4Kb of memory, I might be able to do more after profiling.

### Original
| Method                       | Job        | InvocationCount | UnrollFactor | Mean     | Error    | StdDev   | Gen0   | Gen1   | Allocated |
|----------------------------- |----------- |---------------- |------------- |---------:|---------:|---------:|-------:|-------:|----------:|
| CreateService                | DefaultJob | Default         | 16           | 71.07 us | 1.320 us | 1.412 us | 5.1270 | 0.1221 |  47.17 KB |
| ConstantRouteAsync           | DefaultJob | Default         | 16           | 56.56 us | 0.908 us | 0.758 us | 5.8594 |      - |  55.27 KB |
| ComplexRequestAsync          | DefaultJob | Default         | 16           | 59.39 us | 1.143 us | 1.122 us | 6.1035 | 0.1221 |  57.09 KB |
| FirstCallConstantRouteAsync  | Job-NYYUCJ | 1               | 1            | 32.87 us | 0.640 us | 0.897 us |      - |      - |   9.08 KB |
| FirstCallComplexRequestAsync | Job-NYYUCJ | 1               | 1            | 58.53 us | 1.669 us | 4.843 us |      - |      - |   11.9 KB |


### Changes

| Method                       | Job        | InvocationCount | UnrollFactor | Mean     | Error    | StdDev   | Median   | Gen0   | Gen1   | Allocated |
|----------------------------- |----------- |---------------- |------------- |---------:|---------:|---------:|---------:|-------:|-------:|----------:|
| CreateService                | DefaultJob | Default         | 16           | 46.24 us | 0.828 us | 0.692 us | 46.30 us | 4.6387 | 0.1221 |     43 KB |
| ConstantRouteAsync           | DefaultJob | Default         | 16           | 51.42 us | 0.282 us | 0.236 us | 51.41 us | 5.5542 | 0.1221 |   51.1 KB |
| ComplexRequestAsync          | DefaultJob | Default         | 16           | 55.17 us | 0.730 us | 0.683 us | 55.13 us | 5.7373 | 0.1221 |  52.94 KB |
| FirstCallConstantRouteAsync  | Job-OIQPYS | 1               | 1            | 36.07 us | 1.025 us | 2.873 us | 35.20 us |      - |      - |   9.08 KB |
| FirstCallComplexRequestAsync | Job-OIQPYS | 1               | 1            | 50.36 us | 1.357 us | 3.738 us | 49.30 us |      - |      - |   11.9 KB |
