### PR TITLE
Add the ability to register Refit clients as keyed services

### DIFF
--- a/Refit.HttpClientFactory/HttpClientFactoryExtensions.cs
+++ b/Refit.HttpClientFactory/HttpClientFactoryExtensions.cs
@@ -154,8 +154,13 @@ namespace Refit
                     )
             );
 
+            httpClientName ??=
+                UniqueName.ForType<T>()
+                + (serviceKey is null or ""
+                    ? string.Empty
+                    : $";{serviceKey}");
             return services
-                .AddHttpClient(httpClientName ?? UniqueName.ForType<T>())
+                .AddHttpClient(httpClientName)
                 .ConfigurePrimaryHttpMessageHandler(serviceProvider =>
                 {
                     var settings = serviceProvider.GetRequiredKeyedService<SettingsFor<T>>(serviceKey).Settings;

--- a/Refit.HttpClientFactory/HttpClientFactoryExtensions.cs
+++ b/Refit.HttpClientFactory/HttpClientFactoryExtensions.cs
@@ -154,13 +154,8 @@ namespace Refit
                     )
             );
 
-            httpClientName ??=
-                UniqueName.ForType<T>()
-                + (serviceKey is null or ""
-                    ? string.Empty
-                    : $";{serviceKey}");
             return services
-                .AddHttpClient(httpClientName)
+                .AddHttpClient(httpClientName ?? UniqueName.ForType<T>(serviceKey))
                 .ConfigurePrimaryHttpMessageHandler(serviceProvider =>
                 {
                     var settings = serviceProvider.GetRequiredKeyedService<SettingsFor<T>>(serviceKey).Settings;
@@ -297,7 +292,7 @@ namespace Refit
             );
 
             return services
-                .AddHttpClient(httpClientName ?? UniqueName.ForType(refitInterfaceType))
+                .AddHttpClient(httpClientName ?? UniqueName.ForType(refitInterfaceType, serviceKey))
                 .ConfigurePrimaryHttpMessageHandler(serviceProvider =>
                 {
                     var settings = (ISettingsFor)serviceProvider.GetRequiredKeyedService(settingsType, serviceKey);

--- a/Refit.HttpClientFactory/HttpClientFactoryExtensions.cs
+++ b/Refit.HttpClientFactory/HttpClientFactoryExtensions.cs
@@ -31,6 +31,24 @@ namespace Refit
         /// <summary>
         /// Adds a Refit client to the DI container
         /// </summary>
+        /// <typeparam name="T">Type of the Refit interface</typeparam>
+        /// <param name="services">container</param>
+        /// <param name="serviceKey">An optional key to associate with the specific Refit client instance</param>
+        /// <param name="settings">Optional. Settings to configure the instance with</param>
+        /// <returns></returns>
+        public static IHttpClientBuilder AddKeyedRefitClient<T>(
+            this IServiceCollection services,
+            object? serviceKey,
+            RefitSettings? settings = null
+        )
+            where T : class
+        {
+            return AddKeyedRefitClient<T>(services, serviceKey, _ => settings);
+        }
+
+        /// <summary>
+        /// Adds a Refit client to the DI container
+        /// </summary>
         /// <param name="services">container</param>
         /// <param name="refitInterfaceType">Type of the Refit interface</param>
         /// <param name="settings">Optional. Settings to configure the instance with</param>
@@ -42,6 +60,24 @@ namespace Refit
         )
         {
             return AddRefitClient(services, refitInterfaceType, _ => settings);
+        }
+
+        /// <summary>
+        /// Adds a Refit client to the DI container
+        /// </summary>
+        /// <param name="services">container</param>
+        /// <param name="refitInterfaceType">Type of the Refit interface</param>
+        /// <param name="serviceKey">An optional key to associate with the specific Refit client instance</param>
+        /// <param name="settings">Optional. Settings to configure the instance with</param>
+        /// <returns></returns>
+        public static IHttpClientBuilder AddKeyedRefitClient(
+            this IServiceCollection services,
+            Type refitInterfaceType,
+            object? serviceKey,
+            RefitSettings? settings = null
+        )
+        {
+            return AddKeyedRefitClient(services, refitInterfaceType, serviceKey, _ => settings);
         }
 
         /// <summary>
@@ -87,6 +123,60 @@ namespace Refit
                         RestService.For<T>(
                             client,
                             serviceProvider.GetService<IRequestBuilder<T>>()!
+                        )
+                );
+        }
+
+        /// <summary>
+        /// Adds a Refit client to the DI container with a specified service key
+        /// </summary>
+        /// <typeparam name="T">Type of the Refit interface</typeparam>
+        /// <param name="services">container</param>
+        /// <param name="serviceKey">An optional key to associate with the specific Refit client instance</param>
+        /// <param name="settingsAction">Optional. Action to configure refit settings.  This method is called once and only once, avoid using any scoped dependencies that maybe be disposed automatically.</param>
+        /// <param name="httpClientName">Optional. Allows users to change the HttpClient name as provided to IServiceCollection.AddHttpClient. Useful for logging scenarios.</param>
+        /// <returns></returns>
+        public static IHttpClientBuilder AddKeyedRefitClient<T>(
+            this IServiceCollection services,
+            object? serviceKey,
+            Func<IServiceProvider, RefitSettings?>? settingsAction,
+            string? httpClientName = null
+        )
+            where T : class
+        {
+            services.AddKeyedSingleton(serviceKey,
+                (provider, _) => new SettingsFor<T>(settingsAction?.Invoke(provider)));
+            services.AddKeyedSingleton(
+                serviceKey,
+                (provider, _) =>
+                    RequestBuilder.ForType<T>(
+                        provider.GetRequiredKeyedService<SettingsFor<T>>(serviceKey).Settings
+                    )
+            );
+
+            return services
+                .AddHttpClient(httpClientName ?? UniqueName.ForType<T>())
+                .ConfigurePrimaryHttpMessageHandler(serviceProvider =>
+                {
+                    var settings = serviceProvider.GetRequiredKeyedService<SettingsFor<T>>(serviceKey).Settings;
+                    return
+                        settings?.HttpMessageHandlerFactory?.Invoke()
+                        ?? new HttpClientHandler();
+                })
+                .ConfigureAdditionalHttpMessageHandlers((handlers, serviceProvider) =>
+                {
+                    var settings = serviceProvider.GetRequiredKeyedService<SettingsFor<T>>(serviceKey).Settings;
+                    if (settings?.AuthorizationHeaderValueGetter is { } getToken)
+                    {
+                        handlers.Add(new AuthenticatedHttpClientHandler(null, getToken));
+                    }
+                })
+                .AddKeyedTypedClient(
+                    serviceKey,
+                    (client, serviceProvider) =>
+                        RestService.For<T>(
+                            client,
+                            serviceProvider.GetKeyedService<IRequestBuilder<T>>(serviceKey)!
                         )
                 );
         }
@@ -158,6 +248,78 @@ namespace Refit
                 );
         }
 
