### PR TITLE
fix: support interfaces with different name casing

### DIFF
--- a/InterfaceStubGenerator.Shared/Parser.cs
+++ b/InterfaceStubGenerator.Shared/Parser.cs
@@ -151,7 +151,7 @@ internal static class Parser
 
         var supportsNullable = options.LanguageVersion >= LanguageVersion.CSharp8;
 
-        var keyCount = new Dictionary<string, int>();
+        var keyCount = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
 
         var attributeText =
             @$"

--- a/Refit.GeneratorTests/InterfaceTests.cs
+++ b/Refit.GeneratorTests/InterfaceTests.cs
@@ -107,6 +107,44 @@ public class InterfaceTests
     }
 
     [Fact]
+    public Task InterfacesWithDifferentCasing()
+    {
+        return Fixture.VerifyForType(
+            """
+            public interface IApi
+            {
+                [Get("/users")]
+                Task<string> Get();
+            }
+
+            public interface Iapi
+            {
+                [Get("/users")]
+                Task<string> Get();
+            }
+            """);
+    }
+
+    [Fact]
+    public Task InterfacesWithDifferentSignature()
+    {
+        return Fixture.VerifyForType(
+            """
+            public interface IApi
+            {
+                [Get("/users")]
+                Task<string> Get();
+            }
+
+            public interface IApi<T>
+            {
+                [Get("/users")]
+                Task<string> Get();
+            }
+            """);
+    }
+
+    [Fact]
     public Task NestedNamespaceTest()
     {
         return Fixture.VerifyForDeclaration(

--- a/Refit.GeneratorTests/_snapshots/InterfaceTests.InterfacesWithDifferentCasing#IApi.g.verified.cs
+++ b/Refit.GeneratorTests/_snapshots/InterfaceTests.InterfacesWithDifferentCasing#IApi.g.verified.cs
@@ -1,0 +1,53 @@
+﻿//HintName: IApi.g.cs
+#nullable disable
+#pragma warning disable
+namespace Refit.Implementation
+{
+
+    partial class Generated
+    {
+
+    /// <inheritdoc />
+    [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    [global::System.Diagnostics.DebuggerNonUserCode]
+    [global::RefitInternalGenerated.PreserveAttribute]
+    [global::System.Reflection.Obfuscation(Exclude=true)]
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    partial class RefitGeneratorTestIApi
+        : global::RefitGeneratorTest.IApi
+
+    {
+        /// <inheritdoc />
+        public global::System.Net.Http.HttpClient Client { get; }
+        readonly global::Refit.IRequestBuilder requestBuilder;
+
+        /// <inheritdoc />
+        public RefitGeneratorTestIApi(global::System.Net.Http.HttpClient client, global::Refit.IRequestBuilder requestBuilder)
+        {
+            Client = client;
+            this.requestBuilder = requestBuilder;
+        }
+
+
+        /// <inheritdoc />
+        public async global::System.Threading.Tasks.Task<string> Get()
+        {
+            var ______arguments = global::System.Array.Empty<object>();
+            var ______func = requestBuilder.BuildRestResultFuncForMethod("Get", global::System.Array.Empty<global::System.Type>() );
+
+            return await ((global::System.Threading.Tasks.Task<string>)______func(this.Client, ______arguments)).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc />
+        async global::System.Threading.Tasks.Task<string> global::RefitGeneratorTest.IApi.Get()
+        {
+            var ______arguments = global::System.Array.Empty<object>();
+            var ______func = requestBuilder.BuildRestResultFuncForMethod("Get", global::System.Array.Empty<global::System.Type>() );
+
+            return await ((global::System.Threading.Tasks.Task<string>)______func(this.Client, ______arguments)).ConfigureAwait(false);
+        }
+    }
+    }
+}
+
+#pragma warning restore

--- a/Refit.GeneratorTests/_snapshots/InterfaceTests.InterfacesWithDifferentCasing#Iapi1.g.verified.cs
+++ b/Refit.GeneratorTests/_snapshots/InterfaceTests.InterfacesWithDifferentCasing#Iapi1.g.verified.cs
@@ -1,0 +1,53 @@
+﻿//HintName: Iapi1.g.cs
+#nullable disable
+#pragma warning disable
+namespace Refit.Implementation
+{
+
+    partial class Generated
+    {
+
+    /// <inheritdoc />
+    [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    [global::System.Diagnostics.DebuggerNonUserCode]
+    [global::RefitInternalGenerated.PreserveAttribute]
+    [global::System.Reflection.Obfuscation(Exclude=true)]
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    partial class RefitGeneratorTestIapi
+        : global::RefitGeneratorTest.Iapi
+
+    {
+        /// <inheritdoc />
+        public global::System.Net.Http.HttpClient Client { get; }
+        readonly global::Refit.IRequestBuilder requestBuilder;
+
+        /// <inheritdoc />
+        public RefitGeneratorTestIapi(global::System.Net.Http.HttpClient client, global::Refit.IRequestBuilder requestBuilder)
+        {
+            Client = client;
+            this.requestBuilder = requestBuilder;
+        }
+
+
+        /// <inheritdoc />
+        public async global::System.Threading.Tasks.Task<string> Get()
+        {
+            var ______arguments = global::System.Array.Empty<object>();
+            var ______func = requestBuilder.BuildRestResultFuncForMethod("Get", global::System.Array.Empty<global::System.Type>() );
+
+            return await ((global::System.Threading.Tasks.Task<string>)______func(this.Client, ______arguments)).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc />
+        async global::System.Threading.Tasks.Task<string> global::RefitGeneratorTest.Iapi.Get()
+        {
+            var ______arguments = global::System.Array.Empty<object>();
+            var ______func = requestBuilder.BuildRestResultFuncForMethod("Get", global::System.Array.Empty<global::System.Type>() );
+
+            return await ((global::System.Threading.Tasks.Task<string>)______func(this.Client, ______arguments)).ConfigureAwait(false);
+        }
+    }
+    }
+}
+
+#pragma warning restore

--- a/Refit.GeneratorTests/_snapshots/InterfaceTests.InterfacesWithDifferentSignature#IApi.g.verified.cs
+++ b/Refit.GeneratorTests/_snapshots/InterfaceTests.InterfacesWithDifferentSignature#IApi.g.verified.cs
@@ -1,0 +1,53 @@
+﻿//HintName: IApi.g.cs
+#nullable disable
+#pragma warning disable
+namespace Refit.Implementation
+{
+
+    partial class Generated
+    {
+
+    /// <inheritdoc />
+    [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    [global::System.Diagnostics.DebuggerNonUserCode]
+    [global::RefitInternalGenerated.PreserveAttribute]
+    [global::System.Reflection.Obfuscation(Exclude=true)]
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    partial class RefitGeneratorTestIApi
+        : global::RefitGeneratorTest.IApi
+
+    {
+        /// <inheritdoc />
+        public global::System.Net.Http.HttpClient Client { get; }
+        readonly global::Refit.IRequestBuilder requestBuilder;
+
+        /// <inheritdoc />
+        public RefitGeneratorTestIApi(global::System.Net.Http.HttpClient client, global::Refit.IRequestBuilder requestBuilder)
+        {
+            Client = client;
+            this.requestBuilder = requestBuilder;
+        }
+
+
+        /// <inheritdoc />
+        public async global::System.Threading.Tasks.Task<string> Get()
+        {
+            var ______arguments = global::System.Array.Empty<object>();
+            var ______func = requestBuilder.BuildRestResultFuncForMethod("Get", global::System.Array.Empty<global::System.Type>() );
+
+            return await ((global::System.Threading.Tasks.Task<string>)______func(this.Client, ______arguments)).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc />
+        async global::System.Threading.Tasks.Task<string> global::RefitGeneratorTest.IApi.Get()
+        {
+            var ______arguments = global::System.Array.Empty<object>();
+            var ______func = requestBuilder.BuildRestResultFuncForMethod("Get", global::System.Array.Empty<global::System.Type>() );
+
+            return await ((global::System.Threading.Tasks.Task<string>)______func(this.Client, ______arguments)).ConfigureAwait(false);
+        }
+    }
+    }
+}
+
+#pragma warning restore

--- a/Refit.GeneratorTests/_snapshots/InterfaceTests.InterfacesWithDifferentSignature#IApi1.g.verified.cs
+++ b/Refit.GeneratorTests/_snapshots/InterfaceTests.InterfacesWithDifferentSignature#IApi1.g.verified.cs
@@ -1,0 +1,53 @@
+﻿//HintName: IApi1.g.cs
+#nullable disable
+#pragma warning disable
+namespace Refit.Implementation
+{
+
+    partial class Generated
+    {
+
+    /// <inheritdoc />
+    [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    [global::System.Diagnostics.DebuggerNonUserCode]
+    [global::RefitInternalGenerated.PreserveAttribute]
+    [global::System.Reflection.Obfuscation(Exclude=true)]
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    partial class RefitGeneratorTestIApi<T>
+        : global::RefitGeneratorTest.IApi<T>
+
+    {
+        /// <inheritdoc />
+        public global::System.Net.Http.HttpClient Client { get; }
+        readonly global::Refit.IRequestBuilder requestBuilder;
+
+        /// <inheritdoc />
+        public RefitGeneratorTestIApi(global::System.Net.Http.HttpClient client, global::Refit.IRequestBuilder requestBuilder)
+        {
+            Client = client;
+            this.requestBuilder = requestBuilder;
+        }
+
+
+        /// <inheritdoc />
+        public async global::System.Threading.Tasks.Task<string> Get()
+        {
+            var ______arguments = global::System.Array.Empty<object>();
+            var ______func = requestBuilder.BuildRestResultFuncForMethod("Get", global::System.Array.Empty<global::System.Type>() );
+
+            return await ((global::System.Threading.Tasks.Task<string>)______func(this.Client, ______arguments)).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc />
+        async global::System.Threading.Tasks.Task<string> global::RefitGeneratorTest.IApi<T>.Get()
+        {
+            var ______arguments = global::System.Array.Empty<object>();
+            var ______func = requestBuilder.BuildRestResultFuncForMethod("Get", global::System.Array.Empty<global::System.Type>() );
+
+            return await ((global::System.Threading.Tasks.Task<string>)______func(this.Client, ______arguments)).ConfigureAwait(false);
+        }
+    }
+    }
+}
+
+#pragma warning restore


### PR DESCRIPTION
- Add `StringComparer.OrdinalIgnoreCase` to `keyCount`
- Added name casing test and same name, different signature test
 
Fixes #1689