### PR TITLE
Add AddRefitClient overloads and tests

### DIFF
--- a/Refit.HttpClientFactory/HttpClientFactoryExtensions.cs
+++ b/Refit.HttpClientFactory/HttpClientFactoryExtensions.cs
@@ -13,6 +13,19 @@ namespace Refit
     public static class HttpClientFactoryExtensions
     {
         /// <summary>
+        /// Adds a Refit client to the DI container.
+        /// </summary>
+        /// <param name="refitInterfaceType">Type of the Refit interface.</param>
+        /// <param name="services">Container.</param>
+        /// <param name="settings">Settings to configure the instance with.</param>
+        /// <returns></returns>
+        public static IHttpClientBuilder AddRefitClient(
+            this IServiceCollection services,
+            Type refitInterfaceType,
+            RefitSettings? settings
+        ) => AddRefitClient(services, refitInterfaceType, settings, httpClientName: null);
+
+        /// <summary>
         /// Adds a Refit client to the DI container
         /// </summary>
         /// <param name="refitInterfaceType">Type of the Refit interface</param>
@@ -56,6 +69,20 @@ namespace Refit
 
             return HttpClientFactoryCore.AddKeyedRefitClientCore(services, refitInterfaceType, serviceKey, _ => settings, httpClientName);
         }
+
+        /// <summary>
+        /// Adds a Refit client to the DI container.
+        /// </summary>
+        /// <typeparam name="T">Type of the Refit interface.</typeparam>
+        /// <param name="services">Container.</param>
+        /// <param name="settings">Settings to configure the instance with.</param>
+        /// <returns></returns>
+        public static IHttpClientBuilder AddRefitClient<T>(
+            this IServiceCollection services,
+            RefitSettings? settings
+        )
+            where T : class =>
+            AddRefitClient<T>(services, settings, httpClientName: null);
 
         /// <summary>
         /// Adds a Refit client to the DI container

--- a/Refit.Tests/HttpClientFactoryExtensionsTests.cs
+++ b/Refit.Tests/HttpClientFactoryExtensionsTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Globalization;
+using System.Linq;
 using System.Net.Http;
 using System.Reflection;
 using System.Text.Json;
@@ -182,6 +183,47 @@ public class HttpClientFactoryExtensionsTests
                 .GetRequiredService<SettingsFor<IFooWithOtherAttribute>>()
                 .Settings!.ContentSerializer
         );
+    }
+
+    [Fact]
+    public void AddRefitClient_ServiceCollectionGenericSettingsOverload_RemainsBinaryCompatible()
+    {
+        var method = typeof(HttpClientFactoryExtensions)
+            .GetMethods(BindingFlags.Public | BindingFlags.Static)
+            .SingleOrDefault(method =>
+                method.Name == nameof(HttpClientFactoryExtensions.AddRefitClient)
+                && method.IsGenericMethodDefinition
+                && method.GetGenericArguments().Length == 1
+                && method.GetParameters() is
+                [
+                    { ParameterType: var servicesType },
+                    { ParameterType: var settingsType }
+                ]
+                && servicesType == typeof(IServiceCollection)
+                && settingsType == typeof(RefitSettings));
+
+        Assert.NotNull(method);
+    }
+
+    [Fact]
+    public void AddRefitClient_ServiceCollectionTypeSettingsOverload_RemainsBinaryCompatible()
+    {
+        var method = typeof(HttpClientFactoryExtensions)
+            .GetMethods(BindingFlags.Public | BindingFlags.Static)
+            .SingleOrDefault(method =>
+                method.Name == nameof(HttpClientFactoryExtensions.AddRefitClient)
+                && !method.IsGenericMethodDefinition
+                && method.GetParameters() is
+                [
+                    { ParameterType: var servicesType },
+                    { ParameterType: var refitInterfaceType },
+                    { ParameterType: var settingsType }
+                ]
+                && servicesType == typeof(IServiceCollection)
+                && refitInterfaceType == typeof(Type)
+                && settingsType == typeof(RefitSettings));
+
+        Assert.NotNull(method);
     }
 
     [Fact]

--- a/Refit.Tests/SerializedContentTests.cs
+++ b/Refit.Tests/SerializedContentTests.cs
@@ -711,6 +711,28 @@ public partial class SerializedContentTests
 
         Assert.Equal(EnumMemberNameStatus.TotallyReady, result.Status);
     }
+
+    [Fact]
+    public async Task RestService_DefaultSystemTextJsonSerializerHonorsJsonStringEnumMemberNameWithAttributedConverter()
+    {
+        string serializedBody = string.Empty;
+        var settings = new RefitSettings(new SystemTextJsonContentSerializer())
+        {
+            HttpMessageHandlerFactory = () => new StubHttpMessageHandler(async request =>
+            {
+                serializedBody = await request.Content!.ReadAsStringAsync();
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("{}", Encoding.UTF8, "application/json")
+                };
+            })
+        };
+
+        var api = RestService.For<IIssue2083ColorApi>(BaseAddress, settings);
+        await api.PostColorAsync(new EnumMemberNameColorEnvelope { Color = EnumMemberNameColor.Green });
+
+        Assert.Equal("""{"color":"GREEN"}""", serializedBody);
+    }
 #endif
 
     [JsonPolymorphic(TypeDiscriminatorPropertyName = "$type")]
@@ -746,6 +768,27 @@ public partial class SerializedContentTests
     {
         [Get("/status")]
         Task<EnumMemberNameEnvelope> GetStatusAsync();
+    }
+
+    [System.Text.Json.Serialization.JsonConverter(typeof(JsonStringEnumConverter<EnumMemberNameColor>))]
+    public enum EnumMemberNameColor
+    {
+        [JsonStringEnumMemberName("GREEN")]
+        Green,
+
+        [JsonStringEnumMemberName("RED")]
+        Red
+    }
+
+    public sealed class EnumMemberNameColorEnvelope
+    {
+        public EnumMemberNameColor Color { get; set; }
+    }
+
+    public interface IIssue2083ColorApi
+    {
+        [Post("/color")]
+        Task PostColorAsync([Body] EnumMemberNameColorEnvelope body);
     }
 #endif
 


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Fixes #2079 
Fixes #2083 

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

#2079 
#2083 

**What is the new behavior?**
<!-- If this is a feature change -->

Introduce two convenience overloads in HttpClientFactoryExtensions: a non-generic AddRefitClient(IServiceCollection, Type, RefitSettings?) and a generic AddRefitClient<T>(IServiceCollection, RefitSettings?). 

Both delegate to existing implementations with httpClientName = null to preserve behavior. 

Add reflection-based tests in HttpClientFactoryExtensionsTests to ensure these overloads remain binary compatible. 

Also add a system-text-json serialization test and supporting types in SerializedContentTests to verify enum serialization honors JsonStringEnumMemberName when using an attributed JsonStringEnumConverter.

**What might this PR break?**



**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

