### PR TITLE
Extend url parameters default formatting

### DIFF
--- a/Refit.Tests/API/ApiApprovalTests.Refit.DotNet6_0.verified.txt
+++ b/Refit.Tests/API/ApiApprovalTests.Refit.DotNet6_0.verified.txt
@@ -119,6 +119,8 @@ namespace Refit
     public class DefaultUrlParameterFormatter : Refit.IUrlParameterFormatter
     {
         public DefaultUrlParameterFormatter() { }
+        public void AddFormat<TParameter>(string format) { }
+        public void AddFormat<TContainer, TParameter>(string format) { }
         public virtual string? Format(object? parameterValue, System.Reflection.ICustomAttributeProvider attributeProvider, System.Type type) { }
     }
     public class DefaultUrlParameterKeyFormatter : Refit.IUrlParameterKeyFormatter

--- a/Refit.Tests/API/ApiApprovalTests.Refit.DotNet8_0.verified.txt
+++ b/Refit.Tests/API/ApiApprovalTests.Refit.DotNet8_0.verified.txt
@@ -119,6 +119,8 @@ namespace Refit
     public class DefaultUrlParameterFormatter : Refit.IUrlParameterFormatter
     {
         public DefaultUrlParameterFormatter() { }
+        public void AddFormat<TParameter>(string format) { }
+        public void AddFormat<TContainer, TParameter>(string format) { }
         public virtual string? Format(object? parameterValue, System.Reflection.ICustomAttributeProvider attributeProvider, System.Type type) { }
     }
     public class DefaultUrlParameterKeyFormatter : Refit.IUrlParameterKeyFormatter

--- a/Refit.Tests/DefaultUrlParameterFormatterTest.cs
+++ b/Refit.Tests/DefaultUrlParameterFormatterTest.cs
@@ -11,6 +11,12 @@ public class DefaultUrlParameterFormatterTests
         [Query(Format = "yyyy")] public DateTime? DateTimeWithAttributeFormatYear { get; set; }
 
         public DateTime? DateTime { get; set; }
+
+        public IEnumerable<DateTime> DateTimeCollection { get; set; }
+
+        public IDictionary<int, DateTime> DateTimeDictionary { get; set; }
+
+        public IDictionary<DateTime, int> DateTimeKeyedDictionary { get; set; }
     }
 
     [Fact]
@@ -181,5 +187,117 @@ public class DefaultUrlParameterFormatterTests
             parameters.GetType());
 
         Assert.Equal("2023", output);
+    }
+
+    [Fact]
+    public void RequestWithPlainDateTimeQueryParameter_ProducesCorrectQueryString()
+    {
+        var urlParameterFormatter = new DefaultUrlParameterFormatter();
+        urlParameterFormatter.AddFormat<DateTime>("yyyy");
+
+        var refitSettings = new RefitSettings { UrlParameterFormatter = urlParameterFormatter };
+        var fixture = new RequestBuilderImplementation<IDummyHttpApi>(refitSettings);
+        var factory = fixture.BuildRequestFactoryForMethod(
+            nameof(IDummyHttpApi.PostWithComplexTypeQuery)
+        );
+
+        var parameters = new DefaultUrlParameterFormatterTestRequest
+        {
+            DateTime = new DateTime(2023, 8, 21),
+        };
+
+        var output = factory([parameters]);
+        var uri = new Uri(new Uri("http://api"), output.RequestUri);
+
+        Assert.Equal(
+            "?DateTime=2023",
+            uri.Query
+        );
+    }
+
+    [Fact]
+    public void RequestWithDateTimeCollectionQueryParameter_ProducesCorrectQueryString()
+    {
+        var urlParameterFormatter = new DefaultUrlParameterFormatter();
+        urlParameterFormatter.AddFormat<DateTime>("yyyy");
+
+        var refitSettings = new RefitSettings { UrlParameterFormatter = urlParameterFormatter };
+        var fixture = new RequestBuilderImplementation<IDummyHttpApi>(refitSettings);
+        var factory = fixture.BuildRequestFactoryForMethod(
+            nameof(IDummyHttpApi.PostWithComplexTypeQuery)
+        );
+
+        var parameters = new DefaultUrlParameterFormatterTestRequest
+        {
+            DateTimeCollection = [new DateTime(2023, 8, 21), new DateTime(2024, 8, 21)],
+        };
+
+        var output = factory([parameters]);
+        var uri = new Uri(new Uri("http://api"), output.RequestUri);
+
+        Assert.Equal(
+            "?DateTimeCollection=2023%2C2024",
+            uri.Query
+        );
+    }
+
+    [Fact]
+    public void RequestWithDateTimeDictionaryQueryParameter_ProducesCorrectQueryString()
+    {
+        var urlParameterFormatter = new DefaultUrlParameterFormatter();
+        urlParameterFormatter.AddFormat<DateTime>("yyyy");
+
+        var refitSettings = new RefitSettings { UrlParameterFormatter = urlParameterFormatter };
+        var fixture = new RequestBuilderImplementation<IDummyHttpApi>(refitSettings);
+        var factory = fixture.BuildRequestFactoryForMethod(
+            nameof(IDummyHttpApi.PostWithComplexTypeQuery)
+        );
+
+        var parameters = new DefaultUrlParameterFormatterTestRequest
+        {
+            DateTimeDictionary = new Dictionary<int, DateTime>
+            {
+                { 1, new DateTime(2023, 8, 21) },
+                { 2, new DateTime(2024, 8, 21) },
+            },
+        };
+
+        var output = factory([parameters]);
+        var uri = new Uri(new Uri("http://api"), output.RequestUri);
+
+        Assert.Equal(
+            "?DateTimeDictionary.1=2023&DateTimeDictionary.2=2024",
+            uri.Query
+        );
+    }
+
+    [Fact]
+    public void RequestWithDateTimeKeyedDictionaryQueryParameter_ProducesCorrectQueryString()
+    {
+        var urlParameterFormatter = new DefaultUrlParameterFormatter();
+        urlParameterFormatter.AddFormat<DateTime>("yyyy");
+
+        var refitSettings = new RefitSettings { UrlParameterFormatter = urlParameterFormatter };
+        var fixture = new RequestBuilderImplementation<IDummyHttpApi>(refitSettings);
+        var factory = fixture.BuildRequestFactoryForMethod(
+            nameof(IDummyHttpApi.PostWithComplexTypeQuery)
+        );
+
+        var parameters = new DefaultUrlParameterFormatterTestRequest
+        {
+            DateTimeKeyedDictionary = new Dictionary<DateTime, int>
+            {
+                { new DateTime(2023, 8, 21), 1 },
+                { new DateTime(2024, 8, 21), 2 },
+            },
+        };
+
+        var output = factory([parameters]);
+        var uri = new Uri(new Uri("http://api"), output.RequestUri);
+
+        Assert.Equal(
+            "?DateTimeKeyedDictionary.2023=1&DateTimeKeyedDictionary.2024=2",
+            uri.Query
+        );
     }
 }

