### PR TITLE
fix: detect nullable CancellationToken parameters

### DIFF
--- a/src/Refit.Tests/RequestBuilder.cs
+++ b/src/Refit.Tests/RequestBuilder.cs
@@ -2180,6 +2180,9 @@ namespace Refit.Tests
 
         [Get("/foo")]
         Task<string> GetWithCancellationAndReturn(CancellationToken token = default);
+
+        [Get("/foo/{id}")]
+        Task GetWithNullableCancellation(int id, CancellationToken? token = default);
     }
 
     interface IAuthenticatedCancellableMethods
@@ -2346,6 +2349,34 @@ namespace Refit.Tests
             var uri = new Uri(new Uri("http://api"), output.RequestMessage.RequestUri);
             Assert.Equal("/foo", uri.PathAndQuery);
             Assert.False(output.CancellationToken.IsCancellationRequested);
+        }
+
+        [Test]
+        public void MethodsWithNullableCancellationTokenShouldBuildRequest()
+        {
+            var fixture = new RequestBuilderImplementation<ICancellableMethods>();
+            var factory = fixture.RunRequest("GetWithNullableCancellation");
+
+            using var cts = new CancellationTokenSource();
+            var output = factory(new object[] { 42, cts.Token });
+
+            var uri = new Uri(new Uri("http://api"), output.RequestMessage.RequestUri);
+            Assert.Equal("/foo/42", uri.PathAndQuery);
+            Assert.False(output.CancellationToken.IsCancellationRequested);
+        }
+
+        [Test]
+        public void MethodsWithNullableCancellationTokenShouldCancelWhenRequested()
+        {
+            var fixture = new RequestBuilderImplementation<ICancellableMethods>();
+            var factory = fixture.RunRequest("GetWithNullableCancellation");
+
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            var output = factory(new object[] { 42, cts.Token });
+
+            Assert.True(output.CancellationToken.IsCancellationRequested);
         }
 
         [Test]

--- a/src/Refit/RestMethodInfo.cs
+++ b/src/Refit/RestMethodInfo.cs
@@ -155,7 +155,7 @@ namespace Refit
 
             var ctParamEnumerable = methodInfo
                 .GetParameters()
-                .Where(p => p.ParameterType == typeof(CancellationToken))
+                .Where(p => p.ParameterType == typeof(CancellationToken) || p.ParameterType == typeof(CancellationToken?))
                 .TryGetSingle(out var ctParam);
             if (ctParamEnumerable == EnumerablePeek.Many)
             {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix for parameter handling.

## What is the new behavior?

A method parameter typed as `CancellationToken?` is recognised as the request cancellation token, so methods such as `Task GetThing(int id, CancellationToken? token = default)` build and send correctly. Closes #2043.

## What is the current behavior?

A `CancellationToken?` parameter is excluded from the parameter list used to build the query, header and body maps, but is not detected as the cancellation token. The runtime parameter list and those maps end up misaligned, and building the request throws (for example `Index was outside the bounds of the array`).

## What might this PR break?

None. The detection is widened to match the nullable form, mirroring the exclusion rule that already accounts for both `CancellationToken` and `CancellationToken?`.

## Checklist

- [x] I have read the Contribute guide
- [x] Tests have been added or updated (for bug fixes / features)
- [ ] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the `main` branch
- [x] PR title follows Conventional Commits

## Additional information

New tests build a request for a method with a `CancellationToken?` parameter alongside a path parameter, and verify the token still flows through and triggers cancellation.
