### PR TITLE
feat: change `IPerformanceService` to return `HttpResponseMessage`

### DIFF
--- a/Refit.Benchmarks/IPerformanceService.cs
+++ b/Refit.Benchmarks/IPerformanceService.cs
@@ -3,20 +3,20 @@
 public interface IPerformanceService
 {
     [Get("/users")]
-    public Task<string> ConstantRoute();
+    public Task<HttpResponseMessage> ConstantRoute();
 
     [Get("/users/{id}")]
-    public Task<string> DynamicRoute(int id);
+    public Task<HttpResponseMessage> DynamicRoute(int id);
 
     [Get("/users/{id}/{user}/{status}")]
-    public Task<string> ComplexDynamicRoute(int id, string user, string status);
+    public Task<HttpResponseMessage> ComplexDynamicRoute(int id, string user, string status);
 
     [Get("/users/{request.someProperty}")]
-    public Task<string> ObjectRequest(PathBoundObject request);
+    public Task<HttpResponseMessage> ObjectRequest(PathBoundObject request);
 
     [Post("/users/{id}/{request.someProperty}")]
     [Headers("User-Agent: Awesome Octocat App", "X-Emoji: :smile_cat:")]
-    public Task<string> ComplexRequest(int id, PathBoundObject request, [Query(CollectionFormat.Multi)]int[] queries);
+    public Task<HttpResponseMessage> ComplexRequest(int id, PathBoundObject request, [Query(CollectionFormat.Multi)]int[] queries);
 }
 
 public class PathBoundObject

--- a/Refit.Benchmarks/PerformanceBenchmark.cs
+++ b/Refit.Benchmarks/PerformanceBenchmark.cs
@@ -32,17 +32,17 @@ public class PerformanceBenchmark
     }
 
     [Benchmark]
-    public async Task<string> ConstantRouteAsync() => await service.ConstantRoute();
+    public async Task<HttpResponseMessage> ConstantRouteAsync() => await service.ConstantRoute();
 
     [Benchmark]
-    public async Task<string> DynamicRouteAsync() => await service.DynamicRoute(101);
+    public async Task<HttpResponseMessage> DynamicRouteAsync() => await service.DynamicRoute(101);
 
     [Benchmark]
-    public async Task<string> ComplexDynamicRouteAsync() => await service.ComplexDynamicRoute(101, "tom", "yCxv");
+    public async Task<HttpResponseMessage> ComplexDynamicRouteAsync() => await service.ComplexDynamicRoute(101, "tom", "yCxv");
 
     [Benchmark]
-    public async Task<string> ObjectRequestAsync() => await service.ObjectRequest(new PathBoundObject(){SomeProperty = "myProperty", SomeQuery = "myQuery"});
+    public async Task<HttpResponseMessage> ObjectRequestAsync() => await service.ObjectRequest(new PathBoundObject(){SomeProperty = "myProperty", SomeQuery = "myQuery"});
 
     [Benchmark]
-    public async Task<string> ComplexRequestAsync() => await service.ComplexRequest(101, new PathBoundObject(){SomeProperty = "myProperty", SomeQuery = "myQuery"}, [1,2,3,4,5,6]);
+    public async Task<HttpResponseMessage> ComplexRequestAsync() => await service.ComplexRequest(101, new PathBoundObject(){SomeProperty = "myProperty", SomeQuery = "myQuery"}, [1,2,3,4,5,6]);
 }

--- a/Refit.Benchmarks/StartupBenchmark.cs
+++ b/Refit.Benchmarks/StartupBenchmark.cs
@@ -28,20 +28,20 @@ public class StartupBenchmark
     public IPerformanceService CreateService() => RestService.For<IPerformanceService>(Host, settings);
 
     [Benchmark]
-    public async Task<string> FirstCallConstantRouteAsync() => await initialisedService.ConstantRoute();
+    public async Task<HttpResponseMessage> FirstCallConstantRouteAsync() => await initialisedService.ConstantRoute();
 
     [Benchmark]
-    public async Task<string> ConstantRouteAsync()
+    public async Task<HttpResponseMessage> ConstantRouteAsync()
     {
         var service = RestService.For<IPerformanceService>(Host, settings);
         return await service.ConstantRoute();
     }
 
     [Benchmark]
-    public async Task<string> FirstCallComplexRequestAsync() => await initialisedService.ObjectRequest(new PathBoundObject(){SomeProperty = "myProperty", SomeQuery = "myQuery"});
+    public async Task<HttpResponseMessage> FirstCallComplexRequestAsync() => await initialisedService.ObjectRequest(new PathBoundObject(){SomeProperty = "myProperty", SomeQuery = "myQuery"});
 
     [Benchmark]
-    public async Task<string> ComplexRequestAsync()
+    public async Task<HttpResponseMessage> ComplexRequestAsync()
     {
         var service = RestService.For<IPerformanceService>(Host, settings);
         return await service.ObjectRequest(new PathBoundObject(){SomeProperty = "myProperty", SomeQuery = "myQuery"});


### PR DESCRIPTION
Change return types from `Task<string>` to `Task<HttpResponseMessage`. This makes the benchmarks more accurate as they are intended to measure the cost of configuring and sending a `HttpRequestMessage` and not the time taken to convert the response into a `string`.

On a related note why isn't refit using `ReadAsStringAsync`?


### New Benchmark
| Method                   | Mean      | Error     | StdDev    | Gen0   | Allocated |
|------------------------- |----------:|----------:|----------:|-------:|----------:|
| ConstantRouteAsync       |  2.072 us | 0.0110 us | 0.0097 us | 0.2937 |   2.71 KB |
| DynamicRouteAsync        |  2.783 us | 0.0259 us | 0.0202 us | 0.3319 |   3.07 KB |
| ComplexDynamicRouteAsync |  4.060 us | 0.0226 us | 0.0200 us | 0.4044 |   3.78 KB |
| ObjectRequestAsync       |  4.954 us | 0.0295 us | 0.0262 us | 0.4807 |   4.48 KB |
| ComplexRequestAsync      | 14.455 us | 0.0686 us | 0.0642 us | 1.1597 |  10.67 KB |

### Old
Method | Mean | Error | StdDev | Gen0 | Gen1 | Allocated
-- | -- | -- | -- | -- | -- | --
ConstantRouteAsync | 2.045 us | 0.0395 us | 0.0638 us | 0.6828 | 0.0114 | 6.28 KB
DynamicRouteAsync | 2.601 us | 0.0518 us | 0.0532 us | 0.7172 | 0.0038 | 6.6 KB
ComplexDynamicRouteAsync | 3.799 us | 0.0651 us | 0.0891 us | 0.7858 | - | 7.24 KB
ObjectRequestAsync | 4.560 us | 0.0886 us | 0.1021 us | 0.8698 | - | 8.05 KB
ComplexRequestAsync | 12.951 us | 0.2575 us | 0.4643 us | 1.5259 | - | 14.19 KB


