### PR TITLE
feat: fix invalid `unmanaged struct` constraint generation

### DIFF
--- a/InterfaceStubGenerator.Shared/InterfaceStubGenerator.cs
+++ b/InterfaceStubGenerator.Shared/InterfaceStubGenerator.cs
@@ -565,7 +565,9 @@ namespace Refit.Implementation
             {
                 parameters.Add("unmanaged");
             }
-            if (typeParameter.HasValueTypeConstraint)
+
+            // unmanaged constraints are both structs and unmanaged so the struct constraint is redundant
+            if (typeParameter.HasValueTypeConstraint && !typeParameter.HasUnmanagedTypeConstraint)
             {
                 parameters.Add("struct");
             }


### PR DESCRIPTION
When writing a generic contraint for types constrained to `unmanaged`, Refit will incorrectly emit the invalid syntax `unmanaged struct`.
This is because types constrained with `unmanaged` are implicitly `struct` types meaning that both `HasValueTypeConstraint` and `HasUnmanagedTypeConstraint` will return true, emitting the invalid code.

Related #1859