### PR TITLE
Remove unnecessary try/catch block as to not lose the stack trace

### DIFF
--- a/InterfaceStubGenerator.Shared/InterfaceStubGenerator.cs
+++ b/InterfaceStubGenerator.Shared/InterfaceStubGenerator.cs
@@ -385,7 +385,6 @@ namespace Refit.Implementation
             Client = client;
             this.requestBuilder = requestBuilder;
         }}
-
 "
             );
             // Get any other methods on the refit interfaces. We'll need to generate something for them and warn
@@ -531,14 +530,8 @@ namespace Refit.Implementation
                 @$"
             var ______arguments = {argumentsArrayString};
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""{methodSymbol.Name}"", {parameterTypesExpression}{genericString} );
-            try
-            {{
-                {@return}({returnType})______func(this.Client, ______arguments){configureAwait};
-            }}
-            catch (global::System.Exception ______ex)
-            {{
-                throw ______ex;
-            }}
+
+            {@return}({returnType})______func(this.Client, ______arguments){configureAwait};
 "
             );
 

--- a/Refit.GeneratorTests/_snapshots/GeneratedTest.ShouldEmitAllFiles#IGeneratedClient.g.verified.cs
+++ b/Refit.GeneratorTests/_snapshots/GeneratedTest.ShouldEmitAllFiles#IGeneratedClient.g.verified.cs
@@ -29,20 +29,13 @@ namespace Refit.Implementation
         }
 
 
-
         /// <inheritdoc />
         public async global::System.Threading.Tasks.Task<string> Get()
         {
             var ______arguments = global::System.Array.Empty<object>();
             var ______func = requestBuilder.BuildRestResultFuncForMethod("Get", global::System.Array.Empty<global::System.Type>() );
-            try
-            {
-                return await ((global::System.Threading.Tasks.Task<string>)______func(this.Client, ______arguments)).ConfigureAwait(false);
-            }
-            catch (global::System.Exception ______ex)
-            {
-                throw ______ex;
-            }
+
+            return await ((global::System.Threading.Tasks.Task<string>)______func(this.Client, ______arguments)).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
@@ -50,14 +43,8 @@ namespace Refit.Implementation
         {
             var ______arguments = global::System.Array.Empty<object>();
             var ______func = requestBuilder.BuildRestResultFuncForMethod("Get", global::System.Array.Empty<global::System.Type>() );
-            try
-            {
-                return await ((global::System.Threading.Tasks.Task<string>)______func(this.Client, ______arguments)).ConfigureAwait(false);
-            }
-            catch (global::System.Exception ______ex)
-            {
-                throw ______ex;
-            }
+
+            return await ((global::System.Threading.Tasks.Task<string>)______func(this.Client, ______arguments)).ConfigureAwait(false);
         }
     }
     }

--- a/Refit.GeneratorTests/_snapshots/InterfaceTests.ContainedInterfaceTest#IContainedInterface.g.verified.cs
+++ b/Refit.GeneratorTests/_snapshots/InterfaceTests.ContainedInterfaceTest#IContainedInterface.g.verified.cs
@@ -29,20 +29,13 @@ namespace Refit.Implementation
         }
 
 
-
         /// <inheritdoc />
         public async global::System.Threading.Tasks.Task<string> Get()
         {
             var ______arguments = global::System.Array.Empty<object>();
             var ______func = requestBuilder.BuildRestResultFuncForMethod("Get", global::System.Array.Empty<global::System.Type>() );
-            try
-            {
-                return await ((global::System.Threading.Tasks.Task<string>)______func(this.Client, ______arguments)).ConfigureAwait(false);
-            }
-            catch (global::System.Exception ______ex)
-            {
-                throw ______ex;
-            }
+
+            return await ((global::System.Threading.Tasks.Task<string>)______func(this.Client, ______arguments)).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
@@ -50,14 +43,8 @@ namespace Refit.Implementation
         {
             var ______arguments = global::System.Array.Empty<object>();
             var ______func = requestBuilder.BuildRestResultFuncForMethod("Get", global::System.Array.Empty<global::System.Type>() );
-            try
-            {
-                return await ((global::System.Threading.Tasks.Task<string>)______func(this.Client, ______arguments)).ConfigureAwait(false);
-            }
-            catch (global::System.Exception ______ex)
-            {
-                throw ______ex;
-            }
+
+            return await ((global::System.Threading.Tasks.Task<string>)______func(this.Client, ______arguments)).ConfigureAwait(false);
         }
     }
     }

--- a/Refit.GeneratorTests/_snapshots/InterfaceTests.GlobalNamespaceTest#IGeneratedInterface.g.verified.cs
+++ b/Refit.GeneratorTests/_snapshots/InterfaceTests.GlobalNamespaceTest#IGeneratedInterface.g.verified.cs
@@ -29,20 +29,13 @@ namespace Refit.Implementation
         }
 
 
-
         /// <inheritdoc />
         public async global::System.Threading.Tasks.Task<string> Get()
         {
             var ______arguments = global::System.Array.Empty<object>();
             var ______func = requestBuilder.BuildRestResultFuncForMethod("Get", global::System.Array.Empty<global::System.Type>() );
-            try
-            {
-                return await ((global::System.Threading.Tasks.Task<string>)______func(this.Client, ______arguments)).ConfigureAwait(false);
-            }
-            catch (global::System.Exception ______ex)
-            {
-                throw ______ex;
-            }
+
+            return await ((global::System.Threading.Tasks.Task<string>)______func(this.Client, ______arguments)).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
@@ -50,14 +43,8 @@ namespace Refit.Implementation
         {
             var ______arguments = global::System.Array.Empty<object>();
             var ______func = requestBuilder.BuildRestResultFuncForMethod("Get", global::System.Array.Empty<global::System.Type>() );
-            try
-            {
-                return await ((global::System.Threading.Tasks.Task<string>)______func(this.Client, ______arguments)).ConfigureAwait(false);
-            }
-            catch (global::System.Exception ______ex)
-            {
-                throw ______ex;
-            }
+
+            return await ((global::System.Threading.Tasks.Task<string>)______func(this.Client, ______arguments)).ConfigureAwait(false);
         }
     }
     }

--- a/Refit.GeneratorTests/_snapshots/InterfaceTests.InterfaceDerivedFromRefitBaseTest#IBaseInterface.g.verified.cs
+++ b/Refit.GeneratorTests/_snapshots/InterfaceTests.InterfaceDerivedFromRefitBaseTest#IBaseInterface.g.verified.cs
@@ -29,20 +29,13 @@ namespace Refit.Implementation
         }
 
 
-
         /// <inheritdoc />
         public async global::System.Threading.Tasks.Task<string> Get()
         {
             var ______arguments = global::System.Array.Empty<object>();
             var ______func = requestBuilder.BuildRestResultFuncForMethod("Get", global::System.Array.Empty<global::System.Type>() );
-            try
-            {
-                return await ((global::System.Threading.Tasks.Task<string>)______func(this.Client, ______arguments)).ConfigureAwait(false);
-            }
-            catch (global::System.Exception ______ex)
-            {
-                throw ______ex;
-            }
+
+            return await ((global::System.Threading.Tasks.Task<string>)______func(this.Client, ______arguments)).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
@@ -50,14 +43,8 @@ namespace Refit.Implementation
         {
             var ______arguments = global::System.Array.Empty<object>();
             var ______func = requestBuilder.BuildRestResultFuncForMethod("Get", global::System.Array.Empty<global::System.Type>() );
-            try
-            {
-                return await ((global::System.Threading.Tasks.Task<string>)______func(this.Client, ______arguments)).ConfigureAwait(false);
-            }
-            catch (global::System.Exception ______ex)
-            {
-                throw ______ex;
-            }
+
+            return await ((global::System.Threading.Tasks.Task<string>)______func(this.Client, ______arguments)).ConfigureAwait(false);
         }
     }
     }

--- a/Refit.GeneratorTests/_snapshots/InterfaceTests.InterfaceDerivedFromRefitBaseTest#IDerivedInterface.g.verified.cs
+++ b/Refit.GeneratorTests/_snapshots/InterfaceTests.InterfaceDerivedFromRefitBaseTest#IDerivedInterface.g.verified.cs
@@ -29,20 +29,13 @@ namespace Refit.Implementation
         }
 
 
-
         /// <inheritdoc />
         async global::System.Threading.Tasks.Task<string> global::RefitGeneratorTest.IBaseInterface.Get()
         {
             var ______arguments = global::System.Array.Empty<object>();
             var ______func = requestBuilder.BuildRestResultFuncForMethod("Get", global::System.Array.Empty<global::System.Type>() );
-            try
-            {
-                return await ((global::System.Threading.Tasks.Task<string>)______func(this.Client, ______arguments)).ConfigureAwait(false);
-            }
-            catch (global::System.Exception ______ex)
-            {
-                throw ______ex;
-            }
+
+            return await ((global::System.Threading.Tasks.Task<string>)______func(this.Client, ______arguments)).ConfigureAwait(false);
         }
     }
     }

--- a/Refit.GeneratorTests/_snapshots/InterfaceTests.NestedNamespaceTest#IGeneratedInterface.g.verified.cs
+++ b/Refit.GeneratorTests/_snapshots/InterfaceTests.NestedNamespaceTest#IGeneratedInterface.g.verified.cs
@@ -29,20 +29,13 @@ namespace Refit.Implementation
         }
 
 
-
         /// <inheritdoc />
         public async global::System.Threading.Tasks.Task<string> Get()
         {
             var ______arguments = global::System.Array.Empty<object>();
             var ______func = requestBuilder.BuildRestResultFuncForMethod("Get", global::System.Array.Empty<global::System.Type>() );
-            try
-            {
-                return await ((global::System.Threading.Tasks.Task<string>)______func(this.Client, ______arguments)).ConfigureAwait(false);
-            }
-            catch (global::System.Exception ______ex)
-            {
-                throw ______ex;
-            }
+
+            return await ((global::System.Threading.Tasks.Task<string>)______func(this.Client, ______arguments)).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
@@ -50,14 +43,8 @@ namespace Refit.Implementation
         {
             var ______arguments = global::System.Array.Empty<object>();
             var ______func = requestBuilder.BuildRestResultFuncForMethod("Get", global::System.Array.Empty<global::System.Type>() );
-            try
-            {
-                return await ((global::System.Threading.Tasks.Task<string>)______func(this.Client, ______arguments)).ConfigureAwait(false);
-            }
-            catch (global::System.Exception ______ex)
-            {
-                throw ______ex;
-            }
+
+            return await ((global::System.Threading.Tasks.Task<string>)______func(this.Client, ______arguments)).ConfigureAwait(false);
         }
     }
     }

--- a/Refit.GeneratorTests/_snapshots/InterfaceTests.RefitInterfaceDerivedFromBaseTest#IGeneratedInterface.g.verified.cs
+++ b/Refit.GeneratorTests/_snapshots/InterfaceTests.RefitInterfaceDerivedFromBaseTest#IGeneratedInterface.g.verified.cs
@@ -29,20 +29,13 @@ namespace Refit.Implementation
         }
 
 
-
         /// <inheritdoc />
         public async global::System.Threading.Tasks.Task<string> Get()
         {
             var ______arguments = global::System.Array.Empty<object>();
             var ______func = requestBuilder.BuildRestResultFuncForMethod("Get", global::System.Array.Empty<global::System.Type>() );
-            try
-            {
-                return await ((global::System.Threading.Tasks.Task<string>)______func(this.Client, ______arguments)).ConfigureAwait(false);
-            }
-            catch (global::System.Exception ______ex)
-            {
-                throw ______ex;
-            }
+
+            return await ((global::System.Threading.Tasks.Task<string>)______func(this.Client, ______arguments)).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
@@ -50,14 +43,8 @@ namespace Refit.Implementation
         {
             var ______arguments = global::System.Array.Empty<object>();
             var ______func = requestBuilder.BuildRestResultFuncForMethod("Get", global::System.Array.Empty<global::System.Type>() );
-            try
-            {
-                return await ((global::System.Threading.Tasks.Task<string>)______func(this.Client, ______arguments)).ConfigureAwait(false);
-            }
-            catch (global::System.Exception ______ex)
-            {
-                throw ______ex;
-            }
+
+            return await ((global::System.Threading.Tasks.Task<string>)______func(this.Client, ______arguments)).ConfigureAwait(false);
         }
     }
     }

--- a/Refit.GeneratorTests/_snapshots/InterfaceTests.RefitInterfaceDerivedFromRefitBaseTest#IBaseInterface.g.verified.cs
+++ b/Refit.GeneratorTests/_snapshots/InterfaceTests.RefitInterfaceDerivedFromRefitBaseTest#IBaseInterface.g.verified.cs
@@ -29,20 +29,13 @@ namespace Refit.Implementation
         }
 
 
-
         /// <inheritdoc />
         public async global::System.Threading.Tasks.Task<string> GetPosts()
         {
             var ______arguments = global::System.Array.Empty<object>();
             var ______func = requestBuilder.BuildRestResultFuncForMethod("GetPosts", global::System.Array.Empty<global::System.Type>() );
-            try
-            {
-                return await ((global::System.Threading.Tasks.Task<string>)______func(this.Client, ______arguments)).ConfigureAwait(false);
-            }
-            catch (global::System.Exception ______ex)
-            {
-                throw ______ex;
-            }
+
+            return await ((global::System.Threading.Tasks.Task<string>)______func(this.Client, ______arguments)).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
@@ -50,14 +43,8 @@ namespace Refit.Implementation
         {
             var ______arguments = global::System.Array.Empty<object>();
             var ______func = requestBuilder.BuildRestResultFuncForMethod("GetPosts", global::System.Array.Empty<global::System.Type>() );
-            try
-            {
-                return await ((global::System.Threading.Tasks.Task<string>)______func(this.Client, ______arguments)).ConfigureAwait(false);
-            }
-            catch (global::System.Exception ______ex)
-            {
-                throw ______ex;
-            }
+
+            return await ((global::System.Threading.Tasks.Task<string>)______func(this.Client, ______arguments)).ConfigureAwait(false);
         }
     }
     }

--- a/Refit.GeneratorTests/_snapshots/InterfaceTests.RefitInterfaceDerivedFromRefitBaseTest#IGeneratedInterface.g.verified.cs
+++ b/Refit.GeneratorTests/_snapshots/InterfaceTests.RefitInterfaceDerivedFromRefitBaseTest#IGeneratedInterface.g.verified.cs
@@ -29,20 +29,13 @@ namespace Refit.Implementation
         }
 
 
-
         /// <inheritdoc />
         public async global::System.Threading.Tasks.Task<string> Get()
         {
             var ______arguments = global::System.Array.Empty<object>();
             var ______func = requestBuilder.BuildRestResultFuncForMethod("Get", global::System.Array.Empty<global::System.Type>() );
-            try
-            {
-                return await ((global::System.Threading.Tasks.Task<string>)______func(this.Client, ______arguments)).ConfigureAwait(false);
-            }
-            catch (global::System.Exception ______ex)
-            {
-                throw ______ex;
-            }
+
+            return await ((global::System.Threading.Tasks.Task<string>)______func(this.Client, ______arguments)).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
@@ -50,14 +43,8 @@ namespace Refit.Implementation
         {
             var ______arguments = global::System.Array.Empty<object>();
             var ______func = requestBuilder.BuildRestResultFuncForMethod("Get", global::System.Array.Empty<global::System.Type>() );
-            try
-            {
-                return await ((global::System.Threading.Tasks.Task<string>)______func(this.Client, ______arguments)).ConfigureAwait(false);
-            }
-            catch (global::System.Exception ______ex)
-            {
-                throw ______ex;
-            }
+
+            return await ((global::System.Threading.Tasks.Task<string>)______func(this.Client, ______arguments)).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
@@ -65,14 +52,8 @@ namespace Refit.Implementation
         {
             var ______arguments = global::System.Array.Empty<object>();
             var ______func = requestBuilder.BuildRestResultFuncForMethod("GetPosts", global::System.Array.Empty<global::System.Type>() );
-            try
-            {
-                return await ((global::System.Threading.Tasks.Task<string>)______func(this.Client, ______arguments)).ConfigureAwait(false);
-            }
-            catch (global::System.Exception ______ex)
-            {
-                throw ______ex;
-            }
+
+            return await ((global::System.Threading.Tasks.Task<string>)______func(this.Client, ______arguments)).ConfigureAwait(false);
         }
     }
     }

--- a/Refit.GeneratorTests/_snapshots/ReturnTypeTests.GenericTaskShouldWork#IGeneratedClient.g.verified.cs
+++ b/Refit.GeneratorTests/_snapshots/ReturnTypeTests.GenericTaskShouldWork#IGeneratedClient.g.verified.cs
@@ -29,20 +29,13 @@ namespace Refit.Implementation
         }
 
 
-
         /// <inheritdoc />
         public async global::System.Threading.Tasks.Task<string> Get()
         {
             var ______arguments = global::System.Array.Empty<object>();
             var ______func = requestBuilder.BuildRestResultFuncForMethod("Get", global::System.Array.Empty<global::System.Type>() );
-            try
-            {
-                return await ((global::System.Threading.Tasks.Task<string>)______func(this.Client, ______arguments)).ConfigureAwait(false);
-            }
-            catch (global::System.Exception ______ex)
-            {
-                throw ______ex;
-            }
+
+            return await ((global::System.Threading.Tasks.Task<string>)______func(this.Client, ______arguments)).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
@@ -50,14 +43,8 @@ namespace Refit.Implementation
         {
             var ______arguments = global::System.Array.Empty<object>();
             var ______func = requestBuilder.BuildRestResultFuncForMethod("Get", global::System.Array.Empty<global::System.Type>() );
-            try
-            {
-                return await ((global::System.Threading.Tasks.Task<string>)______func(this.Client, ______arguments)).ConfigureAwait(false);
-            }
-            catch (global::System.Exception ______ex)
-            {
-                throw ______ex;
-            }
+
+            return await ((global::System.Threading.Tasks.Task<string>)______func(this.Client, ______arguments)).ConfigureAwait(false);
         }
     }
     }

--- a/Refit.GeneratorTests/_snapshots/ReturnTypeTests.VoidTaskShouldWork#IGeneratedClient.g.verified.cs
+++ b/Refit.GeneratorTests/_snapshots/ReturnTypeTests.VoidTaskShouldWork#IGeneratedClient.g.verified.cs
@@ -29,20 +29,13 @@ namespace Refit.Implementation
         }
 
 
-
         /// <inheritdoc />
         public async global::System.Threading.Tasks.Task Post()
         {
             var ______arguments = global::System.Array.Empty<object>();
             var ______func = requestBuilder.BuildRestResultFuncForMethod("Post", global::System.Array.Empty<global::System.Type>() );
-            try
-            {
-                await ((global::System.Threading.Tasks.Task)______func(this.Client, ______arguments)).ConfigureAwait(false);
-            }
-            catch (global::System.Exception ______ex)
-            {
-                throw ______ex;
-            }
+
+            await ((global::System.Threading.Tasks.Task)______func(this.Client, ______arguments)).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
@@ -50,14 +43,8 @@ namespace Refit.Implementation
         {
             var ______arguments = global::System.Array.Empty<object>();
             var ______func = requestBuilder.BuildRestResultFuncForMethod("Post", global::System.Array.Empty<global::System.Type>() );
-            try
-            {
-                await ((global::System.Threading.Tasks.Task)______func(this.Client, ______arguments)).ConfigureAwait(false);
-            }
-            catch (global::System.Exception ______ex)
-            {
-                throw ______ex;
-            }
+
+            await ((global::System.Threading.Tasks.Task)______func(this.Client, ______arguments)).ConfigureAwait(false);
         }
     }
     }

--- a/Refit.Tests/InterfaceStubGenerator.cs
+++ b/Refit.Tests/InterfaceStubGenerator.cs
@@ -216,7 +216,6 @@ namespace Refit.Implementation
         }
 
 
-
         private static readonly global::System.Type[] ______typeParameters = new global::System.Type[] {typeof(string) };
 
         /// <inheritdoc />
@@ -224,14 +223,8 @@ namespace Refit.Implementation
         {
             var ______arguments = new object[] { @userName };
             var ______func = requestBuilder.BuildRestResultFuncForMethod("GetUser", ______typeParameters );
-            try
-            {
-                return await ((global::System.Threading.Tasks.Task<global::Refit.Tests.User>)______func(this.Client, ______arguments)).ConfigureAwait(false);
-            }
-            catch (global::System.Exception ______ex)
-            {
-                throw ______ex;
-            }
+
+            return await ((global::System.Threading.Tasks.Task<global::Refit.Tests.User>)______func(this.Client, ______arguments)).ConfigureAwait(false);
         }
 
         private static readonly global::System.Type[] ______typeParameters0 = new global::System.Type[] {typeof(string) };
