### PR TITLE
fix: request building edge cases for headers, query and enum params

### DIFF
--- a/src/Refit.Tests/DefaultUrlParameterFormatterTest.cs
+++ b/src/Refit.Tests/DefaultUrlParameterFormatterTest.cs
@@ -299,4 +299,47 @@ public class DefaultUrlParameterFormatterTests
             uri.Query
         );
     }
+
+    [Flags]
+    enum SampleFlags
+    {
+        None = 0,
+        First = 1,
+        Second = 2
+    }
+
+    class FlagsRequest
+    {
+        public SampleFlags Flags { get; set; }
+    }
+
+    [Test]
+    public void CombinedFlagsEnumValue_DoesNotThrow()
+    {
+        var parameters = new FlagsRequest { Flags = SampleFlags.First | SampleFlags.Second };
+
+        var urlParameterFormatter = new DefaultUrlParameterFormatter();
+
+        var output = urlParameterFormatter.Format(
+            parameters.Flags,
+            parameters.GetType().GetProperty(nameof(parameters.Flags))!,
+            parameters.GetType());
+
+        Assert.Equal("First, Second", output);
+    }
+
+    [Test]
+    public void UndefinedEnumValue_DoesNotThrow()
+    {
+        var parameters = new FlagsRequest { Flags = (SampleFlags)(-1) };
+
+        var urlParameterFormatter = new DefaultUrlParameterFormatter();
+
+        var output = urlParameterFormatter.Format(
+            parameters.Flags,
+            parameters.GetType().GetProperty(nameof(parameters.Flags))!,
+            parameters.GetType());
+
+        Assert.Equal("-1", output);
+    }
 }

--- a/src/Refit.Tests/RequestBuilder.cs
+++ b/src/Refit.Tests/RequestBuilder.cs
@@ -1842,6 +1842,16 @@ namespace Refit.Tests
         [Headers("Content-Type: literally/anything")]
         Task<string> PostSomeStuffWithHardCodedContentTypeHeader(int id, [Body] string content);
 
+        [Post("/foo/bar/{id}")]
+        [Headers("Content-type: application/soap+xml")]
+        Task<string> PostSomeStuffWithNonCanonicalContentTypeHeader(int id, [Body] string content);
+
+        [Get("/foo/bar/{id}")]
+        Task<string> FetchSomeStuffWithPropertyAndQuery(
+            int id,
+            [Property("SomeProperty")] [Query] string someValue
+        );
+
         [Get("/foo/bar/{id}")]
         [Headers("Authorization: SRSLY aHR0cDovL2kuaW1ndXIuY29tL0NGRzJaLmdpZg==")]
         Task<string> FetchSomeStuffWithDynamicHeader(
@@ -3033,6 +3043,31 @@ namespace Refit.Tests
                 "Content headers include Content-Type header"
             );
             Assert.Equal("literally/anything", output.Content.Headers.ContentType.ToString());
+        }
+
+        [Test]
+        public void NonCanonicalContentTypeHeaderCasingIsNotDuplicated()
+        {
+            var fixture = new RequestBuilderImplementation<IDummyHttpApi>();
+            var factory = fixture.BuildRequestFactoryForMethod(
+                "PostSomeStuffWithNonCanonicalContentTypeHeader"
+            );
+            var output = factory(new object[] { 6, "stuff" });
+
+            Assert.Equal("application/soap+xml", output.Content.Headers.ContentType.ToString());
+        }
+
+        [Test]
+        public void ParameterWithPropertyAndQueryAttributesIsAddedToQuery()
+        {
+            var fixture = new RequestBuilderImplementation<IDummyHttpApi>();
+            var factory = fixture.BuildRequestFactoryForMethod(
+                "FetchSomeStuffWithPropertyAndQuery"
+            );
+            var output = factory(new object[] { 6, "value1" });
+
+            var uri = new Uri(new Uri("http://api"), output.RequestUri);
+            Assert.Equal("/foo/bar/6?someValue=value1", uri.PathAndQuery);
         }
 
         [Test]

--- a/src/Refit/RefitSettings.cs
+++ b/src/Refit/RefitSettings.cs
@@ -324,8 +324,8 @@ namespace Refit
                     val =>
                         parameterType
                             .GetMember(val)
-                            .First()
-                            .GetCustomAttribute<EnumMemberAttribute>()
+                            .FirstOrDefault()
+                            ?.GetCustomAttribute<EnumMemberAttribute>()
                 );
             }
 
@@ -386,8 +386,8 @@ namespace Refit
                     val =>
                         parameterType
                             .GetMember(val)
-                            .First()
-                            .GetCustomAttribute<EnumMemberAttribute>()
+                            .FirstOrDefault()
+                            ?.GetCustomAttribute<EnumMemberAttribute>()
                 );
             }
 

--- a/src/Refit/RequestBuilderImplementation.cs
+++ b/src/Refit/RequestBuilderImplementation.cs
@@ -1071,7 +1071,10 @@ namespace Refit
                         isParameterMappedToRequest = true;
                     }
 
-                    if (restMethod.PropertyParameterMap.ContainsKey(i))
+                    // A property parameter that also carries [Query] should still contribute to
+                    // the query string, so do not treat it as fully mapped in that case.
+                    if (restMethod.PropertyParameterMap.ContainsKey(i)
+                        && restMethod.ParameterInfoArray[i].GetCustomAttribute<QueryAttribute>() == null)
                     {
                         isParameterMappedToRequest = true;
                     }
@@ -1771,12 +1774,16 @@ namespace Refit
 
             // NB: We have to enumerate the header names to check existence because
             // Contains throws if it's the wrong header type for the collection.
-            if (request.Headers.Any(x => x.Key == name))
+            // HTTP header names are case-insensitive, so compare them that way; otherwise a
+            // differently cased header (e.g. "Content-type" vs "Content-Type") is not removed
+            // and ends up duplicated.
+            if (request.Headers.Any(x => string.Equals(x.Key, name, StringComparison.OrdinalIgnoreCase)))
             {
                 request.Headers.Remove(name);
             }
 
-            if (request.Content != null && request.Content.Headers.Any(x => x.Key == name))
+            if (request.Content != null
+                && request.Content.Headers.Any(x => string.Equals(x.Key, name, StringComparison.OrdinalIgnoreCase)))
             {
                 request.Content.Headers.Remove(name);
             }

--- a/src/Refit/RestMethodInfo.cs
+++ b/src/Refit/RestMethodInfo.cs
@@ -138,7 +138,10 @@ namespace Refit
                 if (
                     ParameterMap.ContainsKey(i)
                     || HeaderParameterMap.ContainsKey(i)
-                    || PropertyParameterMap.ContainsKey(i)
+                    // A parameter can carry both [Property] and [Query]; only exclude it from the
+                    // query map when it is a property AND does not also opt into the query string.
+                    || (PropertyParameterMap.ContainsKey(i)
+                        && ParameterInfoArray[i].GetCustomAttribute<QueryAttribute>() == null)
                     || HeaderCollectionAt(i)
                     || (BodyParameterInfo != null && BodyParameterInfo.Item3 == i)
                     || (AuthorizeParameterInfo != null && AuthorizeParameterInfo.Item2 == i)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fixes for request building. Three small, independent fixes grouped together as they all concern how parameters and headers are turned into the outgoing request.

## What is the new behavior?

- Hardcoded headers are de-duplicated case-insensitively, so a `[Headers("Content-type: ...")]` declaration (note the lowercase `t`) replaces the auto-generated `Content-Type` instead of doubling it. Closes #1314.
- A parameter declared with both `[Property]` and `[Query]` is added to the query string and still set as a request property. Closes #1937.
- A combined `[Flags]` enum value, or an undefined enum value, used as a URL or form parameter is formatted as its string representation instead of throwing. Closes #1478.

## What is the current behavior?

- Header existence checks use a case-sensitive comparison. A differently cased header name does not match the canonical one, so the existing header is not removed and the request ends up with a duplicate (which can cause a `415` from the server).
- A parameter with both `[Property]` and `[Query]` is treated only as a property and dropped from the query string.
- Formatting a combined `[Flags]` or undefined enum value calls `GetMember(...).First()`, which throws `InvalidOperationException: Sequence contains no elements` because no single member matches.

## What might this PR break?

None expected. Each case previously threw or produced a malformed request. HTTP header names are case-insensitive by specification, so the header change only affects names that differ in casing.

## Checklist

- [x] I have read the Contribute guide
- [x] Tests have been added or updated (for bug fixes / features)
- [ ] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the `main` branch
- [x] PR title follows Conventional Commits

## Additional information

New tests cover the non-canonical `Content-Type` casing, the `[Property]` + `[Query]` combination, and combined/undefined enum values for the URL parameter formatter.
