### PR TITLE
feat: added larger benchmark

### DIFF
--- a/Refit.Benchmarks/SourceGeneratorBenchmark.cs
+++ b/Refit.Benchmarks/SourceGeneratorBenchmark.cs
@@ -12,40 +12,6 @@ namespace Refit.Benchmarks;
 [MemoryDiagnoser]
 public class SourceGeneratorBenchmark
 {
-    #region SourceText
-    private const string SmallInterface =
-        """
-        using System;
-        using System.Collections.Generic;
-        using System.Linq;
-        using System.Net.Http;
-        using System.Text;
-        using System.Threading;
-        using System.Threading.Tasks;
-        using Refit;
-
-        namespace RefitGeneratorTest;
-
-        public interface IReallyExcitingCrudApi<T, in TKey> where T : class
-        {
-            [Post("")]
-            Task<T> Create([Body] T payload);
-
-            [Get("")]
-            Task<List<T>> ReadAll();
-
-            [Get("/{key}")]
-            Task<T> ReadOne(TKey key);
-
-            [Put("/{key}")]
-            Task Update(TKey key, [Body]T payload);
-
-            [Delete("/{key}")]
-            Task Delete(TKey key);
-        }
-        """;
-    #endregion
-
     static readonly MetadataReference RefitAssembly = MetadataReference.CreateFromFile(
         typeof(GetAttribute).Assembly.Location,
         documentation: XmlDocumentationProvider.CreateFromFile(
@@ -97,7 +63,7 @@ public class SourceGeneratorBenchmark
     }
 
     [GlobalSetup(Target = nameof(Compile))]
-    public void SetupSmall() => Setup(SmallInterface);
+    public void SetupSmall() => Setup(SourceGeneratorBenchmarksProjects.SmallInterface);
 
     [Benchmark]
     public GeneratorDriver Compile()
@@ -108,13 +74,36 @@ public class SourceGeneratorBenchmark
     [GlobalSetup(Target = nameof(Cached))]
     public void SetupCached()
     {
-        Setup(SmallInterface);
+        Setup(SourceGeneratorBenchmarksProjects.SmallInterface);
         driver = (CSharpGeneratorDriver)driver.RunGeneratorsAndUpdateCompilation(compilation, out _, out _);
         compilation = compilation.AddSyntaxTrees(CSharpSyntaxTree.ParseText("struct MyValue {}"));
     }
 
     [Benchmark]
     public GeneratorDriver Cached()
+    {
+        return driver.RunGeneratorsAndUpdateCompilation(compilation, out _, out _);
+    }
+
+    [GlobalSetup(Target = nameof(CompileMany))]
+    public void SetupMany() => Setup(SourceGeneratorBenchmarksProjects.ManyInterfaces);
+
+    [Benchmark]
+    public GeneratorDriver CompileMany()
+    {
+        return driver.RunGeneratorsAndUpdateCompilation(compilation, out _, out _);
+    }
+
+    [GlobalSetup(Target = nameof(CachedMany))]
+    public void SetupCachedMany()
+    {
+        Setup(SourceGeneratorBenchmarksProjects.ManyInterfaces);
+        driver = (CSharpGeneratorDriver)driver.RunGeneratorsAndUpdateCompilation(compilation, out _, out _);
+        compilation = compilation.AddSyntaxTrees(CSharpSyntaxTree.ParseText("struct MyValue {}"));
+    }
+
+    [Benchmark]
+    public GeneratorDriver CachedMany()
     {
         return driver.RunGeneratorsAndUpdateCompilation(compilation, out _, out _);
     }

--- a/Refit.Benchmarks/SourceGeneratorBenchmarksProjects.cs
+++ b/Refit.Benchmarks/SourceGeneratorBenchmarksProjects.cs
@@ -1,0 +1,1755 @@
+﻿namespace Refit.Benchmarks;
+
+public static class SourceGeneratorBenchmarksProjects
+{
+    #region SmallInterface
+    public const string SmallInterface =
+        """
+        using System;
+        using System.Collections.Generic;
+        using System.Linq;
+        using System.Net.Http;
+        using System.Text;
+        using System.Threading;
+        using System.Threading.Tasks;
+        using Refit;
+
+        namespace RefitGeneratorTest;
+
+        public interface IReallyExcitingCrudApi<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        """;
+    #endregion
+
+    #region LargeInterface
+    public const string ManyInterfaces =
+        """
+        using System;
+        using System.Collections.Generic;
+        using System.Linq;
+        using System.Net.Http;
+        using System.Text;
+        using System.Threading;
+        using System.Threading.Tasks;
+        using Refit;
+
+        namespace RefitGeneratorTest;
+
+        public interface IReallyExcitingCrudApi0<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi1<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi2<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi3<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi4<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi5<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi6<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi7<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi8<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi9<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi10<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi11<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi12<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi13<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi14<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi15<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi16<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi17<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi18<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi19<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi20<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi21<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi22<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi23<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi24<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi25<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi26<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi27<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi28<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi29<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi30<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi31<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi32<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi33<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi34<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi35<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi36<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi37<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi38<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi39<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi40<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi41<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi42<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi43<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi44<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi45<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi46<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi47<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi48<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi49<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi50<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi51<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi52<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi53<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi54<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi55<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi56<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi57<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi58<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi59<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi60<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi61<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi62<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi63<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi64<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi65<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi66<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi67<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi68<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi69<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi70<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi71<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi72<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi73<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi74<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi75<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi76<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi77<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi78<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi79<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi80<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi81<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi82<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi83<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi84<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi85<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi86<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi87<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi88<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi89<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi90<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi91<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi92<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi93<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi94<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi95<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi96<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi97<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi98<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        public interface IReallyExcitingCrudApi99<T, in TKey> where T : class
+        {
+            [Post("")]
+            Task<T> Create([Body] T payload);
+
+            [Get("")]
+            Task<List<T>> ReadAll();
+
+            [Get("/{key}")]
+            Task<T> ReadOne(TKey key);
+
+            [Put("/{key}")]
+            Task Update(TKey key, [Body]T payload);
+
+            [Delete("/{key}")]
+            Task Delete(TKey key);
+        }
+        """;
+    #endregion
+}


### PR DESCRIPTION
- Added benchmark for larger projects (`SmallInterface` copied 100 times).
- Moved the project text to a dedicated class.
- Kept it "small" so benchmarks will run under 2 minutes.


### Benchmarks
| Method      | Mean       | Error    | StdDev   | Gen0     | Gen1     | Allocated  |
|------------ |-----------:|---------:|---------:|---------:|---------:|-----------:|
| Compile     |   250.0 us |  2.03 us |  1.80 us |  12.6953 |   2.9297 |  117.52 KB |
| Cached      |   217.7 us |  3.63 us |  4.04 us |  12.2070 |   2.9297 |  114.87 KB |
| CompileMany | 8,920.5 us | 36.61 us | 34.24 us | 687.5000 | 343.7500 | 6354.55 KB |
| CachedMany  | 7,919.1 us | 57.02 us | 47.61 us | 671.8750 | 328.1250 | 6289.47 KB |

#1791
