### PR TITLE
feat: calculate path substitutions in `RestMethodInfo`

### DIFF
--- a/Refit.Tests/RestService.cs
+++ b/Refit.Tests/RestService.cs
@@ -421,6 +421,25 @@ public class RestServiceIntegrationTests
     }
 
     [Fact]
+    public async Task GetWithLongPathBoundObject()
+    {
+        var mockHttp = new MockHttpMessageHandler();
+        var longPathString = string.Concat(Enumerable.Repeat("barNone", 1000));
+        mockHttp
+            .Expect(HttpMethod.Get, $"http://foo/foos/12345/bar/{longPathString}")
+            .WithExactQueryString("")
+            .Respond("application/json", "Ok");
+
+        var settings = new RefitSettings { HttpMessageHandlerFactory = () => mockHttp };
+        var fixture = RestService.For<IApiBindPathToObject>("http://foo", settings);
+
+        await fixture.GetFooBars(
+            new PathBoundObject() { SomeProperty = 12345, SomeProperty2 = longPathString }
+        );
+        mockHttp.VerifyNoOutstandingExpectation();
+    }
+
+    [Fact]
     public async Task GetWithPathBoundObjectDifferentCasing()
     {
         var mockHttp = new MockHttpMessageHandler();

--- a/Refit/RestMethodInfo.cs
+++ b/Refit/RestMethodInfo.cs
@@ -46,6 +46,7 @@ namespace Refit
         public Dictionary<int, Tuple<string, string>> AttachmentNameMap { get; set; }
         public ParameterInfo[] ParameterInfoArray { get; set; }
         public Dictionary<int, RestMethodParameterInfo> ParameterMap { get; set; }
+        public List<ParameterFragment> FragmentPath { get ; set ; }
         public Type ReturnType { get; set; }
         public Type ReturnResultType { get; set; }
         public Type DeserializedResultType { get; set; }
@@ -53,7 +54,7 @@ namespace Refit
         public bool IsApiResponse { get; }
         public bool ShouldDisposeResponse { get; private set; }
 
-        static readonly Regex ParameterRegex = new(@"{(.*?)}");
+        static readonly Regex ParameterRegex = new("{(([^/?\r\n])*?)}");
         static readonly HttpMethod PatchMethod = new("PATCH");
 
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
@@ -90,7 +91,7 @@ namespace Refit
                 .GetParameters()
                 .Where(static p => p.ParameterType != typeof(CancellationToken))
                 .ToArray();
-            ParameterMap = BuildParameterMap(RelativePath, ParameterInfoArray);
+            (ParameterMap, FragmentPath) = BuildParameterMap(RelativePath, ParameterInfoArray);
             BodyParameterInfo = FindBodyParameter(ParameterInfoArray, IsMultipart, hma.Method);
             AuthorizeParameterInfo = FindAuthorizationParameter(ParameterInfoArray);
 
@@ -267,7 +268,7 @@ namespace Refit
                 );
         }
 
