### PR TITLE
refactor: move diagnostics to dedicated class

### DIFF
--- a/InterfaceStubGenerator.Shared/DiagnosticDescriptors.cs
+++ b/InterfaceStubGenerator.Shared/DiagnosticDescriptors.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.CodeAnalysis;
+
+namespace Refit.Generator;
+
+internal static class DiagnosticDescriptors
+{
+#pragma warning disable RS2008 // Enable analyzer release tracking
+    public static readonly DiagnosticDescriptor InvalidRefitMember =
+        new(
+            "RF001",
+            "Refit types must have Refit HTTP method attributes",
+            "Method {0}.{1} either has no Refit HTTP method attribute or you've used something other than a string literal for the 'path' argument",
+            "Refit",
+            DiagnosticSeverity.Warning,
+            true
+        );
+
+    public static readonly DiagnosticDescriptor RefitNotReferenced =
+        new(
+            "RF002",
+            "Refit must be referenced",
+            "Refit is not referenced. Add a reference to Refit.",
+            "Refit",
+            DiagnosticSeverity.Error,
+            true
+        );
+#pragma warning restore RS2008 // Enable analyzer release tracking
+}
+

--- a/InterfaceStubGenerator.Shared/InterfaceStubGenerator.Shared.projitems
+++ b/InterfaceStubGenerator.Shared/InterfaceStubGenerator.Shared.projitems
@@ -9,6 +9,7 @@
     <Import_RootNamespace>InterfaceStubGenerator.Shared</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)DiagnosticDescriptors.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)InterfaceStubGenerator.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ITypeSymbolExtensions.cs" />
   </ItemGroup>

--- a/InterfaceStubGenerator.Shared/InterfaceStubGenerator.cs
+++ b/InterfaceStubGenerator.Shared/InterfaceStubGenerator.cs
@@ -27,28 +27,6 @@ namespace Refit.Generator
     {
         private const string TypeParameterVariableName = "______typeParameters";
 
-#pragma warning disable RS2008 // Enable analyzer release tracking
-        static readonly DiagnosticDescriptor InvalidRefitMember =
-            new(
-                "RF001",
-                "Refit types must have Refit HTTP method attributes",
-                "Method {0}.{1} either has no Refit HTTP method attribute or you've used something other than a string literal for the 'path' argument",
-                "Refit",
-                DiagnosticSeverity.Warning,
-                true
-            );
-
-        static readonly DiagnosticDescriptor RefitNotReferenced =
-            new(
-                "RF002",
-                "Refit must be referenced",
-                "Refit is not referenced. Add a reference to Refit.",
-                "Refit",
-                DiagnosticSeverity.Error,
-                true
-            );
-#pragma warning restore RS2008 // Enable analyzer release tracking
-
 #if !ROSLYN_4
 
         /// <summary>
@@ -115,7 +93,7 @@ namespace Refit.Generator
 
             if (httpMethodBaseAttributeSymbol == null)
             {
-                reportDiagnostic(context, Diagnostic.Create(RefitNotReferenced, null));
+                reportDiagnostic(context, Diagnostic.Create(DiagnosticDescriptors.RefitNotReferenced, null));
                 return;
             }
 
@@ -640,7 +618,7 @@ namespace Refit.Implementation
             foreach (var location in methodSymbol.Locations)
             {
                 var diagnostic = Diagnostic.Create(
-                    InvalidRefitMember,
+                    DiagnosticDescriptors.InvalidRefitMember,
                     location,
                     methodSymbol.ContainingType.Name,
                     methodSymbol.Name


### PR DESCRIPTION
Refactor: move diagnostics descriptors to separate file
- Will use `InternalsVisibleTo` to expose descriptors for future #1829 changes.
- Ideally refit could do with some more descriptors, this should be a future PR