--- a/Refit.Tests/DefaultUrlParameterFormatterTest.cs
+++ b/Refit.Tests/DefaultUrlParameterFormatterTest.cs
@@ -6,29 +6,26 @@ namespace Refit.Tests;
 
 public class DefaultUrlParameterFormatterTests
 {
-    class DateTimeRequestWithQueryAttribute
+    class DefaultUrlParameterFormatterTestRequest
     {
-        [Query(Format = "yyyy")] public DateTime? DateTimeYear { get; set; }
-    }
+        [Query(Format = "yyyy")] public DateTime? DateTimeWithAttributeFormatYear { get; set; }
 
-    class DateTimeRequestWithoutQueryAttribute
-    {
-        public DateTime DateTime { get; set; }
+        public DateTime? DateTime { get; set; }
     }
 
     [Fact]
     public void NullParameterValue_ReturnsNull()
     {
-        var parameters = new DateTimeRequestWithQueryAttribute
+        var parameters = new DefaultUrlParameterFormatterTestRequest
         {
-            DateTimeYear = null
+            DateTime = null
         };
 
         var urlParameterFormatter = new DefaultUrlParameterFormatter();
 
         var output = urlParameterFormatter.Format(
-            parameters.DateTimeYear,
-            parameters.GetType().GetProperty(nameof(parameters.DateTimeYear))!,
+            parameters.DateTime,
+            parameters.GetType().GetProperty(nameof(parameters.DateTime))!,
             parameters.GetType());
 
         Assert.Null(output);
@@ -37,7 +34,7 @@ public class DefaultUrlParameterFormatterTests
     [Fact]
     public void NoFormatters_UseDefaultFormat()
     {
-        var parameters = new DateTimeRequestWithoutQueryAttribute
+        var parameters = new DefaultUrlParameterFormatterTestRequest
         {
             DateTime = new DateTime(2023, 8, 21)
         };
@@ -55,16 +52,16 @@ public class DefaultUrlParameterFormatterTests
     [Fact]
     public void QueryAttributeFormatOnly_UseQueryAttributeFormat()
     {
-        var parameters = new DateTimeRequestWithQueryAttribute
+        var parameters = new DefaultUrlParameterFormatterTestRequest
         {
-            DateTimeYear = new DateTime(2023, 8, 21)
+            DateTimeWithAttributeFormatYear = new DateTime(2023, 8, 21)
         };
 
         var urlParameterFormatter = new DefaultUrlParameterFormatter();
 
         var output = urlParameterFormatter.Format(
-            parameters.DateTimeYear,
-            parameters.GetType().GetProperty(nameof(parameters.DateTimeYear))!,
+            parameters.DateTimeWithAttributeFormatYear,
+            parameters.GetType().GetProperty(nameof(parameters.DateTimeWithAttributeFormatYear))!,
             parameters.GetType());
 
         Assert.Equal("2023", output);
@@ -73,17 +70,17 @@ public class DefaultUrlParameterFormatterTests
     [Fact]
     public void QueryAttributeAndGeneralFormat_UseQueryAttributeFormat()
     {
-        var parameters = new DateTimeRequestWithQueryAttribute
+        var parameters = new DefaultUrlParameterFormatterTestRequest
         {
-            DateTimeYear = new DateTime(2023, 8, 21)
+            DateTimeWithAttributeFormatYear = new DateTime(2023, 8, 21)
         };
 
         var urlParameterFormatter = new DefaultUrlParameterFormatter();
         urlParameterFormatter.AddFormat<DateTime>("yyyy-MM-dd");
 
         var output = urlParameterFormatter.Format(
-            parameters.DateTimeYear,
-            parameters.GetType().GetProperty(nameof(parameters.DateTimeYear))!,
+            parameters.DateTimeWithAttributeFormatYear,
+            parameters.GetType().GetProperty(nameof(parameters.DateTimeWithAttributeFormatYear))!,
             parameters.GetType());
 
         Assert.Equal("2023", output);
@@ -92,17 +89,17 @@ public class DefaultUrlParameterFormatterTests
     [Fact]
     public void QueryAttributeAndSpecificFormat_UseQueryAttributeFormat()
     {
-        var parameters = new DateTimeRequestWithQueryAttribute
+        var parameters = new DefaultUrlParameterFormatterTestRequest
         {
-            DateTimeYear = new DateTime(2023, 8, 21)
+            DateTimeWithAttributeFormatYear = new DateTime(2023, 8, 21)
         };
 
         var urlParameterFormatter = new DefaultUrlParameterFormatter();
-        urlParameterFormatter.AddFormat<DateTimeRequestWithQueryAttribute, DateTime>("yyyy-MM-dd");
+        urlParameterFormatter.AddFormat<DefaultUrlParameterFormatterTestRequest, DateTime>("yyyy-MM-dd");
 
         var output = urlParameterFormatter.Format(
-            parameters.DateTimeYear,
-            parameters.GetType().GetProperty(nameof(parameters.DateTimeYear))!,
+            parameters.DateTimeWithAttributeFormatYear,
+            parameters.GetType().GetProperty(nameof(parameters.DateTimeWithAttributeFormatYear))!,
             parameters.GetType());
 
         Assert.Equal("2023", output);
@@ -111,18 +108,18 @@ public class DefaultUrlParameterFormatterTests
     [Fact]
     public void AllFormats_UseQueryAttributeFormat()
     {
-        var parameters = new DateTimeRequestWithQueryAttribute
+        var parameters = new DefaultUrlParameterFormatterTestRequest
         {
-            DateTimeYear = new DateTime(2023, 8, 21)
+            DateTimeWithAttributeFormatYear = new DateTime(2023, 8, 21)
         };
 
         var urlParameterFormatter = new DefaultUrlParameterFormatter();
         urlParameterFormatter.AddFormat<DateTime>("yyyy-MM-dd");
-        urlParameterFormatter.AddFormat<DateTimeRequestWithoutQueryAttribute, DateTime>("yyyy-MM-dd");
+        urlParameterFormatter.AddFormat<DefaultUrlParameterFormatterTestRequest, DateTime>("yyyy-MM-dd");
 
         var output = urlParameterFormatter.Format(
-            parameters.DateTimeYear,
-            parameters.GetType().GetProperty(nameof(parameters.DateTimeYear))!,
+            parameters.DateTimeWithAttributeFormatYear,
+            parameters.GetType().GetProperty(nameof(parameters.DateTimeWithAttributeFormatYear))!,
             parameters.GetType());
 
         Assert.Equal("2023", output);
@@ -131,7 +128,7 @@ public class DefaultUrlParameterFormatterTests
     [Fact]
     public void GeneralFormatOnly_UseGeneralFormat()
     {
-        var parameters = new DateTimeRequestWithoutQueryAttribute
+        var parameters = new DefaultUrlParameterFormatterTestRequest
         {
             DateTime = new DateTime(2023, 8, 21)
         };
@@ -150,13 +147,13 @@ public class DefaultUrlParameterFormatterTests
     [Fact]
     public void SpecificFormatOnly_UseSpecificFormat()
     {
-        var parameters = new DateTimeRequestWithoutQueryAttribute
+        var parameters = new DefaultUrlParameterFormatterTestRequest
         {
             DateTime = new DateTime(2023, 8, 21)
         };
 
         var urlParameterFormatter = new DefaultUrlParameterFormatter();
-        urlParameterFormatter.AddFormat<DateTimeRequestWithoutQueryAttribute, DateTime>("yyyy");
+        urlParameterFormatter.AddFormat<DefaultUrlParameterFormatterTestRequest, DateTime>("yyyy");
 
         var output = urlParameterFormatter.Format(
             parameters.DateTime,
@@ -169,14 +166,14 @@ public class DefaultUrlParameterFormatterTests
     [Fact]
     public void GeneralAndSpecificFormats_UseSpecificFormat()
     {
-        var parameters = new DateTimeRequestWithoutQueryAttribute
+        var parameters = new DefaultUrlParameterFormatterTestRequest
         {
             DateTime = new DateTime(2023, 8, 21)
         };
 
         var urlParameterFormatter = new DefaultUrlParameterFormatter();
         urlParameterFormatter.AddFormat<DateTime>("yyyy-MM-dd");
-        urlParameterFormatter.AddFormat<DateTimeRequestWithoutQueryAttribute, DateTime>("yyyy");
+        urlParameterFormatter.AddFormat<DefaultUrlParameterFormatterTestRequest, DateTime>("yyyy");
 
         var output = urlParameterFormatter.Format(
             parameters.DateTime,

--- a/Refit.Tests/DefaultUrlParameterFormatterTests.cs
+++ b/Refit.Tests/DefaultUrlParameterFormatterTests.cs
@@ -1,0 +1,188 @@
+﻿using System.Globalization;
+using System.Reflection;
+using Xunit;
+
+namespace Refit.Tests;
+
+public class DefaultUrlParameterFormatterTests
+{
+    class DateTimeRequestWithQueryAttribute
+    {
+        [Query(Format = "yyyy")] public DateTime? DateTimeYear { get; set; }
+    }
+
+    class DateTimeRequestWithoutQueryAttribute
+    {
+        public DateTime DateTime { get; set; }
+    }
+
+    [Fact]
+    public void NullParameterValue_ReturnsNull()
+    {
+        var parameters = new DateTimeRequestWithQueryAttribute
+        {
+            DateTimeYear = null
+        };
+
+        var urlParameterFormatter = new DefaultUrlParameterFormatter();
+
+        var output = urlParameterFormatter.Format(
+            parameters.DateTimeYear,
+            parameters.GetType().GetProperty(nameof(parameters.DateTimeYear))!,
+            parameters.GetType());
+
+        Assert.Null(output);
+    }
+
+    [Fact]
+    public void NoFormatters_UseDefaultFormat()
+    {
+        var parameters = new DateTimeRequestWithoutQueryAttribute
+        {
+            DateTime = new DateTime(2023, 8, 21)
+        };
+
+        var urlParameterFormatter = new DefaultUrlParameterFormatter();
+
+        var output = urlParameterFormatter.Format(
+            parameters.DateTime,
+            parameters.GetType().GetProperty(nameof(parameters.DateTime))!,
+            parameters.GetType());
+
+        Assert.Equal("08/21/2023 00:00:00", output);
+    }
+
+    [Fact]
+    public void QueryAttributeFormatOnly_FormattedByQueryAttribute()
+    {
+        var parameters = new DateTimeRequestWithQueryAttribute
+        {
+            DateTimeYear = new DateTime(2023, 8, 21)
+        };
+
+        var urlParameterFormatter = new DefaultUrlParameterFormatter();
+
+        var output = urlParameterFormatter.Format(
+            parameters.DateTimeYear,
+            parameters.GetType().GetProperty(nameof(parameters.DateTimeYear))!,
+            parameters.GetType());
+
+        Assert.Equal("2023", output);
+    }
+
+    [Fact]
+    public void QueryAttributeAndGeneralFormats_FormattedByQueryAttribute()
+    {
+        var parameters = new DateTimeRequestWithQueryAttribute
+        {
+            DateTimeYear = new DateTime(2023, 8, 21)
+        };
+
+        var urlParameterFormatter = new DefaultUrlParameterFormatter();
+        urlParameterFormatter.AddFormat<DateTime>("yyyy-MM-dd");
+
+        var output = urlParameterFormatter.Format(
+            parameters.DateTimeYear,
+            parameters.GetType().GetProperty(nameof(parameters.DateTimeYear))!,
+            parameters.GetType());
+
+        Assert.Equal("2023", output);
+    }
+
+    [Fact]
+    public void QueryAttributeAndSpecificFormats_FormattedByQueryAttribute()
+    {
+        var parameters = new DateTimeRequestWithQueryAttribute
+        {
+            DateTimeYear = new DateTime(2023, 8, 21)
+        };
+
+        var urlParameterFormatter = new DefaultUrlParameterFormatter();
+        urlParameterFormatter.AddFormat<DateTimeRequestWithQueryAttribute, DateTime>("yyyy-MM-dd");
+
+        var output = urlParameterFormatter.Format(
+            parameters.DateTimeYear,
+            parameters.GetType().GetProperty(nameof(parameters.DateTimeYear))!,
+            parameters.GetType());
+
+        Assert.Equal("2023", output);
+    }
+
+    [Fact]
+    public void AllFormats_FormattedByQueryAttribute()
+    {
+        var parameters = new DateTimeRequestWithQueryAttribute
+        {
+            DateTimeYear = new DateTime(2023, 8, 21)
+        };
+
+        var urlParameterFormatter = new DefaultUrlParameterFormatter();
+        urlParameterFormatter.AddFormat<DateTime>("yyyy-MM-dd");
+        urlParameterFormatter.AddFormat<DateTimeRequestWithoutQueryAttribute, DateTime>("yyyy-MM-dd");
+
+        var output = urlParameterFormatter.Format(
+            parameters.DateTimeYear,
+            parameters.GetType().GetProperty(nameof(parameters.DateTimeYear))!,
+            parameters.GetType());
+
+        Assert.Equal("2023", output);
+    }
+
+    [Fact]
+    public void GeneralFormatOnly_FormattedByGeneralFormat()
+    {
+        var parameters = new DateTimeRequestWithoutQueryAttribute
+        {
+            DateTime = new DateTime(2023, 8, 21)
+        };
+
+        var urlParameterFormatter = new DefaultUrlParameterFormatter();
+        urlParameterFormatter.AddFormat<DateTime>("yyyy");
+
+        var output = urlParameterFormatter.Format(
+            parameters.DateTime,
+            parameters.GetType().GetProperty(nameof(parameters.DateTime))!,
+            parameters.GetType());
+
+        Assert.Equal("2023", output);
+    }
+
+    [Fact]
+    public void SpecificFormatOnly_FormattedBySpecificFormat()
+    {
+        var parameters = new DateTimeRequestWithoutQueryAttribute
+        {
+            DateTime = new DateTime(2023, 8, 21)
+        };
+
+        var urlParameterFormatter = new DefaultUrlParameterFormatter();
+        urlParameterFormatter.AddFormat<DateTimeRequestWithoutQueryAttribute, DateTime>("yyyy");
+
+        var output = urlParameterFormatter.Format(
+            parameters.DateTime,
+            parameters.GetType().GetProperty(nameof(parameters.DateTime))!,
+            parameters.GetType());
+
+        Assert.Equal("2023", output);
+    }
+
+    [Fact]
+    public void GeneralAndSpecificFormats_FormattedBySpecificFormat()
+    {
+        var parameters = new DateTimeRequestWithoutQueryAttribute
+        {
+            DateTime = new DateTime(2023, 8, 21)
+        };
+
+        var urlParameterFormatter = new DefaultUrlParameterFormatter();
+        urlParameterFormatter.AddFormat<DateTime>("yyyy-MM-dd");
+        urlParameterFormatter.AddFormat<DateTimeRequestWithoutQueryAttribute, DateTime>("yyyy");
+
+        var output = urlParameterFormatter.Format(
+            parameters.DateTime,
+            parameters.GetType().GetProperty(nameof(parameters.DateTime))!,
+            parameters.GetType());
+
+        Assert.Equal("2023", output);
+    }
+}

--- a/Refit.Tests/DefaultUrlParameterFormatterTests.cs
+++ b/Refit.Tests/DefaultUrlParameterFormatterTests.cs
@@ -53,7 +53,7 @@ public class DefaultUrlParameterFormatterTests
     }
 
     [Fact]
-    public void QueryAttributeFormatOnly_FormattedByQueryAttribute()
+    public void QueryAttributeFormatOnly_UseQueryAttributeFormat()
     {
         var parameters = new DateTimeRequestWithQueryAttribute
         {
@@ -71,7 +71,7 @@ public class DefaultUrlParameterFormatterTests
     }
 
     [Fact]
-    public void QueryAttributeAndGeneralFormats_FormattedByQueryAttribute()
+    public void QueryAttributeAndGeneralFormat_UseQueryAttributeFormat()
     {
         var parameters = new DateTimeRequestWithQueryAttribute
         {
@@ -90,7 +90,7 @@ public class DefaultUrlParameterFormatterTests
     }
 
     [Fact]
-    public void QueryAttributeAndSpecificFormats_FormattedByQueryAttribute()
+    public void QueryAttributeAndSpecificFormat_UseQueryAttributeFormat()
     {
         var parameters = new DateTimeRequestWithQueryAttribute
         {
@@ -109,7 +109,7 @@ public class DefaultUrlParameterFormatterTests
     }
 
     [Fact]
-    public void AllFormats_FormattedByQueryAttribute()
+    public void AllFormats_UseQueryAttributeFormat()
     {
         var parameters = new DateTimeRequestWithQueryAttribute
         {
@@ -129,7 +129,7 @@ public class DefaultUrlParameterFormatterTests
     }
 
     [Fact]
-    public void GeneralFormatOnly_FormattedByGeneralFormat()
+    public void GeneralFormatOnly_UseGeneralFormat()
     {
         var parameters = new DateTimeRequestWithoutQueryAttribute
         {
@@ -148,7 +148,7 @@ public class DefaultUrlParameterFormatterTests
     }
 
     [Fact]
-    public void SpecificFormatOnly_FormattedBySpecificFormat()
+    public void SpecificFormatOnly_UseSpecificFormat()
     {
         var parameters = new DateTimeRequestWithoutQueryAttribute
         {
@@ -167,7 +167,7 @@ public class DefaultUrlParameterFormatterTests
     }
 
     [Fact]
-    public void GeneralAndSpecificFormats_FormattedBySpecificFormat()
+    public void GeneralAndSpecificFormats_UseSpecificFormat()
     {
         var parameters = new DateTimeRequestWithoutQueryAttribute
         {

--- a/Refit/RefitSettings.cs
+++ b/Refit/RefitSettings.cs
@@ -40,7 +40,8 @@ namespace Refit
             IFormUrlEncodedParameterFormatter? formUrlEncodedParameterFormatter
         )
             : this(contentSerializer, urlParameterFormatter, formUrlEncodedParameterFormatter, null)
-        { }
+        {
+        }
 
         /// <summary>
         /// Creates a new <see cref="RefitSettings"/> instance with the specified parameters
@@ -245,6 +246,11 @@ namespace Refit
                 throw new ArgumentNullException(nameof(attributeProvider));
             }
 
+            if (parameterValue == null)
+            {
+                return null;
+            }
+
             // See if we have a format
             var formatString = attributeProvider
                 .GetCustomAttributes(typeof(QueryAttribute), true)
@@ -252,34 +258,29 @@ namespace Refit
                 .FirstOrDefault()
                 ?.Format;
 
-            EnumMemberAttribute? enummember = null;
-            if (parameterValue != null)
+            EnumMemberAttribute? enumMember = null;
+            var parameterType = parameterValue.GetType();
+            if (parameterType.IsEnum)
             {
-                var parameterType = parameterValue.GetType();
-                if (parameterType.IsEnum)
-                {
-                    var cached = EnumMemberCache.GetOrAdd(
-                        parameterType,
-                        t => new ConcurrentDictionary<string, EnumMemberAttribute?>()
-                    );
-                    enummember = cached.GetOrAdd(
-                        parameterValue.ToString()!,
-                        val =>
-                            parameterType
-                                .GetMember(val)
-                                .First()
-                                .GetCustomAttribute<EnumMemberAttribute>()
-                    );
-                }
+                var cached = EnumMemberCache.GetOrAdd(
+                    parameterType,
+                    t => new ConcurrentDictionary<string, EnumMemberAttribute?>()
+                );
+                enumMember = cached.GetOrAdd(
+                    parameterValue.ToString()!,
+                    val =>
+                        parameterType
+                            .GetMember(val)
+                            .First()
+                            .GetCustomAttribute<EnumMemberAttribute>()
+                );
             }
 
-            return parameterValue == null
-                ? null
-                : string.Format(
-                    CultureInfo.InvariantCulture,
-                    string.IsNullOrWhiteSpace(formatString) ? "{0}" : $"{{0:{formatString}}}",
-                    enummember?.Value ?? parameterValue
-                );
+            return string.Format(
+                CultureInfo.InvariantCulture,
+                string.IsNullOrWhiteSpace(formatString) ? "{0}" : $"{{0:{formatString}}}",
+                enumMember?.Value ?? parameterValue
+            );
         }
     }
 
@@ -302,18 +303,20 @@ namespace Refit
         public virtual string? Format(object? parameterValue, string? formatString)
         {
             if (parameterValue == null)
+            {
                 return null;
+            }
 
             var parameterType = parameterValue.GetType();
 
-            EnumMemberAttribute? enummember = null;
+            EnumMemberAttribute? enumMember = null;
             if (parameterType.GetTypeInfo().IsEnum)
             {
                 var cached = EnumMemberCache.GetOrAdd(
                     parameterType,
                     t => new ConcurrentDictionary<string, EnumMemberAttribute?>()
                 );
-                enummember = cached.GetOrAdd(
+                enumMember = cached.GetOrAdd(
                     parameterValue.ToString()!,
                     val =>
                         parameterType
@@ -326,7 +329,7 @@ namespace Refit
             return string.Format(
                 CultureInfo.InvariantCulture,
                 string.IsNullOrWhiteSpace(formatString) ? "{0}" : $"{{0:{formatString}}}",
-                enummember?.Value ?? parameterValue
+                enumMember?.Value ?? parameterValue
             );
         }
     }


### PR DESCRIPTION
Closes #1775 

This PR extends the `DefaultUrlParameterFormatter` with additional formatting options based on parameter type or a combination of request and parameter types. This allows values with no `QueryAttribute` format to be custom-formatted without the necessity of fully reimplementing `DefaultUrlParameterFormatter`.

**Example usage:**

```c#
class CustomUrlParameterFormatter : DefaultUrlParameterFormatter
{
	public CustomUrlParameterFormatter()
	{
		AddFormat<DateTime>("yyyy-MM-ddTHH:mm:ss");
		AddFormat<MyRequest, DateTime>("yyyy-MM-ddTHH:mm:ss.fffZ");
	}
}
```

or

```c#
var urlParameterFormatter = new DefaultUrlParameterFormatter();
urlParameterFormatter.AddFormat<DateTime>("yyyy-MM-ddTHH:mm:ss");
urlParameterFormatter.AddFormat<MyRequest, DateTime>("yyyy-MM-ddTHH:mm:ss.fffZ");
```

**Formatting priority:**
1. `QueryAttribute` format
2. `AddFormat<TContainer, TParameter>` (might be suppressed by a `QueryAttribute` format)
3. `AddFormat<TParameter>` (might be suppressed by a `QueryAttribute` format or a container specific format)