### PR TITLE
First step to target fully source gen implementation

### DIFF
--- a/InterfaceStubGenerator.Shared/InterfaceStubGenerator.Shared.projitems
+++ b/InterfaceStubGenerator.Shared/InterfaceStubGenerator.Shared.projitems
@@ -6,10 +6,12 @@
     <SharedGUID>b591423d-f92d-4e00-b0eb-615c9853506c</SharedGUID>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
-    <Import_RootNamespace>InterfaceStubGenerator.Shared</Import_RootNamespace>
+    <Import_RootNamespace>Refit.Generator</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)RefitClientModel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)InterfaceStubGenerator.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ITypeSymbolExtensions.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)RefitMetadata.cs" />
   </ItemGroup>
 </Project>

--- a/InterfaceStubGenerator.Shared/RefitClientModel.cs
+++ b/InterfaceStubGenerator.Shared/RefitClientModel.cs
@@ -1,0 +1,113 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+using Microsoft.CodeAnalysis;
+
+namespace Refit.Generator;
+
+internal class RefitClientModel
+{
+    readonly RefitMetadata refitMetadata;
+
+    public RefitClientModel(INamedTypeSymbol refitInterface, List<IMethodSymbol> refitMethods, RefitMetadata refitMetadata)
+    {
+        RefitInterface = refitInterface;
+        RefitMethods = refitMethods;
+        this.refitMetadata = refitMetadata;
+
+        // Get any other methods on the refit interfaces. We'll need to generate something for them and warn
+        var nonRefitMethods = refitInterface
+            .GetMembers()
+            .OfType<IMethodSymbol>()
+            .Except(refitMethods, SymbolEqualityComparer.Default)
+            .Cast<IMethodSymbol>()
+            .ToList();
+
+        // get methods for all inherited
+        var derivedMethods = refitInterface
+            .AllInterfaces.SelectMany(i => i.GetMembers().OfType<IMethodSymbol>())
+            .ToList();
+
+        // Look for disposable
+        DisposeMethod = derivedMethods.Find(
+                m =>
+                    m.ContainingType?.Equals(
+                        refitMetadata.DisposableInterfaceSymbol,
+                        SymbolEqualityComparer.Default
+                    ) == true
+            );
+        if (DisposeMethod != null)
+        {
+            //remove it from the derived methods list so we don't process it with the rest
+            derivedMethods.Remove(DisposeMethod);
+        }
+
+        // Pull out the refit methods from the derived types
+        var derivedRefitMethods = derivedMethods.Where(refitMetadata.IsRefitMethod).ToList();
+        var derivedNonRefitMethods = derivedMethods.Except(derivedMethods, SymbolEqualityComparer.Default).Cast<IMethodSymbol>().ToList();
+
+        AllRefitMethods = refitMethods.Concat(derivedRefitMethods);
+        NonRefitMethods = nonRefitMethods.Concat(derivedNonRefitMethods)
+            .Where(static method =>
+            {
+                return !(method.IsStatic ||
+                    method.MethodKind == MethodKind.PropertyGet ||
+                    method.MethodKind == MethodKind.PropertySet ||
+                    !method.IsAbstract);
+            });
+    }
+
+    public INamedTypeSymbol RefitInterface { get; }
+    public List<IMethodSymbol> RefitMethods { get; }
+    public IEnumerable<IMethodSymbol> AllRefitMethods { get; }
+    public IEnumerable<IMethodSymbol> NonRefitMethods { get; }
+
+    public string FileName => RefitInterface.Name;
+
+    public string ClassDeclaration
+    {
+        get
+        {
+            // Get the class name with the type parameters, then remove the namespace
+            var className = RefitInterface.ToDisplayString();
+            var lastDot = className.LastIndexOf('.');
+            if (lastDot > 0)
+            {
+                className = className.Substring(lastDot + 1);
+            }
+            var classDeclaration = $"{RefitInterface.ContainingType?.Name}{className}";
+            return classDeclaration;
+        }
+    }
+
+    public string ClassSuffix
+    {
+        get
+        {
+            // Get the class name itself
+            var classSuffix = $"{RefitInterface.ContainingType?.Name}{RefitInterface.Name}";
+            return classSuffix;
+        }
+    }
+
+    public string NamespacePrefix
+    {
+        get
+        {
+            var ns = RefitInterface.ContainingNamespace?.ToDisplayString();
+
+            // if it's the global namespace, our lookup rules say it should be the same as the class name
+            if (RefitInterface.ContainingNamespace != null && RefitInterface.ContainingNamespace.IsGlobalNamespace)
+            {
+                return string.Empty;
+            }
+
+            // Remove dots
+            ns = ns!.Replace(".", "");
+            return ns;
+        }
+    }
+    public string BaseInterfaceDeclaration => $"{RefitInterface.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)}";
+
+    public IMethodSymbol DisposeMethod { get; }
+}

--- a/InterfaceStubGenerator.Shared/RefitMetadata.cs
+++ b/InterfaceStubGenerator.Shared/RefitMetadata.cs
@@ -1,0 +1,22 @@
+﻿using System.Linq;
+
+using Microsoft.CodeAnalysis;
+
+namespace Refit.Generator;
+
+internal class RefitMetadata
+{
+    public RefitMetadata(INamedTypeSymbol? disposableInterfaceSymbol, INamedTypeSymbol httpMethodBaseAttributeSymbol)
+    {
+        DisposableInterfaceSymbol = disposableInterfaceSymbol;
+        HttpMethodBaseAttributeSymbol = httpMethodBaseAttributeSymbol;
+    }
+
+    public INamedTypeSymbol? DisposableInterfaceSymbol { get; }
+    public INamedTypeSymbol HttpMethodBaseAttributeSymbol { get; }
+
+    public bool IsRefitMethod(IMethodSymbol? methodSymbol)
+    {
+        return methodSymbol?.GetAttributes().Any(ad => ad.AttributeClass?.InheritsFromOrEquals(HttpMethodBaseAttributeSymbol) == true) == true;
+    }
+}


### PR DESCRIPTION
I extract simple model for Refit client representation withing source gen That to allow facilitate process
- Parse Syntax (done by Roslyn itslef)
- Build internal model
- Write based on model only, so logic would be as simple as possible

Also that allows write more robust test if we test just internal model extraction from symbols. Otherwise if we will capture generated output, if we decide improve generation it will produce a lot of churn. I do not agains churn like that, but not sure that's would be appropriate.

Related to https://github.com/reactiveui/refit/issues/1389