### PR TITLE
Add workaround and missing `[MemberNotNullWhen]` attributes

### DIFF
--- a/Refit.Tests/API/ApiApprovalTests.Refit.DotNet6_0.verified.txt
+++ b/Refit.Tests/API/ApiApprovalTests.Refit.DotNet6_0.verified.txt
@@ -198,6 +198,15 @@ namespace Refit
     public interface IApiResponse<out T> : Refit.IApiResponse, System.IDisposable
     {
         T Content { get; }
+        new System.Net.Http.Headers.HttpContentHeaders? ContentHeaders { get; }
+        new Refit.ApiException? Error { get; }
+        [System.Diagnostics.CodeAnalysis.MemberNotNullWhen(false, "Error")]
+        [System.Diagnostics.CodeAnalysis.MemberNotNullWhen(true, "Content")]
+        [System.Diagnostics.CodeAnalysis.MemberNotNullWhen(true, "ContentHeaders")]
+        [get: System.Diagnostics.CodeAnalysis.MemberNotNullWhen(false, "Error")]
+        [get: System.Diagnostics.CodeAnalysis.MemberNotNullWhen(true, "Content")]
+        [get: System.Diagnostics.CodeAnalysis.MemberNotNullWhen(true, "ContentHeaders")]
+        new bool IsSuccessStatusCode { get; }
     }
     public interface IFormUrlEncodedParameterFormatter
     {

--- a/Refit.Tests/API/ApiApprovalTests.Refit.DotNet8_0.verified.txt
+++ b/Refit.Tests/API/ApiApprovalTests.Refit.DotNet8_0.verified.txt
@@ -198,6 +198,15 @@ namespace Refit
     public interface IApiResponse<out T> : Refit.IApiResponse, System.IDisposable
     {
         T Content { get; }
+        new System.Net.Http.Headers.HttpContentHeaders? ContentHeaders { get; }
+        new Refit.ApiException? Error { get; }
+        [System.Diagnostics.CodeAnalysis.MemberNotNullWhen(false, "Error")]
+        [System.Diagnostics.CodeAnalysis.MemberNotNullWhen(true, "Content")]
+        [System.Diagnostics.CodeAnalysis.MemberNotNullWhen(true, "ContentHeaders")]
+        [get: System.Diagnostics.CodeAnalysis.MemberNotNullWhen(false, "Error")]
+        [get: System.Diagnostics.CodeAnalysis.MemberNotNullWhen(true, "Content")]
+        [get: System.Diagnostics.CodeAnalysis.MemberNotNullWhen(true, "ContentHeaders")]
+        new bool IsSuccessStatusCode { get; }
     }
     public interface IFormUrlEncodedParameterFormatter
     {

--- a/Refit/ApiResponse.cs
+++ b/Refit/ApiResponse.cs
@@ -152,6 +152,31 @@ namespace Refit
     /// <inheritdoc/>
     public interface IApiResponse<out T> : IApiResponse
     {
+#if NET6_0_OR_GREATER
+        /// <summary>
+        /// The <see cref="ApiException"/> object in case of unsuccessful response.
+        /// </summary>
+        [SuppressMessage(
+            "Naming",
+            "CA1716:Identifiers should not match keywords",
+            Justification = "By Design"
+        )]
+        new ApiException? Error { get; }
+
+        /// <summary>
+        /// HTTP response content headers as defined in RFC 2616.
+        /// </summary>
+        new HttpContentHeaders? ContentHeaders { get; }
+
+        /// <summary>
+        /// Indicates whether the request was successful.
+        /// </summary>
+        [MemberNotNullWhen(true, nameof(Content))]
+        [MemberNotNullWhen(true, nameof(ContentHeaders))]
+        [MemberNotNullWhen(false, nameof(Error))]
+        new bool IsSuccessStatusCode { get; }
+#endif
+
         /// <summary>
         /// Deserialized request content as <typeparamref name="T"/>.
         /// </summary>


### PR DESCRIPTION
**What kind of change does this PR introduce?**
This is the second attempt to add `[MemberNotNullWhen]` attribute for `Content` property of `IApiResponse<T>`. 
Issue https://github.com/reactiveui/refit/issues/1671

**What is the current behavior?**
Analyzer doesn't know that `Content` is not null if `IsSuccessStatusCode` is `true`.
![image](https://github.com/user-attachments/assets/669914c0-9bb0-41c0-a835-6bdf9a797dd8)

**What is the new behavior?**
Analyzer sees new attributes and doesn't show warning\error about possible null ref.
![image](https://github.com/user-attachments/assets/25fd3069-56ec-41ad-967a-2f9582683940)

**What might this PR break?**
I hope nothing. 
- I had to add 3 `new` properties to the derived interface otherwise Rider shows the waring and analyzer ignores attribute for property, declared in the base interface. 
![image](https://github.com/user-attachments/assets/9a489a69-b974-4ea1-a48c-b1e617865a11)
- Explicit base property implementation may lead to the unexpected behavior based on the resolved interface ([sharplab](https://sharplab.io/#v2:EYLgtghglgdgNAFxAJwK4wD4AEBMAGAWAChcBGY4rAZgAJYEBTZAMwgGMGaBJAIQgGcGxAN7Ea4ujAQ0AsgE8ACsgD2AByYI5NYTQDmDBAG4aAX2JmilWvSasO3ACJMoANwYATGiG59BIsRIwDADuktLySmoaWjr6RqbmFCS0uLJyAMIANgL8Xo7Obu7+RBI01GFpkerImjQAvAB8NAAsOIYB4vQ+AgwAdBEq1bWNNDik7UQWVmU4ZaQA7MWluDgd2mulXE7Irh407gV7dTRBofJZOQAUAJQTpcukAJyXBzuF/YqD0bc0APS/NAA8qgEKoQfxvK0kvcJLwejRgD0uFJbOxOMdTmkLvx+Dc7jC5s9EYJkYwWGiPlVvsZ/kCQWCEBDRuQShILCYgA=))
![image](https://github.com/user-attachments/assets/952df29c-2fb2-45af-9d50-0d1d45a3e2ba)
But we are not going to add explicit implementation and `ApiResponse<T>` class is `sealed` so nobody will be able to make a derived class with explicit base implementation.
- I didn't introduce any breaking changes (I hope) like I did last time (change inheritance hierarchy with `IApiResponseBase`)
- We have 3 `new` properties in the `IApiResponse<T>` interface (with summary and `[SuppressMessage]`) just for making `[MemberNotNullWhen]` work. But they are wrapped with `#if NET6_0_OR_GREATER` directive so will be invisible for older frameworks.
- The `new` behavior for `interface` is safer than for `class` so I can't imagine any other problems we may have.

**Please check if the PR fulfills these requirements**
not applicable - [ ] Tests for the changes have been added (for bug fixes / features)
not applicable - [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:
I hope we finally can get rid of this annoying additional check we have everywhere now
![image](https://github.com/user-attachments/assets/23bac6f8-b13e-4643-8966-ad16c8dd2389)
