### PR TITLE
Add MemberNotNullWhen annotation for Content / HasContent pair

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -36,7 +36,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(IsTestProject)' != 'true'">
-    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.10.48" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.11.20" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Refit.GeneratorTests/Refit.GeneratorTests.csproj
+++ b/Refit.GeneratorTests/Refit.GeneratorTests.csproj
@@ -20,7 +20,7 @@
         <PackageReference Include="System.Collections.Immutable" Version="9.0.0-preview.5.24306.7" />
         <PackageReference Include="Verify.DiffPlex" Version="3.1.0" />
         <PackageReference Include="Verify.SourceGenerators" Version="2.3.0" />
-        <PackageReference Include="Verify.Xunit" Version="22.11.5" />
+        <PackageReference Include="Verify.Xunit" Version="26.2.0" />
         <PackageReference Include="System.Reactive" Version="6.0.1" />
         <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" />
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.9.2" />

--- a/Refit.GeneratorTests/ReturnTypeTests.cs
+++ b/Refit.GeneratorTests/ReturnTypeTests.cs
@@ -1,6 +1,5 @@
-namespace Refit.GeneratorTests;
+﻿namespace Refit.GeneratorTests;
 
-[UsesVerify]
 public class ReturnTypeTests
 {
     [Fact]

--- a/Refit.Tests/API/ApiApprovalTests.Refit.DotNet6_0.verified.txt
+++ b/Refit.Tests/API/ApiApprovalTests.Refit.DotNet6_0.verified.txt
@@ -18,6 +18,8 @@ namespace Refit
         protected ApiException(string exceptionMessage, System.Net.Http.HttpRequestMessage message, System.Net.Http.HttpMethod httpMethod, string? content, System.Net.HttpStatusCode statusCode, string? reasonPhrase, System.Net.Http.Headers.HttpResponseHeaders headers, Refit.RefitSettings refitSettings, System.Exception? innerException = null) { }
         public string? Content { get; }
         public System.Net.Http.Headers.HttpContentHeaders? ContentHeaders { get; }
+        [System.Diagnostics.CodeAnalysis.MemberNotNullWhen(true, "Content")]
+        [get: System.Diagnostics.CodeAnalysis.MemberNotNullWhen(true, "Content")]
         public bool HasContent { get; }
         public System.Net.Http.Headers.HttpResponseHeaders Headers { get; }
         public System.Net.Http.HttpMethod HttpMethod { get; }

--- a/Refit.Tests/API/ApiApprovalTests.Refit.DotNet8_0.verified.txt
+++ b/Refit.Tests/API/ApiApprovalTests.Refit.DotNet8_0.verified.txt
@@ -18,6 +18,8 @@ namespace Refit
         protected ApiException(string exceptionMessage, System.Net.Http.HttpRequestMessage message, System.Net.Http.HttpMethod httpMethod, string? content, System.Net.HttpStatusCode statusCode, string? reasonPhrase, System.Net.Http.Headers.HttpResponseHeaders headers, Refit.RefitSettings refitSettings, System.Exception? innerException = null) { }
         public string? Content { get; }
         public System.Net.Http.Headers.HttpContentHeaders? ContentHeaders { get; }
+        [System.Diagnostics.CodeAnalysis.MemberNotNullWhen(true, "Content")]
+        [get: System.Diagnostics.CodeAnalysis.MemberNotNullWhen(true, "Content")]
         public bool HasContent { get; }
         public System.Net.Http.Headers.HttpResponseHeaders Headers { get; }
         public System.Net.Http.HttpMethod HttpMethod { get; }

--- a/Refit/ApiException.cs
+++ b/Refit/ApiException.cs
@@ -1,4 +1,5 @@
-﻿using System.Net;
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 

--- a/Refit/ApiException.cs
+++ b/Refit/ApiException.cs
@@ -53,6 +53,9 @@ namespace Refit
         /// <summary>
         /// Does the response have content?
         /// </summary>
+        #if NET6_0_OR_GREATER
+        [MemberNotNullWhen(true, nameof(Content))]
+        #endif
         public bool HasContent => !string.IsNullOrWhiteSpace(Content);
 
         /// <summary>

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "7.1.2",
+  "version": "7.2.0",
   "publicReleaseRefSpec": [
     "^refs/heads/main$", // we release out of main
     "^refs/heads/rel/v\\d+\\.\\d+" // we also release branches starting with vN.N


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
It adds the MemberNotNullWhen annotation to the Content / HasContent pair in ApiException.


**What is the current behavior?**
<!-- You can also link to an open issue here. -->
VS does not recognize `Content` being non-null when `HasContent` is `true`.


**What is the new behavior?**
<!-- If this is a feature change -->
VS should recognize `Content` being non-null when `HasContent` is `true`.



**What might this PR break?**



**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

