### PR TITLE
Fix: serialize body by runtime type for interface/abstract parameters (#2118)

### DIFF
--- a/src/Refit.Tests/SerializedContentTests.cs
+++ b/src/Refit.Tests/SerializedContentTests.cs
@@ -661,6 +661,52 @@ public partial class SerializedContentTests
         Assert.Contains("\"name\":\"Photon\"", serializedBody, StringComparison.Ordinal);
     }
 
+    [Test]
+    public async Task RestService_SerializesBodyUsingRuntimeTypeWhenDeclaredTypeIsInterface()
+    {
+        string? serializedBody = null;
+        var settings = new RefitSettings(new SystemTextJsonContentSerializer())
+        {
+            HttpMessageHandlerFactory = () => new StubHttpMessageHandler(async request =>
+            {
+                serializedBody = await request.Content!.ReadAsStringAsync();
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("{}", Encoding.UTF8, "application/json")
+                };
+            })
+        };
+
+        var api = RestService.For<IInterfaceRequestApi>(BaseAddress, settings);
+        await api.CreateWeapon(new InterfaceLaserWeaponRequest { Name = "Photon" });
+
+        Assert.NotNull(serializedBody);
+        Assert.Equal("""{"name":"Photon"}""", serializedBody);
+    }
+
+    [Test]
+    public async Task RestService_SerializesBodyUsingRuntimeTypeWhenDeclaredTypeIsAbstract()
+    {
+        string? serializedBody = null;
+        var settings = new RefitSettings(new SystemTextJsonContentSerializer())
+        {
+            HttpMessageHandlerFactory = () => new StubHttpMessageHandler(async request =>
+            {
+                serializedBody = await request.Content!.ReadAsStringAsync();
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("{}", Encoding.UTF8, "application/json")
+                };
+            })
+        };
+
+        var api = RestService.For<IAbstractRequestApi>(BaseAddress, settings);
+        await api.CreateWeapon(new AbstractLaserWeaponRequest { Name = "Photon" });
+
+        Assert.NotNull(serializedBody);
+        Assert.Equal("""{"name":"Photon"}""", serializedBody);
+    }
+
 #if NET9_0_OR_GREATER
     [Test]
     public async Task SystemTextJsonContentSerializer_SupportsJsonStringEnumMemberName()
@@ -747,6 +793,32 @@ public partial class SerializedContentTests
     {
         [Post("/weapons")]
         Task CreateWeapon(CreateWeaponRequest request);
+    }
+
+    public interface InterfaceCreateWeaponRequest;
+
+    public sealed class InterfaceLaserWeaponRequest : InterfaceCreateWeaponRequest
+    {
+        public string? Name { get; set; }
+    }
+
+    public interface IInterfaceRequestApi
+    {
+        [Post("/weapons")]
+        Task CreateWeapon([Body] InterfaceCreateWeaponRequest request);
+    }
+
+    public abstract class AbstractCreateWeaponRequest;
+
+    public sealed class AbstractLaserWeaponRequest : AbstractCreateWeaponRequest
+    {
+        public string? Name { get; set; }
+    }
+
+    public interface IAbstractRequestApi
+    {
+        [Post("/weapons")]
+        Task CreateWeapon([Body] AbstractCreateWeaponRequest request);
     }
 
 #if NET9_0_OR_GREATER

--- a/src/Refit.Tests/SerializedContentTests.cs
+++ b/src/Refit.Tests/SerializedContentTests.cs
@@ -795,7 +795,7 @@ public partial class SerializedContentTests
         Task CreateWeapon(CreateWeaponRequest request);
     }
 
-    public interface InterfaceCreateWeaponRequest;
+    public interface InterfaceCreateWeaponRequest { }
 
     public sealed class InterfaceLaserWeaponRequest : InterfaceCreateWeaponRequest
     {
@@ -808,7 +808,7 @@ public partial class SerializedContentTests
         Task CreateWeapon([Body] InterfaceCreateWeaponRequest request);
     }
 
