### PR TITLE
feat: add `ShouldNotEmitFiles` test

### DIFF
--- a/Refit.GeneratorTests/GeneratedTest.cs
+++ b/Refit.GeneratorTests/GeneratedTest.cs
@@ -11,4 +11,11 @@ public class GeneratedTest
             Task<string> Get();
             """, false);
     }
+
+    [Fact]
+    public Task ShouldNotEmitFilesWhenNoRefitInterfaces()
+    {
+        // Refit should not generate any code when no valid Refit interfaces are present.
+        return Fixture.VerifyForBody("", false);
+    }
 }


### PR DESCRIPTION
- Added test to verify that the generator does not emit any code when no valid refit interfaces are present.
- Verifies that line 169 in `InterfaceStubGenerator` functions.

Added to prevent me breaking this in #1791