### PR TITLE
feat: fix form url encoded strings #1593

### DIFF
--- a/Refit.Tests/RequestBuilder.cs
+++ b/Refit.Tests/RequestBuilder.cs
@@ -3242,6 +3242,29 @@ namespace Refit.Tests
         }
 
         [Fact]
+        public void BodyContentGetsUrlEncodedWithCollectionFormat()
+        {
+            var settings = new RefitSettings() { CollectionFormat = CollectionFormat.Csv };
+            var fixture = new RequestBuilderImplementation<IDummyHttpApi>(settings);
+            var factory = fixture.RunRequest("PostSomeUrlEncodedStuff");
+            var output = factory(
+                new object[]
+                {
+                    6,
+                    new
+                    {
+                        Foo = "Something",
+                        Bar = 100,
+                        FooBar = new [] {5,7},
+                        Baz = "" // explicitly use blank to preserve value that would be stripped if null
+                    }
+                }
+            );
+
+            Assert.Equal("Foo=Something&Bar=100&FooBar=5%2C7&Baz=", output.SendContent);
+        }
+
+        [Fact]
         public void FormFieldGetsAliased()
         {
             var fixture = new RequestBuilderImplementation<IDummyHttpApi>();

--- a/Refit/FormValueMultimap.cs
+++ b/Refit/FormValueMultimap.cs
@@ -65,7 +65,8 @@ namespace Refit
                     // see if there's a query attribute
                     var attrib = property.GetCustomAttribute<QueryAttribute>(true);
 
-                    if (value is not IEnumerable enumerable)
+                    // add strings/non enumerable properties
+                    if (value is not IEnumerable enumerable || value is string)
                     {
                         Add(
                             fieldName,


### PR DESCRIPTION
Add check for strings to form url encoded requests. This way strings aren't serialized as collections. Added relevant test.

Fixes #1593