### PR TITLE
Fix to disable Header and Authorise attributes containing CRLF

### DIFF
--- a/Refit/RestMethodInfo.cs
+++ b/Refit/RestMethodInfo.cs
@@ -259,6 +259,12 @@ namespace Refit
                 throw new ArgumentException(
                     $"URL path {relativePath} must start with '/' and be of the form '/foo/bar/baz'"
                 );
+
+            // CRLF injection protection
+            if (relativePath.Contains("\r") || relativePath.Contains("\n"))
+                throw new ArgumentException(
+                    $"URL path {relativePath} must not contain CR or LF characters"
+                );
         }
 
         static Dictionary<int, RestMethodParameterInfo> BuildParameterMap(


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Fix

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

Header and Authorise attributes could CRLF which may cause issues

**What is the new behavior?**
<!-- If this is a feature change -->

Added detection and correction of CRLF characters.

**What might this PR break?**

None expected

**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

