### PR TITLE
feat: added interface snapshot `InterfaceTests`

### DIFF
--- a/Refit.GeneratorTests/Fixture.cs
+++ b/Refit.GeneratorTests/Fixture.cs
@@ -57,6 +57,46 @@ public static class Fixture
         return VerifyGenerator(source);
     }
 
+    public static Task VerifyForType(string declarations)
+    {
+        var source =
+            $$"""
+              using System;
+              using System.Collections.Generic;
+              using System.Linq;
+              using System.Net.Http;
+              using System.Text;
+              using System.Threading;
+              using System.Threading.Tasks;
+              using Refit;
+
+              namespace RefitGeneratorTest;
+
+              {{declarations}}
+              """;
+
+        return VerifyGenerator(source);
+    }
+
+    public static Task VerifyForDeclaration(string declarations)
+    {
+        var source =
+            $$"""
+              using System;
+              using System.Collections.Generic;
+              using System.Linq;
+              using System.Net.Http;
+              using System.Text;
+              using System.Threading;
+              using System.Threading.Tasks;
+              using Refit;
+
+              {{declarations}}
+              """;
+
+        return VerifyGenerator(source);
+    }
+
     private static CSharpCompilation CreateLibrary(params string[] source)
     {
         var references = new List<MetadataReference>();

--- a/Refit.GeneratorTests/InterfaceTests.cs
+++ b/Refit.GeneratorTests/InterfaceTests.cs
@@ -1,0 +1,85 @@
+﻿namespace Refit.GeneratorTests;
+
+public class InterfaceTests
+{
+    [Fact]
+    public Task ContainedInterfaceTest()
+    {
+        return Fixture.VerifyForType(
+            """
+            public class ContainerType
+            {
+                public interface IContainedInterface
+                {
+                    [Get("/users")]
+                    Task<string> Get();
+                }
+            }
+            """);
+    }
+
+    [Fact]
+    public Task DerivedRefitInterfaceTest()
+    {
+        return Fixture.VerifyForType(
+            """
+            public interface IGeneratedInterface : IBaseInterface
+            {
+                [Get("/users")]
+                Task<string> Get();
+            }
+
+            public interface IBaseInterface
+            {
+                [Get("/posts")]
+                Task<string> GetPosts();
+            }
+            """);
+    }
+
+    [Fact]
+    public Task DerivedNonRefitInterfaceTest()
+    {
+        return Fixture.VerifyForType(
+            """
+            public interface IGeneratedInterface : IBaseInterface
+            {
+                [Get("/users")]
+                Task<string> Get();
+            }
+
+            public interface IBaseInterface
+            {
+                void NonRefitMethod();
+            }
+            """);
+    }
+
+    [Fact]
+    public Task NestedNamespaceTest()
+    {
+        return Fixture.VerifyForDeclaration(
+            """
+            namespace Nested.RefitGeneratorTest;
+
+            public interface IGeneratedInterface
+            {
+                [Get("/users")]
+                Task<string> Get();
+            }
+            """);
+    }
+
+    [Fact]
+    public Task GlobalNamespaceTest()
+    {
+        return Fixture.VerifyForDeclaration(
+            """
+            public interface IGeneratedInterface
+            {
+                [Get("/users")]
+                Task<string> Get();
+            }
+            """);
+    }
+}

--- a/Refit.GeneratorTests/_snapshots/InterfaceTests.ContainedInterfaceTest#Generated.g.verified.cs
+++ b/Refit.GeneratorTests/_snapshots/InterfaceTests.ContainedInterfaceTest#Generated.g.verified.cs
@@ -1,0 +1,24 @@
+﻿//HintName: Generated.g.cs
+
+#pragma warning disable
+namespace Refit.Implementation
+{
+
+    /// <inheritdoc />
+    [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    [global::System.Diagnostics.DebuggerNonUserCode]
+    [global::RefitInternalGenerated.PreserveAttribute]
+    [global::System.Reflection.Obfuscation(Exclude=true)]
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    internal static partial class Generated
+    {
+#if NET5_0_OR_GREATER
+        [System.Runtime.CompilerServices.ModuleInitializer]
+        [System.Diagnostics.CodeAnalysis.DynamicDependency(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All, typeof(global::Refit.Implementation.Generated))]
+        public static void Initialize()
+        {
+        }
+#endif
+    }
+}
+#pragma warning restore

--- a/Refit.GeneratorTests/_snapshots/InterfaceTests.ContainedInterfaceTest#IContainedInterface.g.verified.cs
+++ b/Refit.GeneratorTests/_snapshots/InterfaceTests.ContainedInterfaceTest#IContainedInterface.g.verified.cs
@@ -1,0 +1,66 @@
+﻿//HintName: IContainedInterface.g.cs
+#nullable disable
+#pragma warning disable
+namespace Refit.Implementation
+{
+
+    partial class Generated
+    {
+
+    /// <inheritdoc />
+    [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    [global::System.Diagnostics.DebuggerNonUserCode]
+    [global::RefitInternalGenerated.PreserveAttribute]
+    [global::System.Reflection.Obfuscation(Exclude=true)]
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    partial class RefitGeneratorTestContainerTypeIContainedInterface
+        : global::RefitGeneratorTest.ContainerType.IContainedInterface
+
+    {
+        /// <inheritdoc />
+        public global::System.Net.Http.HttpClient Client { get; }
+        readonly global::Refit.IRequestBuilder requestBuilder;
+
+        /// <inheritdoc />
+        public RefitGeneratorTestContainerTypeIContainedInterface(global::System.Net.Http.HttpClient client, global::Refit.IRequestBuilder requestBuilder)
+        {
+            Client = client;
+            this.requestBuilder = requestBuilder;
+        }
+
+
+
+        /// <inheritdoc />
+        public async global::System.Threading.Tasks.Task<string> Get()
+        {
+            var ______arguments = global::System.Array.Empty<object>();
+            var ______func = requestBuilder.BuildRestResultFuncForMethod("Get", global::System.Array.Empty<global::System.Type>() );
+            try
+            {
+                return await ((global::System.Threading.Tasks.Task<string>)______func(this.Client, ______arguments)).ConfigureAwait(false);
+            }
+            catch (global::System.Exception ______ex)
+            {
+                throw ______ex;
+            }
+        }
+
+        /// <inheritdoc />
+        async global::System.Threading.Tasks.Task<string> global::RefitGeneratorTest.ContainerType.IContainedInterface.Get()
+        {
+            var ______arguments = global::System.Array.Empty<object>();
+            var ______func = requestBuilder.BuildRestResultFuncForMethod("Get", global::System.Array.Empty<global::System.Type>() );
+            try
+            {
+                return await ((global::System.Threading.Tasks.Task<string>)______func(this.Client, ______arguments)).ConfigureAwait(false);
+            }
+            catch (global::System.Exception ______ex)
+            {
+                throw ______ex;
+            }
+        }
+    }
+    }
+}
+
+#pragma warning restore

--- a/Refit.GeneratorTests/_snapshots/InterfaceTests.ContainedInterfaceTest#PreserveAttribute.g.verified.cs
+++ b/Refit.GeneratorTests/_snapshots/InterfaceTests.ContainedInterfaceTest#PreserveAttribute.g.verified.cs
@@ -1,0 +1,19 @@
+﻿//HintName: PreserveAttribute.g.cs
+
+#pragma warning disable
+namespace RefitInternalGenerated
+{
+    [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    [global::System.AttributeUsage (global::System.AttributeTargets.Class | global::System.AttributeTargets.Struct | global::System.AttributeTargets.Enum | global::System.AttributeTargets.Constructor | global::System.AttributeTargets.Method | global::System.AttributeTargets.Property | global::System.AttributeTargets.Field | global::System.AttributeTargets.Event | global::System.AttributeTargets.Interface | global::System.AttributeTargets.Delegate)]
+    sealed class PreserveAttribute : global::System.Attribute
+    {
+        //
+        // Fields
+        //
+        public bool AllMembers;
+
+        public bool Conditional;
+    }
+}
+#pragma warning restore

--- a/Refit.GeneratorTests/_snapshots/InterfaceTests.DerivedNonRefitInterfaceTest#Generated.g.verified.cs
+++ b/Refit.GeneratorTests/_snapshots/InterfaceTests.DerivedNonRefitInterfaceTest#Generated.g.verified.cs
@@ -1,0 +1,24 @@
+﻿//HintName: Generated.g.cs
+
+#pragma warning disable
+namespace Refit.Implementation
+{
+
+    /// <inheritdoc />
+    [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    [global::System.Diagnostics.DebuggerNonUserCode]
+    [global::RefitInternalGenerated.PreserveAttribute]
+    [global::System.Reflection.Obfuscation(Exclude=true)]
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    internal static partial class Generated
+    {
+#if NET5_0_OR_GREATER
+        [System.Runtime.CompilerServices.ModuleInitializer]
+        [System.Diagnostics.CodeAnalysis.DynamicDependency(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All, typeof(global::Refit.Implementation.Generated))]
+        public static void Initialize()
+        {
+        }
+#endif
+    }
+}
+#pragma warning restore

--- a/Refit.GeneratorTests/_snapshots/InterfaceTests.DerivedNonRefitInterfaceTest#IGeneratedInterface.g.verified.cs
+++ b/Refit.GeneratorTests/_snapshots/InterfaceTests.DerivedNonRefitInterfaceTest#IGeneratedInterface.g.verified.cs
@@ -1,0 +1,66 @@
+﻿//HintName: IGeneratedInterface.g.cs
+#nullable disable
+#pragma warning disable
+namespace Refit.Implementation
+{
+
+    partial class Generated
+    {
+
+    /// <inheritdoc />
+    [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    [global::System.Diagnostics.DebuggerNonUserCode]
+    [global::RefitInternalGenerated.PreserveAttribute]
+    [global::System.Reflection.Obfuscation(Exclude=true)]
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    partial class RefitGeneratorTestIGeneratedInterface
+        : global::RefitGeneratorTest.IGeneratedInterface
+
+    {
+        /// <inheritdoc />
+        public global::System.Net.Http.HttpClient Client { get; }
+        readonly global::Refit.IRequestBuilder requestBuilder;
+
+        /// <inheritdoc />
+        public RefitGeneratorTestIGeneratedInterface(global::System.Net.Http.HttpClient client, global::Refit.IRequestBuilder requestBuilder)
+        {
+            Client = client;
+            this.requestBuilder = requestBuilder;
+        }
+
+
+
+        /// <inheritdoc />
+        public async global::System.Threading.Tasks.Task<string> Get()
+        {
+            var ______arguments = global::System.Array.Empty<object>();
+            var ______func = requestBuilder.BuildRestResultFuncForMethod("Get", global::System.Array.Empty<global::System.Type>() );
+            try
+            {
+                return await ((global::System.Threading.Tasks.Task<string>)______func(this.Client, ______arguments)).ConfigureAwait(false);
+            }
+            catch (global::System.Exception ______ex)
+            {
+                throw ______ex;
+            }
+        }
+
+        /// <inheritdoc />
+        async global::System.Threading.Tasks.Task<string> global::RefitGeneratorTest.IGeneratedInterface.Get()
+        {
+            var ______arguments = global::System.Array.Empty<object>();
+            var ______func = requestBuilder.BuildRestResultFuncForMethod("Get", global::System.Array.Empty<global::System.Type>() );
+            try
+            {
+                return await ((global::System.Threading.Tasks.Task<string>)______func(this.Client, ______arguments)).ConfigureAwait(false);
+            }
+            catch (global::System.Exception ______ex)
+            {
+                throw ______ex;
+            }
+        }
+    }
+    }
+}
+
+#pragma warning restore

--- a/Refit.GeneratorTests/_snapshots/InterfaceTests.DerivedNonRefitInterfaceTest#PreserveAttribute.g.verified.cs
+++ b/Refit.GeneratorTests/_snapshots/InterfaceTests.DerivedNonRefitInterfaceTest#PreserveAttribute.g.verified.cs
@@ -1,0 +1,19 @@
+﻿//HintName: PreserveAttribute.g.cs
+
+#pragma warning disable
+namespace RefitInternalGenerated
+{
+    [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    [global::System.AttributeUsage (global::System.AttributeTargets.Class | global::System.AttributeTargets.Struct | global::System.AttributeTargets.Enum | global::System.AttributeTargets.Constructor | global::System.AttributeTargets.Method | global::System.AttributeTargets.Property | global::System.AttributeTargets.Field | global::System.AttributeTargets.Event | global::System.AttributeTargets.Interface | global::System.AttributeTargets.Delegate)]
+    sealed class PreserveAttribute : global::System.Attribute
+    {
+        //
+        // Fields
+        //
+        public bool AllMembers;
+
+        public bool Conditional;
+    }
+}
+#pragma warning restore

--- a/Refit.GeneratorTests/_snapshots/InterfaceTests.DerivedRefitInterfaceTest#Generated.g.verified.cs
+++ b/Refit.GeneratorTests/_snapshots/InterfaceTests.DerivedRefitInterfaceTest#Generated.g.verified.cs
@@ -1,0 +1,24 @@
+﻿//HintName: Generated.g.cs
+
+#pragma warning disable
+namespace Refit.Implementation
+{
+
+    /// <inheritdoc />
+    [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    [global::System.Diagnostics.DebuggerNonUserCode]
+    [global::RefitInternalGenerated.PreserveAttribute]
+    [global::System.Reflection.Obfuscation(Exclude=true)]
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    internal static partial class Generated
+    {
+#if NET5_0_OR_GREATER
+        [System.Runtime.CompilerServices.ModuleInitializer]
+        [System.Diagnostics.CodeAnalysis.DynamicDependency(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All, typeof(global::Refit.Implementation.Generated))]
+        public static void Initialize()
+        {
+        }
+#endif
+    }
+}
+#pragma warning restore

--- a/Refit.GeneratorTests/_snapshots/InterfaceTests.DerivedRefitInterfaceTest#IBaseInterface.g.verified.cs
+++ b/Refit.GeneratorTests/_snapshots/InterfaceTests.DerivedRefitInterfaceTest#IBaseInterface.g.verified.cs
@@ -1,0 +1,66 @@
+﻿//HintName: IBaseInterface.g.cs
+#nullable disable
+#pragma warning disable
+namespace Refit.Implementation
+{
+
+    partial class Generated
+    {
+
+    /// <inheritdoc />
+    [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    [global::System.Diagnostics.DebuggerNonUserCode]
+    [global::RefitInternalGenerated.PreserveAttribute]
+    [global::System.Reflection.Obfuscation(Exclude=true)]
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    partial class RefitGeneratorTestIBaseInterface
+        : global::RefitGeneratorTest.IBaseInterface
+
+    {
+        /// <inheritdoc />
+        public global::System.Net.Http.HttpClient Client { get; }
+        readonly global::Refit.IRequestBuilder requestBuilder;
+
+        /// <inheritdoc />
+        public RefitGeneratorTestIBaseInterface(global::System.Net.Http.HttpClient client, global::Refit.IRequestBuilder requestBuilder)
+        {
+            Client = client;
+            this.requestBuilder = requestBuilder;
+        }
+
+
+
+        /// <inheritdoc />
+        public async global::System.Threading.Tasks.Task<string> GetPosts()
+        {
+            var ______arguments = global::System.Array.Empty<object>();
+            var ______func = requestBuilder.BuildRestResultFuncForMethod("GetPosts", global::System.Array.Empty<global::System.Type>() );
+            try
+            {
+                return await ((global::System.Threading.Tasks.Task<string>)______func(this.Client, ______arguments)).ConfigureAwait(false);
+            }
+            catch (global::System.Exception ______ex)
+            {
+                throw ______ex;
+            }
+        }
+
+        /// <inheritdoc />
+        async global::System.Threading.Tasks.Task<string> global::RefitGeneratorTest.IBaseInterface.GetPosts()
+        {
+            var ______arguments = global::System.Array.Empty<object>();
+            var ______func = requestBuilder.BuildRestResultFuncForMethod("GetPosts", global::System.Array.Empty<global::System.Type>() );
+            try
+            {
+                return await ((global::System.Threading.Tasks.Task<string>)______func(this.Client, ______arguments)).ConfigureAwait(false);
+            }
+            catch (global::System.Exception ______ex)
+            {
+                throw ______ex;
+            }
+        }
+    }
+    }
+}
+
+#pragma warning restore

--- a/Refit.GeneratorTests/_snapshots/InterfaceTests.DerivedRefitInterfaceTest#IGeneratedInterface.g.verified.cs
+++ b/Refit.GeneratorTests/_snapshots/InterfaceTests.DerivedRefitInterfaceTest#IGeneratedInterface.g.verified.cs
@@ -1,0 +1,81 @@
+﻿//HintName: IGeneratedInterface.g.cs
+#nullable disable
+#pragma warning disable
+namespace Refit.Implementation
+{
+
+    partial class Generated
+    {
+
+    /// <inheritdoc />
+    [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    [global::System.Diagnostics.DebuggerNonUserCode]
+    [global::RefitInternalGenerated.PreserveAttribute]
+    [global::System.Reflection.Obfuscation(Exclude=true)]
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    partial class RefitGeneratorTestIGeneratedInterface
+        : global::RefitGeneratorTest.IGeneratedInterface
+
+    {
+        /// <inheritdoc />
+        public global::System.Net.Http.HttpClient Client { get; }
+        readonly global::Refit.IRequestBuilder requestBuilder;
+
+        /// <inheritdoc />
+        public RefitGeneratorTestIGeneratedInterface(global::System.Net.Http.HttpClient client, global::Refit.IRequestBuilder requestBuilder)
+        {
+            Client = client;
+            this.requestBuilder = requestBuilder;
+        }
+
+
+
+        /// <inheritdoc />
+        public async global::System.Threading.Tasks.Task<string> Get()
+        {
+            var ______arguments = global::System.Array.Empty<object>();
+            var ______func = requestBuilder.BuildRestResultFuncForMethod("Get", global::System.Array.Empty<global::System.Type>() );
+            try
+            {
+                return await ((global::System.Threading.Tasks.Task<string>)______func(this.Client, ______arguments)).ConfigureAwait(false);
+            }
+            catch (global::System.Exception ______ex)
+            {
+                throw ______ex;
+            }
+        }
+
+        /// <inheritdoc />
+        async global::System.Threading.Tasks.Task<string> global::RefitGeneratorTest.IGeneratedInterface.Get()
+        {
+            var ______arguments = global::System.Array.Empty<object>();
+            var ______func = requestBuilder.BuildRestResultFuncForMethod("Get", global::System.Array.Empty<global::System.Type>() );
+            try
+            {
+                return await ((global::System.Threading.Tasks.Task<string>)______func(this.Client, ______arguments)).ConfigureAwait(false);
+            }
+            catch (global::System.Exception ______ex)
+            {
+                throw ______ex;
+            }
+        }
+
+        /// <inheritdoc />
+        async global::System.Threading.Tasks.Task<string> global::RefitGeneratorTest.IBaseInterface.GetPosts()
+        {
+            var ______arguments = global::System.Array.Empty<object>();
+            var ______func = requestBuilder.BuildRestResultFuncForMethod("GetPosts", global::System.Array.Empty<global::System.Type>() );
+            try
+            {
+                return await ((global::System.Threading.Tasks.Task<string>)______func(this.Client, ______arguments)).ConfigureAwait(false);
+            }
+            catch (global::System.Exception ______ex)
+            {
+                throw ______ex;
+            }
+        }
+    }
+    }
+}
+
+#pragma warning restore

--- a/Refit.GeneratorTests/_snapshots/InterfaceTests.DerivedRefitInterfaceTest#PreserveAttribute.g.verified.cs
+++ b/Refit.GeneratorTests/_snapshots/InterfaceTests.DerivedRefitInterfaceTest#PreserveAttribute.g.verified.cs
@@ -1,0 +1,19 @@
+﻿//HintName: PreserveAttribute.g.cs
+
+#pragma warning disable
+namespace RefitInternalGenerated
+{
+    [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    [global::System.AttributeUsage (global::System.AttributeTargets.Class | global::System.AttributeTargets.Struct | global::System.AttributeTargets.Enum | global::System.AttributeTargets.Constructor | global::System.AttributeTargets.Method | global::System.AttributeTargets.Property | global::System.AttributeTargets.Field | global::System.AttributeTargets.Event | global::System.AttributeTargets.Interface | global::System.AttributeTargets.Delegate)]
+    sealed class PreserveAttribute : global::System.Attribute
+    {
+        //
+        // Fields
+        //
+        public bool AllMembers;
+
+        public bool Conditional;
+    }
+}
+#pragma warning restore

--- a/Refit.GeneratorTests/_snapshots/InterfaceTests.GlobalNamespaceTest#Generated.g.verified.cs
+++ b/Refit.GeneratorTests/_snapshots/InterfaceTests.GlobalNamespaceTest#Generated.g.verified.cs
@@ -1,0 +1,24 @@
+﻿//HintName: Generated.g.cs
+
+#pragma warning disable
+namespace Refit.Implementation
+{
+
+    /// <inheritdoc />
+    [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    [global::System.Diagnostics.DebuggerNonUserCode]
+    [global::RefitInternalGenerated.PreserveAttribute]
+    [global::System.Reflection.Obfuscation(Exclude=true)]
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    internal static partial class Generated
+    {
+#if NET5_0_OR_GREATER
+        [System.Runtime.CompilerServices.ModuleInitializer]
+        [System.Diagnostics.CodeAnalysis.DynamicDependency(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All, typeof(global::Refit.Implementation.Generated))]
+        public static void Initialize()
+        {
+        }
+#endif
+    }
+}
+#pragma warning restore

--- a/Refit.GeneratorTests/_snapshots/InterfaceTests.GlobalNamespaceTest#IGeneratedInterface.g.verified.cs
+++ b/Refit.GeneratorTests/_snapshots/InterfaceTests.GlobalNamespaceTest#IGeneratedInterface.g.verified.cs
@@ -1,0 +1,66 @@
+﻿//HintName: IGeneratedInterface.g.cs
+#nullable disable
+#pragma warning disable
+namespace Refit.Implementation
+{
+
+    partial class Generated
+    {
+
+    /// <inheritdoc />
+    [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    [global::System.Diagnostics.DebuggerNonUserCode]
+    [global::RefitInternalGenerated.PreserveAttribute]
+    [global::System.Reflection.Obfuscation(Exclude=true)]
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    partial class IGeneratedInterface
+        : global::IGeneratedInterface
+
+    {
+        /// <inheritdoc />
+        public global::System.Net.Http.HttpClient Client { get; }
+        readonly global::Refit.IRequestBuilder requestBuilder;
+
+        /// <inheritdoc />
+        public IGeneratedInterface(global::System.Net.Http.HttpClient client, global::Refit.IRequestBuilder requestBuilder)
+        {
+            Client = client;
+            this.requestBuilder = requestBuilder;
+        }
+
+
+
+        /// <inheritdoc />
+        public async global::System.Threading.Tasks.Task<string> Get()
+        {
+            var ______arguments = global::System.Array.Empty<object>();
+            var ______func = requestBuilder.BuildRestResultFuncForMethod("Get", global::System.Array.Empty<global::System.Type>() );
+            try
+            {
+                return await ((global::System.Threading.Tasks.Task<string>)______func(this.Client, ______arguments)).ConfigureAwait(false);
+            }
+            catch (global::System.Exception ______ex)
+            {
+                throw ______ex;
+            }
+        }
+
+        /// <inheritdoc />
+        async global::System.Threading.Tasks.Task<string> global::IGeneratedInterface.Get()
+        {
+            var ______arguments = global::System.Array.Empty<object>();
+            var ______func = requestBuilder.BuildRestResultFuncForMethod("Get", global::System.Array.Empty<global::System.Type>() );
+            try
+            {
+                return await ((global::System.Threading.Tasks.Task<string>)______func(this.Client, ______arguments)).ConfigureAwait(false);
+            }
+            catch (global::System.Exception ______ex)
+            {
+                throw ______ex;
+            }
+        }
+    }
+    }
+}
+
+#pragma warning restore

--- a/Refit.GeneratorTests/_snapshots/InterfaceTests.GlobalNamespaceTest#PreserveAttribute.g.verified.cs
+++ b/Refit.GeneratorTests/_snapshots/InterfaceTests.GlobalNamespaceTest#PreserveAttribute.g.verified.cs
@@ -1,0 +1,19 @@
+﻿//HintName: PreserveAttribute.g.cs
+
+#pragma warning disable
+namespace RefitInternalGenerated
+{
+    [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    [global::System.AttributeUsage (global::System.AttributeTargets.Class | global::System.AttributeTargets.Struct | global::System.AttributeTargets.Enum | global::System.AttributeTargets.Constructor | global::System.AttributeTargets.Method | global::System.AttributeTargets.Property | global::System.AttributeTargets.Field | global::System.AttributeTargets.Event | global::System.AttributeTargets.Interface | global::System.AttributeTargets.Delegate)]
+    sealed class PreserveAttribute : global::System.Attribute
+    {
+        //
+        // Fields
+        //
+        public bool AllMembers;
+
+        public bool Conditional;
+    }
+}
+#pragma warning restore

--- a/Refit.GeneratorTests/_snapshots/InterfaceTests.NestedNamespaceTest#Generated.g.verified.cs
+++ b/Refit.GeneratorTests/_snapshots/InterfaceTests.NestedNamespaceTest#Generated.g.verified.cs
@@ -1,0 +1,24 @@
+﻿//HintName: Generated.g.cs
+
+#pragma warning disable
+namespace Refit.Implementation
+{
+
+    /// <inheritdoc />
+    [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    [global::System.Diagnostics.DebuggerNonUserCode]
+    [global::RefitInternalGenerated.PreserveAttribute]
+    [global::System.Reflection.Obfuscation(Exclude=true)]
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    internal static partial class Generated
+    {
+#if NET5_0_OR_GREATER
+        [System.Runtime.CompilerServices.ModuleInitializer]
+        [System.Diagnostics.CodeAnalysis.DynamicDependency(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All, typeof(global::Refit.Implementation.Generated))]
+        public static void Initialize()
+        {
+        }
+#endif
+    }
+}
+#pragma warning restore

--- a/Refit.GeneratorTests/_snapshots/InterfaceTests.NestedNamespaceTest#IGeneratedInterface.g.verified.cs
+++ b/Refit.GeneratorTests/_snapshots/InterfaceTests.NestedNamespaceTest#IGeneratedInterface.g.verified.cs
@@ -1,0 +1,66 @@
+﻿//HintName: IGeneratedInterface.g.cs
+#nullable disable
+#pragma warning disable
+namespace Refit.Implementation
+{
+
+    partial class Generated
+    {
+
+    /// <inheritdoc />
+    [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    [global::System.Diagnostics.DebuggerNonUserCode]
+    [global::RefitInternalGenerated.PreserveAttribute]
+    [global::System.Reflection.Obfuscation(Exclude=true)]
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    partial class NestedRefitGeneratorTestIGeneratedInterface
+        : global::Nested.RefitGeneratorTest.IGeneratedInterface
+
+    {
+        /// <inheritdoc />
+        public global::System.Net.Http.HttpClient Client { get; }
+        readonly global::Refit.IRequestBuilder requestBuilder;
+
+        /// <inheritdoc />
+        public NestedRefitGeneratorTestIGeneratedInterface(global::System.Net.Http.HttpClient client, global::Refit.IRequestBuilder requestBuilder)
+        {
+            Client = client;
+            this.requestBuilder = requestBuilder;
+        }
+
+
+
+        /// <inheritdoc />
+        public async global::System.Threading.Tasks.Task<string> Get()
+        {
+            var ______arguments = global::System.Array.Empty<object>();
+            var ______func = requestBuilder.BuildRestResultFuncForMethod("Get", global::System.Array.Empty<global::System.Type>() );
+            try
+            {
+                return await ((global::System.Threading.Tasks.Task<string>)______func(this.Client, ______arguments)).ConfigureAwait(false);
+            }
+            catch (global::System.Exception ______ex)
+            {
+                throw ______ex;
+            }
+        }
+
+        /// <inheritdoc />
+        async global::System.Threading.Tasks.Task<string> global::Nested.RefitGeneratorTest.IGeneratedInterface.Get()
+        {
+            var ______arguments = global::System.Array.Empty<object>();
+            var ______func = requestBuilder.BuildRestResultFuncForMethod("Get", global::System.Array.Empty<global::System.Type>() );
+            try
+            {
+                return await ((global::System.Threading.Tasks.Task<string>)______func(this.Client, ______arguments)).ConfigureAwait(false);
+            }
+            catch (global::System.Exception ______ex)
+            {
+                throw ______ex;
+            }
+        }
+    }
+    }
+}
+
+#pragma warning restore

--- a/Refit.GeneratorTests/_snapshots/InterfaceTests.NestedNamespaceTest#PreserveAttribute.g.verified.cs
+++ b/Refit.GeneratorTests/_snapshots/InterfaceTests.NestedNamespaceTest#PreserveAttribute.g.verified.cs
@@ -1,0 +1,19 @@
+﻿//HintName: PreserveAttribute.g.cs
+
+#pragma warning disable
+namespace RefitInternalGenerated
+{
+    [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    [global::System.AttributeUsage (global::System.AttributeTargets.Class | global::System.AttributeTargets.Struct | global::System.AttributeTargets.Enum | global::System.AttributeTargets.Constructor | global::System.AttributeTargets.Method | global::System.AttributeTargets.Property | global::System.AttributeTargets.Field | global::System.AttributeTargets.Event | global::System.AttributeTargets.Interface | global::System.AttributeTargets.Delegate)]
+    sealed class PreserveAttribute : global::System.Attribute
+    {
+        //
+        // Fields
+        //
+        public bool AllMembers;
+
+        public bool Conditional;
+    }
+}
+#pragma warning restore


### PR DESCRIPTION
Added interface snapshot tests. In preparation for #1791
- Updated `Fixture` to support custom type and namespace tests.
- Added tests for:
  - Derived scenarios
  - Nested/global namespaces
  - Inner interfaces

Discovered #1801