@@ -241,14 +234,8 @@ namespace Refit.Implementation
         {
             var ______arguments = new object[] { @userName };
             var ______func = requestBuilder.BuildRestResultFuncForMethod("GetUserObservable", ______typeParameters0 );
-            try
-            {
-                return (global::System.IObservable<global::Refit.Tests.User>)______func(this.Client, ______arguments);
-            }
-            catch (global::System.Exception ______ex)
-            {
-                throw ______ex;
-            }
+
+            return (global::System.IObservable<global::Refit.Tests.User>)______func(this.Client, ______arguments);
         }
 
         private static readonly global::System.Type[] ______typeParameters1 = new global::System.Type[] {typeof(string) };
@@ -258,14 +245,8 @@ namespace Refit.Implementation
         {
             var ______arguments = new object[] { @userName };
             var ______func = requestBuilder.BuildRestResultFuncForMethod("GetUserCamelCase", ______typeParameters1 );
-            try
-            {
-                return (global::System.IObservable<global::Refit.Tests.User>)______func(this.Client, ______arguments);
-            }
-            catch (global::System.Exception ______ex)
-            {
-                throw ______ex;
-            }
+
+            return (global::System.IObservable<global::Refit.Tests.User>)______func(this.Client, ______arguments);
         }
 
         private static readonly global::System.Type[] ______typeParameters2 = new global::System.Type[] {typeof(string), typeof(global::System.Threading.CancellationToken) };
@@ -275,14 +256,8 @@ namespace Refit.Implementation
         {
             var ______arguments = new object[] { @orgName, @cancellationToken };
             var ______func = requestBuilder.BuildRestResultFuncForMethod("GetOrgMembers", ______typeParameters2 );
-            try
-            {
-                return await ((global::System.Threading.Tasks.Task<global::System.Collections.Generic.List<global::Refit.Tests.User>>)______func(this.Client, ______arguments)).ConfigureAwait(false);
-            }
-            catch (global::System.Exception ______ex)
-            {
-                throw ______ex;
-            }
+
+            return await ((global::System.Threading.Tasks.Task<global::System.Collections.Generic.List<global::Refit.Tests.User>>)______func(this.Client, ______arguments)).ConfigureAwait(false);
         }
 
         private static readonly global::System.Type[] ______typeParameters3 = new global::System.Type[] {typeof(string) };
