### PR TITLE
build: default examples to IsPackable=false

### DIFF
--- a/src/examples/Directory.Build.props
+++ b/src/examples/Directory.Build.props
@@ -1,0 +1,11 @@
+<Project>
+  <!-- Inherit the repo-wide build settings (this file would otherwise stop the
+       upward search for Directory.Build.props). -->
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
+  <!-- Examples are never published to NuGet. This is a safety net so a new example
+       project added without its own setting can't be packed/published by accident. -->
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
## What
Adds `src/examples/Directory.Build.props` setting `IsPackable=false` for the whole examples folder (re-importing the parent `src/Directory.Build.props` so the repo-wide build settings still apply).

## Why
Two sample projects — `ConsoleSampleUsingLocalApi` and `LibraryWithSDKandRefitService` — were accidentally published to NuGet as **10.1.3** (before #2092 added `IsPackable=false` to the individual samples). Those versions have now been **unlisted** on nuget.org (they were also signed with the since-revoked code-signing certificate).

All current example projects already set `IsPackable=false`; this adds a folder-wide default as a **safety net** so a new example added without its own setting can't be packed or published by accident.

## Verification
`dotnet msbuild` on an example resolves `IsPackable=false` and still inherits parent props (`Authors`, `LangVersion`), confirming the import chain is intact.