### PR TITLE
custom exception factory for deserialization exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1426,7 +1426,20 @@ var gitHubApi = RestService.For<IGitHubApi>("https://api.github.com",
     });
 ```
 
-Note that exceptions raised when attempting to deserialize the response are not affected by this.
+For exceptions raised when attempting to deserialize the response use DeserializationExceptionFactory described bellow.
+
+#### Providing a custom `DeserializationExceptionFactory`
+
+You can override default deserialization exceptions behavior that are raised by the `DeserializationExceptionFactory` when processing the result by providing a custom exception factory in `RefitSettings`. For example, you can suppress all deserialization exceptions with the following:
+
+```csharp
+var nullTask = Task.FromResult<Exception>(null);
+
+var gitHubApi = RestService.For<IGitHubApi>("https://api.github.com",
+    new RefitSettings {
+        DeserializationExceptionFactory = (httpResponse, exception) => nullTask;
+    });
+```
 
 #### `ApiException` deconstruction with Serilog
 

--- a/Refit.Tests/DeserializationExceptionFactoryTests.cs
+++ b/Refit.Tests/DeserializationExceptionFactoryTests.cs
@@ -1,0 +1,154 @@
+﻿using System.Net;
+using System.Net.Http;
+using RichardSzalay.MockHttp;
+using Xunit;
+
+namespace Refit.Tests;
+
+public class DeserializationExceptionFactoryTests
+{
+    public interface IMyService
+    {
+        [Get("/get-with-result")]
+        Task<int> GetWithResult();
+    }
+
+    [Fact]
+    public async Task NoDeserializationExceptionFactory_WithSuccessfulDeserialization()
+    {
+        var handler = new MockHttpMessageHandler();
+        var settings = new RefitSettings()
+        {
+            HttpMessageHandlerFactory = () => handler,
+        };
+
+        var intContent = 123;
+        handler
+            .Expect(HttpMethod.Get, "http://api/get-with-result")
+            .Respond(HttpStatusCode.OK, new StringContent($"{intContent}"));
+
+        var fixture = RestService.For<IMyService>("http://api", settings);
+
+        var result = await fixture.GetWithResult();
+
+        handler.VerifyNoOutstandingExpectation();
+
+        Assert.Equal(intContent, result);
+    }
+
+    [Fact]
+    public async Task NoDeserializationExceptionFactory_WithUnsuccessfulDeserialization()
+    {
+        var handler = new MockHttpMessageHandler();
+        var settings = new RefitSettings()
+        {
+            HttpMessageHandlerFactory = () => handler,
+        };
+
+        handler
+            .Expect(HttpMethod.Get, "http://api/get-with-result")
+            .Respond(HttpStatusCode.OK, new StringContent("non-int-result"));
+
+        var fixture = RestService.For<IMyService>("http://api", settings);
+
+        var thrownException = await Assert.ThrowsAsync<ApiException>(() => fixture.GetWithResult());
+        Assert.Equal("An error occured deserializing the response.", thrownException.Message);
+
+        handler.VerifyNoOutstandingExpectation();
+    }
+
+    [Fact]
+    public async Task ProvideFactoryWhichReturnsNull_WithSuccessfulDeserialization()
+    {
+        var handler = new MockHttpMessageHandler();
+        var settings = new RefitSettings()
+        {
+            HttpMessageHandlerFactory = () => handler,
+            DeserializationExceptionFactory = (_, _) => Task.FromResult<Exception>(null)
+        };
+
+        var intContent = 123;
+        handler
+            .Expect(HttpMethod.Get, "http://api/get-with-result")
+            .Respond(HttpStatusCode.OK, new StringContent($"{intContent}"));
+
+        var fixture = RestService.For<IMyService>("http://api", settings);
+
+        var result = await fixture.GetWithResult();
+
+        handler.VerifyNoOutstandingExpectation();
+
+        Assert.Equal(intContent, result);
+    }
+
+    [Fact]
+    public async Task ProvideFactoryWhichReturnsNull_WithUnsuccessfulDeserialization()
+    {
+        var handler = new MockHttpMessageHandler();
+        var settings = new RefitSettings()
+        {
+            HttpMessageHandlerFactory = () => handler,
+            DeserializationExceptionFactory = (_, _) => Task.FromResult<Exception>(null)
+        };
+
+        handler
+            .Expect(HttpMethod.Get, "http://api/get-with-result")
+            .Respond(HttpStatusCode.OK, new StringContent("non-int-result"));
+
+        var fixture = RestService.For<IMyService>("http://api", settings);
+
+        var result = await fixture.GetWithResult();
+
+        handler.VerifyNoOutstandingExpectation();
+
+        Assert.Equal(default, result);
+    }
+
+    [Fact]
+    public async Task ProvideFactoryWhichReturnsException_WithUnsuccessfulDeserialization()
+    {
+        var handler = new MockHttpMessageHandler();
+        var exception = new Exception("Unsuccessful Deserialization Exception");
+        var settings = new RefitSettings()
+        {
+            HttpMessageHandlerFactory = () => handler,
+            DeserializationExceptionFactory = (_, _) => Task.FromResult<Exception>(exception)
+        };
+
+        handler
+            .Expect(HttpMethod.Get, "http://api/get-with-result")
+            .Respond(HttpStatusCode.OK, new StringContent("non-int-result"));
+
+        var fixture = RestService.For<IMyService>("http://api", settings);
+
+        var thrownException = await Assert.ThrowsAsync<Exception>(() => fixture.GetWithResult());
+        Assert.Equal(exception, thrownException);
+
+        handler.VerifyNoOutstandingExpectation();
+    }
+
+    [Fact]
+    public async Task ProvideFactoryWhichReturnsException_WithSuccessfulDeserialization()
+    {
+        var handler = new MockHttpMessageHandler();
+        var exception = new Exception("Unsuccessful Deserialization Exception");
+        var settings = new RefitSettings()
+        {
+            HttpMessageHandlerFactory = () => handler,
+            DeserializationExceptionFactory = (_, _) => Task.FromResult<Exception>(exception)
+        };
+
+        var intContent = 123;
+        handler
+            .Expect(HttpMethod.Get, "http://api/get-with-result")
+            .Respond(HttpStatusCode.OK, new StringContent($"{intContent}"));
+
+        var fixture = RestService.For<IMyService>("http://api", settings);
+
+        var result = await fixture.GetWithResult();
+
+        handler.VerifyNoOutstandingExpectation();
+
+        Assert.Equal(intContent, result);
+    }
+}

--- a/Refit/RefitSettings.cs
+++ b/Refit/RefitSettings.cs
@@ -93,6 +93,12 @@ namespace Refit
         public Func<HttpResponseMessage, Task<Exception?>> ExceptionFactory { get; set; }
 
         /// <summary>
+        /// Supply a function to provide <see cref="Exception"/> when deserialization exception is encountered.
+        /// If function returns null - no exception is thrown.
+        /// </summary>
+        public Func<HttpResponseMessage, Exception, Task<Exception?>>? DeserializationExceptionFactory { get; set; }
+
+        /// <summary>
         /// Defines how requests' content should be serialized. (defaults to <see cref="SystemTextJsonContentSerializer"/>)
         /// </summary>
         public IHttpContentSerializer ContentSerializer { get; set; }


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
feature described here: https://github.com/reactiveui/refit/issues/1815


**What is the current behavior?**
<!-- You can also link to an open issue here. -->
there is no way to suppress or override deserialization exceptions


**What is the new behavior?**
<!-- If this is a feature change -->
provides the option to suppress or override deserialization exceptions


**What might this PR break?**
no breaking changes


**Please check if the PR fulfills these requirements**
- [ X ] Tests for the changes have been added (for bug fixes / features)
- [ X ] Docs have been added / updated (for bug fixes / features)

**Other information**:

