### PR TITLE
feat: prevent serialization of `CancellationToken?`

### DIFF
--- a/Refit.Tests/RestService.cs
+++ b/Refit.Tests/RestService.cs
@@ -324,6 +324,18 @@ public interface IFragmentApi
     Task QueryAfterFragment();
 }
 
+public interface ICancellableApi
+{
+    [Get("/foo")]
+    Task GetWithCancellation(CancellationToken token = default);
+
+    [Get("/foo")]
+    Task<string> GetWithCancellationAndReturn(CancellationToken token = default);
+
+    [Get("/foo")]
+    Task GetWithNullableCancellation(CancellationToken? token);
+}
+
 public class HttpBinGet
 {
     public Dictionary<string, object> Args { get; set; }
@@ -2564,6 +2576,50 @@ public class RestServiceIntegrationTests
         var fixture = RestService.For<IFragmentApi>("https://github.com", settings);
 
         await fixture.QueryAfterFragment();
+
+        mockHttp.VerifyNoOutstandingExpectation();
+    }
+
+    [Fact]
+    public async Task TaskShouldCancelWhenRequested()
+    {
+        var ctSource = new CancellationTokenSource();
+        var token = ctSource.Token;
+
+        var fixture = RestService.For<ICancellableApi>("https://github.com");
+
+        ctSource.Cancel();
+        var task = fixture.GetWithCancellation(token);
+        await Assert.ThrowsAsync<TaskCanceledException>(async () => await task);
+    }
+
+    [Fact]
+    public async Task TaskResultShouldCancelWhenRequested()
+    {
+        var ctSource = new CancellationTokenSource();
+        var token = ctSource.Token;
+
+        var fixture = RestService.For<ICancellableApi>("https://github.com");
+
+        ctSource.Cancel();
+        var task = fixture.GetWithCancellationAndReturn(token);
+        await Assert.ThrowsAsync<TaskCanceledException>(async () => await task);
+    }
+
+
+    [Fact]
+    public async Task NullableCancellationTokenShouldBeIgnored()
+    {
+        var mockHttp = new MockHttpMessageHandler();
+        var settings = new RefitSettings { HttpMessageHandlerFactory = () => mockHttp, };
+
+        mockHttp
+            .Expect(HttpMethod.Get, "https://github.com/foo")
+            .Respond(HttpStatusCode.OK);
+
+        var fixture = RestService.For<ICancellableApi>("https://github.com", settings);
+
+        await fixture.GetWithNullableCancellation(null);
 
         mockHttp.VerifyNoOutstandingExpectation();
     }

--- a/Refit/RestMethodInfo.cs
+++ b/Refit/RestMethodInfo.cs
@@ -89,7 +89,7 @@ namespace Refit
             // Exclude cancellation token parameters from this list
             ParameterInfoArray = methodInfo
                 .GetParameters()
-                .Where(static p => p.ParameterType != typeof(CancellationToken))
+                .Where(static p => p.ParameterType != typeof(CancellationToken) && p.ParameterType != typeof(CancellationToken?))
                 .ToArray();
             (ParameterMap, FragmentPath) = BuildParameterMap(RelativePath, ParameterInfoArray);
             BodyParameterInfo = FindBodyParameter(ParameterInfoArray, IsMultipart, hma.Method);


### PR DESCRIPTION
- Prevent `CancellationToken?` being serialized.
- Add cancellation tests to `Tests/RestService`, including `NullableCancellationTokenShouldBeIgnored` 


I'm not sure how Refit should handle nullable Cancellation token, it's a struct so it isn't nullable by default. My two ideas:

- Refit functions containing a `CancellationToken` parameter should throw an exception or emit a diagnostic.
- Accept `CancellationToken?`, check these tokens for nullability. If they are null then substitute it with a default token.

See #1915