### PR TITLE
fix: support - symbols in csproj names

### DIFF
--- a/InterfaceStubGenerator.Shared/Parser.cs
+++ b/InterfaceStubGenerator.Shared/Parser.cs
@@ -34,6 +34,9 @@ internal static class Parser
 
         refitInternalNamespace = $"{refitInternalNamespace ?? string.Empty}RefitInternalGenerated";
 
+        // Remove - as they are valid in csproj, but invalid in a namespace
+        refitInternalNamespace = refitInternalNamespace.Replace('-', '_').Replace('@', '_');
+
         // we're going to create a new compilation that contains the attribute.
         // TODO: we should allow source generators to provide source during initialize, so that this step isn't required.
         var options = (CSharpParseOptions)compilation.SyntaxTrees[0].Options;

--- a/InterfaceStubGenerator.Shared/Parser.cs
+++ b/InterfaceStubGenerator.Shared/Parser.cs
@@ -265,7 +265,7 @@ namespace {refitInternalNamespace}
         }
 
         // Remove dots
-        ns = ns!.Replace(".", "").Replace('-', '_');
+        ns = ns!.Replace(".", "");
         var interfaceDisplayName = interfaceSymbol.ToDisplayString(
             SymbolDisplayFormat.FullyQualifiedFormat
         );

--- a/InterfaceStubGenerator.Shared/Parser.cs
+++ b/InterfaceStubGenerator.Shared/Parser.cs
@@ -265,7 +265,7 @@ namespace {refitInternalNamespace}
         }
 
         // Remove dots
-        ns = ns!.Replace(".", "");
+        ns = ns!.Replace(".", "").Replace('-', '_');
         var interfaceDisplayName = interfaceSymbol.ToDisplayString(
             SymbolDisplayFormat.FullyQualifiedFormat
         );

--- a/Refit/UniqueName.cs
+++ b/Refit/UniqueName.cs
@@ -39,7 +39,7 @@
             interfaceTypeName = interfaceTypeName.Replace("+", "");
 
             // Get the namespace and remove the dots
-            var ns = refitInterfaceType.Namespace?.Replace(".", "").Replace("-", "_");
+            var ns = refitInterfaceType.Namespace?.Replace(".", "");
 
             // Refit types will be generated as private classes within a Generated type in namespace
             // Refit.Implementation

--- a/Refit/UniqueName.cs
+++ b/Refit/UniqueName.cs
@@ -39,7 +39,7 @@
             interfaceTypeName = interfaceTypeName.Replace("+", "");
 
             // Get the namespace and remove the dots
-            var ns = refitInterfaceType.Namespace?.Replace(".", "");
+            var ns = refitInterfaceType.Namespace?.Replace(".", "").Replace("-", "_");
 
             // Refit types will be generated as private classes within a Generated type in namespace
             // Refit.Implementation


### PR DESCRIPTION
Replaces `-`/`@` with `_`. in `refitInternalNamespace`.

Do you know what characters csproj supports?

Fixes #1920