-        static Dictionary<int, RestMethodParameterInfo> BuildParameterMap(
+        static (Dictionary<int, RestMethodParameterInfo> ret, List<ParameterFragment> fragmentList) BuildParameterMap(
             string relativePath,
             ParameterInfo[] parameterInfo
         )
@@ -275,123 +276,140 @@ namespace Refit
             var ret = new Dictionary<int, RestMethodParameterInfo>();
 
             // This section handles pattern matching in the URL. We also need it to add parameter key/values for any attribute with a [Query]
-            var parameterizedParts = relativePath
-                .Split('/', '?')
-                .SelectMany(x => ParameterRegex.Matches(x).Cast<Match>())
-                .ToList();
+            var parameterizedParts = ParameterRegex.Matches(relativePath).Cast<Match>().ToArray();
 
-            if (parameterizedParts.Count > 0)
+            if (parameterizedParts.Length == 0)
             {
-                var paramValidationDict = parameterInfo.ToDictionary(
-                    k => GetUrlNameForParameter(k).ToLowerInvariant(),
-                    v => v
-                );
-                //if the param is an lets make a dictionary for all it's potential parameters
-                var objectParamValidationDict = parameterInfo
-                    .Where(x => x.ParameterType.GetTypeInfo().IsClass)
-                    .SelectMany(x => GetParameterProperties(x).Select(p => Tuple.Create(x, p)))
-                    .GroupBy(
-                        i => $"{i.Item1.Name}.{GetUrlNameForProperty(i.Item2)}".ToLowerInvariant()
-                    )
-                    .ToDictionary(k => k.Key, v => v.First());
-                foreach (var match in parameterizedParts)
+                if(string.IsNullOrEmpty(relativePath))
+                    return (ret, []);
+
+                return (ret, [ParameterFragment.Constant(relativePath)]);
+            }
+
+            var paramValidationDict = parameterInfo.ToDictionary(
+                k => GetUrlNameForParameter(k).ToLowerInvariant(),
+                v => v
+            );
+            //if the param is an lets make a dictionary for all it's potential parameters
+            var objectParamValidationDict = parameterInfo
+                .Where(x => x.ParameterType.GetTypeInfo().IsClass)
+                .SelectMany(x => GetParameterProperties(x).Select(p => Tuple.Create(x, p)))
+                .GroupBy(
+                    i => $"{i.Item1.Name}.{GetUrlNameForProperty(i.Item2)}".ToLowerInvariant()
+                )
+                .ToDictionary(k => k.Key, v => v.First());
+
+            var fragmentList = new List<ParameterFragment>();
+            var index = 0;
+
+           foreach (var match in parameterizedParts)
+            {
+                // Add constant value from given http path
+                if (match.Index != index)
                 {
-                    var rawName = match.Groups[1].Value.ToLowerInvariant();
-                    var isRoundTripping = rawName.StartsWith("**");
-                    string name;
-                    if (isRoundTripping)
+                    fragmentList.Add(ParameterFragment.Constant(relativePath.Substring(index, match.Index - index)));
+                }
+                index = match.Index + match.Length;
+
+                var rawName = match.Groups[1].Value.ToLowerInvariant();
+                var isRoundTripping = rawName.StartsWith("**");
+                var name = isRoundTripping ? rawName.Substring(2) : rawName;
+
+                if (paramValidationDict.TryGetValue(name, out var value)) //if it's a standard parameter
+                {
+                    var paramType = value.ParameterType;
+                    if (isRoundTripping && paramType != typeof(string))
                     {
-                        name = rawName.Substring(2);
+                        throw new ArgumentException(
+                            $"URL {relativePath} has round-tripping parameter {rawName}, but the type of matched method parameter is {paramType.FullName}. It must be a string."
+                        );
+                    }
+                    var parameterType = isRoundTripping
+                        ? ParameterType.RoundTripping
+                        : ParameterType.Normal;
+                    var restMethodParameterInfo = new RestMethodParameterInfo(name, value)
+                    {
+                        Type = parameterType
+                    };
+
+                    var parameterIndex = Array.IndexOf(parameterInfo, restMethodParameterInfo.ParameterInfo);
+                    fragmentList.Add(ParameterFragment.Dynamic(parameterIndex));
+#if NET6_0_OR_GREATER
+                    ret.TryAdd(
+                        parameterIndex,
+                        restMethodParameterInfo
+                    );
+#else
+                    if (!ret.ContainsKey(parameterIndex))
+                    {
+                        ret.Add(parameterIndex, restMethodParameterInfo);
+                    }
+#endif
+                }
+                //else if it's a property on a object parameter
+                else if (
+                    objectParamValidationDict.TryGetValue(name, out var value1)
+                    && !isRoundTripping
+                )
+                {
+                    var property = value1;
+                    var parameterIndex = Array.IndexOf(parameterInfo, property.Item1);
+                    //If we already have this parameter, add additional ParameterProperty
+                    if (ret.TryGetValue(parameterIndex, out var value2))
+                    {
+                        if (!value2.IsObjectPropertyParameter)
+                        {
+                            throw new ArgumentException(
+                                $"Parameter {property.Item1.Name} matches both a parameter and nested parameter on a parameter object"
+                            );
+                        }
+
+                        value2.ParameterProperties.Add(
+                            new RestMethodParameterProperty(name, property.Item2)
+                        );
+                        fragmentList.Add(ParameterFragment.DynamicObject(parameterIndex, value2.ParameterProperties.Count - 1));
                     }
                     else
                     {
-                        name = rawName;
-                    }
+                        var restMethodParameterInfo = new RestMethodParameterInfo(
+                            true,
+                            property.Item1
+                        );
+                        restMethodParameterInfo.ParameterProperties.Add(
+                            new RestMethodParameterProperty(name, property.Item2)
+                        );
 
-                    if (paramValidationDict.TryGetValue(name, out var value)) //if it's a standard parameter
-                    {
-                        var paramType = value.ParameterType;
-                        if (isRoundTripping && paramType != typeof(string))
-                        {
-                            throw new ArgumentException(
-                                $"URL {relativePath} has round-tripping parameter {rawName}, but the type of matched method parameter is {paramType.FullName}. It must be a string."
-                            );
-                        }
-                        var parameterType = isRoundTripping
-                            ? ParameterType.RoundTripping
-                            : ParameterType.Normal;
-                        var restMethodParameterInfo = new RestMethodParameterInfo(name, value)
-                        {
-                            Type = parameterType
-                        };
+                        var idx = Array.IndexOf(parameterInfo, restMethodParameterInfo.ParameterInfo);
+                        fragmentList.Add(ParameterFragment.DynamicObject(idx, 0));
 #if NET6_0_OR_GREATER
                         ret.TryAdd(
-                            Array.IndexOf(parameterInfo, restMethodParameterInfo.ParameterInfo),
+                            idx,
                             restMethodParameterInfo
                         );
 #else
-                        var idx = Array.IndexOf(parameterInfo, restMethodParameterInfo.ParameterInfo);
+                        // Do the contains check
                         if (!ret.ContainsKey(idx))
                         {
                             ret.Add(idx, restMethodParameterInfo);
                         }
 #endif
                     }
-                    //else if it's a property on a object parameter
-                    else if (
-                        objectParamValidationDict.TryGetValue(name, out var value1)
-                        && !isRoundTripping
-                    )
-                    {
-                        var property = value1;
-                        var parameterIndex = Array.IndexOf(parameterInfo, property.Item1);
-                        //If we already have this parameter, add additional ParameterProperty
-                        if (ret.TryGetValue(parameterIndex, out var value2))
-                        {
-                            if (!value2.IsObjectPropertyParameter)
-                            {
-                                throw new ArgumentException(
-                                    $"Parameter {property.Item1.Name} matches both a parameter and nested parameter on a parameter object"
-                                );
-                            }
-
-                            value2.ParameterProperties.Add(
-                                new RestMethodParameterProperty(name, property.Item2)
-                            );
-                        }
-                        else
-                        {
-                            var restMethodParameterInfo = new RestMethodParameterInfo(
-                                true,
-                                property.Item1
-                            );
-                            restMethodParameterInfo.ParameterProperties.Add(
-                                new RestMethodParameterProperty(name, property.Item2)
-                            );
-#if NET6_0_OR_GREATER
-                            ret.TryAdd(
-                                Array.IndexOf(parameterInfo, restMethodParameterInfo.ParameterInfo),
-                                restMethodParameterInfo
-                            );
-#else
-                            // Do the contains check
-                            var idx = Array.IndexOf(parameterInfo, restMethodParameterInfo.ParameterInfo);
-                            if (!ret.ContainsKey(idx))
-                            {
-                                ret.Add(idx, restMethodParameterInfo);
-                            }
-#endif
-                        }
-                    }
-                    else
-                    {
-                        throw new ArgumentException(
-                            $"URL {relativePath} has parameter {rawName}, but no method parameter matches"
-                        );
-                    }
+                }
+                else
+                {
+                    throw new ArgumentException(
+                        $"URL {relativePath} has parameter {rawName}, but no method parameter matches"
+                    );
                 }
             }
-            return ret;
+
+            // add trailing string
+            if (index < relativePath.Length - 1)
+            {
+                var trailingConstant = relativePath.Substring(index, relativePath.Length - index);
+                fragmentList.Add(ParameterFragment.Constant(trailingConstant));
+            }
+            return (ret, fragmentList);
         }
 
         static string GetUrlNameForParameter(ParameterInfo paramInfo)
