### PR TITLE
feat: add URL fragment tests

### DIFF
--- a/Refit.Tests/RestService.cs
+++ b/Refit.Tests/RestService.cs
@@ -311,6 +311,9 @@ public interface IFragmentApi
     [Get("/foo#")]
     Task EmptyFragment();
 
+    [Get("/foo#first#second")]
+    Task ManyFragments();
+
     [Get("/foo#{frag}")]
     Task ParameterFragment(string frag);
 
@@ -2492,6 +2495,23 @@ public class RestServiceIntegrationTests
         var fixture = RestService.For<IFragmentApi>("https://github.com", settings);
 
         await fixture.EmptyFragment();
+
+        mockHttp.VerifyNoOutstandingExpectation();
+    }
+
+    [Fact]
+    public async Task ShouldStripManyFragments()
+    {
+        var mockHttp = new MockHttpMessageHandler();
+        var settings = new RefitSettings { HttpMessageHandlerFactory = () => mockHttp, };
+
+        mockHttp
+            .Expect(HttpMethod.Get, "https://github.com/foo")
+            .Respond(HttpStatusCode.OK);
+
+        var fixture = RestService.For<IFragmentApi>("https://github.com", settings);
+
+        await fixture.ManyFragments();
 
         mockHttp.VerifyNoOutstandingExpectation();
     }

--- a/Refit.Tests/RestServiceExceptions.cs
+++ b/Refit.Tests/RestServiceExceptions.cs
@@ -57,6 +57,12 @@ public interface IInvalidParamSubstitution
     Task<string> GetValue(string path);
 }
 
+public interface IInvalidFragmentParamSubstitution
+{
+    [Get("/{#path}")]
+    Task<string> GetValue(string path);
+}
+
 public interface IUrlNoMatchingParameters
 {
     [Get("/{value}")]
@@ -158,10 +164,19 @@ public class RestServiceExceptionTests
     }
 
     [Fact]
-    public void InvalidParamSubstitutionShouldNotThrow()
+    public async Task InvalidParamSubstitutionShouldThrow()
     {
         var service = RestService.For<IInvalidParamSubstitution>("https://api.github.com");
         Assert.NotNull(service);
+
+        await Assert.ThrowsAsync<ApiException>(() => service.GetValue("throws"));
+    }
+
+    [Fact]
+    public void InvalidFragmentParamSubstitutionShouldThrow()
+    {
+        var exception = Assert.Throws<ArgumentException>(() => RestService.For<IInvalidFragmentParamSubstitution>("https://api.github.com"));
+        AssertExceptionContains("but no method parameter matches", exception);
     }
 
     [Fact]


### PR DESCRIPTION
- Added fragment tests, ensuring that the fragment is always removed. ie `/foo#name` -> `/foo`
- Updated `InvalidParamSubstitutionShouldThrow`
- Added `InvalidFragmentParamSubstitutionShouldThrow` 

This is to prevent future changes to Uri from breaking things. I'm looking at removing `Uri` and `UriBuilder` creation in [RequestBuilderImplementation.](https://github.com/reactiveui/refit/blob/961984118885db34c39d8b4eb2a326786c560e71/Refit/RequestBuilderImplementation.cs#L761)
Out of curiosity why doesn't refit support fragments, is this intentional or an oversight?