### PR TITLE
Upgrade to System.Text.Json 8.0.4 on all framework versions

### DIFF
--- a/Refit/Refit.csproj
+++ b/Refit/Refit.csproj
@@ -10,9 +10,6 @@
 
   <ItemGroup>
     <PackageReference Include="System.Net.Http.Json" Version="8.0.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'net462'">
     <PackageReference Include="System.Text.Json" Version="8.0.4" />
   </ItemGroup>
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Fixes #1782 


**What is the current behavior?**
Including Refit in a new NET8.0 project causes a HIGH severity security scan.



**What is the new behavior?**
System.Text.Json is force-upgraded to 8.0.4 on all framework versions, not just the oldest framework versions.



**What might this PR break?**
Nothing


**Other information**:
Should version ranges be used instead of a static version reference that must be maintained?
