### PR TITLE
Remove Dependency System.Net.Http.Json from Net 6+

### DIFF
--- a/Refit/Refit.csproj
+++ b/Refit/Refit.csproj
@@ -8,12 +8,9 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="System.Net.Http.Json" Version="8.0.0" />
-  </ItemGroup>
-
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'net462'">
     <PackageReference Include="System.Text.Json" Version="8.0.4" />
+    <PackageReference Include="System.Net.Http.Json" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

closes #1782 

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

A dependency exists for System.Net.Http.Json, this has a dependency on System.Text.Json which has a vulnerability.

**What is the new behavior?**
<!-- If this is a feature change -->

Removing System.Net.Http.Json from Net 6+ will ensure that the current Net6.0.x or Net8.0.x assemblies will be used

**What might this PR break?**

None

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:
