### PR TITLE
feat: added source generator benchmarks

### DIFF
--- a/Refit.Benchmarks/Program.cs
+++ b/Refit.Benchmarks/Program.cs
@@ -10,4 +10,5 @@ else
     BenchmarkRunner.Run<EndToEndBenchmark>();
     // BenchmarkRunner.Run<StartupBenchmark>();
     // BenchmarkRunner.Run<PerformanceBenchmark>();
+    // BenchmarkRunner.Run<SourceGeneratorBenchmark>();
 }

--- a/Refit.Benchmarks/Refit.Benchmarks.csproj
+++ b/Refit.Benchmarks/Refit.Benchmarks.csproj
@@ -20,6 +20,7 @@
     <ItemGroup>
       <PackageReference Include="AutoFixture" Version="4.18.1" />
       <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
+      <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.12.0-3.24430.2" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Refit.Benchmarks/SourceGeneratorBenchmark.cs
+++ b/Refit.Benchmarks/SourceGeneratorBenchmark.cs
@@ -1,0 +1,121 @@
+﻿using System.Reflection;
+
+using BenchmarkDotNet.Attributes;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+using Refit.Generator;
+
+namespace Refit.Benchmarks;
+
+[MemoryDiagnoser]
+public class SourceGeneratorBenchmark
+{
+    #region SourceText
+    private const string SmallInterface =
+        """
+        using System;
+        using System.Collections.Generic;
+        using System.Linq;
+        using System.Net.Http;
+        using System.Text;
+        using System.Threading;
+        using System.Threading.Tasks;
+        using Refit;
+
+        namespace RefitGeneratorTest;
+
+        public interface IReallyExcitingCrudApi<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        """;
+    #endregion
+
+    static readonly MetadataReference RefitAssembly = MetadataReference.CreateFromFile(
+        typeof(GetAttribute).Assembly.Location,
+        documentation: XmlDocumentationProvider.CreateFromFile(
+            Path.ChangeExtension(typeof(GetAttribute).Assembly.Location, ".xml")
+        )
+    );
+    static readonly Type[] ImportantAssemblies = {
+        typeof(Binder),
+        typeof(GetAttribute),
+        typeof(Enumerable),
+        typeof(Newtonsoft.Json.JsonConvert),
+        typeof(HttpContent),
+        typeof(Attribute)
+    };
+
+    static Assembly[] AssemblyReferencesForCodegen =>
+        AppDomain.CurrentDomain
+            .GetAssemblies()
+            .Concat(ImportantAssemblies.Select(x=>x.Assembly))
+            .Distinct()
+            .Where(a => !a.IsDynamic)
+            .ToArray();
+
+    private Compilation compilation;
+    private CSharpGeneratorDriver driver;
+
+    private void Setup(string sourceText)
+    {
+        var references = new List<MetadataReference>();
+        var assemblies = AssemblyReferencesForCodegen;
+        foreach (var assembly in assemblies)
+        {
+            if (!assembly.IsDynamic)
+            {
+                references.Add(MetadataReference.CreateFromFile(assembly.Location));
+            }
+        }
+
+        references.Add(RefitAssembly);
+        compilation = CSharpCompilation.Create(
+            "compilation",
+            [CSharpSyntaxTree.ParseText(sourceText)],
+            references,
+            new CSharpCompilationOptions(OutputKind.ConsoleApplication)
+        );
+
+        var generator = new InterfaceStubGeneratorV2().AsSourceGenerator();
+        driver = CSharpGeneratorDriver.Create(generator);
+    }
+
+    [GlobalSetup(Target = nameof(Compile))]
+    public void SetupSmall() => Setup(SmallInterface);
+
+    [Benchmark]
+    public GeneratorDriver Compile()
+    {
+        return driver.RunGeneratorsAndUpdateCompilation(compilation, out _, out _);
+    }
+
+    [GlobalSetup(Target = nameof(Cached))]
+    public void SetupCached()
+    {
+        Setup(SmallInterface);
+        driver = (CSharpGeneratorDriver)driver.RunGeneratorsAndUpdateCompilation(compilation, out _, out _);
+        compilation = compilation.AddSyntaxTrees(CSharpSyntaxTree.ParseText("struct MyValue {}"));
+    }
+
+    [Benchmark]
+    public GeneratorDriver Cached()
+    {
+        return driver.RunGeneratorsAndUpdateCompilation(compilation, out _, out _);
+    }
+}


### PR DESCRIPTION
Added benchmarks for source generation.

Assuming these benchmarks are valid, the results show a very small benefit from caching.

### Benchmarks
| Method  | Mean     | Error   | StdDev  | Gen0    | Gen1   | Allocated |
|-------- |---------:|--------:|--------:|--------:|-------:|----------:|
| Compile | 225.9 us | 3.34 us | 2.96 us | 13.1836 | 2.9297 | 124.09 KB |
| Cached  | 196.7 us | 3.37 us | 2.99 us | 13.1836 | 2.9297 | 122.19 KB |

| Method  | Mean     | Error   | StdDev  | Median   | Gen0    | Gen1   | Allocated |
|-------- |---------:|--------:|--------:|---------:|--------:|-------:|----------:|
| Compile | 225.0 us | 4.42 us | 9.22 us | 221.2 us | 13.1836 | 2.9297 | 124.09 KB |
| Cached  | 197.6 us | 2.77 us | 2.59 us | 197.0 us | 13.1836 | 2.9297 | 122.18 KB |

| Method  | Mean     | Error   | StdDev  | Gen0    | Gen1   | Allocated |
|-------- |---------:|--------:|--------:|--------:|-------:|----------:|
| Compile | 228.9 us | 4.55 us | 6.67 us | 13.1836 | 2.9297 | 124.09 KB |
| Cached  | 197.5 us | 2.14 us | 2.00 us | 13.1836 | 2.9297 | 122.18 KB |


#1791