### PR TITLE
fix: prevent duplicate Refit analyzers on legacy toolchains

### DIFF
--- a/src/Refit/targets/refit.targets
+++ b/src/Refit/targets/refit.targets
@@ -24,9 +24,11 @@
           DependsOnTargets="_RefitGatherAnalyzers">
 
     <ItemGroup>
-      <!-- Remove our analyzers targeting roslyn4.x -->
+      <!-- On toolchains without Roslyn component versioning, NuGet does not select a single
+           analyzer folder. Keep only the baseline roslyn3.8 analyzer and remove the other
+           variants so exactly one source generator runs. -->
       <Analyzer Remove="@(_RefitAnalyzer)"
-                Condition="$([System.String]::Copy('%(_RefitAnalyzer.Identity)').IndexOf('roslyn4')) &gt;= 0"/>
+                Condition="$([System.String]::Copy('%(_RefitAnalyzer.Identity)').IndexOf('roslyn3.8')) &lt; 0"/>
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
## What kind of change does this PR introduce?
Bug fix (build / packaging).

## What is the new behavior?
On toolchains without Roslyn component versioning, the `refit.targets` fallback (`_RefitAnalyzerMultiTargeting`) keeps only the baseline `roslyn3.8` analyzer and removes the other variants, so exactly one source generator runs and no duplicate generated classes are produced.

## What is the current behavior?
On those toolchains more than one analyzer variant can be referenced at once, so the source generator runs multiple times and emits duplicate generated classes.

Closes #2095.

## What might this PR break?
None expected. Modern SDK toolchains use NuGet's Roslyn component versioning and select a single analyzer folder, so they are unaffected. `packages.config` projects remain explicitly unsupported via the existing `_RefitProjectRestoreTypeCheck` error.

## Checklist
- [x] I have read the Contribute guide
- [ ] Tests have been added or updated (for bug fixes / features)
- [ ] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the `main` branch
- [x] PR title follows Conventional Commits

## Additional information
`roslyn3.8` is the safe baseline for consumers whose toolchain lacks component versioning. This is an MSBuild packaging fallback that the unit test suite does not exercise; verified by packing and confirming a single analyzer is referenced on a non-component-versioning consumer.
