### PR TITLE
test: add unsupported return type test

### DIFF
--- a/Refit.GeneratorTests/ReturnTypeTests.cs
+++ b/Refit.GeneratorTests/ReturnTypeTests.cs
@@ -81,4 +81,14 @@ public class ReturnTypeTests
             IObservable<HttpResponseMessage> GetUser(string user);
             """);
     }
+
+    [Fact]
+    public Task ReturnUnsupportedType()
+    {
+        return Fixture.VerifyForBody(
+            """
+            [Get("/users/{user}")]
+            string GetUser(string user);
+            """);
+    }
 }

--- a/Refit.GeneratorTests/_snapshots/ReturnTypeTests.ReturnUnsupportedType#IGeneratedClient.g.verified.cs
+++ b/Refit.GeneratorTests/_snapshots/ReturnTypeTests.ReturnUnsupportedType#IGeneratedClient.g.verified.cs
@@ -1,0 +1,57 @@
+﻿//HintName: IGeneratedClient.g.cs
+#nullable disable
+#pragma warning disable
+namespace Refit.Implementation
+{
+
+    partial class Generated
+    {
+
+    /// <inheritdoc />
+    [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    [global::System.Diagnostics.DebuggerNonUserCode]
+    [global::RefitInternalGenerated.PreserveAttribute]
+    [global::System.Reflection.Obfuscation(Exclude=true)]
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+    partial class RefitGeneratorTestIGeneratedClient
+        : global::RefitGeneratorTest.IGeneratedClient
+
+    {
+        /// <inheritdoc />
+        public global::System.Net.Http.HttpClient Client { get; }
+        readonly global::Refit.IRequestBuilder requestBuilder;
+
+        /// <inheritdoc />
+        public RefitGeneratorTestIGeneratedClient(global::System.Net.Http.HttpClient client, global::Refit.IRequestBuilder requestBuilder)
+        {
+            Client = client;
+            this.requestBuilder = requestBuilder;
+        }
+
+
+        private static readonly global::System.Type[] ______typeParameters = new global::System.Type[] {typeof(string) };
+
+        /// <inheritdoc />
+        public string GetUser(string @user)
+        {
+            var ______arguments = new object[] { @user };
+            var ______func = requestBuilder.BuildRestResultFuncForMethod("GetUser", ______typeParameters );
+
+            return (string)______func(this.Client, ______arguments);
+        }
+
+        private static readonly global::System.Type[] ______typeParameters0 = new global::System.Type[] {typeof(string) };
+
+        /// <inheritdoc />
+        string global::RefitGeneratorTest.IGeneratedClient.GetUser(string @user)
+        {
+            var ______arguments = new object[] { @user };
+            var ______func = requestBuilder.BuildRestResultFuncForMethod("GetUser", ______typeParameters0 );
+
+            return (string)______func(this.Client, ______arguments);
+        }
+    }
+    }
+}
+
+#pragma warning restore


### PR DESCRIPTION
Adds a generated code test for a refit method that does not have a `Task`/`IObservable` return type signature.