### PR TITLE
fix: correct URL and query string building edge cases

### DIFF
--- a/src/Refit.Tests/RequestBuilder.cs
+++ b/src/Refit.Tests/RequestBuilder.cs
@@ -559,6 +559,61 @@ namespace Refit.Tests
         }
 
         [Test]
+        public void CultureInfoQueryParameterDoesNotStackOverflow()
+        {
+            var fixture = new RequestBuilderImplementation<IDummyHttpApi>();
+
+            var factory = fixture.BuildRequestFactoryForMethod(
+                nameof(IDummyHttpApi.QueryWithCultureInfo)
+            );
+
+            var output = factory(new object[] { new System.Globalization.CultureInfo("en-US") });
+
+            var uri = new Uri(new Uri("http://api"), output.RequestUri);
+
+            Assert.Equal("/foo?culture=en-US", uri.PathAndQuery);
+        }
+
+        [Test]
+        public void BaseAddressWithTrailingSlashDoesNotProduceDoubleSlash()
+        {
+            var fixture = new RequestBuilderImplementation<IDummyHttpApi>();
+
+            var factory = fixture.BuildRequestFactoryForMethod(
+                nameof(IDummyHttpApi.FetchSomeStuff),
+                baseAddress: "http://api/v1/"
+            );
+
+            var output = factory(new object[] { 42 });
+
+            var uri = new Uri(new Uri("http://api"), output.RequestUri);
+
+            Assert.Equal("/v1/foo/bar/42", uri.AbsolutePath);
+        }
+
+        [Test]
+        [Arguments("/api/123?SomeProperty2=test&text=title&filters=A&filters=B")]
+        public void DerivedPathBoundObjectDoesNotDuplicatePathPropertyAsQuery(string expectedQuery)
+        {
+            var fixture = new RequestBuilderImplementation<IDummyHttpApi>();
+            var factory = fixture.BuildRequestFactoryForMethod(
+                "QueryWithOptionalParametersPathBoundObject"
+            );
+            var output = factory(
+                new object[]
+                {
+                    new DerivedPathBoundObject() { SomeProperty = 123, SomeProperty2 = "test" },
+                    "title",
+                    null,
+                    new string[] { "A", "B" }
+                }
+            );
+
+            var uri = new Uri(new Uri("http://api"), output.RequestUri);
+            Assert.Equal(expectedQuery, uri.PathAndQuery);
+        }
+
+        [Test]
         public void PostWithObjectQueryParameterHasCorrectQuerystring()
         {
             var fixture = new RequestBuilderImplementation<IDummyHttpApi>();
@@ -1790,6 +1845,9 @@ namespace Refit.Tests
     [Headers("User-Agent: RefitTestClient", "Api-Version: 1")]
     public interface IDummyHttpApi
     {
+        [Get("/foo")]
+        Task QueryWithCultureInfo([Query] System.Globalization.CultureInfo culture);
+
         [Get("/foo/bar/{id}")]
         Task<ApiResponse<string>> FetchSomeStringWithMetadata(int id);
 

--- a/src/Refit.Tests/RestService.cs
+++ b/src/Refit.Tests/RestService.cs
@@ -144,6 +144,10 @@ public class PathBoundObject
     public string SomeProperty2 { get; set; }
 }
 
+public class DerivedPathBoundObject : PathBoundObject
+{
+}
+
 public class PathBoundObjectWithQuery
 {
     public int SomeProperty { get; set; }
@@ -664,7 +668,9 @@ public class RestServiceIntegrationTests
     [Test]
     public async Task GetWithDerivedObjectAsBaseType()
     {
-        // possibly a bug see https://github.com/reactiveui/refit/issues/1882
+        // see https://github.com/reactiveui/refit/issues/1882: a property bound to the
+        // path must not also be emitted as a query parameter when a derived instance is
+        // passed for a base-typed parameter.
         var mockHttp = new MockHttpMessageHandler();
         mockHttp
             .Expect(HttpMethod.Get, "http://foo/foos/1/bar")
@@ -672,8 +678,7 @@ public class RestServiceIntegrationTests
                 new[]
                 {
                     new KeyValuePair<string, string>("SomeProperty3", "test"),
-                    new KeyValuePair<string, string>("SomeProperty2", "barNone"),
-                    new KeyValuePair<string, string>("SomeProperty", "1")
+                    new KeyValuePair<string, string>("SomeProperty2", "barNone")
                 }
             )
             .Respond("application/json", "Ok");

--- a/src/Refit/RequestBuilderImplementation.cs
+++ b/src/Refit/RequestBuilderImplementation.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections;
 using System.Collections.Concurrent;
 using System.Diagnostics;
+using System.Globalization;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Reflection;
@@ -846,7 +847,10 @@ namespace Refit
                 //if we have a parameter info lets check it to make sure it isn't bound to the path
                 if (parameterInfo is { IsObjectPropertyParameter: true })
                 {
-                    if (parameterInfo.ParameterProperties.Any(x => x.PropertyInfo == propertyInfo))
+                    // Compare by name rather than PropertyInfo reference: for a derived runtime
+                    // type the inherited property is a different PropertyInfo instance, which
+                    // would otherwise be wrongly emitted as a duplicate query parameter.
+                    if (parameterInfo.ParameterProperties.Any(x => x.PropertyInfo.Name == propertyInfo.Name))
                     {
                         continue;
                     }
@@ -1141,7 +1145,9 @@ namespace Refit
 
         string BuildRelativePath(string basePath, RestMethodInfoInternal restMethod, object[] paramList)
         {
-            basePath = basePath == "/" ? string.Empty : basePath;
+            // Every path fragment is prefixed with '/', so trim a trailing slash from the
+            // base path to avoid emitting a double slash when the base address ends with one.
+            basePath = basePath == "/" ? string.Empty : basePath.TrimEnd('/');
             var pathFragments = restMethod.FragmentPath;
             if (pathFragments.Count == 0)
             {
@@ -1759,7 +1765,8 @@ namespace Refit
                       || type == typeof(bool)
                       || type == typeof(char)
                       || typeof(IFormattable).IsAssignableFrom(type)
-                      || type == typeof(Uri);
+                      || type == typeof(Uri)
+                      || typeof(CultureInfo).IsAssignableFrom(type);
         }
 
         static void SetHeader(HttpRequestMessage request, string name, string? value)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fixes for URL and query string building. Three small, independent fixes grouped together as they all touch `RequestBuilderImplementation` request construction.

## What is the new behavior?

- A `CultureInfo` query parameter is formatted as a leaf value (for example `?culture=en-US`) instead of being reflected into. Closes #1323.
- A base address that ends with a slash (for example `http://host/api/`) produces a single slash before the route, so the request URL is `/api/foo` rather than `/api//foo`. Closes #1358.
- When a derived instance is passed for a parameter declared as a base type, a property that is bound to the URL path is no longer also emitted as a query parameter. Closes #1882.

## What is the current behavior?

- A `CultureInfo` query parameter is treated as a complex object and recursed into. Because `CultureInfo` exposes a self-referencing `Parent`, this recurses without bound and throws a `StackOverflowException`.
- A base address ending with a slash is concatenated with a route that already starts with a slash, producing a double slash in the path.
- Path-bound properties are matched against the parameter's declared type by `PropertyInfo` reference. For a derived runtime instance the inherited property is a different `PropertyInfo`, so the match fails and the path property is duplicated into the query string.

## What might this PR break?

None expected. `CultureInfo` and trailing-slash base addresses previously failed or produced malformed URLs. The derived-type change only removes a duplicated query parameter; the existing test for that scenario has been updated to assert the corrected behavior.

## Checklist

- [x] I have read the Contribute guide
- [x] Tests have been added or updated (for bug fixes / features)
- [ ] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the `main` branch
- [x] PR title follows Conventional Commits

## Additional information

New unit tests cover the `CultureInfo` and trailing-slash cases; the existing `GetWithDerivedObjectAsBaseType` integration test now asserts that the path-bound property is not duplicated into the query.
