### PR TITLE
feat: added generator tests

### DIFF
--- a/Refit.GeneratorTests/Fixture.cs
+++ b/Refit.GeneratorTests/Fixture.cs
@@ -1,0 +1,95 @@
+﻿using System.Reflection;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Refit.Generator;
+
+namespace Refit.GeneratorTests;
+
+public static class Fixture
+{
+    static readonly MetadataReference RefitAssembly = MetadataReference.CreateFromFile(
+        typeof(GetAttribute).Assembly.Location,
+        documentation: XmlDocumentationProvider.CreateFromFile(
+            Path.ChangeExtension(typeof(GetAttribute).Assembly.Location, ".xml")
+        )
+    );
+
+    private static readonly Type[] ImportantAssemblies = {
+        typeof(Binder),
+        typeof(GetAttribute),
+        typeof(System.Reactive.Unit),
+        typeof(Enumerable),
+        typeof(Newtonsoft.Json.JsonConvert),
+        typeof(FactAttribute),
+        typeof(HttpContent),
+        typeof(Attribute)
+    };
+
+    private static Assembly[] AssemblyReferencesForCodegen =>
+        AppDomain.CurrentDomain
+            .GetAssemblies()
+            .Concat(ImportantAssemblies.Select(x=>x.Assembly))
+            .Distinct()
+            .Where(a => !a.IsDynamic)
+            .ToArray();
+
+    public static Task VerifyForBody(string body)
+    {
+        var source =
+            $$"""
+              using System;
+              using System.Collections.Generic;
+              using System.Linq;
+              using System.Net.Http;
+              using System.Text;
+              using System.Threading;
+              using System.Threading.Tasks;
+              using Refit;
+
+              namespace RefitGeneratorTest;
+
+              public interface IGeneratedClient
+              {
+              {{body}}
+              }
+              """;
+
+        return VerifyGenerator(source);
+    }
+
+    private static CSharpCompilation CreateLibrary(params string[] source)
+    {
+        var references = new List<MetadataReference>();
+        var assemblies = AssemblyReferencesForCodegen;
+        foreach (var assembly in assemblies)
+        {
+            if (!assembly.IsDynamic)
+            {
+                references.Add(MetadataReference.CreateFromFile(assembly.Location));
+            }
+        }
+
+        references.Add(RefitAssembly);
+        var compilation = CSharpCompilation.Create(
+            "compilation",
+            source.Select(s => CSharpSyntaxTree.ParseText(s)),
+            references,
+            new CSharpCompilationOptions(OutputKind.ConsoleApplication)
+        );
+
+        return compilation;
+    }
+
+    private static Task<VerifyResult> VerifyGenerator(string source)
+    {
+        var compilation = CreateLibrary(source);
+
+        var generator = new InterfaceStubGenerator();
+        var driver = CSharpGeneratorDriver.Create(generator);
+
+        var ranDriver = driver.RunGenerators(compilation);
+        var settings = new VerifySettings();
+        var verify = VerifyXunit.Verifier.Verify(ranDriver, settings);
+        return verify.ToTask();
+    }
+}

--- a/Refit.GeneratorTests/ModuleInitializer.cs
+++ b/Refit.GeneratorTests/ModuleInitializer.cs
@@ -1,0 +1,19 @@
+﻿using System.Runtime.CompilerServices;
+using VerifyTests.DiffPlex;
+
+namespace Refit.GeneratorTests;
+
+public static class ModuleInitializer
+{
+    // ModuleInitializer should only be used in apps
+#pragma warning disable CA2255
+    [ModuleInitializer]
+#pragma warning restore CA2255
+    public static void Init()
+    {
+        DerivePathInfo((file, _, type, method) => new(Path.Combine(Path.GetDirectoryName(file), "_snapshots"), type.Name, method.Name));
+
+        VerifySourceGenerators.Initialize();
+        VerifyDiffPlex.Initialize(OutputType.Compact);
+    }
+}

