### PR TITLE
Avoid extra allocations when deserializing with Newtonsoft.Json

### DIFF
--- a/Refit.Newtonsoft.Json/NewtonsoftJsonContentSerializer.cs
+++ b/Refit.Newtonsoft.Json/NewtonsoftJsonContentSerializer.cs
@@ -58,11 +58,52 @@ namespace Refit
 
             var serializer = JsonSerializer.Create(jsonSerializerSettings.Value);
 
-            var json = await content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
-            using var reader = new StringReader(json);
-            using var jsonTextReader = new JsonTextReader(reader);
+            await content.LoadIntoBufferAsync(cancellationToken).ConfigureAwait(false);
+            var stream = await content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
 
-            return serializer.Deserialize<T>(jsonTextReader);
+#if NET6_0_OR_GREATER
+            await using (stream.ConfigureAwait(false))
+#else
+            using (stream)
+#endif
+            {
+                using var reader = new StreamReader(stream, GetEncoding(content) ?? Encoding.UTF8);
+
+                var jsonTextReader = new JsonTextReader(reader);
+#if NET6_0_OR_GREATER
+                await using (jsonTextReader.ConfigureAwait(false))
+#else
+                using (jsonTextReader)
+#endif
+                {
+                    return serializer.Deserialize<T>(jsonTextReader);
+                }
+            }
+        }
+
+        // Mirrors System.Text.Json's charset handling so behavior matches across serializers.
+        // See JsonHelpers.GetEncoding in System.Net.Http.Json:
+        // https://github.com/dotnet/runtime/blob/main/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/JsonHelpers.cs
+        private static Encoding? GetEncoding(HttpContent content)
+        {
+            var charset = content.Headers.ContentType?.CharSet;
+            if (charset is null)
+            {
+                return null;
+            }
+
+            try
+            {
+                if (charset.Length > 2 && charset[0] == '"' && charset[charset.Length - 1] == '"')
+                {
+                    charset = charset.Substring(1, charset.Length - 2);
+                }
+                return Encoding.GetEncoding(charset);
+            }
+            catch (ArgumentException e)
+            {
+                throw new InvalidOperationException("The character set provided in ContentType is invalid.", e);
+            }
         }
 
         /// <summary>

--- a/Refit/HttpContentExtensions.cs
+++ b/Refit/HttpContentExtensions.cs
@@ -2,11 +2,20 @@
 
 namespace Refit
 {
-#if !NET6_0_OR_GREATER
+#if !NET9_0_OR_GREATER
     static class HttpContentExtensions
     {
 #pragma warning disable IDE0079 // Remove unnecessary suppression
 #pragma warning disable IDE0060 // Remove unused parameter
+        public static Task LoadIntoBufferAsync(
+            this HttpContent httpContent,
+            CancellationToken cancellationToken
+        )
+        {
+            return httpContent.LoadIntoBufferAsync();
+        }
+#if !NET6_0_OR_GREATER
+
         public static Task<Stream> ReadAsStreamAsync(
             this HttpContent httpContent,
             CancellationToken cancellationToken
@@ -22,6 +31,7 @@ namespace Refit
         {
             return httpContent.ReadAsStringAsync();
         }
+#endif
 #pragma warning restore IDE0060 // Remove unused parameter
 #pragma warning restore IDE0079 // Remove unnecessary suppression
     }


### PR DESCRIPTION
Replace `ReadAsStringAsync` with `LoadIntoBufferAsync` + stream-based deserialization, dropping the full-body string allocation.

**What kind of change does this PR introduce?**

Performance/allocation reduction in `NewtonsoftJsonContentSerializer`.

**What is the current behavior?**

`FromHttpContentAsync` calls `ReadAsStringAsync`, which buffers the body into HttpContent's internal `MemoryStream` and then decodes the entire body into a `string`. For large responses that string lands on the LOH.

**What is the new behavior?**

`FromHttpContentAsync` now calls `LoadIntoBufferAsync(cancellationToken)` and deserializes from the resulting `MemoryStream` view via `StreamReader` + `JsonTextReader`. The full-body `string` allocation is gone - `StreamReader` decodes incrementally into a 1 KiB char buffer, and Newtonsoft pulls tokens as it walks the object graph.

The `Content-Type` charset is still respected: a small `GetEncoding(HttpContent)` helper mirrors `JsonHelpers.GetEncoding` from `System.Net.Http.Json`, so behavior matches `SystemTextJsonContentSerializer` (UTF-8 fallback when missing, `InvalidOperationException` on invalid charset).

**What might this PR break?**

Nothing is expected for well-formed responses. Charset handling is preserved end-to-end and verified by the existing test suite.

**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added - covered by existing `StreamDeserialization_UsingNewtonsoftJsonContentSerializer_DoesNotUseSynchronousReads`
- [ ] Docs have been added / updated - n/a

**Other information**:

For true streaming deserialization, prefer `SystemTextJsonContentSerializer` — Newtonsoft has no `DeserializeAsync`.

