### PR TITLE
Add AOT and trimming support for .NET 10+

### DIFF
--- a/Refit.HttpClientFactory/Refit.HttpClientFactory.csproj
+++ b/Refit.HttpClientFactory/Refit.HttpClientFactory.csproj
@@ -5,6 +5,7 @@
     <Description>Refit HTTP Client Factory Extensions</Description>
     <TargetFrameworks>$(RefitTargets)</TargetFrameworks>
     <Nullable>enable</Nullable>
+    <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Refit.Newtonsoft.Json/Refit.Newtonsoft.Json.csproj
+++ b/Refit.Newtonsoft.Json/Refit.Newtonsoft.Json.csproj
@@ -7,6 +7,7 @@
     <GenerateDocumentationFile Condition=" '$(Configuration)' == 'Release' ">true</GenerateDocumentationFile>
     <RootNamespace>Refit</RootNamespace>
     <Nullable>enable</Nullable>
+    <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Refit.Tests/API/_snapshots/ApiApprovalTests.Refit.DotNet10_0.verified.txt
+++ b/Refit.Tests/API/_snapshots/ApiApprovalTests.Refit.DotNet10_0.verified.txt
@@ -1,4 +1,5 @@
-﻿[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Refit.HttpClientFactory")]
+﻿[assembly: System.Runtime.CompilerServices.DisableRuntimeMarshalling]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Refit.HttpClientFactory")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Refit.Newtonsoft.Json")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Refit.Tests")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Refit.Xml")]
@@ -367,10 +368,14 @@ namespace Refit
     }
     public static class RequestBuilder
     {
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Refit uses reflection to analyze interface methods. Ensure referenced interfaces " +
+            "and DTOs are preserved when trimming.")]
         public static Refit.IRequestBuilder ForType(System.Type refitInterfaceType) { }
-        public static Refit.IRequestBuilder ForType(System.Type refitInterfaceType, Refit.RefitSettings? settings) { }
-        public static Refit.IRequestBuilder<T> ForType<T>() { }
-        public static Refit.IRequestBuilder<T> ForType<T>(Refit.RefitSettings? settings) { }
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Refit uses reflection to analyze interface methods. Ensure referenced interfaces " +
+            "and DTOs are preserved when trimming.")]
+        public static Refit.IRequestBuilder ForType([System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicMethods | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.NonPublicMethods)] System.Type refitInterfaceType, Refit.RefitSettings? settings) { }
+        public static Refit.IRequestBuilder<T> ForType<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicMethods | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.NonPublicMethods)]  T>() { }
+        public static Refit.IRequestBuilder<T> ForType<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicMethods | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.NonPublicMethods)]  T>(Refit.RefitSettings? settings) { }
     }
     public class RestMethodInfo : System.IEquatable<Refit.RestMethodInfo>
     {

--- a/Refit.Tests/Refit.Tests.csproj
+++ b/Refit.Tests/Refit.Tests.csproj
@@ -7,7 +7,7 @@
     <Deterministic>false</Deterministic>
     <!-- Some tests rely on CallerFilePath -->
     <RestoreAdditionalProjectSources>https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json</RestoreAdditionalProjectSources>
-    <NoWarn>$(NoWarn);CS1591;CA1819;CA2000;CA2007;CA1056;CA1707;CA1861;xUnit1031</NoWarn>
+    <NoWarn>$(NoWarn);CS1591;CA1819;CA2000;CA2007;CA1056;CA1707;CA1861;CA1515;xUnit1031</NoWarn>
     <MockHttpVersion>6.0.0</MockHttpVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Refit.Xml/Refit.Xml.csproj
+++ b/Refit.Xml/Refit.Xml.csproj
@@ -7,6 +7,7 @@
     <GenerateDocumentationFile Condition=" '$(Configuration)' == 'Release' ">true</GenerateDocumentationFile>
     <RootNamespace>Refit</RootNamespace>
     <Nullable>enable</Nullable>
+    <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>  
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">

--- a/Refit/AotCompatibility.cs
+++ b/Refit/AotCompatibility.cs
@@ -1,0 +1,14 @@
+﻿using System.Runtime.CompilerServices;
+using System.Diagnostics.CodeAnalysis;
+#if NET7_0_OR_GREATER
+using System.Runtime.InteropServices;
+#endif
+
+namespace Refit
+{
+    internal static class AotCompatibility
+    {
+        // Intentionally left blank to avoid changing public API surface (e.g., assembly-level attributes)
+        // while keeping a central place for any future AOT-related initializers if needed.
+    }
+}

--- a/Refit/Polyfills.Trimming.cs
+++ b/Refit/Polyfills.Trimming.cs
@@ -1,0 +1,19 @@
+﻿#if NETSTANDARD2_0 || NET462
+namespace System.Diagnostics.CodeAnalysis
+{
+    [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Constructor | System.AttributeTargets.Method | System.AttributeTargets.Property | System.AttributeTargets.Event, Inherited = false)]
+    internal sealed class RequiresUnreferencedCodeAttribute : System.Attribute
+    {
+        public RequiresUnreferencedCodeAttribute(string message) => Message = message;
+        public string Message { get; }
+        public string? Url { get; set; }
+    }
+
+    [System.AttributeUsage(System.AttributeTargets.Constructor | System.AttributeTargets.Method, AllowMultiple = true)]
+    internal sealed class DynamicDependencyAttribute : System.Attribute
+    {
+        public DynamicDependencyAttribute(DynamicallyAccessedMemberTypes memberTypes, System.Type type) { }
+        public DynamicDependencyAttribute(string memberSignature, System.Type type) { }
+    }
+}
+#endif

--- a/Refit/Refit.csproj
+++ b/Refit/Refit.csproj
@@ -9,11 +9,23 @@
   </PropertyGroup>
   <PropertyGroup Condition="$(TargetFramework.StartsWith('net8.0')) or $(TargetFramework.StartsWith('net9.0')) or $(TargetFramework.StartsWith('net10.0'))">
     <IsAotCompatible>true</IsAotCompatible>
+    <PublishAotSupported>true</PublishAotSupported>
+    <TrimMode>link</TrimMode>
+    <IsTrimmable>true</IsTrimmable>
+    <IlcGenerateCompleteTypeMetadata>true</IlcGenerateCompleteTypeMetadata>
+  </PropertyGroup>
+
+  <!-- Ensure DisableRuntimeMarshalling is only emitted for .NET 10, not .NET 8/9 -->
+  <PropertyGroup Condition="$(TargetFramework.StartsWith('net8.0')) or $(TargetFramework.StartsWith('net9.0'))">
+    <DisableRuntimeMarshalling>false</DisableRuntimeMarshalling>
+  </PropertyGroup>
+  <PropertyGroup Condition="$(TargetFramework.StartsWith('net10.0'))">
+    <DisableRuntimeMarshalling>true</DisableRuntimeMarshalling>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'net462'">
-    <PackageReference Include="System.Text.Json" Version="9.0.3" />
-    <PackageReference Include="System.Net.Http.Json" Version="9.0.3" />
+    <PackageReference Include="System.Text.Json" Version="9.0.9" />
+    <PackageReference Include="System.Net.Http.Json" Version="9.0.9" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">

--- a/Refit/RequestBuilder.cs
+++ b/Refit/RequestBuilder.cs
@@ -1,19 +1,12 @@
 ﻿using System.Net.Http;
