### PR TITLE
Fix for unused reference System.Net.Http

### DIFF
--- a/Refit/Refit.csproj
+++ b/Refit/Refit.csproj
@@ -15,7 +15,6 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
     <Reference Include="System.Web" />
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <ProjectReference Include="..\InterfaceStubGenerator.Roslyn38\InterfaceStubGenerator.Roslyn38.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\InterfaceStubGenerator.Roslyn41\InterfaceStubGenerator.Roslyn41.csproj" ReferenceOutputAssembly="false" />
   </ItemGroup>


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

fix
closes #1552

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

Contains a reference that has no useage

**What is the new behavior?**
<!-- If this is a feature change -->

The reference to System.Net.Http has been removed

**What might this PR break?**

Not expected unless the System.Net.Http lib is being relied upon by end user for their own code.

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:
