### PR TITLE
fix: handle empty responses and edge cases in JSON serialization

### DIFF
--- a/src/Refit.Tests/RestService.cs
+++ b/src/Refit.Tests/RestService.cs
@@ -284,6 +284,15 @@ public interface IValidApi
     Task Get();
 }
 
+public interface INoContentApi
+{
+    [Get("/values")]
+    Task<List<string>> GetValues();
+
+    [Get("/values")]
+    Task<ApiResponse<List<string>>> GetValuesResponse();
+}
+
 public interface IQueryApi
 {
     [Get("/foo?")]
@@ -471,6 +480,38 @@ public class RestServiceIntegrationTests
         var fixture = RestService.For<ITrimTrailingForwardSlashApi>("http://foo", settings);
 
         await fixture.Get();
+        mockHttp.VerifyNoOutstandingExpectation();
+    }
+
+    [Test]
+    public async Task GetWithNoContentResponseReturnsDefault()
+    {
+        var mockHttp = new MockHttpMessageHandler();
+        mockHttp.Expect(HttpMethod.Get, "http://foo/values").Respond(HttpStatusCode.NoContent);
+
+        var settings = new RefitSettings { HttpMessageHandlerFactory = () => mockHttp };
+        var fixture = RestService.For<INoContentApi>("http://foo", settings);
+
+        var result = await fixture.GetValues();
+
+        Assert.Null(result);
+        mockHttp.VerifyNoOutstandingExpectation();
+    }
+
+    [Test]
+    public async Task GetWithNoContentApiResponseReturnsNullContent()
+    {
+        var mockHttp = new MockHttpMessageHandler();
+        mockHttp.Expect(HttpMethod.Get, "http://foo/values").Respond(HttpStatusCode.NoContent);
+
+        var settings = new RefitSettings { HttpMessageHandlerFactory = () => mockHttp };
+        var fixture = RestService.For<INoContentApi>("http://foo", settings);
+
+        using var response = await fixture.GetValuesResponse();
+
+        Assert.True(response.IsSuccessStatusCode);
+        Assert.Null(response.Content);
+        Assert.Null(response.Error);
         mockHttp.VerifyNoOutstandingExpectation();
     }
 

--- a/src/Refit.Tests/SerializedContentTests.cs
+++ b/src/Refit.Tests/SerializedContentTests.cs
@@ -707,6 +707,40 @@ public partial class SerializedContentTests
         Assert.Equal("""{"name":"Photon"}""", serializedBody);
     }
 
+    [Test]
+    public async Task SystemTextJsonContentSerializer_SerializesBareObjectAsEmptyJson()
+    {
+        var serializer = new SystemTextJsonContentSerializer();
+
+        var content = serializer.ToHttpContent(new object());
+        var serialized = await content.ReadAsStringAsync();
+
+        Assert.Equal("{}", serialized);
+    }
+
+    [Test]
+    public async Task SystemTextJsonContentSerializer_RoundTripsEnumDictionaryKeys()
+    {
+        var serializer = new SystemTextJsonContentSerializer();
+
+        var source = new Dictionary<CamelCaseEnum, string>
+        {
+            [CamelCaseEnum.ValueOne] = "first",
+            [CamelCaseEnum.alreadyLowercase] = "second"
+        };
+
+        var content = serializer.ToHttpContent(source);
+        var serialized = await content.ReadAsStringAsync();
+
+        var roundTrip = await serializer.FromHttpContentAsync<Dictionary<CamelCaseEnum, string>>(
+            new StringContent(serialized, Encoding.UTF8, "application/json")
+        );
+
+        Assert.NotNull(roundTrip);
+        Assert.Equal("first", roundTrip[CamelCaseEnum.ValueOne]);
+        Assert.Equal("second", roundTrip[CamelCaseEnum.alreadyLowercase]);
+    }
+
 #if NET9_0_OR_GREATER
     [Test]
     public async Task SystemTextJsonContentSerializer_SupportsJsonStringEnumMemberName()

--- a/src/Refit/RequestBuilderImplementation.cs
+++ b/src/Refit/RequestBuilderImplementation.cs
@@ -806,6 +806,15 @@ namespace Refit
             }
             else
             {
+                // A 204 No Content response (or an explicitly empty body) has nothing to
+                // deserialize. Return the default value rather than letting the serializer
+                // fail on empty content.
+                if (resp.StatusCode == System.Net.HttpStatusCode.NoContent
+                    || content.Headers.ContentLength == 0)
+                {
+                    return default;
+                }
+
                 result = await serializer
                     .FromHttpContentAsync<T>(content, cancellationToken)
                     .ConfigureAwait(false);

--- a/src/Refit/SystemTextJsonContentSerializer.cs
+++ b/src/Refit/SystemTextJsonContentSerializer.cs
@@ -1,4 +1,5 @@
-﻿using System.Net.Http;
+﻿using System.Globalization;
+using System.Net.Http;
 using System.Net.Http.Json;
 using System.Reflection;
 using System.Text.Json;
@@ -184,14 +185,26 @@ namespace Refit
             JsonSerializerOptions options
         )
         {
+            var runtimeType = objectToWrite.GetType();
+
+            // A bare System.Object has no properties to serialize. Serializing it by its
+            // runtime type would re-enter this converter (registered for object) and recurse
+            // until the stack overflows, so emit an empty JSON object directly.
+            if (runtimeType == typeof(object))
+            {
+                writer.WriteStartObject();
+                writer.WriteEndObject();
+                return;
+            }
+
 #if NET8_0_OR_GREATER
             if (options.TypeInfoResolver is not null)
             {
-                JsonSerializer.Serialize(writer, objectToWrite, options.GetTypeInfo(objectToWrite.GetType()));
+                JsonSerializer.Serialize(writer, objectToWrite, options.GetTypeInfo(runtimeType));
                 return;
             }
 #endif
-            JsonSerializer.Serialize(writer, objectToWrite, objectToWrite.GetType(), options);
+            JsonSerializer.Serialize(writer, objectToWrite, runtimeType, options);
         }
     }
 
@@ -285,6 +298,42 @@ namespace Refit
                 }
 
                 writer.WriteStringValue(name);
+            }
+
+            public override object? ReadAsPropertyName(
+                ref Utf8JsonReader reader,
+                Type typeToConvert,
+                JsonSerializerOptions options
+            )
+            {
+                var value = reader.GetString();
+                if (!string.IsNullOrWhiteSpace(value))
+                {
+                    if (namesToValues.TryGetValue(value!, out var namedValue))
+                        return namedValue;
+
+                    if (namesToValuesIgnoreCase.TryGetValue(value!, out var namedValueIgnoreCase))
+                        return namedValueIgnoreCase;
+                }
+
+                throw new JsonException($"Unable to convert '{value}' to {targetType}.");
+            }
+
+            public override void WriteAsPropertyName(
+                Utf8JsonWriter writer,
+                object? value,
+                JsonSerializerOptions options
+            )
+            {
+                if (value is not null && valuesToNames.TryGetValue(value, out var name))
+                {
+                    writer.WritePropertyName(name);
+                    return;
+                }
+
+                writer.WritePropertyName(
+                    Convert.ToInt64(value).ToString(CultureInfo.InvariantCulture)
+                );
             }
 
             static Dictionary<string, object> GetNamesToValues(


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fixes for JSON serialization edge cases. Three small, independent fixes grouped together as they all touch System.Text.Json serialization behaviour.

## What is the new behavior?

- A `204 No Content` response, or any response with an empty body, returns the default value (for example `null`). For `ApiResponse<T>` the `Content` is null and no `Error` is set. Closes #1128.
- Serializing a bare `System.Object` as a request body produces an empty JSON object `{}`. Closes #1540.
- Enum dictionary keys (for example `Dictionary<MyEnum, string>`) round-trip correctly with the default Refit settings. Closes #2111.

## What is the current behavior?

- An empty body is passed to the serializer, and System.Text.Json throws `The input does not contain any JSON tokens` on a successful response with no content.
- A bare `System.Object` body is serialized via its runtime type, which re-enters the converter registered for `object` and recurses until the stack overflows.
- Enum dictionary keys are routed through the enum converter, which only handled values (not property names), so serialization and deserialization failed.

## What might this PR break?

None expected. Each case previously threw or crashed. The empty-response change only short-circuits when the status is `204` or the content length is `0`, so responses that carry a body are unaffected.

## Checklist

- [x] I have read the Contribute guide
- [x] Tests have been added or updated (for bug fixes / features)
- [ ] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the `main` branch
- [x] PR title follows Conventional Commits

## Additional information

New tests cover the empty/`204` response for both `Task<T>` and `ApiResponse<T>`, the bare-object body, and an enum-keyed dictionary round-trip.
