### PR TITLE
fix: replace `Append` with `WriteLine` and remove blank spaces

### DIFF
--- a/InterfaceStubGenerator.Shared/Emitter.cs
+++ b/InterfaceStubGenerator.Shared/Emitter.cs
@@ -18,54 +18,54 @@ internal static class Emitter
 
         var attributeText = $$"""
 
-              #pragma warning disable
-              namespace {{model.RefitInternalNamespace}}
-              {
-                  [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-                  [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-                  [global::System.AttributeUsage (global::System.AttributeTargets.Class | global::System.AttributeTargets.Struct | global::System.AttributeTargets.Enum | global::System.AttributeTargets.Constructor | global::System.AttributeTargets.Method | global::System.AttributeTargets.Property | global::System.AttributeTargets.Field | global::System.AttributeTargets.Event | global::System.AttributeTargets.Interface | global::System.AttributeTargets.Delegate)]
-                  sealed class PreserveAttribute : global::System.Attribute
-                  {
-                      //
-                      // Fields
-                      //
-                      public bool AllMembers;
+            #pragma warning disable
+            namespace {{model.RefitInternalNamespace}}
+            {
+                [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+                [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+                [global::System.AttributeUsage (global::System.AttributeTargets.Class | global::System.AttributeTargets.Struct | global::System.AttributeTargets.Enum | global::System.AttributeTargets.Constructor | global::System.AttributeTargets.Method | global::System.AttributeTargets.Property | global::System.AttributeTargets.Field | global::System.AttributeTargets.Event | global::System.AttributeTargets.Interface | global::System.AttributeTargets.Delegate)]
+                sealed class PreserveAttribute : global::System.Attribute
+                {
+                    //
+                    // Fields
+                    //
+                    public bool AllMembers;
 
-                      public bool Conditional;
-                  }
-              }
-              #pragma warning restore
+                    public bool Conditional;
+                }
+            }
+            #pragma warning restore
 
-              """;
+            """;
         // add the attribute text
         addSource("PreserveAttribute.g.cs", SourceText.From(attributeText, Encoding.UTF8));
 
         var generatedClassText = $$"""
 
-              #pragma warning disable
-              namespace Refit.Implementation
-              {
+            #pragma warning disable
+            namespace Refit.Implementation
+            {
 
-                  /// <inheritdoc />
-                  [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-                  [global::System.Diagnostics.DebuggerNonUserCode]
-                  [{{model.PreserveAttributeDisplayName}}]
-                  [global::System.Reflection.Obfuscation(Exclude=true)]
-                  [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-                  internal static partial class Generated
-                  {
-              #if NET5_0_OR_GREATER
-                      [System.Runtime.CompilerServices.ModuleInitializer]
-                      [System.Diagnostics.CodeAnalysis.DynamicDependency(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All, typeof(global::Refit.Implementation.Generated))]
-                      public static void Initialize()
-                      {
-                      }
-              #endif
-                  }
-              }
-              #pragma warning restore
+                /// <inheritdoc />
+                [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+                [global::System.Diagnostics.DebuggerNonUserCode]
+                [{{model.PreserveAttributeDisplayName}}]
+                [global::System.Reflection.Obfuscation(Exclude=true)]
+                [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+                internal static partial class Generated
+                {
+            #if NET5_0_OR_GREATER
+                    [System.Runtime.CompilerServices.ModuleInitializer]
+                    [System.Diagnostics.CodeAnalysis.DynamicDependency(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All, typeof(global::Refit.Implementation.Generated))]
+                    public static void Initialize()
+                    {
+                    }
+            #endif
+                }
+            }
+            #pragma warning restore
 
-              """;
+            """;
         addSource("Generated.g.cs", SourceText.From(generatedClassText, Encoding.UTF8));
     }
 
@@ -76,39 +76,53 @@ internal static class Emitter
         // if nullability is supported emit the nullable directive
         if (model.Nullability != Nullability.None)
         {
-            source.WriteLine("#nullable " + (model.Nullability == Nullability.Enabled ? "enable" : "disable"));
+            source.WriteLine(
+                "#nullable " + (model.Nullability == Nullability.Enabled ? "enable" : "disable")
+            );
         }
 
         source.WriteLine(
-            $@"#pragma warning disable
-namespace Refit.Implementation
-{{
+            $$"""
+            #pragma warning disable
+            namespace Refit.Implementation
+            {
 
-    partial class Generated
-    {{
+                partial class Generated
+                {
 
-    /// <inheritdoc />
-    [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-    [global::System.Diagnostics.DebuggerNonUserCode]
-    [{model.PreserveAttributeDisplayName}]
-    [global::System.Reflection.Obfuscation(Exclude=true)]
-    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    partial class {model.Ns}{model.ClassDeclaration}
-        : {model.InterfaceDisplayName}{GenerateConstraints(model.Constraints, false)}
-
-    {{
-        /// <inheritdoc />
-        public global::System.Net.Http.HttpClient Client {{ get; }}
-        readonly global::Refit.IRequestBuilder requestBuilder;
-
-        /// <inheritdoc />
-        public {model.Ns}{model.ClassSuffix}(global::System.Net.Http.HttpClient client, global::Refit.IRequestBuilder requestBuilder)
-        {{
-            Client = client;
-            this.requestBuilder = requestBuilder;
-        }}"
+                /// <inheritdoc />
+                [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+                [global::System.Diagnostics.DebuggerNonUserCode]
+                [{{model.PreserveAttributeDisplayName}}]
+                [global::System.Reflection.Obfuscation(Exclude=true)]
+                [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+                partial class {{model.Ns}}{{model.ClassDeclaration}}
+                    : {{model.InterfaceDisplayName}}
+            """
         );
 
+        source.Indentation += 2;
+        GenerateConstraints(source, model.Constraints, false);
+        source.Indentation--;
+
+        source.WriteLine(
+            $$"""
+            {
+                /// <inheritdoc />
+                public global::System.Net.Http.HttpClient Client { get; }
+                readonly global::Refit.IRequestBuilder requestBuilder;
+
+                /// <inheritdoc />
+                public {{model.Ns}}{{model.ClassSuffix}}(global::System.Net.Http.HttpClient client, global::Refit.IRequestBuilder requestBuilder)
+                {
+                    Client = client;
+                    this.requestBuilder = requestBuilder;
+                }
+
+            """
+        );
+
+        source.Indentation++;
         var uniqueNames = new UniqueNameBuilder();
         uniqueNames.Reserve(model.MemberNames);
 
@@ -135,13 +149,15 @@ namespace Refit.Implementation
             WriteDisposableMethod(source);
         }
 
+        source.Indentation -= 2;
         source.WriteLine(
-            @"
-    }
-    }
-}
+            """
+                }
+                }
+            }
 
-#pragma warning restore"
+            #pragma warning restore
+            """
         );
         return source.ToSourceText();
     }
