### PR TITLE
fix: support nullable value type collection in queries

### DIFF
--- a/Refit.Tests/RestService.cs
+++ b/Refit.Tests/RestService.cs
@@ -298,6 +298,9 @@ public interface IQueryApi
 
     [Get("/foo?{key}={value}")]
     Task ParameterMappedQuery(string key, string value);
+
+    [Get("/foo")]
+    Task NullableIntCollectionQuery([Query] int?[] values);
 }
 
 public interface IFragmentApi
@@ -2452,6 +2455,24 @@ public class RestServiceIntegrationTests
         var fixture = RestService.For<IQueryApi>("https://github.com", settings);
 
         await fixture.ParameterMappedQuery("key1,", "value1,");
+
+        mockHttp.VerifyNoOutstandingExpectation();
+    }
+
+    [Fact]
+    public async Task NullableIntCollectionQuery()
+    {
+        var mockHttp = new MockHttpMessageHandler();
+        var settings = new RefitSettings { HttpMessageHandlerFactory = () => mockHttp, };
+
+        mockHttp
+            .Expect(HttpMethod.Get, "https://github.com/foo")
+            .WithExactQueryString("values=3%2C4%2C")
+            .Respond(HttpStatusCode.OK);
+
+        var fixture = RestService.For<IQueryApi>("https://github.com", settings);
+
+        await fixture.NullableIntCollectionQuery([3, 4, null]);
 
         mockHttp.VerifyNoOutstandingExpectation();
     }

--- a/Refit/RequestBuilderImplementation.cs
+++ b/Refit/RequestBuilderImplementation.cs
@@ -1349,12 +1349,15 @@ namespace Refit
             type = intType.GetGenericArguments()[0];
             return ShouldReturn(type);
 
+            // Check if type is a simple string or IFormattable type, check underlying type if Nullable<T>
             static bool ShouldReturn(Type type) =>
-                type == typeof(string)
-                || type == typeof(bool)
-                || type == typeof(char)
-                || typeof(IFormattable).IsAssignableFrom(type)
-                || type == typeof(Uri);
+                Nullable.GetUnderlyingType(type) is { } underlyingType
+                    ? ShouldReturn(underlyingType)
+                    : type == typeof(string)
+                      || type == typeof(bool)
+                      || type == typeof(char)
+                      || typeof(IFormattable).IsAssignableFrom(type)
+                      || type == typeof(Uri);
         }
 
         static void SetHeader(HttpRequestMessage request, string name, string? value)


### PR DESCRIPTION
- Add check in `ShouldReturn` for `Nullable<T>` types.
- Added test to `Tests/RestService`

Fixes #1568