### PR TITLE
fix: Blazor WASM synchronous block

### DIFF
--- a/src/Refit/RequestBuilderImplementation.cs
+++ b/src/Refit/RequestBuilderImplementation.cs
@@ -626,12 +626,13 @@ namespace Refit
                         "BaseAddress must be set on the HttpClient instance"
                     );
 
-                var factory = BuildRequestFactoryForMethod(
+                var rq = await BuildRequestMessageForMethodAsync(
                     restMethod,
                     client.BaseAddress.AbsolutePath,
-                    restMethod.CancellationToken != null
-                );
-                var rq = factory(paramList);
+                    restMethod.CancellationToken != null,
+                    paramList
+                ).ConfigureAwait(false);
+
                 HttpResponseMessage? resp = null;
                 HttpContent? content = null;
                 var disposeResponse = true;
@@ -982,24 +983,6 @@ namespace Refit
 
             return false;
         }
-
-        Func<object[], HttpRequestMessage?> BuildRequestFactoryForMethod(
-            RestMethodInfoInternal restMethod,
-            string basePath,
-            bool paramsContainsCancellationToken
-        )
-        {
-            return paramList =>
-                RunSynchronous(() =>
-                    BuildRequestMessageForMethodAsync(
-                        restMethod,
-                        basePath,
-                        paramsContainsCancellationToken,
-                        paramList
-                    )
-                );
-        }
-
         async Task<HttpRequestMessage?> BuildRequestMessageForMethodAsync(
             RestMethodInfoInternal restMethod,
             string basePath,


### PR DESCRIPTION
<!-- Please read our [Contribute guide](https://www.reactiveui.net/contribute/index.html) before opening a PR, and give this PR a title that follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `fix:`, `feat:`, `docs:`, `build:`). -->

## What kind of change does this PR introduce?
Bug fix

## What is the new behavior?
This PR should fix #2115

## What is the current behavior?
The version 11.0.0 introduced a blocking call which breaks using refit in single threaded environments like blazor WASM.

## What might this PR break?
None

## Checklist
- [ ] I have read the [Contribute guide](https://www.reactiveui.net/contribute/index.html)
- [ ] Tests have been added or updated (for bug fixes / features)
- [ ] Docs have been added or updated (for bug fixes / features)
- [ ] Changes target the `main` branch
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional information
<!-- Screenshots, benchmarks, links, or anything else that helps reviewers. -->
