### PR TITLE
feat: add non refit method raises diagnostic test

### DIFF
--- a/Refit.GeneratorTests/InterfaceTests.cs
+++ b/Refit.GeneratorTests/InterfaceTests.cs
@@ -111,4 +111,16 @@ public class InterfaceTests
             }
             """);
     }
+
+    [Fact]
+    public Task NonRefitMethodShouldRaiseDiagnostic()
+    {
+        return Fixture.VerifyForBody(
+            """
+            [Get("/users")]
+            Task<string> Get();
+
+            void NonRefitMethod();
+            """);
+    }
 }

--- a/Refit.GeneratorTests/_snapshots/InterfaceTests.NonRefitMethodShouldRaiseDiagnostic#IGeneratedClient.g.verified.cs
+++ b/Refit.GeneratorTests/_snapshots/InterfaceTests.NonRefitMethodShouldRaiseDiagnostic#IGeneratedClient.g.verified.cs
@@ -1,0 +1,59 @@
+﻿//HintName: IGeneratedClient.g.cs
+#nullable disable
+#pragma warning disable
+namespace Refit.Implementation
+{
+
+    partial class Generated
+    {
+
+    /// <inheritdoc />
+    [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    [global::System.Diagnostics.DebuggerNonUserCode]
+    [global::RefitInternalGenerated.PreserveAttribute]
+    [global::System.Reflection.Obfuscation(Exclude=true)]
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    partial class RefitGeneratorTestIGeneratedClient
+        : global::RefitGeneratorTest.IGeneratedClient
+
+    {
+        /// <inheritdoc />
+        public global::System.Net.Http.HttpClient Client { get; }
+        readonly global::Refit.IRequestBuilder requestBuilder;
+
+        /// <inheritdoc />
+        public RefitGeneratorTestIGeneratedClient(global::System.Net.Http.HttpClient client, global::Refit.IRequestBuilder requestBuilder)
+        {
+            Client = client;
+            this.requestBuilder = requestBuilder;
+        }
+
+
+        /// <inheritdoc />
+        public async global::System.Threading.Tasks.Task<string> Get()
+        {
+            var ______arguments = global::System.Array.Empty<object>();
+            var ______func = requestBuilder.BuildRestResultFuncForMethod("Get", global::System.Array.Empty<global::System.Type>() );
+
+            return await ((global::System.Threading.Tasks.Task<string>)______func(this.Client, ______arguments)).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc />
+        async global::System.Threading.Tasks.Task<string> global::RefitGeneratorTest.IGeneratedClient.Get()
+        {
+            var ______arguments = global::System.Array.Empty<object>();
+            var ______func = requestBuilder.BuildRestResultFuncForMethod("Get", global::System.Array.Empty<global::System.Type>() );
+
+            return await ((global::System.Threading.Tasks.Task<string>)______func(this.Client, ______arguments)).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc />
+        void global::RefitGeneratorTest.IGeneratedClient.NonRefitMethod()
+        {
+                throw new global::System.NotImplementedException("Either this method has no Refit HTTP method attribute or you've used something other than a string literal for the 'path' argument.");
+        }
+    }
+    }
+}
+
+#pragma warning restore

--- a/Refit.GeneratorTests/_snapshots/InterfaceTests.NonRefitMethodShouldRaiseDiagnostic.verified.txt
+++ b/Refit.GeneratorTests/_snapshots/InterfaceTests.NonRefitMethodShouldRaiseDiagnostic.verified.txt
@@ -1,0 +1,14 @@
+﻿{
+  Diagnostics: [
+    {
+      Id: RF001,
+      Title: Refit types must have Refit HTTP method attributes,
+      Severity: Warning,
+      WarningLevel: 1,
+      Location: : (16,5)-(16,19),
+      MessageFormat: Method {0}.{1} either has no Refit HTTP method attribute or you've used something other than a string literal for the 'path' argument,
+      Message: Method IGeneratedClient.NonRefitMethod either has no Refit HTTP method attribute or you've used something other than a string literal for the 'path' argument,
+      Category: Refit
+    }
+  ]
+}


### PR DESCRIPTION
Add test to ensure that non refit methods generate `NotImplementedException` and raise a diagnostic