### PR TITLE
feat: generate code for derived non refit methods.

### DIFF
--- a/InterfaceStubGenerator.Shared/Parser.cs
+++ b/InterfaceStubGenerator.Shared/Parser.cs
@@ -300,7 +300,7 @@ namespace {refitInternalNamespace}
             .Where(m => IsRefitMethod(m, httpMethodBaseAttributeSymbol))
             .ToArray();
         var derivedNonRefitMethods = derivedMethods
-            .Except(derivedMethods, SymbolEqualityComparer.Default)
+            .Except(derivedRefitMethods, SymbolEqualityComparer.Default)
             .Cast<IMethodSymbol>()
             .ToArray();
 

--- a/Refit.GeneratorTests/Incremental/InheritanceTest.cs
+++ b/Refit.GeneratorTests/Incremental/InheritanceTest.cs
@@ -74,7 +74,6 @@ public class InheritanceTest
     [Fact]
     public void InheritFromInterfaceDoesRegenerate()
     {
-        // TODO: this currently generates invalid code see issue #1801 for more information
         var syntaxTree = CSharpSyntaxTree.ParseText(TwoInterface, CSharpParseOptions.Default);
         var compilation1 = Fixture.CreateLibrary(syntaxTree);
 
@@ -94,6 +93,6 @@ public class InheritanceTest
             """
         );
         var driver2 = driver1.RunGenerators(compilation2);
-        TestHelper.AssertRunReasons(driver2, IncrementalGeneratorRunReasons.Cached);
+        TestHelper.AssertRunReasons(driver2, IncrementalGeneratorRunReasons.Modified);
     }
 }

--- a/Refit.GeneratorTests/InterfaceTests.cs
+++ b/Refit.GeneratorTests/InterfaceTests.cs
@@ -40,7 +40,6 @@ public class InterfaceTests
     [Fact]
     public Task RefitInterfaceDerivedFromBaseTest()
     {
-        // TODO: this currently generates invalid code see issue #1801 for more information
         return Fixture.VerifyForType(
             """
             public interface IGeneratedInterface : IBaseInterface

--- a/Refit.GeneratorTests/_snapshots/InterfaceTests.RefitInterfaceDerivedFromBaseTest#IGeneratedInterface.g.verified.cs
+++ b/Refit.GeneratorTests/_snapshots/InterfaceTests.RefitInterfaceDerivedFromBaseTest#IGeneratedInterface.g.verified.cs
@@ -46,6 +46,12 @@ namespace Refit.Implementation
 
             return await ((global::System.Threading.Tasks.Task<string>)______func(this.Client, ______arguments)).ConfigureAwait(false);
         }
+
+        /// <inheritdoc />
+        void global::RefitGeneratorTest.IBaseInterface.NonRefitMethod()
+        {
+                throw new global::System.NotImplementedException("Either this method has no Refit HTTP method attribute or you've used something other than a string literal for the 'path' argument.");
+        }
     }
     }
 }

--- a/Refit.GeneratorTests/_snapshots/InterfaceTests.RefitInterfaceDerivedFromBaseTest.verified.txt
+++ b/Refit.GeneratorTests/_snapshots/InterfaceTests.RefitInterfaceDerivedFromBaseTest.verified.txt
@@ -1,0 +1,24 @@
+﻿{
+  Diagnostics: [
+    {
+      Location: /*
+{
+    void NonRefitMethod();
+         ^^^^^^^^^^^^^^
+}
+*/
+ : (19,9)-(19,23),
+      Message: Method IBaseInterface.NonRefitMethod either has no Refit HTTP method attribute or you've used something other than a string literal for the 'path' argument,
+      Severity: Warning,
+      WarningLevel: 1,
+      Descriptor: {
+        Id: RF001,
+        Title: Refit types must have Refit HTTP method attributes,
+        MessageFormat: Method {0}.{1} either has no Refit HTTP method attribute or you've used something other than a string literal for the 'path' argument,
+        Category: Refit,
+        DefaultSeverity: Warning,
+        IsEnabledByDefault: true
+      }
+    }
+  ]
+}

--- a/Refit.Tests/InheritedInterfacesApi.cs
+++ b/Refit.Tests/InheritedInterfacesApi.cs
@@ -66,6 +66,14 @@ namespace Refit.Tests
         [Get("/DoSomethingElse")]
         public new Task DoSomethingElse();
     }
+
+    public interface IImplementTheInterfaceAndDontUseRefit : IAmInterfaceD
+    {
+#pragma warning disable CS0108 // Member hides inherited member; missing new keyword
+        Task<string> Test();
+#pragma warning restore CS0108 // Member hides inherited member; missing new keyword
+    }
+
     public interface IMyClient
     {
         [Get("/")]


### PR DESCRIPTION
Fixes #1801

- Raise diagnostics and create empty methods for derived non refit methods.
- Incomplete as [this comment](https://github.com/reactiveui/refit/issues/1801#issuecomment-2406124552) needs to be addressed.

@ChrisPulman do you have any guidance here? Is this PR blocking you from the next release.