@@ -292,14 +267,8 @@ namespace Refit.Implementation
         {
             var ______arguments = new object[] { @q };
             var ______func = requestBuilder.BuildRestResultFuncForMethod("FindUsers", ______typeParameters3 );
-            try
-            {
-                return await ((global::System.Threading.Tasks.Task<global::Refit.Tests.UserSearchResult>)______func(this.Client, ______arguments)).ConfigureAwait(false);
-            }
-            catch (global::System.Exception ______ex)
-            {
-                throw ______ex;
-            }
+
+            return await ((global::System.Threading.Tasks.Task<global::Refit.Tests.UserSearchResult>)______func(this.Client, ______arguments)).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
@@ -307,14 +276,8 @@ namespace Refit.Implementation
         {
             var ______arguments = global::System.Array.Empty<object>();
             var ______func = requestBuilder.BuildRestResultFuncForMethod("GetIndex", global::System.Array.Empty<global::System.Type>() );
-            try
-            {
-                return await ((global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage>)______func(this.Client, ______arguments)).ConfigureAwait(false);
-            }
-            catch (global::System.Exception ______ex)
-            {
-                throw ______ex;
-            }
+
+            return await ((global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage>)______func(this.Client, ______arguments)).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
@@ -322,14 +285,8 @@ namespace Refit.Implementation
         {
             var ______arguments = global::System.Array.Empty<object>();
             var ______func = requestBuilder.BuildRestResultFuncForMethod("GetIndexObservable", global::System.Array.Empty<global::System.Type>() );
-            try
-            {
-                return (global::System.IObservable<string>)______func(this.Client, ______arguments);
-            }
-            catch (global::System.Exception ______ex)
-            {
-                throw ______ex;
-            }
+
+            return (global::System.IObservable<string>)______func(this.Client, ______arguments);
         }
 
         /// <inheritdoc />
@@ -337,14 +294,8 @@ namespace Refit.Implementation
         {
             var ______arguments = global::System.Array.Empty<object>();
             var ______func = requestBuilder.BuildRestResultFuncForMethod("NothingToSeeHere", global::System.Array.Empty<global::System.Type>() );
-            try
-            {
-                return await ((global::System.Threading.Tasks.Task<global::Refit.Tests.User>)______func(this.Client, ______arguments)).ConfigureAwait(false);
-            }
-            catch (global::System.Exception ______ex)
-            {
-                throw ______ex;
-            }
+
+            return await ((global::System.Threading.Tasks.Task<global::Refit.Tests.User>)______func(this.Client, ______arguments)).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
@@ -352,14 +303,8 @@ namespace Refit.Implementation
         {
             var ______arguments = global::System.Array.Empty<object>();
             var ______func = requestBuilder.BuildRestResultFuncForMethod("NothingToSeeHereWithMetadata", global::System.Array.Empty<global::System.Type>() );
-            try
-            {
-                return await ((global::System.Threading.Tasks.Task<global::Refit.ApiResponse<global::Refit.Tests.User>>)______func(this.Client, ______arguments)).ConfigureAwait(false);
-            }
-            catch (global::System.Exception ______ex)
-            {
-                throw ______ex;
-            }
+
+            return await ((global::System.Threading.Tasks.Task<global::Refit.ApiResponse<global::Refit.Tests.User>>)______func(this.Client, ______arguments)).ConfigureAwait(false);
         }
 
         private static readonly global::System.Type[] ______typeParameters4 = new global::System.Type[] {typeof(string) };
@@ -369,14 +314,8 @@ namespace Refit.Implementation
         {
             var ______arguments = new object[] { @userName };
             var ______func = requestBuilder.BuildRestResultFuncForMethod("GetUserWithMetadata", ______typeParameters4 );
-            try
-            {
-                return await ((global::System.Threading.Tasks.Task<global::Refit.ApiResponse<global::Refit.Tests.User>>)______func(this.Client, ______arguments)).ConfigureAwait(false);
-            }
-            catch (global::System.Exception ______ex)
-            {
-                throw ______ex;
-            }
+
+            return await ((global::System.Threading.Tasks.Task<global::Refit.ApiResponse<global::Refit.Tests.User>>)______func(this.Client, ______arguments)).ConfigureAwait(false);
         }
 
         private static readonly global::System.Type[] ______typeParameters5 = new global::System.Type[] {typeof(string) };
@@ -386,14 +325,8 @@ namespace Refit.Implementation
         {
             var ______arguments = new object[] { @userName };
             var ______func = requestBuilder.BuildRestResultFuncForMethod("GetUserObservableWithMetadata", ______typeParameters5 );
-            try
-            {
-                return (global::System.IObservable<global::Refit.ApiResponse<global::Refit.Tests.User>>)______func(this.Client, ______arguments);
-            }
-            catch (global::System.Exception ______ex)
-            {
-                throw ______ex;
-            }
+
+            return (global::System.IObservable<global::Refit.ApiResponse<global::Refit.Tests.User>>)______func(this.Client, ______arguments);
         }
 
         private static readonly global::System.Type[] ______typeParameters6 = new global::System.Type[] {typeof(global::Refit.Tests.User) };
@@ -403,14 +336,8 @@ namespace Refit.Implementation
         {
             var ______arguments = new object[] { @user };
             var ______func = requestBuilder.BuildRestResultFuncForMethod("CreateUser", ______typeParameters6 );
-            try
-            {
-                return await ((global::System.Threading.Tasks.Task<global::Refit.Tests.User>)______func(this.Client, ______arguments)).ConfigureAwait(false);
-            }
-            catch (global::System.Exception ______ex)
-            {
-                throw ______ex;
-            }
+
+            return await ((global::System.Threading.Tasks.Task<global::Refit.Tests.User>)______func(this.Client, ______arguments)).ConfigureAwait(false);
         }
 
         private static readonly global::System.Type[] ______typeParameters7 = new global::System.Type[] {typeof(global::Refit.Tests.User) };
@@ -420,14 +347,8 @@ namespace Refit.Implementation
         {
             var ______arguments = new object[] { @user };
             var ______func = requestBuilder.BuildRestResultFuncForMethod("CreateUserWithMetadata", ______typeParameters7 );
-            try
-            {
-                return await ((global::System.Threading.Tasks.Task<global::Refit.ApiResponse<global::Refit.Tests.User>>)______func(this.Client, ______arguments)).ConfigureAwait(false);
-            }
-            catch (global::System.Exception ______ex)
-            {
-                throw ______ex;
-            }
+
+            return await ((global::System.Threading.Tasks.Task<global::Refit.ApiResponse<global::Refit.Tests.User>>)______func(this.Client, ______arguments)).ConfigureAwait(false);
         }
 
         private static readonly global::System.Type[] ______typeParameters8 = new global::System.Type[] {typeof(string) };
@@ -437,14 +358,8 @@ namespace Refit.Implementation
         {
             var ______arguments = new object[] { @userName };
             var ______func = requestBuilder.BuildRestResultFuncForMethod("GetUser", ______typeParameters8 );
-            try
-            {
-                return await ((global::System.Threading.Tasks.Task<global::Refit.Tests.User>)______func(this.Client, ______arguments)).ConfigureAwait(false);
-            }
-            catch (global::System.Exception ______ex)
-            {
-                throw ______ex;
-            }
+
+            return await ((global::System.Threading.Tasks.Task<global::Refit.Tests.User>)______func(this.Client, ______arguments)).ConfigureAwait(false);
         }
 
         private static readonly global::System.Type[] ______typeParameters9 = new global::System.Type[] {typeof(string) };
@@ -454,14 +369,8 @@ namespace Refit.Implementation
         {
             var ______arguments = new object[] { @userName };
             var ______func = requestBuilder.BuildRestResultFuncForMethod("GetUserObservable", ______typeParameters9 );
-            try
-            {
-                return (global::System.IObservable<global::Refit.Tests.User>)______func(this.Client, ______arguments);
-            }
-            catch (global::System.Exception ______ex)
-            {
-                throw ______ex;
-            }
+
+            return (global::System.IObservable<global::Refit.Tests.User>)______func(this.Client, ______arguments);
         }
 
         private static readonly global::System.Type[] ______typeParameters10 = new global::System.Type[] {typeof(string) };
@@ -471,14 +380,8 @@ namespace Refit.Implementation
         {
             var ______arguments = new object[] { @userName };
             var ______func = requestBuilder.BuildRestResultFuncForMethod("GetUserCamelCase", ______typeParameters10 );
-            try
-            {
-                return (global::System.IObservable<global::Refit.Tests.User>)______func(this.Client, ______arguments);
-            }
-            catch (global::System.Exception ______ex)
-            {
-                throw ______ex;
-            }
+
+            return (global::System.IObservable<global::Refit.Tests.User>)______func(this.Client, ______arguments);
         }
 
         private static readonly global::System.Type[] ______typeParameters11 = new global::System.Type[] {typeof(string), typeof(global::System.Threading.CancellationToken) };
@@ -488,14 +391,8 @@ namespace Refit.Implementation
         {
             var ______arguments = new object[] { @orgName, @cancellationToken };
             var ______func = requestBuilder.BuildRestResultFuncForMethod("GetOrgMembers", ______typeParameters11 );
-            try
-            {
-                return await ((global::System.Threading.Tasks.Task<global::System.Collections.Generic.List<global::Refit.Tests.User>>)______func(this.Client, ______arguments)).ConfigureAwait(false);
-            }
-            catch (global::System.Exception ______ex)
-            {
-                throw ______ex;
-            }
+
+            return await ((global::System.Threading.Tasks.Task<global::System.Collections.Generic.List<global::Refit.Tests.User>>)______func(this.Client, ______arguments)).ConfigureAwait(false);
         }
 
         private static readonly global::System.Type[] ______typeParameters12 = new global::System.Type[] {typeof(string) };
@@ -505,14 +402,8 @@ namespace Refit.Implementation
         {
             var ______arguments = new object[] { @q };
             var ______func = requestBuilder.BuildRestResultFuncForMethod("FindUsers", ______typeParameters12 );
-            try
-            {
-                return await ((global::System.Threading.Tasks.Task<global::Refit.Tests.UserSearchResult>)______func(this.Client, ______arguments)).ConfigureAwait(false);
-            }
-            catch (global::System.Exception ______ex)
-            {
-                throw ______ex;
-            }
+
+            return await ((global::System.Threading.Tasks.Task<global::Refit.Tests.UserSearchResult>)______func(this.Client, ______arguments)).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
@@ -520,14 +411,8 @@ namespace Refit.Implementation
         {
             var ______arguments = global::System.Array.Empty<object>();
             var ______func = requestBuilder.BuildRestResultFuncForMethod("GetIndex", global::System.Array.Empty<global::System.Type>() );
-            try
-            {
-                return await ((global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage>)______func(this.Client, ______arguments)).ConfigureAwait(false);
-            }
-            catch (global::System.Exception ______ex)
-            {
-                throw ______ex;
-            }
+
+            return await ((global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage>)______func(this.Client, ______arguments)).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
@@ -535,14 +420,8 @@ namespace Refit.Implementation
         {
             var ______arguments = global::System.Array.Empty<object>();
             var ______func = requestBuilder.BuildRestResultFuncForMethod("GetIndexObservable", global::System.Array.Empty<global::System.Type>() );
-            try
-            {
-                return (global::System.IObservable<string>)______func(this.Client, ______arguments);
-            }
-            catch (global::System.Exception ______ex)
-            {
-                throw ______ex;
-            }
+
+            return (global::System.IObservable<string>)______func(this.Client, ______arguments);
         }
 
         /// <inheritdoc />
@@ -550,14 +429,8 @@ namespace Refit.Implementation
         {
             var ______arguments = global::System.Array.Empty<object>();
             var ______func = requestBuilder.BuildRestResultFuncForMethod("NothingToSeeHere", global::System.Array.Empty<global::System.Type>() );
-            try
-            {
-                return await ((global::System.Threading.Tasks.Task<global::Refit.Tests.User>)______func(this.Client, ______arguments)).ConfigureAwait(false);
-            }
-            catch (global::System.Exception ______ex)
-            {
-                throw ______ex;
-            }
+
+            return await ((global::System.Threading.Tasks.Task<global::Refit.Tests.User>)______func(this.Client, ______arguments)).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
@@ -565,14 +438,8 @@ namespace Refit.Implementation
         {
             var ______arguments = global::System.Array.Empty<object>();
             var ______func = requestBuilder.BuildRestResultFuncForMethod("NothingToSeeHereWithMetadata", global::System.Array.Empty<global::System.Type>() );
-            try
-            {
-                return await ((global::System.Threading.Tasks.Task<global::Refit.ApiResponse<global::Refit.Tests.User>>)______func(this.Client, ______arguments)).ConfigureAwait(false);
-            }
-            catch (global::System.Exception ______ex)
-            {
-                throw ______ex;
-            }
+
+            return await ((global::System.Threading.Tasks.Task<global::Refit.ApiResponse<global::Refit.Tests.User>>)______func(this.Client, ______arguments)).ConfigureAwait(false);
         }
 
         private static readonly global::System.Type[] ______typeParameters13 = new global::System.Type[] {typeof(string) };
@@ -582,14 +449,8 @@ namespace Refit.Implementation
         {
             var ______arguments = new object[] { @userName };
             var ______func = requestBuilder.BuildRestResultFuncForMethod("GetUserWithMetadata", ______typeParameters13 );
-            try
-            {
-                return await ((global::System.Threading.Tasks.Task<global::Refit.ApiResponse<global::Refit.Tests.User>>)______func(this.Client, ______arguments)).ConfigureAwait(false);
-            }
-            catch (global::System.Exception ______ex)
-            {
-                throw ______ex;
-            }
+
+            return await ((global::System.Threading.Tasks.Task<global::Refit.ApiResponse<global::Refit.Tests.User>>)______func(this.Client, ______arguments)).ConfigureAwait(false);
         }
 
         private static readonly global::System.Type[] ______typeParameters14 = new global::System.Type[] {typeof(string) };
@@ -599,14 +460,8 @@ namespace Refit.Implementation
         {
             var ______arguments = new object[] { @userName };
             var ______func = requestBuilder.BuildRestResultFuncForMethod("GetUserObservableWithMetadata", ______typeParameters14 );
-            try
-            {
-                return (global::System.IObservable<global::Refit.ApiResponse<global::Refit.Tests.User>>)______func(this.Client, ______arguments);
-            }
-            catch (global::System.Exception ______ex)
-            {
-                throw ______ex;
-            }
+
+            return (global::System.IObservable<global::Refit.ApiResponse<global::Refit.Tests.User>>)______func(this.Client, ______arguments);
         }
 
         private static readonly global::System.Type[] ______typeParameters15 = new global::System.Type[] {typeof(global::Refit.Tests.User) };
@@ -616,14 +471,8 @@ namespace Refit.Implementation
         {
             var ______arguments = new object[] { @user };
             var ______func = requestBuilder.BuildRestResultFuncForMethod("CreateUser", ______typeParameters15 );
-            try
-            {
-                return await ((global::System.Threading.Tasks.Task<global::Refit.Tests.User>)______func(this.Client, ______arguments)).ConfigureAwait(false);
-            }
-            catch (global::System.Exception ______ex)
-            {
-                throw ______ex;
-            }
+
+            return await ((global::System.Threading.Tasks.Task<global::Refit.Tests.User>)______func(this.Client, ______arguments)).ConfigureAwait(false);
         }
 
         private static readonly global::System.Type[] ______typeParameters16 = new global::System.Type[] {typeof(global::Refit.Tests.User) };
@@ -633,14 +482,8 @@ namespace Refit.Implementation
         {
             var ______arguments = new object[] { @user };
             var ______func = requestBuilder.BuildRestResultFuncForMethod("CreateUserWithMetadata", ______typeParameters16 );
-            try
-            {
-                return await ((global::System.Threading.Tasks.Task<global::Refit.ApiResponse<global::Refit.Tests.User>>)______func(this.Client, ______arguments)).ConfigureAwait(false);
-            }
-            catch (global::System.Exception ______ex)
-            {
-                throw ______ex;
-            }
+
+            return await ((global::System.Threading.Tasks.Task<global::Refit.ApiResponse<global::Refit.Tests.User>>)______func(this.Client, ______arguments)).ConfigureAwait(false);
         }
     }
     }
@@ -680,20 +523,13 @@ namespace Refit.Implementation
         }
 
 
-
         /// <inheritdoc />
         public async global::System.Threading.Tasks.Task RefitMethod()
         {
             var ______arguments = global::System.Array.Empty<object>();
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""RefitMethod"", global::System.Array.Empty<global::System.Type>() );
-            try
-            {
-                await ((global::System.Threading.Tasks.Task)______func(this.Client, ______arguments)).ConfigureAwait(false);
-            }
-            catch (global::System.Exception ______ex)
-            {
-                throw ______ex;
-            }
+
+            await ((global::System.Threading.Tasks.Task)______func(this.Client, ______arguments)).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
@@ -701,14 +537,8 @@ namespace Refit.Implementation
         {
             var ______arguments = global::System.Array.Empty<object>();
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""RefitMethod"", global::System.Array.Empty<global::System.Type>() );
-            try
-            {
-                await ((global::System.Threading.Tasks.Task)______func(this.Client, ______arguments)).ConfigureAwait(false);
-            }
-            catch (global::System.Exception ______ex)
-            {
-                throw ______ex;
-            }
+
+            await ((global::System.Threading.Tasks.Task)______func(this.Client, ______arguments)).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
@@ -753,7 +583,6 @@ namespace Refit.Implementation
         }
 
 
-
         private static readonly global::System.Type[] ______typeParameters = new global::System.Type[] {typeof(string) };
 
         /// <inheritdoc />
@@ -761,14 +590,8 @@ namespace Refit.Implementation
         {
             var ______arguments = new object[] { @userName };
             var ______func = requestBuilder.BuildRestResultFuncForMethod("GetUser", ______typeParameters );
-            try
-            {
-                return await ((global::System.Threading.Tasks.Task<global::Refit.Tests.User>)______func(this.Client, ______arguments)).ConfigureAwait(false);
-            }
-            catch (global::System.Exception ______ex)
-            {
-                throw ______ex;
-            }
+
+            return await ((global::System.Threading.Tasks.Task<global::Refit.Tests.User>)______func(this.Client, ______arguments)).ConfigureAwait(false);
         }
 
         private static readonly global::System.Type[] ______typeParameters0 = new global::System.Type[] {typeof(string) };
@@ -778,14 +601,8 @@ namespace Refit.Implementation
         {
             var ______arguments = new object[] { @userName };
             var ______func = requestBuilder.BuildRestResultFuncForMethod("GetUserObservable", ______typeParameters0 );
-            try
-            {
-                return (global::System.IObservable<global::Refit.Tests.User>)______func(this.Client, ______arguments);
-            }
-            catch (global::System.Exception ______ex)
-            {
-                throw ______ex;
-            }
+
+            return (global::System.IObservable<global::Refit.Tests.User>)______func(this.Client, ______arguments);
         }
 
         private static readonly global::System.Type[] ______typeParameters1 = new global::System.Type[] {typeof(string) };
@@ -795,14 +612,8 @@ namespace Refit.Implementation
         {
             var ______arguments = new object[] { @userName };
             var ______func = requestBuilder.BuildRestResultFuncForMethod("GetUserCamelCase", ______typeParameters1 );
-            try
-            {
-                return (global::System.IObservable<global::Refit.Tests.User>)______func(this.Client, ______arguments);
-            }
-            catch (global::System.Exception ______ex)
-            {
-                throw ______ex;
-            }
+
+            return (global::System.IObservable<global::Refit.Tests.User>)______func(this.Client, ______arguments);
         }
 
         private static readonly global::System.Type[] ______typeParameters2 = new global::System.Type[] {typeof(string) };
@@ -812,14 +623,8 @@ namespace Refit.Implementation
         {
             var ______arguments = new object[] { @orgName };
             var ______func = requestBuilder.BuildRestResultFuncForMethod("GetOrgMembers", ______typeParameters2 );
-            try
-            {
-                return await ((global::System.Threading.Tasks.Task<global::System.Collections.Generic.List<global::Refit.Tests.User>>)______func(this.Client, ______arguments)).ConfigureAwait(false);
-            }
-            catch (global::System.Exception ______ex)
-            {
-                throw ______ex;
-            }
+
+            return await ((global::System.Threading.Tasks.Task<global::System.Collections.Generic.List<global::Refit.Tests.User>>)______func(this.Client, ______arguments)).ConfigureAwait(false);
         }
 
         private static readonly global::System.Type[] ______typeParameters3 = new global::System.Type[] {typeof(string) };
@@ -829,14 +634,8 @@ namespace Refit.Implementation
         {
             var ______arguments = new object[] { @q };
             var ______func = requestBuilder.BuildRestResultFuncForMethod("FindUsers", ______typeParameters3 );
-            try
-            {
-                return await ((global::System.Threading.Tasks.Task<global::Refit.Tests.UserSearchResult>)______func(this.Client, ______arguments)).ConfigureAwait(false);
-            }
-            catch (global::System.Exception ______ex)
-            {
-                throw ______ex;
-            }
+
+            return await ((global::System.Threading.Tasks.Task<global::Refit.Tests.UserSearchResult>)______func(this.Client, ______arguments)).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
@@ -844,14 +643,8 @@ namespace Refit.Implementation
         {
             var ______arguments = global::System.Array.Empty<object>();
             var ______func = requestBuilder.BuildRestResultFuncForMethod("GetIndex", global::System.Array.Empty<global::System.Type>() );
-            try
-            {
-                return await ((global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage>)______func(this.Client, ______arguments)).ConfigureAwait(false);
-            }
-            catch (global::System.Exception ______ex)
-            {
-                throw ______ex;
-            }
+
+            return await ((global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage>)______func(this.Client, ______arguments)).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
@@ -859,14 +652,8 @@ namespace Refit.Implementation
         {
             var ______arguments = global::System.Array.Empty<object>();
             var ______func = requestBuilder.BuildRestResultFuncForMethod("GetIndexObservable", global::System.Array.Empty<global::System.Type>() );
-            try
-            {
-                return (global::System.IObservable<string>)______func(this.Client, ______arguments);
-            }
-            catch (global::System.Exception ______ex)
-            {
-                throw ______ex;
-            }
+
+            return (global::System.IObservable<string>)______func(this.Client, ______arguments);
         }
 
         /// <inheritdoc />
@@ -874,14 +661,8 @@ namespace Refit.Implementation
         {
             var ______arguments = global::System.Array.Empty<object>();
             var ______func = requestBuilder.BuildRestResultFuncForMethod("NothingToSeeHere", global::System.Array.Empty<global::System.Type>() );
-            try
-            {
-                await ((global::System.Threading.Tasks.Task)______func(this.Client, ______arguments)).ConfigureAwait(false);
-            }
-            catch (global::System.Exception ______ex)
-            {
-                throw ______ex;
-            }
+
+            await ((global::System.Threading.Tasks.Task)______func(this.Client, ______arguments)).ConfigureAwait(false);
         }
 
         private static readonly global::System.Type[] ______typeParameters4 = new global::System.Type[] {typeof(string) };
@@ -891,14 +672,8 @@ namespace Refit.Implementation
         {
             var ______arguments = new object[] { @userName };
             var ______func = requestBuilder.BuildRestResultFuncForMethod("GetUser", ______typeParameters4 );
-            try
-            {
-                return await ((global::System.Threading.Tasks.Task<global::Refit.Tests.User>)______func(this.Client, ______arguments)).ConfigureAwait(false);
-            }
-            catch (global::System.Exception ______ex)
-            {
-                throw ______ex;
-            }
+
+            return await ((global::System.Threading.Tasks.Task<global::Refit.Tests.User>)______func(this.Client, ______arguments)).ConfigureAwait(false);
         }
 
         private static readonly global::System.Type[] ______typeParameters5 = new global::System.Type[] {typeof(string) };
@@ -908,14 +683,8 @@ namespace Refit.Implementation
         {
             var ______arguments = new object[] { @userName };
             var ______func = requestBuilder.BuildRestResultFuncForMethod("GetUserObservable", ______typeParameters5 );
-            try
-            {
-                return (global::System.IObservable<global::Refit.Tests.User>)______func(this.Client, ______arguments);
-            }
-            catch (global::System.Exception ______ex)
-            {
-                throw ______ex;
-            }
+
+            return (global::System.IObservable<global::Refit.Tests.User>)______func(this.Client, ______arguments);
         }
 
         private static readonly global::System.Type[] ______typeParameters6 = new global::System.Type[] {typeof(string) };
@@ -925,14 +694,8 @@ namespace Refit.Implementation
         {
             var ______arguments = new object[] { @userName };
             var ______func = requestBuilder.BuildRestResultFuncForMethod("GetUserCamelCase", ______typeParameters6 );
-            try
-            {
-                return (global::System.IObservable<global::Refit.Tests.User>)______func(this.Client, ______arguments);
-            }
-            catch (global::System.Exception ______ex)
-            {
-                throw ______ex;
-            }
+
+            return (global::System.IObservable<global::Refit.Tests.User>)______func(this.Client, ______arguments);
         }
 
         private static readonly global::System.Type[] ______typeParameters7 = new global::System.Type[] {typeof(string) };
@@ -942,14 +705,8 @@ namespace Refit.Implementation
         {
             var ______arguments = new object[] { @orgName };
             var ______func = requestBuilder.BuildRestResultFuncForMethod("GetOrgMembers", ______typeParameters7 );
-            try
-            {
-                return await ((global::System.Threading.Tasks.Task<global::System.Collections.Generic.List<global::Refit.Tests.User>>)______func(this.Client, ______arguments)).ConfigureAwait(false);
-            }
-            catch (global::System.Exception ______ex)
-            {
-                throw ______ex;
-            }
+
+            return await ((global::System.Threading.Tasks.Task<global::System.Collections.Generic.List<global::Refit.Tests.User>>)______func(this.Client, ______arguments)).ConfigureAwait(false);
         }
 
         private static readonly global::System.Type[] ______typeParameters8 = new global::System.Type[] {typeof(string) };
@@ -959,14 +716,8 @@ namespace Refit.Implementation
         {
             var ______arguments = new object[] { @q };
             var ______func = requestBuilder.BuildRestResultFuncForMethod("FindUsers", ______typeParameters8 );
-            try
-            {
-                return await ((global::System.Threading.Tasks.Task<global::Refit.Tests.UserSearchResult>)______func(this.Client, ______arguments)).ConfigureAwait(false);
-            }
-            catch (global::System.Exception ______ex)
-            {
-                throw ______ex;
-            }
+
+            return await ((global::System.Threading.Tasks.Task<global::Refit.Tests.UserSearchResult>)______func(this.Client, ______arguments)).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
@@ -974,14 +725,8 @@ namespace Refit.Implementation
         {
             var ______arguments = global::System.Array.Empty<object>();
             var ______func = requestBuilder.BuildRestResultFuncForMethod("GetIndex", global::System.Array.Empty<global::System.Type>() );
-            try
-            {
-                return await ((global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage>)______func(this.Client, ______arguments)).ConfigureAwait(false);
-            }
-            catch (global::System.Exception ______ex)
-            {
-                throw ______ex;
-            }
+
+            return await ((global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage>)______func(this.Client, ______arguments)).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
@@ -989,14 +734,8 @@ namespace Refit.Implementation
         {
             var ______arguments = global::System.Array.Empty<object>();
             var ______func = requestBuilder.BuildRestResultFuncForMethod("GetIndexObservable", global::System.Array.Empty<global::System.Type>() );
-            try
-            {
-                return (global::System.IObservable<string>)______func(this.Client, ______arguments);
-            }
-            catch (global::System.Exception ______ex)
-            {
-                throw ______ex;
-            }
+
+            return (global::System.IObservable<string>)______func(this.Client, ______arguments);
         }
 
         /// <inheritdoc />
@@ -1004,14 +743,8 @@ namespace Refit.Implementation
         {
             var ______arguments = global::System.Array.Empty<object>();
             var ______func = requestBuilder.BuildRestResultFuncForMethod("NothingToSeeHere", global::System.Array.Empty<global::System.Type>() );
-            try
-            {
-                await ((global::System.Threading.Tasks.Task)______func(this.Client, ______arguments)).ConfigureAwait(false);
-            }
-            catch (global::System.Exception ______ex)
-            {
-                throw ______ex;
-            }
+
+            await ((global::System.Threading.Tasks.Task)______func(this.Client, ______arguments)).ConfigureAwait(false);
         }
     }
     }
@@ -1145,20 +878,13 @@ namespace Refit.Implementation
         }
 
 
-
         /// <inheritdoc />
         public async global::System.Threading.Tasks.Task GetRoot()
         {
             var ______arguments = global::System.Array.Empty<object>();
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetRoot"", global::System.Array.Empty<global::System.Type>() );
-            try
-            {
-                await ((global::System.Threading.Tasks.Task)______func(this.Client, ______arguments)).ConfigureAwait(false);
-            }
-            catch (global::System.Exception ______ex)
-            {
-                throw ______ex;
-            }
+
+            await ((global::System.Threading.Tasks.Task)______func(this.Client, ______arguments)).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
@@ -1166,14 +892,8 @@ namespace Refit.Implementation
         {
             var ______arguments = global::System.Array.Empty<object>();
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""PostRoot"", global::System.Array.Empty<global::System.Type>() );
-            try
-            {
-                await ((global::System.Threading.Tasks.Task)______func(this.Client, ______arguments)).ConfigureAwait(false);
-            }
-            catch (global::System.Exception ______ex)
-            {
-                throw ______ex;
-            }
+
+            await ((global::System.Threading.Tasks.Task)______func(this.Client, ______arguments)).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
@@ -1181,14 +901,8 @@ namespace Refit.Implementation
         {
             var ______arguments = global::System.Array.Empty<object>();
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""GetRoot"", global::System.Array.Empty<global::System.Type>() );
-            try
-            {
-                await ((global::System.Threading.Tasks.Task)______func(this.Client, ______arguments)).ConfigureAwait(false);
-            }
-            catch (global::System.Exception ______ex)
-            {
-                throw ______ex;
-            }
+
+            await ((global::System.Threading.Tasks.Task)______func(this.Client, ______arguments)).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
@@ -1196,14 +910,8 @@ namespace Refit.Implementation
         {
             var ______arguments = global::System.Array.Empty<object>();
             var ______func = requestBuilder.BuildRestResultFuncForMethod(""PostRoot"", global::System.Array.Empty<global::System.Type>() );
-            try
-            {
-                await ((global::System.Threading.Tasks.Task)______func(this.Client, ______arguments)).ConfigureAwait(false);
-            }
-            catch (global::System.Exception ______ex)
-            {
-                throw ______ex;
-            }
+
+            await ((global::System.Threading.Tasks.Task)______func(this.Client, ______arguments)).ConfigureAwait(false);
         }
     }
     }

--- a/Refit.Tests/RestService.cs
+++ b/Refit.Tests/RestService.cs
@@ -1097,7 +1097,7 @@ public class RestServiceIntegrationTests
             async () => await fixture.GetOrgMembers("github", cts.Token)
         );
 
