### PR TITLE
Version 7 - Fix for CRLF injection vulnerability (#1834)

### DIFF
--- a/Refit/RestMethodInfo.cs
+++ b/Refit/RestMethodInfo.cs
@@ -259,6 +259,12 @@ namespace Refit
                 throw new ArgumentException(
                     $"URL path {relativePath} must start with '/' and be of the form '/foo/bar/baz'"
                 );
+
+            // CRLF injection protection
+            if (relativePath.Contains("\r") || relativePath.Contains("\n"))
+                throw new ArgumentException(
+                    $"URL path {relativePath} must not contain CR or LF characters"
+                );
         }
 
         static Dictionary<int, RestMethodParameterInfo> BuildParameterMap(


### PR DESCRIPTION
This PR is meant for a backport of this specific fix https://github.com/reactiveui/refit/pull/1834 for the 7.2.1 version.

Hash of the commit used for the cherry pick : https://github.com/reactiveui/refit/commit/483b1d8df18098f137ca0eca056b7e9ec19f70dd