@@ -172,12 +188,11 @@ namespace Refit.Implementation
             ReturnTypeInfo.AsyncVoid => (true, "await (", ").ConfigureAwait(false)"),
             ReturnTypeInfo.AsyncResult => (true, "return await (", ").ConfigureAwait(false)"),
             ReturnTypeInfo.Return => (false, "return ", ""),
-            _
-                => throw new ArgumentOutOfRangeException(
-                    nameof(methodModel.ReturnTypeMetadata),
-                    methodModel.ReturnTypeMetadata,
-                    "Unsupported value."
-                )
+            _ => throw new ArgumentOutOfRangeException(
+                nameof(methodModel.ReturnTypeMetadata),
+                methodModel.ReturnTypeMetadata,
+                "Unsupported value."
+            ),
         };
 
         WriteMethodOpening(source, methodModel, !isTopLevel, isAsync);
@@ -204,13 +219,13 @@ namespace Refit.Implementation
                 ? $", new global::System.Type[] {{ {string.Join(", ", genericArray)} }}"
                 : string.Empty;
 
-        source.Append(
-            @$"
+        source.WriteLine(
+            $"""
             var ______arguments = {argumentsArrayString};
-            var ______func = requestBuilder.BuildRestResultFuncForMethod(""{methodModel.Name}"", {parameterTypesExpression}{genericString} );
+            var ______func = requestBuilder.BuildRestResultFuncForMethod("{methodModel.Name}", {parameterTypesExpression}{genericString} );
 
             {@return}({returnType})______func(this.Client, ______arguments){configureAwait};
-    "
+            """
         );
 
         WriteMethodClosing(source);
@@ -221,12 +236,10 @@ namespace Refit.Implementation
         WriteMethodOpening(source, methodModel, true);
 
         source.WriteLine(
-            @"
-            throw new global::System.NotImplementedException(""Either this method has no Refit HTTP method attribute or you've used something other than a string literal for the 'path' argument."");");
+            @"throw new global::System.NotImplementedException(""Either this method has no Refit HTTP method attribute or you've used something other than a string literal for the 'path' argument."");"
+        );
 
-        source.Indentation += 1;
         WriteMethodClosing(source);
-        source.Indentation -= 1;
     }
 
     // TODO: This assumes that the Dispose method is a void that takes no parameters.
@@ -234,16 +247,15 @@ namespace Refit.Implementation
     // Does the bool overload cause an issue here.
     private static void WriteDisposableMethod(SourceWriter source)
     {
-        source.Append(
+        source.WriteLine(
             """
 
-
-                              /// <inheritdoc />
-                              void global::System.IDisposable.Dispose()
-                              {
-                                      Client?.Dispose();
-                              }
-                      """
+            /// <inheritdoc />
+            void global::System.IDisposable.Dispose()
+            {
+                    Client?.Dispose();
+            }
+            """
         );
     }
 
@@ -267,12 +279,12 @@ namespace Refit.Implementation
         // find a name and generate field declaration.
         var typeParameterFieldName = uniqueNames.New(TypeParameterVariableName);
         var types = string.Join(", ", methodModel.Parameters.Select(x => $"typeof({x.Type})"));
-        source.Append(
+
+        source.WriteLine(
             $$"""
 
-
-                        private static readonly global::System.Type[] {{typeParameterFieldName}} = new global::System.Type[] {{{types}} };
-                """
+            private static readonly global::System.Type[] {{typeParameterFieldName}} = new global::System.Type[] {{{types}} };
+            """
         );
 
         return typeParameterFieldName;
@@ -288,18 +300,17 @@ namespace Refit.Implementation
         var visibility = !isExplicitInterface ? "public " : string.Empty;
         var async = isAsync ? "async " : "";
 
-        source.Append(
-            @$"
-
-        /// <inheritdoc />
-        {visibility}{async}{methodModel.ReturnType} "
+        var builder = new StringBuilder();
+        builder.Append(
+            @$"/// <inheritdoc />
+{visibility}{async}{methodModel.ReturnType} "
         );
 
         if (isExplicitInterface)
         {
-            source.Append(@$"{methodModel.ContainingType}.");
+            builder.Append(@$"{methodModel.ContainingType}.");
         }
-        source.Append(@$"{methodModel.DeclaredMethod}(");
+        builder.Append(@$"{methodModel.DeclaredMethod}(");
 
         if (methodModel.Parameters.Count > 0)
         {
@@ -311,38 +322,45 @@ namespace Refit.Implementation
                 list.Add($@"{param.Type}{(annotation ? '?' : string.Empty)} @{param.MetadataName}");
             }
 
-            source.Append(string.Join(", ", list));
+            builder.Append(string.Join(", ", list));
         }
 
-        source.Append(
-            @$"){GenerateConstraints(methodModel.Constraints, isExplicitInterface)}
-        {{"
-        );
+        builder.Append(")");
+
+        source.WriteLine();
+        source.WriteLine(builder.ToString());
+        source.Indentation++;
+        GenerateConstraints(source, methodModel.Constraints, isExplicitInterface);
+        source.Indentation--;
+        source.WriteLine("{");
+        source.Indentation++;
     }
 
-    private static void WriteMethodClosing(SourceWriter source) => source.Append(@"    }");
+    private static void WriteMethodClosing(SourceWriter source)
+    {
+        source.Indentation--;
+        source.WriteLine("}");
+    }
 
-    private static string GenerateConstraints(
+    private static void GenerateConstraints(
+        SourceWriter writer,
         ImmutableEquatableArray<TypeConstraint> typeParameters,
         bool isOverrideOrExplicitImplementation
     )
     {
-        var source = new StringBuilder();
         // Need to loop over the constraints and create them
         foreach (var typeParameter in typeParameters)
         {
             WriteConstraintsForTypeParameter(
-                source,
+                writer,
                 typeParameter,
                 isOverrideOrExplicitImplementation
             );
         }
-
-        return source.ToString();
     }
 
     private static void WriteConstraintsForTypeParameter(
-        StringBuilder source,
+        SourceWriter source,
         TypeConstraint typeParameter,
         bool isOverrideOrExplicitImplementation
     )
@@ -388,10 +406,7 @@ namespace Refit.Implementation
 
         if (parameters.Count > 0)
         {
-            source.Append(
-                @$"
-         where {typeParameter.TypeName} : {string.Join(", ", parameters)}"
-            );
+            source.WriteLine($"where {typeParameter.TypeName} : {string.Join(", ", parameters)}");
         }
     }
 }

--- a/Refit.GeneratorTests/_snapshots/GeneratedTest.ShouldEmitAllFiles#IGeneratedClient.g.verified.cs
+++ b/Refit.GeneratorTests/_snapshots/GeneratedTest.ShouldEmitAllFiles#IGeneratedClient.g.verified.cs
@@ -15,7 +15,6 @@ namespace Refit.Implementation
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
     partial class RefitGeneratorTestIGeneratedClient
         : global::RefitGeneratorTest.IGeneratedClient
-
     {
         /// <inheritdoc />
         public global::System.Net.Http.HttpClient Client { get; }

--- a/Refit.GeneratorTests/_snapshots/InterfaceTests.ContainedInterfaceTest#IContainedInterface.g.verified.cs
+++ b/Refit.GeneratorTests/_snapshots/InterfaceTests.ContainedInterfaceTest#IContainedInterface.g.verified.cs
@@ -15,7 +15,6 @@ namespace Refit.Implementation
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
     partial class RefitGeneratorTestContainerTypeIContainedInterface
         : global::RefitGeneratorTest.ContainerType.IContainedInterface
-
     {
         /// <inheritdoc />
         public global::System.Net.Http.HttpClient Client { get; }

--- a/Refit.GeneratorTests/_snapshots/InterfaceTests.DefaultInterfaceMethod#IGeneratedInterface.g.verified.cs
+++ b/Refit.GeneratorTests/_snapshots/InterfaceTests.DefaultInterfaceMethod#IGeneratedInterface.g.verified.cs
@@ -15,7 +15,6 @@ namespace Refit.Implementation
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
     partial class RefitGeneratorTestIGeneratedInterface
         : global::RefitGeneratorTest.IGeneratedInterface
-
     {
         /// <inheritdoc />
         public global::System.Net.Http.HttpClient Client { get; }

--- a/Refit.GeneratorTests/_snapshots/InterfaceTests.DerivedDefaultInterfaceMethod#IBaseInterface.g.verified.cs
+++ b/Refit.GeneratorTests/_snapshots/InterfaceTests.DerivedDefaultInterfaceMethod#IBaseInterface.g.verified.cs
@@ -15,7 +15,6 @@ namespace Refit.Implementation
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
     partial class RefitGeneratorTestIBaseInterface
         : global::RefitGeneratorTest.IBaseInterface
-
     {
         /// <inheritdoc />
         public global::System.Net.Http.HttpClient Client { get; }

--- a/Refit.GeneratorTests/_snapshots/InterfaceTests.DerivedDefaultInterfaceMethod#IGeneratedInterface.g.verified.cs
+++ b/Refit.GeneratorTests/_snapshots/InterfaceTests.DerivedDefaultInterfaceMethod#IGeneratedInterface.g.verified.cs
@@ -15,7 +15,6 @@ namespace Refit.Implementation
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
     partial class RefitGeneratorTestIGeneratedInterface
         : global::RefitGeneratorTest.IGeneratedInterface
-
     {
         /// <inheritdoc />
         public global::System.Net.Http.HttpClient Client { get; }

--- a/Refit.GeneratorTests/_snapshots/InterfaceTests.DisposableTest#IGeneratedInterface.g.verified.cs
+++ b/Refit.GeneratorTests/_snapshots/InterfaceTests.DisposableTest#IGeneratedInterface.g.verified.cs
@@ -15,7 +15,6 @@ namespace Refit.Implementation
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
     partial class IGeneratedInterface
         : global::IGeneratedInterface
-
     {
         /// <inheritdoc />
         public global::System.Net.Http.HttpClient Client { get; }

--- a/Refit.GeneratorTests/_snapshots/InterfaceTests.GlobalNamespaceTest#IGeneratedInterface.g.verified.cs
+++ b/Refit.GeneratorTests/_snapshots/InterfaceTests.GlobalNamespaceTest#IGeneratedInterface.g.verified.cs
@@ -15,7 +15,6 @@ namespace Refit.Implementation
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
     partial class IGeneratedInterface
         : global::IGeneratedInterface
-
     {
         /// <inheritdoc />
         public global::System.Net.Http.HttpClient Client { get; }

--- a/Refit.GeneratorTests/_snapshots/InterfaceTests.InterfaceDerivedFromRefitBaseTest#IBaseInterface.g.verified.cs
+++ b/Refit.GeneratorTests/_snapshots/InterfaceTests.InterfaceDerivedFromRefitBaseTest#IBaseInterface.g.verified.cs
@@ -15,7 +15,6 @@ namespace Refit.Implementation
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
     partial class RefitGeneratorTestIBaseInterface
         : global::RefitGeneratorTest.IBaseInterface
-
     {
         /// <inheritdoc />
         public global::System.Net.Http.HttpClient Client { get; }

--- a/Refit.GeneratorTests/_snapshots/InterfaceTests.InterfaceDerivedFromRefitBaseTest#IDerivedInterface.g.verified.cs
+++ b/Refit.GeneratorTests/_snapshots/InterfaceTests.InterfaceDerivedFromRefitBaseTest#IDerivedInterface.g.verified.cs
@@ -15,7 +15,6 @@ namespace Refit.Implementation
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
     partial class RefitGeneratorTestIDerivedInterface
         : global::RefitGeneratorTest.IDerivedInterface
-
     {
         /// <inheritdoc />
         public global::System.Net.Http.HttpClient Client { get; }

--- a/Refit.GeneratorTests/_snapshots/InterfaceTests.InterfaceWithGenericConstraint#IGeneratedInterface.g.verified.cs
+++ b/Refit.GeneratorTests/_snapshots/InterfaceTests.InterfaceWithGenericConstraint#IGeneratedInterface.g.verified.cs
@@ -15,12 +15,11 @@ namespace Refit.Implementation
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
     partial class IGeneratedInterface<T1, T2, T3, T4, T5>
         : global::IGeneratedInterface<T1, T2, T3, T4, T5>
-         where T1 : class
-         where T2 : unmanaged
-         where T3 : struct
-         where T4 : notnull
-         where T5 : class, global::System.IDisposable, new()
-
+        where T1 : class
+        where T2 : unmanaged
+        where T3 : struct
+        where T4 : notnull
+        where T5 : class, global::System.IDisposable, new()
     {
         /// <inheritdoc />
         public global::System.Net.Http.HttpClient Client { get; }

--- a/Refit.GeneratorTests/_snapshots/InterfaceTests.InterfacesWithDifferentCasing#IApi.g.verified.cs
+++ b/Refit.GeneratorTests/_snapshots/InterfaceTests.InterfacesWithDifferentCasing#IApi.g.verified.cs
@@ -15,7 +15,6 @@ namespace Refit.Implementation
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
     partial class RefitGeneratorTestIApi
         : global::RefitGeneratorTest.IApi
-
     {
         /// <inheritdoc />
         public global::System.Net.Http.HttpClient Client { get; }

--- a/Refit.GeneratorTests/_snapshots/InterfaceTests.InterfacesWithDifferentCasing#Iapi1.g.verified.cs
+++ b/Refit.GeneratorTests/_snapshots/InterfaceTests.InterfacesWithDifferentCasing#Iapi1.g.verified.cs
@@ -15,7 +15,6 @@ namespace Refit.Implementation
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
     partial class RefitGeneratorTestIapi
         : global::RefitGeneratorTest.Iapi
-
     {
         /// <inheritdoc />
         public global::System.Net.Http.HttpClient Client { get; }

--- a/Refit.GeneratorTests/_snapshots/InterfaceTests.InterfacesWithDifferentSignature#IApi.g.verified.cs
+++ b/Refit.GeneratorTests/_snapshots/InterfaceTests.InterfacesWithDifferentSignature#IApi.g.verified.cs
@@ -15,7 +15,6 @@ namespace Refit.Implementation
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
     partial class RefitGeneratorTestIApi
         : global::RefitGeneratorTest.IApi
-
     {
         /// <inheritdoc />
         public global::System.Net.Http.HttpClient Client { get; }

--- a/Refit.GeneratorTests/_snapshots/InterfaceTests.InterfacesWithDifferentSignature#IApi1.g.verified.cs
+++ b/Refit.GeneratorTests/_snapshots/InterfaceTests.InterfacesWithDifferentSignature#IApi1.g.verified.cs
@@ -15,7 +15,6 @@ namespace Refit.Implementation
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
     partial class RefitGeneratorTestIApi<T>
         : global::RefitGeneratorTest.IApi<T>
-
     {
         /// <inheritdoc />
         public global::System.Net.Http.HttpClient Client { get; }

--- a/Refit.GeneratorTests/_snapshots/InterfaceTests.NestedNamespaceTest#IGeneratedInterface.g.verified.cs
+++ b/Refit.GeneratorTests/_snapshots/InterfaceTests.NestedNamespaceTest#IGeneratedInterface.g.verified.cs
@@ -15,7 +15,6 @@ namespace Refit.Implementation
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
     partial class NestedRefitGeneratorTestIGeneratedInterface
         : global::Nested.RefitGeneratorTest.IGeneratedInterface
-
     {
         /// <inheritdoc />
         public global::System.Net.Http.HttpClient Client { get; }

--- a/Refit.GeneratorTests/_snapshots/InterfaceTests.NonRefitMethodShouldRaiseDiagnostic#IGeneratedClient.g.verified.cs
+++ b/Refit.GeneratorTests/_snapshots/InterfaceTests.NonRefitMethodShouldRaiseDiagnostic#IGeneratedClient.g.verified.cs
@@ -15,7 +15,6 @@ namespace Refit.Implementation
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
     partial class RefitGeneratorTestIGeneratedClient
         : global::RefitGeneratorTest.IGeneratedClient
-
     {
         /// <inheritdoc />
         public global::System.Net.Http.HttpClient Client { get; }

--- a/Refit.GeneratorTests/_snapshots/InterfaceTests.RefitInterfaceDerivedFromBaseTest#IGeneratedInterface.g.verified.cs
+++ b/Refit.GeneratorTests/_snapshots/InterfaceTests.RefitInterfaceDerivedFromBaseTest#IGeneratedInterface.g.verified.cs
@@ -15,7 +15,6 @@ namespace Refit.Implementation
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
     partial class RefitGeneratorTestIGeneratedInterface
         : global::RefitGeneratorTest.IGeneratedInterface
-
     {
         /// <inheritdoc />
         public global::System.Net.Http.HttpClient Client { get; }

--- a/Refit.GeneratorTests/_snapshots/InterfaceTests.RefitInterfaceDerivedFromRefitBaseTest#IBaseInterface.g.verified.cs
+++ b/Refit.GeneratorTests/_snapshots/InterfaceTests.RefitInterfaceDerivedFromRefitBaseTest#IBaseInterface.g.verified.cs
@@ -15,7 +15,6 @@ namespace Refit.Implementation
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
     partial class RefitGeneratorTestIBaseInterface
         : global::RefitGeneratorTest.IBaseInterface
-
     {
         /// <inheritdoc />
         public global::System.Net.Http.HttpClient Client { get; }

--- a/Refit.GeneratorTests/_snapshots/InterfaceTests.RefitInterfaceDerivedFromRefitBaseTest#IGeneratedInterface.g.verified.cs
+++ b/Refit.GeneratorTests/_snapshots/InterfaceTests.RefitInterfaceDerivedFromRefitBaseTest#IGeneratedInterface.g.verified.cs
@@ -15,7 +15,6 @@ namespace Refit.Implementation
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
     partial class RefitGeneratorTestIGeneratedInterface
         : global::RefitGeneratorTest.IGeneratedInterface
-
     {
         /// <inheritdoc />
         public global::System.Net.Http.HttpClient Client { get; }

--- a/Refit.GeneratorTests/_snapshots/MethodTests.MethodsWithGenericConstraints#IGeneratedClient.g.verified.cs
+++ b/Refit.GeneratorTests/_snapshots/MethodTests.MethodsWithGenericConstraints#IGeneratedClient.g.verified.cs
@@ -15,7 +15,6 @@ namespace Refit.Implementation
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
     partial class RefitGeneratorTestIGeneratedClient
         : global::RefitGeneratorTest.IGeneratedClient
-
     {
         /// <inheritdoc />
         public global::System.Net.Http.HttpClient Client { get; }
@@ -31,11 +30,11 @@ namespace Refit.Implementation
 
         /// <inheritdoc />
         public async global::System.Threading.Tasks.Task<string> Get<T1, T2, T3, T4, T5>()
-         where T1 : class
-         where T2 : unmanaged
-         where T3 : struct
-         where T4 : notnull
-         where T5 : class, global::System.IDisposable, new()
+            where T1 : class
+            where T2 : unmanaged
+            where T3 : struct
+            where T4 : notnull
+            where T5 : class, global::System.IDisposable, new()
         {
             var ______arguments = global::System.Array.Empty<object>();
             var ______func = requestBuilder.BuildRestResultFuncForMethod("Get", global::System.Array.Empty<global::System.Type>(), new global::System.Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5) } );
@@ -45,9 +44,9 @@ namespace Refit.Implementation
 
         /// <inheritdoc />
         async global::System.Threading.Tasks.Task<string> global::RefitGeneratorTest.IGeneratedClient.Get<T1, T2, T3, T4, T5>()
-         where T1 : class
-         where T3 : struct
-         where T5 : class
+            where T1 : class
+            where T3 : struct
+            where T5 : class
         {
             var ______arguments = global::System.Array.Empty<object>();
             var ______func = requestBuilder.BuildRestResultFuncForMethod("Get", global::System.Array.Empty<global::System.Type>(), new global::System.Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5) } );
@@ -57,9 +56,9 @@ namespace Refit.Implementation
 
         /// <inheritdoc />
         void global::RefitGeneratorTest.IGeneratedClient.NonRefitMethod<T1, T2, T3, T4, T5>()
-         where T1 : class
-         where T3 : struct
-         where T5 : class
+            where T1 : class
+            where T3 : struct
+            where T5 : class
         {
             throw new global::System.NotImplementedException("Either this method has no Refit HTTP method attribute or you've used something other than a string literal for the 'path' argument.");
         }

--- a/Refit.GeneratorTests/_snapshots/ParameterTests.NullableRouteParameter#IGeneratedClient.g.verified.cs
+++ b/Refit.GeneratorTests/_snapshots/ParameterTests.NullableRouteParameter#IGeneratedClient.g.verified.cs
@@ -15,7 +15,6 @@ namespace Refit.Implementation
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
     partial class RefitGeneratorTestIGeneratedClient
         : global::RefitGeneratorTest.IGeneratedClient
-
     {
         /// <inheritdoc />
         public global::System.Net.Http.HttpClient Client { get; }

--- a/Refit.GeneratorTests/_snapshots/ParameterTests.NullableValueTypeRouteParameter#IGeneratedClient.g.verified.cs
+++ b/Refit.GeneratorTests/_snapshots/ParameterTests.NullableValueTypeRouteParameter#IGeneratedClient.g.verified.cs
@@ -15,7 +15,6 @@ namespace Refit.Implementation
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
     partial class RefitGeneratorTestIGeneratedClient
         : global::RefitGeneratorTest.IGeneratedClient
-
     {
         /// <inheritdoc />
         public global::System.Net.Http.HttpClient Client { get; }

--- a/Refit.GeneratorTests/_snapshots/ParameterTests.RouteParameter#IGeneratedClient.g.verified.cs
+++ b/Refit.GeneratorTests/_snapshots/ParameterTests.RouteParameter#IGeneratedClient.g.verified.cs
@@ -15,7 +15,6 @@ namespace Refit.Implementation
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
     partial class RefitGeneratorTestIGeneratedClient
         : global::RefitGeneratorTest.IGeneratedClient
-
     {
         /// <inheritdoc />
         public global::System.Net.Http.HttpClient Client { get; }

--- a/Refit.GeneratorTests/_snapshots/ParameterTests.ValueTypeRouteParameter#IGeneratedClient.g.verified.cs
+++ b/Refit.GeneratorTests/_snapshots/ParameterTests.ValueTypeRouteParameter#IGeneratedClient.g.verified.cs
@@ -15,7 +15,6 @@ namespace Refit.Implementation
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
     partial class RefitGeneratorTestIGeneratedClient
         : global::RefitGeneratorTest.IGeneratedClient
-
     {
         /// <inheritdoc />
         public global::System.Net.Http.HttpClient Client { get; }

--- a/Refit.GeneratorTests/_snapshots/ReturnTypeTests.GenericConstraintReturnTask#IGeneratedClient.g.verified.cs
+++ b/Refit.GeneratorTests/_snapshots/ReturnTypeTests.GenericConstraintReturnTask#IGeneratedClient.g.verified.cs
@@ -15,7 +15,6 @@ namespace Refit.Implementation
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
     partial class RefitGeneratorTestIGeneratedClient
         : global::RefitGeneratorTest.IGeneratedClient
-
     {
         /// <inheritdoc />
         public global::System.Net.Http.HttpClient Client { get; }
@@ -31,7 +30,7 @@ namespace Refit.Implementation
 
         /// <inheritdoc />
         public async global::System.Threading.Tasks.Task<string> Get<T>()
-         where T : class, global::System.IDisposable, new()
+            where T : class, global::System.IDisposable, new()
         {
             var ______arguments = global::System.Array.Empty<object>();
             var ______func = requestBuilder.BuildRestResultFuncForMethod("Get", global::System.Array.Empty<global::System.Type>(), new global::System.Type[] { typeof(T) } );
@@ -41,7 +40,7 @@ namespace Refit.Implementation
 
         /// <inheritdoc />
         async global::System.Threading.Tasks.Task<string> global::RefitGeneratorTest.IGeneratedClient.Get<T>()
-         where T : class
+            where T : class
         {
             var ______arguments = global::System.Array.Empty<object>();
             var ______func = requestBuilder.BuildRestResultFuncForMethod("Get", global::System.Array.Empty<global::System.Type>(), new global::System.Type[] { typeof(T) } );

--- a/Refit.GeneratorTests/_snapshots/ReturnTypeTests.GenericStructConstraintReturnTask#IGeneratedClient.g.verified.cs
+++ b/Refit.GeneratorTests/_snapshots/ReturnTypeTests.GenericStructConstraintReturnTask#IGeneratedClient.g.verified.cs
@@ -15,7 +15,6 @@ namespace Refit.Implementation
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
     partial class RefitGeneratorTestIGeneratedClient
         : global::RefitGeneratorTest.IGeneratedClient
-
     {
         /// <inheritdoc />
         public global::System.Net.Http.HttpClient Client { get; }
@@ -31,7 +30,7 @@ namespace Refit.Implementation
 
         /// <inheritdoc />
         public async global::System.Threading.Tasks.Task<string> Get<T>()
-         where T : struct
+            where T : struct
         {
             var ______arguments = global::System.Array.Empty<object>();
             var ______func = requestBuilder.BuildRestResultFuncForMethod("Get", global::System.Array.Empty<global::System.Type>(), new global::System.Type[] { typeof(T) } );
@@ -41,7 +40,7 @@ namespace Refit.Implementation
 
         /// <inheritdoc />
         async global::System.Threading.Tasks.Task<string> global::RefitGeneratorTest.IGeneratedClient.Get<T>()
-         where T : struct
+            where T : struct
         {
             var ______arguments = global::System.Array.Empty<object>();
             var ______func = requestBuilder.BuildRestResultFuncForMethod("Get", global::System.Array.Empty<global::System.Type>(), new global::System.Type[] { typeof(T) } );

--- a/Refit.GeneratorTests/_snapshots/ReturnTypeTests.GenericTaskShouldWork#IGeneratedClient.g.verified.cs
+++ b/Refit.GeneratorTests/_snapshots/ReturnTypeTests.GenericTaskShouldWork#IGeneratedClient.g.verified.cs
@@ -15,7 +15,6 @@ namespace Refit.Implementation
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
     partial class RefitGeneratorTestIGeneratedClient
         : global::RefitGeneratorTest.IGeneratedClient
-
     {
         /// <inheritdoc />
         public global::System.Net.Http.HttpClient Client { get; }

--- a/Refit.GeneratorTests/_snapshots/ReturnTypeTests.GenericUnmanagedConstraintReturnTask#IGeneratedClient.g.verified.cs
+++ b/Refit.GeneratorTests/_snapshots/ReturnTypeTests.GenericUnmanagedConstraintReturnTask#IGeneratedClient.g.verified.cs
@@ -15,7 +15,6 @@ namespace Refit.Implementation
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
     partial class RefitGeneratorTestIGeneratedClient
         : global::RefitGeneratorTest.IGeneratedClient
-
     {
         /// <inheritdoc />
         public global::System.Net.Http.HttpClient Client { get; }
@@ -31,7 +30,7 @@ namespace Refit.Implementation
 
         /// <inheritdoc />
         public async global::System.Threading.Tasks.Task<string> Get<T>()
-         where T : unmanaged
+            where T : unmanaged
         {
             var ______arguments = global::System.Array.Empty<object>();
             var ______func = requestBuilder.BuildRestResultFuncForMethod("Get", global::System.Array.Empty<global::System.Type>(), new global::System.Type[] { typeof(T) } );

--- a/Refit.GeneratorTests/_snapshots/ReturnTypeTests.ReturnIObservable#IGeneratedClient.g.verified.cs
+++ b/Refit.GeneratorTests/_snapshots/ReturnTypeTests.ReturnIObservable#IGeneratedClient.g.verified.cs
@@ -15,7 +15,6 @@ namespace Refit.Implementation
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
     partial class RefitGeneratorTestIGeneratedClient
         : global::RefitGeneratorTest.IGeneratedClient
-
     {
         /// <inheritdoc />
         public global::System.Net.Http.HttpClient Client { get; }

--- a/Refit.GeneratorTests/_snapshots/ReturnTypeTests.ReturnNullableObject#IGeneratedClient.g.verified.cs
+++ b/Refit.GeneratorTests/_snapshots/ReturnTypeTests.ReturnNullableObject#IGeneratedClient.g.verified.cs
@@ -15,7 +15,6 @@ namespace Refit.Implementation
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
     partial class RefitGeneratorTestIGeneratedClient
         : global::RefitGeneratorTest.IGeneratedClient
-
     {
         /// <inheritdoc />
         public global::System.Net.Http.HttpClient Client { get; }

--- a/Refit.GeneratorTests/_snapshots/ReturnTypeTests.ReturnNullableValueType#IGeneratedClient.g.verified.cs
+++ b/Refit.GeneratorTests/_snapshots/ReturnTypeTests.ReturnNullableValueType#IGeneratedClient.g.verified.cs
@@ -15,7 +15,6 @@ namespace Refit.Implementation
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
     partial class RefitGeneratorTestIGeneratedClient
         : global::RefitGeneratorTest.IGeneratedClient
-
     {
         /// <inheritdoc />
         public global::System.Net.Http.HttpClient Client { get; }

--- a/Refit.GeneratorTests/_snapshots/ReturnTypeTests.ReturnUnsupportedType#IGeneratedClient.g.verified.cs
+++ b/Refit.GeneratorTests/_snapshots/ReturnTypeTests.ReturnUnsupportedType#IGeneratedClient.g.verified.cs
@@ -15,7 +15,6 @@ namespace Refit.Implementation
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
     partial class RefitGeneratorTestIGeneratedClient
         : global::RefitGeneratorTest.IGeneratedClient
-
     {
         /// <inheritdoc />
         public global::System.Net.Http.HttpClient Client { get; }

--- a/Refit.GeneratorTests/_snapshots/ReturnTypeTests.VoidTaskShouldWork#IGeneratedClient.g.verified.cs
+++ b/Refit.GeneratorTests/_snapshots/ReturnTypeTests.VoidTaskShouldWork#IGeneratedClient.g.verified.cs
@@ -15,7 +15,6 @@ namespace Refit.Implementation
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
     partial class RefitGeneratorTestIGeneratedClient
         : global::RefitGeneratorTest.IGeneratedClient
-
     {
         /// <inheritdoc />
         public global::System.Net.Http.HttpClient Client { get; }

--- a/Refit.Tests/InterfaceStubGenerator.cs
+++ b/Refit.Tests/InterfaceStubGenerator.cs
@@ -208,7 +208,6 @@ namespace Refit.Implementation
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
     partial class RefitTestsIGitHubApi
         : global::Refit.Tests.IGitHubApi
-
     {
         /// <inheritdoc />
         public global::System.Net.Http.HttpClient Client { get; }
@@ -515,7 +514,6 @@ namespace Refit.Implementation
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
     partial class RefitTestsIGitHubApiDisposable
         : global::Refit.Tests.IGitHubApiDisposable
-
     {
         /// <inheritdoc />
         public global::System.Net.Http.HttpClient Client { get; }
@@ -575,7 +573,6 @@ namespace Refit.Implementation
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
     partial class RefitTestsTestNestedINestedGitHubApi
         : global::Refit.Tests.TestNested.INestedGitHubApi
-
     {
         /// <inheritdoc />
         public global::System.Net.Http.HttpClient Client { get; }
@@ -870,7 +867,6 @@ namespace Refit.Implementation
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
     partial class IServiceWithoutNamespace
         : global::IServiceWithoutNamespace
-
     {
         /// <inheritdoc />
         public global::System.Net.Http.HttpClient Client { get; }


### PR DESCRIPTION
- Update `Emitter` logic
- Remove blank line before the classes body
- tab align generic contraints
- Cleaned up code with csharpier

Should I remove the other random empty lines? ie 
- The gap after the constructor
- Between `partial class Generated` and `/// <inheritdoc />`
- Between the namespace declartation and the partial class declaration
- Consider using a file scoped namespace to reduce nesting