@@ -669,5 +687,16 @@ namespace Refit
                 && DeserializedResultType != typeof(HttpContent)
                 && DeserializedResultType != typeof(Stream);
         }
+    }
+
+    internal record struct ParameterFragment(string? Value, int ArgumentIndex, int PropertyIndex)
+    {
+        public bool IsConstant => Value != null;
+        public bool IsDynamicRoute => ArgumentIndex >= 0 && PropertyIndex < 0;
+        public bool IsObjectProperty => ArgumentIndex >= 0 && PropertyIndex >= 0;
+
+        public static ParameterFragment Constant(string value) => new (value, -1, -1);
+        public static ParameterFragment Dynamic(int index) => new (null, index, -1);
+        public static ParameterFragment DynamicObject(int index, int propertyIndex) => new (null, index, propertyIndex);
     }
 }


### PR DESCRIPTION
Parse the url target inside `RestMethodInfo`, removing the use of regex on function calls.



Re attempt at #1730. Turns out the additional allocations were caused by [line 829](https://github.com/TimothyMakkison/refict/blob/94bf0a5f521e0ae8dc57e11cd2eb475ff9e003d6/Refit/RequestBuilderImplementation.cs#L829) creating a closure. Looking at the lowered code C# always created the linq closure, even when round tripping was never used 🤔 

