### PR TITLE
Simplify sponsor logos layout in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,9 +80,7 @@ services
 
 Refit is sponsored by the following:
 
-||||
-||||
-|[![lombiq logo](Images/lombiq.svg)](https://lombiq.com)|[![jetbrains logo](Images/jetbrains.svg)](https://www.jetbrains.com)|[![claude logo](Images/claude.svg)](https://claude.com)|
+[![lombiq logo](Images/lombiq.svg)](https://lombiq.com)[![jetbrains logo](Images/jetbrains.svg)](https://www.jetbrains.com)[![claude logo](Images/claude.svg)](https://claude.com)
 
 
 ### Where does this work?


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

docs

**What is the new behavior?**
<!-- If this is a feature change -->

Replace a three-column Markdown table row with a single inline line of sponsor logo links. This removes the table pipe separators and extra empty rows to produce a more compact and straightforward rendering of sponsor logos in the README.

**What might this PR break?**



**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