-        AssertFirstLineContains(nameof(IGitHubApi.GetOrgMembers), result.StackTrace);
+        AssertStackTraceContains(nameof(IGitHubApi.GetOrgMembers), result.StackTrace);
     }
 
     [Fact]
@@ -1573,7 +1573,7 @@ public class RestServiceIntegrationTests
             async () => await fixture.CreateUser(new User { Name = "foo" })
         );
 
-        AssertFirstLineContains(nameof(IGitHubApi.CreateUser), result.StackTrace);
+        AssertStackTraceContains(nameof(IGitHubApi.CreateUser), result.StackTrace);
 
         var errors = await result.GetContentAsAsync<ErrorResponse>();
 
@@ -1704,7 +1704,7 @@ public class RestServiceIntegrationTests
             async () => await fixture.GetUser(null)
         );
 
-        AssertFirstLineContains(nameof(IGitHubApi.GetUser), result.StackTrace);
+        AssertStackTraceContains(nameof(IGitHubApi.GetUser), result.StackTrace);
     }
 
     [Fact]
@@ -2254,10 +2254,8 @@ public class RestServiceIntegrationTests
         Assert.IsType<CollisionB.SomeType>(respC);
     }
 
-    public void AssertFirstLineContains(string expectedSubstring, string actualString)
+    private static void AssertStackTraceContains(string expectedSubstring, string actualString)
     {
-        var eolIndex = actualString.IndexOf('\n');
-        var firstLine = eolIndex < 0 ? actualString : actualString.Substring(0, eolIndex);
-        Assert.Contains(expectedSubstring, firstLine);
+        Assert.Contains(expectedSubstring, actualString);
     }
 }


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
Bug fix


**What is the current behavior?**
Fixes #1809
Currently there is a try/catch block surrounding the api call which rethrows the exception causing the stack trace to be discarded. 


**What is the new behavior?**
As the try catch block was not doing anything specific, it seemed better to remove it completely and have the original exception be thrown.



**What might this PR break?**
Not sure - different type of exceptions?


**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:

