### PR TITLE
[fix] freezing when reading a string response

### DIFF
--- a/src/Refit.Tests/RequestBuilder.cs
+++ b/src/Refit.Tests/RequestBuilder.cs
@@ -2607,7 +2607,7 @@ namespace Refit.Tests
         }
 
         [Test]
-        public async Task ObservableMethodsWithCancellationTokenShouldWork()
+        public void ObservableMethodsWithCancellationTokenShouldCancelWhenRequested()
         {
             var fixture = new RequestBuilderImplementation<IObservableCancellableMethods>();
             var factory = fixture.BuildRestResultFuncForMethod("GetWithCancellation");
@@ -2624,9 +2624,7 @@ namespace Refit.Tests
                     new object[] { "value", cts.Token }
                 )!;
 
-            var result = observable.Wait();
-
-            Assert.Equal("test", result);
+            Assert.Throws<TaskCanceledException>(() => observable.Wait());
             Assert.Equal(
                 "http://api/value/value",
                 testHttpMessageHandler.RequestMessage.RequestUri.ToString()

--- a/src/Refit/RequestBuilderImplementation.cs
+++ b/src/Refit/RequestBuilderImplementation.cs
@@ -473,8 +473,8 @@ namespace Refit
                         {
                             e = await ApiException.Create(
                                 "An error occured deserializing the response.",
-                                resp.RequestMessage!,
-                                resp.RequestMessage!.Method,
+                                rq,
+                                rq.Method,
                                 resp,
                                 settings,
                                 ex
@@ -502,6 +502,10 @@ namespace Refit
                         return await DeserializeContentAsync<T>(resp, content, cancellationToken)
                             .ConfigureAwait(false);
                     }
+                    catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                    {
+                        throw;
+                    }
                     catch (Exception ex)
                     {
                         if (settings.DeserializationExceptionFactory != null)
@@ -517,8 +521,8 @@ namespace Refit
                         {
                             throw await ApiException.Create(
                                 "An error occured deserializing the response.",
-                                resp.RequestMessage!,
-                                resp.RequestMessage!.Method,
+                                rq,
+                                rq.Method,
                                 resp,
                                 settings,
                                 ex
@@ -690,8 +694,8 @@ namespace Refit
                             {
                                 e = await ApiException.Create(
                                     "An error occured deserializing the response.",
-                                    resp.RequestMessage!,
-                                    resp.RequestMessage!.Method,
+                                    rq,
+                                    rq.Method,
                                     resp,
                                     settings,
                                     ex
@@ -719,6 +723,10 @@ namespace Refit
                             return await DeserializeContentAsync<T>(resp, content, ct)
                                 .ConfigureAwait(false);
                         }
+                        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+                        {
+                            throw;
+                        }
                         catch (Exception ex)
                         {
                             if (settings.DeserializationExceptionFactory != null)
@@ -733,8 +741,8 @@ namespace Refit
                             {
                                 throw await ApiException.Create(
                                     "An error occured deserializing the response.",
-                                    resp.RequestMessage!,
-                                    resp.RequestMessage!.Method,
+                                    rq,
+                                    rq.Method,
                                     resp,
                                     settings,
                                     ex
@@ -787,7 +795,12 @@ namespace Refit
                     .ReadAsStreamAsync(cancellationToken)
                     .ConfigureAwait(false);
                 using var reader = new StreamReader(stream);
+#if NET8_0_OR_GREATER
                 var str = (object)await reader.ReadToEndAsync(cancellationToken).ConfigureAwait(false);
+#else
+                cancellationToken.ThrowIfCancellationRequested();
+                var str = (object)await reader.ReadToEndAsync().ConfigureAwait(false);
+#endif
                 result = (T)str;
             }
             else

--- a/src/Refit/RequestBuilderImplementation.cs
+++ b/src/Refit/RequestBuilderImplementation.cs
@@ -787,7 +787,7 @@ namespace Refit
                     .ReadAsStreamAsync(cancellationToken)
                     .ConfigureAwait(false);
                 using var reader = new StreamReader(stream);
-                var str = (object)await reader.ReadToEndAsync().ConfigureAwait(false);
+                var str = (object)await reader.ReadToEndAsync(cancellationToken).ConfigureAwait(false);
                 result = (T)str;
             }
             else


### PR DESCRIPTION
<!-- Please be sure to read our [Contribute guide](https://www.reactiveui.net/contribute/index.html) before opening a PR. -->

## What kind of change does this PR introduce?
Bug fix

## What is the current behavior?
Hang when reading a string response when the connection is broken by the load balancer

## What is the new behavior?
Cancel request by CancellationToken

## What might this PR break?
-

## Checklist
- [X] I have read the [Contribute guide](https://www.reactiveui.net/contribute/index.html)
- [ ] Tests have been added or updated (for bug fixes / features)
- [ ] Docs have been added or updated (for bug fixes / features)
- [X] Changes target the `main` branch
- [X] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional information
