### PR TITLE
feat: defer header dictionary creation

### DIFF
--- a/Refit/RequestBuilderImplementation.cs
+++ b/Refit/RequestBuilderImplementation.cs
@@ -640,7 +640,9 @@ namespace Refit
                 var urlTarget =
                     (basePath == "/" ? string.Empty : basePath) + restMethod.RelativePath;
                 var queryParamsToAdd = new List<KeyValuePair<string, string?>>();
-                var headersToAdd = new Dictionary<string, string?>(restMethod.Headers);
+                var headersToAdd = restMethod.Headers.Count > 0 ?
+                    new Dictionary<string, string?>(restMethod.Headers)
+                    : null;
 
                 RestMethodParameterInfo? parameterInfo = null;
 
@@ -733,6 +735,7 @@ namespace Refit
                     // if header, add to request headers
                     if (restMethod.HeaderParameterMap.TryGetValue(i, out var headerParameterValue))
                     {
+                        headersToAdd ??= new Dictionary<string, string?>();
                         headersToAdd[headerParameterValue] = param?.ToString();
                         isParameterMappedToRequest = true;
                     }
@@ -744,6 +747,7 @@ namespace Refit
                         {
                             foreach (var header in headerCollection)
                             {
+                                headersToAdd ??= new Dictionary<string, string?>();
                                 headersToAdd[header.Key] = header.Value;
                             }
                         }
@@ -757,6 +761,7 @@ namespace Refit
                         && restMethod.AuthorizeParameterInfo.Item2 == i
                     )
                     {
+                        headersToAdd ??= new Dictionary<string, string?>();
                         headersToAdd["Authorization"] =
                             $"{restMethod.AuthorizeParameterInfo.Item1} {param}";
                         isParameterMappedToRequest = true;
@@ -959,22 +964,22 @@ namespace Refit
             }
         }
 
-        static void AddHeadersToRequest(Dictionary<string, string?> headersToAdd, HttpRequestMessage ret)
+        static void AddHeadersToRequest(Dictionary<string, string?>? headersToAdd, HttpRequestMessage ret)
         {
             // NB: We defer setting headers until the body has been
             // added so any custom content headers don't get left out.
-            if (headersToAdd.Count > 0)
-            {
-                // We could have content headers, so we need to make
-                // sure we have an HttpContent object to add them to,
-                // provided the HttpClient will allow it for the method
-                if (ret.Content == null && !IsBodyless(ret.Method))
-                    ret.Content = new ByteArrayContent(Array.Empty<byte>());
+            if (headersToAdd is null || headersToAdd.Count <= 0)
+                return;
 
-                foreach (var header in headersToAdd)
-                {
-                    SetHeader(ret, header.Key, header.Value);
-                }
+            // We could have content headers, so we need to make
+            // sure we have an HttpContent object to add them to,
+            // provided the HttpClient will allow it for the method
+            if (ret.Content == null && !IsBodyless(ret.Method))
+                ret.Content = new ByteArrayContent(Array.Empty<byte>());
+
+            foreach (var header in headersToAdd)
+            {
+                SetHeader(ret, header.Key, header.Value);
             }
         }
 


### PR DESCRIPTION
Defer header dictionary creation, saves 72 bytes if a header is not set.


### Original
| Method                   | Mean      | Error     | StdDev    | Gen0   | Gen1   | Allocated |
|------------------------- |----------:|----------:|----------:|-------:|-------:|----------:|
| ConstantRouteAsync       |  2.032 us | 0.0223 us | 0.0209 us | 0.6905 |      - |   6.36 KB |
| DynamicRouteAsync        |  2.626 us | 0.0186 us | 0.0165 us | 0.7248 | 0.0038 |   6.68 KB |
| ComplexDynamicRouteAsync |  3.825 us | 0.0197 us | 0.0175 us | 0.7935 | 0.0076 |   7.31 KB |
| ObjectRequestAsync       |  4.470 us | 0.0250 us | 0.0234 us | 0.8774 |      - |   8.13 KB |
| ComplexRequestAsync      | 12.379 us | 0.0479 us | 0.0448 us | 1.5411 | 0.0153 |  14.19 KB |

### Header changes
| Method                   | Mean      | Error     | StdDev    | Median    | Gen0   | Gen1   | Allocated |
|------------------------- |----------:|----------:|----------:|----------:|-------:|-------:|----------:|
| ConstantRouteAsync       |  3.560 us | 0.3364 us | 0.9919 us |  3.072 us | 0.6790 | 0.0076 |   6.28 KB |
| DynamicRouteAsync        |  2.939 us | 0.0524 us | 0.0490 us |  2.953 us | 0.7172 |      - |    6.6 KB |
| ComplexDynamicRouteAsync |  4.288 us | 0.0851 us | 0.1796 us |  4.241 us | 0.7858 | 0.0076 |   7.24 KB |
| ObjectRequestAsync       |  4.880 us | 0.0921 us | 0.0905 us |  4.848 us | 0.8698 |      - |   8.05 KB |
| ComplexRequestAsync      | 13.322 us | 0.2608 us | 0.3482 us | 13.142 us | 1.5411 | 0.0153 |  14.19 KB |