--- a/Refit.GeneratorTests/Refit.GeneratorTests.csproj
+++ b/Refit.GeneratorTests/Refit.GeneratorTests.csproj
@@ -1,0 +1,46 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <Import Project="..\Refit\targets\refit.props" />
+
+    <PropertyGroup>
+        <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+        <NoWarn>$(NoWarn);CS1591;CA1819;CA2000;CA2007;CA1056;CA1707;CA1861;xUnit1031</NoWarn>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="coverlet.collector" Version="6.0.0"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
+        <PackageReference Include="xunit" Version="2.5.3"/>
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3"/>
+        <PackageReference Include="System.Collections.Immutable" Version="9.0.0-preview.5.24306.7" />
+        <PackageReference Include="Verify.DiffPlex" Version="2.3.0" />
+        <PackageReference Include="Verify.SourceGenerators" Version="2.2.0" />
+        <PackageReference Include="Verify.Xunit" Version="22.1.4" />
+        <PackageReference Include="System.Reactive" Version="6.0.1" />
+        <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.9.2" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing" Version="1.1.2-beta1.24314.1" />
+        <ProjectReference Include="..\Refit.Newtonsoft.Json\Refit.Newtonsoft.Json.csproj" />
+        <ProjectReference Include="..\Refit.Xml\Refit.Xml.csproj" />
+        <ProjectReference Include="..\InterfaceStubGenerator.Roslyn38\InterfaceStubGenerator.Roslyn38.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="true" />
+        <ProjectReference Include="..\InterfaceStubGenerator.Roslyn40\InterfaceStubGenerator.Roslyn40.csproj" />
+        <ProjectReference Include="..\Refit\Refit.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <None Include="..\Refit.GeneratorTests\_snapshots\**">
+          <Link>%(RecursiveDir)\resources\%(Filename)%(Extension)</Link>
+          <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        </None>
+        <Using Include="Xunit"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <Folder Include="_snapshots\" />
+    </ItemGroup>
+</Project>

--- a/Refit.GeneratorTests/ReturnTypeTests.cs
+++ b/Refit.GeneratorTests/ReturnTypeTests.cs
@@ -1,0 +1,25 @@
+namespace Refit.GeneratorTests;
+
+[UsesVerify]
+public class ReturnTypeTests
+{
+    [Fact]
+    public Task GenericTaskShouldWork()
+    {
+        return Fixture.VerifyForBody(
+            """
+            [Get("/users")]
+            Task<string> Get();
+            """);
+    }
+
+    [Fact]
+    public Task VoidTaskShouldWork()
+    {
+        return Fixture.VerifyForBody(
+            """
+            [Post("/users")]
+            Task Post();
+            """);
+    }
+}