+        /// <summary>
+        /// Adds a Refit client to the DI container with a specified service key
+        /// </summary>
+        /// <param name="services">container</param>
+        /// <param name="refitInterfaceType">Type of the Refit interface</param>
+        /// <param name="serviceKey">An optional key to associate with the specific Refit client instance</param>
+        /// <param name="settingsAction">Optional. Action to configure refit settings.  This method is called once and only once, avoid using any scoped dependencies that maybe be disposed automatically.</param>
+        /// <param name="httpClientName">Optional. Allows users to change the HttpClient name as provided to IServiceCollection.AddHttpClient. Useful for logging scenarios.</param>
+        /// <returns></returns>
+        public static IHttpClientBuilder AddKeyedRefitClient(
+            this IServiceCollection services,
+            Type refitInterfaceType,
+            object? serviceKey,
+            Func<IServiceProvider, RefitSettings?>? settingsAction,
+            string? httpClientName = null
+        )
+        {
+            var settingsType = typeof(SettingsFor<>).MakeGenericType(refitInterfaceType);
+            var requestBuilderType = typeof(IRequestBuilder<>).MakeGenericType(refitInterfaceType);
+            services.AddKeyedSingleton(
+                settingsType,
+                serviceKey,
+                (provider, _) =>
+                    Activator.CreateInstance(
+                        typeof(SettingsFor<>).MakeGenericType(refitInterfaceType)!,
+                        settingsAction?.Invoke(provider)
+                    )!
+            );
+            services.AddKeyedSingleton(
+                requestBuilderType,
+                serviceKey,
+                (provider, _) =>
+                    RequestBuilderGenericForTypeMethod
+                        .MakeGenericMethod(refitInterfaceType)
+                        .Invoke(
+                            null,
+                            new object?[]
+                            {
+                                ((ISettingsFor)provider.GetRequiredKeyedService(settingsType, serviceKey)).Settings
+                            }
+                        )!
+            );
+
+            return services
+                .AddHttpClient(httpClientName ?? UniqueName.ForType(refitInterfaceType))
+                .ConfigurePrimaryHttpMessageHandler(serviceProvider =>
+                {
+                    var settings = (ISettingsFor)serviceProvider.GetRequiredKeyedService(settingsType, serviceKey);
+                    return
+                        settings.Settings?.HttpMessageHandlerFactory?.Invoke()
+                        ?? new HttpClientHandler();
+                })
+                .ConfigureAdditionalHttpMessageHandlers((handlers, serviceProvider) =>
+                {
+                    var settings = (ISettingsFor)serviceProvider.GetRequiredKeyedService(settingsType, serviceKey);
+                    if (settings.Settings?.AuthorizationHeaderValueGetter is { } getToken)
+                    {
+                        handlers.Add(new AuthenticatedHttpClientHandler(null, getToken));
+                    }
+                })
+                .AddKeyedTypedClient(
+                    refitInterfaceType,
+                    serviceKey,
+                    (client, serviceProvider) =>
+                        RestService.For(
+                            refitInterfaceType,
+                            client,
+                            (IRequestBuilder)serviceProvider.GetRequiredKeyedService(requestBuilderType, serviceKey)
+                        )
+                );
+        }
+
         private static readonly MethodInfo RequestBuilderGenericForTypeMethod =
             typeof(RequestBuilder)
                 .GetMethods(BindingFlags.Public | BindingFlags.Static)