-    public abstract class AbstractCreateWeaponRequest;
+    public abstract class AbstractCreateWeaponRequest { }
 
     public sealed class AbstractLaserWeaponRequest : AbstractCreateWeaponRequest
     {

--- a/src/Refit/SystemTextJsonContentSerializer.cs
+++ b/src/Refit/SystemTextJsonContentSerializer.cs
@@ -27,6 +27,13 @@ namespace Refit
         /// <inheritdoc/>
         public HttpContent ToHttpContent<T>(T item)
         {
+            if (item is not null
+                && (typeof(T).IsInterface || typeof(T).IsAbstract)
+                && !DeclaredTypeIsPolymorphic(typeof(T)))
+            {
+                return ToHttpContentRuntimeTyped(item, item.GetType());
+            }
+
 #if NET8_0_OR_GREATER
             if (TryGetJsonTypeInfo<T>(out var jsonTypeInfo))
             {
@@ -34,6 +41,34 @@ namespace Refit
             }
 #endif
             return JsonContent.Create(item, options: jsonSerializerOptions);
+        }
+
+        HttpContent ToHttpContentRuntimeTyped(object item, Type runtimeType)
+        {
+#if NET8_0_OR_GREATER
+            if (jsonSerializerOptions.TypeInfoResolver is not null)
+            {
+                return JsonContent.Create(item, jsonSerializerOptions.GetTypeInfo(runtimeType));
+            }
+#endif
+            return JsonContent.Create(item, runtimeType, options: jsonSerializerOptions);
+        }
+
+        bool DeclaredTypeIsPolymorphic(Type type)
+        {
+            if (type.IsDefined(typeof(JsonPolymorphicAttribute), inherit: false)
+                || type.IsDefined(typeof(JsonDerivedTypeAttribute), inherit: false))
+            {
+                return true;
+            }
+
+#if NET8_0_OR_GREATER
+            if (jsonSerializerOptions.TypeInfoResolver is not null)
+            {
+                return jsonSerializerOptions.GetTypeInfo(type).PolymorphismOptions is not null;
+            }
+#endif
+            return false;
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
## Summary

Fixes #2118.

When a `[Body]` parameter is **declared** as an interface or abstract type but a concrete instance is passed at runtime, the default `System.Text.Json` serializer produced an empty body `{}` instead of the object's properties. This is a regression from 10.x, which serialized the runtime object.

## Cause

`SystemTextJsonContentSerializer.ToHttpContent<T>` serializes using the declared type `T`. For an interface/abstract declared type, System.Text.Json writes only that type's members — none — so the body becomes `{}`. (Concrete types and `object` are unaffected, since System.Text.Json serializes `object` by its runtime type.)

## Fix

`ToHttpContent<T>` now serializes the **runtime type** when the declared type is an interface or abstract type — **unless** that type opts into System.Text.Json polymorphism (`[JsonPolymorphic]` / `[JsonDerivedType]`, or a resolver with `PolymorphismOptions`), in which case the declared type is kept so the `$type` discriminator is still written.

- Concrete body types take the unchanged fast path: the gate (`typeof(T).IsInterface || typeof(T).IsAbstract`) short-circuits before any extra work — no `GetType()`, no reflection, no allocation — so the common path is unaffected.
- Existing `[JsonDerivedType]` polymorphic-body behavior is preserved (still emits `$type`).

## Tests

Added to `SerializedContentTests`:
- interface-declared body → serializes the concrete properties
- non-polymorphic abstract-declared body → serializes the concrete properties
- (existing) polymorphic abstract base → still emits `$type`

## Reproduction

Standalone repro (xUnit + WireMock.Net) contrasting NuGet `10.2.0` (passes) with `11.0.0` (`{}`):
https://github.com/HulinCedric/refit/tree/repro/issue-2118/regression