--- a/Refit.GeneratorTests/_snapshots/ReturnTypeTests.GenericTaskShouldWork#Generated.g.verified.cs
+++ b/Refit.GeneratorTests/_snapshots/ReturnTypeTests.GenericTaskShouldWork#Generated.g.verified.cs
@@ -1,0 +1,24 @@
+﻿//HintName: Generated.g.cs
+
+#pragma warning disable
+namespace Refit.Implementation
+{
+
+    /// <inheritdoc />
+    [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    [global::System.Diagnostics.DebuggerNonUserCode]
+    [global::RefitInternalGenerated.PreserveAttribute]
+    [global::System.Reflection.Obfuscation(Exclude=true)]
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    internal static partial class Generated
+    {
+#if NET5_0_OR_GREATER
+        [System.Runtime.CompilerServices.ModuleInitializer]
+        [System.Diagnostics.CodeAnalysis.DynamicDependency(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All, typeof(global::Refit.Implementation.Generated))]
+        public static void Initialize()
+        {
+        }
+#endif
+    }
+}
+#pragma warning restore

--- a/Refit.GeneratorTests/_snapshots/ReturnTypeTests.GenericTaskShouldWork#IGeneratedClient.g.verified.cs
+++ b/Refit.GeneratorTests/_snapshots/ReturnTypeTests.GenericTaskShouldWork#IGeneratedClient.g.verified.cs
@@ -1,0 +1,66 @@
+﻿//HintName: IGeneratedClient.g.cs
+#nullable disable
+#pragma warning disable
+namespace Refit.Implementation
+{
+
+    partial class Generated
+    {
+
+    /// <inheritdoc />
+    [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    [global::System.Diagnostics.DebuggerNonUserCode]
+    [global::RefitInternalGenerated.PreserveAttribute]
+    [global::System.Reflection.Obfuscation(Exclude=true)]
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    partial class RefitGeneratorTestIGeneratedClient
+        : global::RefitGeneratorTest.IGeneratedClient
+
+    {
+        /// <inheritdoc />
+        public global::System.Net.Http.HttpClient Client { get; }
+        readonly global::Refit.IRequestBuilder requestBuilder;
+
+        /// <inheritdoc />
+        public RefitGeneratorTestIGeneratedClient(global::System.Net.Http.HttpClient client, global::Refit.IRequestBuilder requestBuilder)
+        {
+            Client = client;
+            this.requestBuilder = requestBuilder;
+        }
+
+
+
+        /// <inheritdoc />
+        public async global::System.Threading.Tasks.Task<string> Get()
+        {
+            var ______arguments = global::System.Array.Empty<object>();
+            var ______func = requestBuilder.BuildRestResultFuncForMethod("Get", global::System.Array.Empty<global::System.Type>() );
+            try
+            {
+                return await ((global::System.Threading.Tasks.Task<string>)______func(this.Client, ______arguments)).ConfigureAwait(false);
+            }
+            catch (global::System.Exception ______ex)
+            {
+                throw ______ex;
+            }
+        }
+
+        /// <inheritdoc />
+        async global::System.Threading.Tasks.Task<string> global::RefitGeneratorTest.IGeneratedClient.Get()
+        {
+            var ______arguments = global::System.Array.Empty<object>();
+            var ______func = requestBuilder.BuildRestResultFuncForMethod("Get", global::System.Array.Empty<global::System.Type>() );
+            try
+            {
+                return await ((global::System.Threading.Tasks.Task<string>)______func(this.Client, ______arguments)).ConfigureAwait(false);
+            }
+            catch (global::System.Exception ______ex)
+            {
+                throw ______ex;
+            }
+        }
+    }
+    }
+}
+
+#pragma warning restore

--- a/Refit.GeneratorTests/_snapshots/ReturnTypeTests.GenericTaskShouldWork#PreserveAttribute.g.verified.cs
+++ b/Refit.GeneratorTests/_snapshots/ReturnTypeTests.GenericTaskShouldWork#PreserveAttribute.g.verified.cs
@@ -1,0 +1,19 @@
+﻿//HintName: PreserveAttribute.g.cs
+
+#pragma warning disable
+namespace RefitInternalGenerated
+{
+    [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    [global::System.AttributeUsage (global::System.AttributeTargets.Class | global::System.AttributeTargets.Struct | global::System.AttributeTargets.Enum | global::System.AttributeTargets.Constructor | global::System.AttributeTargets.Method | global::System.AttributeTargets.Property | global::System.AttributeTargets.Field | global::System.AttributeTargets.Event | global::System.AttributeTargets.Interface | global::System.AttributeTargets.Delegate)]
+    sealed class PreserveAttribute : global::System.Attribute
+    {
+        //
+        // Fields
+        //
+        public bool AllMembers;
+
+        public bool Conditional;
+    }
+}
+#pragma warning restore

--- a/Refit.GeneratorTests/_snapshots/ReturnTypeTests.VoidTaskShouldWork#Generated.g.verified.cs
+++ b/Refit.GeneratorTests/_snapshots/ReturnTypeTests.VoidTaskShouldWork#Generated.g.verified.cs
@@ -1,0 +1,24 @@
+﻿//HintName: Generated.g.cs
+
+#pragma warning disable
+namespace Refit.Implementation
+{
+
+    /// <inheritdoc />
+    [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    [global::System.Diagnostics.DebuggerNonUserCode]
+    [global::RefitInternalGenerated.PreserveAttribute]
+    [global::System.Reflection.Obfuscation(Exclude=true)]
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    internal static partial class Generated
+    {
+#if NET5_0_OR_GREATER
+        [System.Runtime.CompilerServices.ModuleInitializer]
+        [System.Diagnostics.CodeAnalysis.DynamicDependency(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All, typeof(global::Refit.Implementation.Generated))]
+        public static void Initialize()
+        {
+        }
+#endif
+    }
+}
+#pragma warning restore

--- a/Refit.GeneratorTests/_snapshots/ReturnTypeTests.VoidTaskShouldWork#IGeneratedClient.g.verified.cs
+++ b/Refit.GeneratorTests/_snapshots/ReturnTypeTests.VoidTaskShouldWork#IGeneratedClient.g.verified.cs
@@ -1,0 +1,66 @@
+﻿//HintName: IGeneratedClient.g.cs
+#nullable disable
+#pragma warning disable
+namespace Refit.Implementation
+{
+
+    partial class Generated
+    {
+
+    /// <inheritdoc />
+    [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    [global::System.Diagnostics.DebuggerNonUserCode]
+    [global::RefitInternalGenerated.PreserveAttribute]
+    [global::System.Reflection.Obfuscation(Exclude=true)]
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    partial class RefitGeneratorTestIGeneratedClient
+        : global::RefitGeneratorTest.IGeneratedClient
+
+    {
+        /// <inheritdoc />
+        public global::System.Net.Http.HttpClient Client { get; }
+        readonly global::Refit.IRequestBuilder requestBuilder;
+
+        /// <inheritdoc />
+        public RefitGeneratorTestIGeneratedClient(global::System.Net.Http.HttpClient client, global::Refit.IRequestBuilder requestBuilder)
+        {
+            Client = client;
+            this.requestBuilder = requestBuilder;
+        }
+
+
+
+        /// <inheritdoc />
+        public async global::System.Threading.Tasks.Task Post()
+        {
+            var ______arguments = global::System.Array.Empty<object>();
+            var ______func = requestBuilder.BuildRestResultFuncForMethod("Post", global::System.Array.Empty<global::System.Type>() );
+            try
+            {
+                await ((global::System.Threading.Tasks.Task)______func(this.Client, ______arguments)).ConfigureAwait(false);
+            }
+            catch (global::System.Exception ______ex)
+            {
+                throw ______ex;
+            }
+        }
+
+        /// <inheritdoc />
+        async global::System.Threading.Tasks.Task global::RefitGeneratorTest.IGeneratedClient.Post()
+        {
+            var ______arguments = global::System.Array.Empty<object>();
+            var ______func = requestBuilder.BuildRestResultFuncForMethod("Post", global::System.Array.Empty<global::System.Type>() );
+            try
+            {
+                await ((global::System.Threading.Tasks.Task)______func(this.Client, ______arguments)).ConfigureAwait(false);
+            }
+            catch (global::System.Exception ______ex)
+            {
+                throw ______ex;
+            }
+        }
+    }
+    }
+}
+
+#pragma warning restore

--- a/Refit.GeneratorTests/_snapshots/ReturnTypeTests.VoidTaskShouldWork#PreserveAttribute.g.verified.cs
+++ b/Refit.GeneratorTests/_snapshots/ReturnTypeTests.VoidTaskShouldWork#PreserveAttribute.g.verified.cs
@@ -1,0 +1,19 @@
+﻿//HintName: PreserveAttribute.g.cs
+
+#pragma warning disable
+namespace RefitInternalGenerated
+{
+    [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    [global::System.AttributeUsage (global::System.AttributeTargets.Class | global::System.AttributeTargets.Struct | global::System.AttributeTargets.Enum | global::System.AttributeTargets.Constructor | global::System.AttributeTargets.Method | global::System.AttributeTargets.Property | global::System.AttributeTargets.Field | global::System.AttributeTargets.Event | global::System.AttributeTargets.Interface | global::System.AttributeTargets.Delegate)]
+    sealed class PreserveAttribute : global::System.Attribute
+    {
+        //
+        // Fields
+        //
+        public bool AllMembers;
+
+        public bool Conditional;
+    }
+}
+#pragma warning restore

--- a/Refit.sln
+++ b/Refit.sln
@@ -34,6 +34,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Refit.Xml", "Refit.Xml\Refi
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Refit.Benchmarks", "Refit.Benchmarks\Refit.Benchmarks.csproj", "{ABD72A27-9C30-481A-8303-D8F825A8FD47}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Refit.GeneratorTests", "Refit.GeneratorTests\Refit.GeneratorTests.csproj", "{CE7894EA-D411-494A-BA8B-1C231D45025D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -174,6 +176,22 @@ Global
 		{ABD72A27-9C30-481A-8303-D8F825A8FD47}.Release|x64.Build.0 = Release|Any CPU
 		{ABD72A27-9C30-481A-8303-D8F825A8FD47}.Release|x86.ActiveCfg = Release|Any CPU
 		{ABD72A27-9C30-481A-8303-D8F825A8FD47}.Release|x86.Build.0 = Release|Any CPU
+		{CE7894EA-D411-494A-BA8B-1C231D45025D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CE7894EA-D411-494A-BA8B-1C231D45025D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CE7894EA-D411-494A-BA8B-1C231D45025D}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{CE7894EA-D411-494A-BA8B-1C231D45025D}.Debug|ARM.Build.0 = Debug|Any CPU
+		{CE7894EA-D411-494A-BA8B-1C231D45025D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{CE7894EA-D411-494A-BA8B-1C231D45025D}.Debug|x64.Build.0 = Debug|Any CPU
+		{CE7894EA-D411-494A-BA8B-1C231D45025D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{CE7894EA-D411-494A-BA8B-1C231D45025D}.Debug|x86.Build.0 = Debug|Any CPU
+		{CE7894EA-D411-494A-BA8B-1C231D45025D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CE7894EA-D411-494A-BA8B-1C231D45025D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CE7894EA-D411-494A-BA8B-1C231D45025D}.Release|ARM.ActiveCfg = Release|Any CPU
+		{CE7894EA-D411-494A-BA8B-1C231D45025D}.Release|ARM.Build.0 = Release|Any CPU
+		{CE7894EA-D411-494A-BA8B-1C231D45025D}.Release|x64.ActiveCfg = Release|Any CPU
+		{CE7894EA-D411-494A-BA8B-1C231D45025D}.Release|x64.Build.0 = Release|Any CPU
+		{CE7894EA-D411-494A-BA8B-1C231D45025D}.Release|x86.ActiveCfg = Release|Any CPU
+		{CE7894EA-D411-494A-BA8B-1C231D45025D}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -181,6 +199,7 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{EB833B36-D3CA-4308-A776-8D574F2ADF64} = {0E99249A-FB80-4C60-8FD3-13820E853FF7}
 		{ABD72A27-9C30-481A-8303-D8F825A8FD47} = {0E99249A-FB80-4C60-8FD3-13820E853FF7}
+		{CE7894EA-D411-494A-BA8B-1C231D45025D} = {0E99249A-FB80-4C60-8FD3-13820E853FF7}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {6E9C2873-AFF9-4D32-A784-1BA094814054}


### PR DESCRIPTION
Redo of #1753, this time focusing on individual cases.

- Added some basic tests.
- I intend to keep `InterfaceStubGenerator` in the main tests to target the latest version of .NET framework if possible. I'm trying not to use unsafe code in a rewrite, but if I do .NET Framework will have to be handled uniquely.
- Using this in my source generator rewrite, I'm trying to split it into smaller PRs so I don't dump a massive change on you.
- Got a pr with `Verify.SourceGenerator` to add a way to ignore certain files. I'd like to use it on the duplicate `PreserveAttribute.cs` files.