@@ -204,6 +366,69 @@ namespace Refit
             builder.Services.AddTransient(
                 type,
                 s =>
+                {
+                    var httpClientFactory = s.GetRequiredService<IHttpClientFactory>();
+                    var httpClient = httpClientFactory.CreateClient(builder.Name);
+
+                    return factory(httpClient, s);
+                }
+            );
+
+            return builder;
+        }
+
+        static IHttpClientBuilder AddKeyedTypedClient(
+            this IHttpClientBuilder builder,
+            Type type,
+            object? serviceKey,
+            Func<HttpClient, IServiceProvider, object> factory
+        )
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            if (factory == null)
+            {
+                throw new ArgumentNullException(nameof(factory));
+            }
+
+            builder.Services.AddKeyedTransient(
+                type,
+                serviceKey,
+                (s, _) =>
+                {
+                    var httpClientFactory = s.GetRequiredService<IHttpClientFactory>();
+                    var httpClient = httpClientFactory.CreateClient(builder.Name);
+
+                    return factory(httpClient, s);
+                }
+            );
+
+            return builder;
+        }
+
+        static IHttpClientBuilder AddKeyedTypedClient<T>(
+            this IHttpClientBuilder builder,
+            object? serviceKey,
+            Func<HttpClient, IServiceProvider, T> factory
+        )
+            where T : class
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            if (factory == null)
+            {
+                throw new ArgumentNullException(nameof(factory));
+            }
+
+            builder.Services.AddKeyedTransient(
+                serviceKey,
+                (s, _) =>
                 {
                     var httpClientFactory = s.GetRequiredService<IHttpClientFactory>();
                     var httpClient = httpClientFactory.CreateClient(builder.Name);

--- a/Refit.Tests/AuthenticatedClientHandlerTests.cs
+++ b/Refit.Tests/AuthenticatedClientHandlerTests.cs
@@ -74,6 +74,14 @@ public class AuthenticatedClientHandlerTests
     }
 
     [Fact]
+    public void DefaultHandlerIsNull()
+    {
+        var handler = new AuthenticatedHttpClientHandler(null, ((_, _) => Task.FromResult(string.Empty)));
+
+        Assert.Null(handler.InnerHandler);
+    }
+
+    [Fact]
     public void NullTokenGetterThrows()
     {
         Assert.Throws<ArgumentNullException>(() => new AuthenticatedHttpClientHandler(null));

--- a/Refit.Tests/HttpClientFactoryExtensionsTests.cs
+++ b/Refit.Tests/HttpClientFactoryExtensionsTests.cs
@@ -30,6 +30,30 @@ public class HttpClientFactoryExtensionsTests
     }
 
     [Fact]
+    public void HttpClientServicesAreDifferentThanKeyedServices()
+    {
+        var serviceCollection = new ServiceCollection();
+        serviceCollection.AddRefitClient<IFooWithOtherAttribute>();
+        serviceCollection.AddKeyedRefitClient<IFooWithOtherAttribute>("keyed");
+
+        var serviceProvider = serviceCollection.BuildServiceProvider();
+        var nonKeyedService = serviceProvider.GetService<IFooWithOtherAttribute>();
+        var keyedService = serviceProvider.GetKeyedService<IFooWithOtherAttribute>("keyed");
+
+        Assert.NotNull(nonKeyedService);
+        Assert.NotNull(keyedService);
+        Assert.NotSame(nonKeyedService, keyedService);
+
+        var nonKeyedSettings = serviceProvider.GetService<SettingsFor<IFooWithOtherAttribute>>();
+        var keyedSettings = serviceProvider.GetKeyedService<SettingsFor<IFooWithOtherAttribute>>("keyed");
+        Assert.NotSame(nonKeyedSettings, keyedSettings);
+
+        var nonKeyedRequestBuilder = serviceProvider.GetService<IRequestBuilder<IFooWithOtherAttribute>>();
+        var keyedRequestBuilder = serviceProvider.GetKeyedService<IRequestBuilder<IFooWithOtherAttribute>>("keyed");
+        Assert.NotSame(nonKeyedRequestBuilder, keyedRequestBuilder);
+    }
+
+    [Fact]
     public void HttpClientServicesAreAddedCorrectlyGivenGenericArgument()
     {
         var serviceCollection = new ServiceCollection();

--- a/Refit/AuthenticatedHttpClientHandler.cs
+++ b/Refit/AuthenticatedHttpClientHandler.cs
@@ -7,6 +7,17 @@ namespace Refit
     {
         readonly Func<HttpRequestMessage, CancellationToken, Task<string>> getToken;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AuthenticatedHttpClientHandler"/> class.
+        /// </summary>
+        /// <param name="getToken">The function to get the authentication token.</param>
+        /// <param name="innerHandler">The optional inner handler.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="getToken"/> must not be null.</exception>
+        /// <remarks>
+        /// Warning: This constructor sets the <see cref="DelegatingHandler.InnerHandler"/> to an instance
+        /// of <see cref="HttpClientHandler"/>, when <paramref name="innerHandler"/> is <c>null</c>. This is
+        /// a behavior which is incompatible with the <code>IHttpClientBuilder</code>.
+        /// </remarks>
         public AuthenticatedHttpClientHandler(
             Func<HttpRequestMessage, CancellationToken, Task<string>> getToken,
             HttpMessageHandler? innerHandler = null
@@ -14,6 +25,28 @@ namespace Refit
             : base(innerHandler ?? new HttpClientHandler())
         {
             this.getToken = getToken ?? throw new ArgumentNullException(nameof(getToken));
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AuthenticatedHttpClientHandler"/> class.
+        /// </summary>
+        /// <param name="innerHandler">The optional inner handler.</param>
+        /// <param name="getToken">The function to get the authentication token.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="getToken"/> must not be null.</exception>
+        /// <remarks>
+        /// This function doesn't set the <see cref="DelegatingHandler.InnerHandler"/> automatically to an
+        /// instance of <see cref="HttpClientHandler"/> when <paramref name="innerHandler"/> is null,
+        /// which is different from the old (legacy) constructor, and compliant with the behavior expected
+        /// by the <code>IHttpClientBuilder</code>.
+        /// </remarks>
+        public AuthenticatedHttpClientHandler(
+            HttpMessageHandler? innerHandler,
+            Func<HttpRequestMessage, CancellationToken, Task<string>> getToken
+        )
+        {
+            this.getToken = getToken ?? throw new ArgumentNullException(nameof(getToken));
+            if (innerHandler != null)
+                InnerHandler = innerHandler;
         }
 
         protected override async Task<HttpResponseMessage> SendAsync(

--- a/Refit/UniqueName.cs
+++ b/Refit/UniqueName.cs
@@ -70,7 +70,7 @@
         /// <returns>The suffix to be added to the unique name of a given type.</returns>
         static string GetServiceKeySuffix(object? serviceKey)
         {
-            return serviceKey is null or "" ? string.Empty : $"{serviceKey}";
+            return serviceKey is null or "" ? string.Empty : $", ServiceKey={serviceKey}";
         }
     }
 }

--- a/Refit/UniqueName.cs
+++ b/Refit/UniqueName.cs
@@ -7,6 +7,16 @@
             return ForType(typeof(T));
         }
 
+        public static string ForType<T>(object? serviceKey)
+        {
+            return ForType(typeof(T), serviceKey);
+        }
+
+        public static string ForType(Type refitInterfaceType, object? serviceKey)
+        {
+            return ForType(refitInterfaceType) + GetServiceKeySuffix(serviceKey);
+        }
+
         public static string ForType(Type refitInterfaceType)
         {
             var interfaceTypeName = refitInterfaceType.FullName!;
@@ -51,6 +61,16 @@
             var assmQualified = $"{refitTypeName}, {refitInterfaceType.Assembly.FullName}";
 
             return assmQualified;
+        }
+
+        /// <summary>
+        /// Returns the suffix for the service key to be added to the unique name for a given type.
+        /// </summary>
+        /// <param name="serviceKey">The service key to create the suffix from.</param>
+        /// <returns>The suffix to be added to the unique name of a given type.</returns>
+        static string GetServiceKeySuffix(object? serviceKey)
+        {
+            return serviceKey is null or "" ? string.Empty : $"{serviceKey}";
         }
     }
 }


### PR DESCRIPTION
This PR fixes #1876.

1. Added new constructor to `AuthenticatedHttpClientHandler` which doesn't automatically set the `InnerHandler` property
2. Adds extension methods to register the Refit client as keyed service
3. Added unit tests

# Why did I add the new constructor to `AuthenticatedHttpClientHandler`?

- To keep the PR as small as possible by avoiding the duplication of code
- Enable the a behavior compatible with `IHttpClientBuilder` by ...
  - ... avoiding the usage of obsolete functions
  - ... avoid setting `InnerHandler`, because this will be done by the builder itself

# Future changes (not scope of this PR)

- `AuthenticatedHttpClientHandler`: Remove the old constructor 
- `AuthenticatedHttpClientHandler`: Remove the `innerHandler` parameter for the new constructor
- `AuthenticatedHttpClientHandler`: Fix the call sites
- Don't call the obsoleted `ConfigureHttpMessageHandlerBuilder`
- Fix the unit tests

# Behavioral changes

When no `httpClientName` was specified, the `UniqueName.ForType<T>` is used and the string representation of the `serviceKey` (when not null or empty string) gets appended to the unique type name, e.g. `Refit.Implementation.Generated+IFooWithOtherAttribute, Refit.Tests, Version=8.0.0.0, Culture=neutral, PublicKeyToken=null, ServiceKey=keyed`