### PR TITLE
feat: revert 29e0e1c

### DIFF
--- a/InterfaceStubGenerator.Roslyn38/InterfaceStubGenerator.Roslyn38.csproj
+++ b/InterfaceStubGenerator.Roslyn38/InterfaceStubGenerator.Roslyn38.csproj
@@ -12,11 +12,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.11.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.8.0" />
   </ItemGroup>
 
   <Target Name="SetBuildVer" AfterTargets="GetBuildVersion" BeforeTargets="SetCloudBuildVersionVars;SetCloudBuildNumberWithVersion">
-    <PropertyGroup>      
+    <PropertyGroup>
       <Version>$(BuildVersion)</Version>
       <AssemblyVersion>$(BuildVersionSimple)</AssemblyVersion>
     </PropertyGroup>

--- a/InterfaceStubGenerator.Roslyn40/InterfaceStubGenerator.Roslyn40.csproj
+++ b/InterfaceStubGenerator.Roslyn40/InterfaceStubGenerator.Roslyn40.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1" PrivateAssets="all" />
   </ItemGroup>
 
   <Target Name="SetBuildVer" AfterTargets="GetBuildVersion" BeforeTargets="SetCloudBuildVersionVars;SetCloudBuildNumberWithVersion">


### PR DESCRIPTION
Fix for #1817 by reverting 29e0e1c. Not sure if `Microsoft.CodeAnalysis.CSharp` was intentionally updated to the latest versions, guessing it broke the source generator for anyone on an older ide.