In future I could optimise round trip to not use `string.Split`, either manually splitting or using `Span.Split`

### Benchmarks (on battery power)
| Method                   | Mean      | Error     | StdDev    | Median    | Gen0   | Allocated |
|------------------------- |----------:|----------:|----------:|----------:|-------:|----------:|
| ConstantRouteAsync       |  9.332 us | 0.6444 us | 1.8999 us |  9.479 us | 0.2899 |   2.71 KB |
| DynamicRouteAsync        |  5.284 us | 0.2704 us | 0.7449 us |  4.957 us | 0.3052 |      3 KB |
| ComplexDynamicRouteAsync |  5.091 us | 0.4201 us | 1.2387 us |  4.433 us | 0.3662 |   3.41 KB |
| ObjectRequestAsync       |  5.942 us | 0.1163 us | 0.2504 us |  5.834 us | 0.4730 |   4.41 KB |
| ComplexRequestAsync      | 18.005 us | 0.4408 us | 1.2359 us | 17.392 us | 1.1292 |  10.44 KB |


### Old benchmarks
| Method                   | Mean      | Error     | StdDev    | Gen0   | Allocated |
|------------------------- |----------:|----------:|----------:|-------:|----------:|
| ConstantRouteAsync       |  2.072 us | 0.0110 us | 0.0097 us | 0.2937 |   2.71 KB |
| DynamicRouteAsync        |  2.783 us | 0.0259 us | 0.0202 us | 0.3319 |   3.07 KB |
| ComplexDynamicRouteAsync |  4.060 us | 0.0226 us | 0.0200 us | 0.4044 |   3.78 KB |
| ObjectRequestAsync       |  4.954 us | 0.0295 us | 0.0262 us | 0.4807 |   4.48 KB |
| ComplexRequestAsync      | 14.455 us | 0.0686 us | 0.0642 us | 1.1597 |  10.67 KB |