+#if NET10_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 
 namespace Refit
 {
-    /// <summary>
-    /// IRequestBuilder.
-    /// </summary>
     public interface IRequestBuilder
     {
-        /// <summary>
-        /// Builds the rest result function for method.
-        /// </summary>
-        /// <param name="methodName">Name of the method.</param>
-        /// <param name="parameterTypes">The parameter types.</param>
-        /// <param name="genericArgumentTypes">The generic argument types.</param>
-        /// <returns></returns>
         Func<HttpClient, object[], object?> BuildRestResultFuncForMethod(
             string methodName,
             Type[]? parameterTypes = null,
@@ -21,51 +14,64 @@ namespace Refit
         );
     }
 
-    /// <summary>
-    ///
-    /// </summary>
-    /// <typeparam name="T"></typeparam>
     public interface IRequestBuilder<T> : IRequestBuilder { }
 
-    /// <summary>
-    /// RequestBuilder.
-    /// </summary>
     public static class RequestBuilder
     {
         static readonly RequestBuilderFactory PlatformRequestBuilderFactory = new();
 
-        /// <summary>
-        /// Fors the type.
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="settings">The settings.</param>
-        /// <returns></returns>
+#if NET10_0_OR_GREATER
+        public static IRequestBuilder<T> ForType< [
+            DynamicallyAccessedMembers(
+                DynamicallyAccessedMemberTypes.None |
+                DynamicallyAccessedMemberTypes.PublicMethods |
+                DynamicallyAccessedMemberTypes.NonPublicMethods
+            )] T >(RefitSettings? settings) =>
+            PlatformRequestBuilderFactory.Create<T>(settings);
+#else
         public static IRequestBuilder<T> ForType<T>(RefitSettings? settings) =>
             PlatformRequestBuilderFactory.Create<T>(settings);
+#endif
 
-        /// <summary>
-        /// Fors the type.
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <returns></returns>
+#if NET10_0_OR_GREATER
+        public static IRequestBuilder<T> ForType< [
+            DynamicallyAccessedMembers(
+                DynamicallyAccessedMemberTypes.None |
+                DynamicallyAccessedMemberTypes.PublicMethods |
+                DynamicallyAccessedMemberTypes.NonPublicMethods
+            )] T >() =>
+            PlatformRequestBuilderFactory.Create<T>(null);
+#else
         public static IRequestBuilder<T> ForType<T>() =>
             PlatformRequestBuilderFactory.Create<T>(null);
+#endif
 
-        /// <summary>
-        /// Fors the type.
-        /// </summary>
-        /// <param name="refitInterfaceType">Type of the refit interface.</param>
-        /// <param name="settings">The settings.</param>
-        /// <returns></returns>
-        public static IRequestBuilder ForType(Type refitInterfaceType, RefitSettings? settings) =>
-            PlatformRequestBuilderFactory.Create(refitInterfaceType, settings);
+#if NET10_0_OR_GREATER
+        [RequiresUnreferencedCode("Refit uses reflection to analyze interface methods. Ensure referenced interfaces and DTOs are preserved when trimming.")]
+        public static IRequestBuilder ForType(
+            [DynamicallyAccessedMembers(
+                DynamicallyAccessedMemberTypes.None |
+                DynamicallyAccessedMemberTypes.PublicMethods |
+                DynamicallyAccessedMemberTypes.NonPublicMethods
+            )] Type refitInterfaceType,
+            RefitSettings? settings
+        )
+#else
+        public static IRequestBuilder ForType(
+            Type refitInterfaceType,
+            RefitSettings? settings
+        )
+#endif
+        {
+            return new CachedRequestBuilderImplementation(
+                new RequestBuilderImplementation(refitInterfaceType, settings)
+            );
+        }
 
-        /// <summary>
-        /// Fors the type.
-        /// </summary>
-        /// <param name="refitInterfaceType">Type of the refit interface.</param>
-        /// <returns></returns>
+#if NET10_0_OR_GREATER
+        [RequiresUnreferencedCode("Refit uses reflection to analyze interface methods. Ensure referenced interfaces and DTOs are preserved when trimming.")]
+#endif
         public static IRequestBuilder ForType(Type refitInterfaceType) =>
-            PlatformRequestBuilderFactory.Create(refitInterfaceType, null);
+            ForType(refitInterfaceType, null);
     }
 }


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

update

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

AOT support is limited

**What is the new behavior?**
<!-- If this is a feature change -->

Introduces AOT compatibility and trimming support by adding new polyfills, attributes, and conditional logic for .NET 10 and higher. Updates project files to mark assemblies as trimmable and set related properties. Enhances RequestBuilder APIs with trimming annotations and DynamicallyAccessedMembers attributes to ensure compatibility with reflection and code trimming. Also updates dependencies for netstandard2.0/net462 and suppresses a new code analysis warning in tests.

**What might this PR break?**

Breaking change

**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

