### PR TITLE
fix: clearer error when a response has no request message

### DIFF
--- a/src/Refit.Tests/ResponseTests.cs
+++ b/src/Refit.Tests/ResponseTests.cs
@@ -582,6 +582,21 @@ public class ResponseTests
         Assert.NotNull(error.Content);
         Assert.Equal(nonJsonResponse, error.Content);
     }
+
+    [Test]
+    public async Task ExceptionFactory_WithoutRequestMessage_ThrowsClearException()
+    {
+        var settings = new RefitSettings();
+
+        using var response = new HttpResponseMessage(HttpStatusCode.BadRequest);
+        // RequestMessage is left null, as a hand-rolled test HttpMessageHandler often does.
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => settings.ExceptionFactory(response)
+        );
+
+        Assert.Contains("RequestMessage", ex.Message, StringComparison.Ordinal);
+    }
 }
 
 public sealed class ThrowOnGetLengthMemoryStream : MemoryStream

--- a/src/Refit/RefitSettings.cs
+++ b/src/Refit/RefitSettings.cs
@@ -428,7 +428,13 @@ namespace Refit
             RefitSettings refitSettings
         )
         {
-            var requestMessage = responseMessage.RequestMessage!;
+            var requestMessage =
+                responseMessage.RequestMessage
+                ?? throw new InvalidOperationException(
+                    "The HttpResponseMessage has no associated RequestMessage. When supplying a "
+                        + "custom HttpMessageHandler (for example in a test), ensure it sets "
+                        + "HttpResponseMessage.RequestMessage."
+                );
             var method = requestMessage.Method;
 
             return await ApiException


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix / diagnostics improvement.

## What is the new behavior?

When a non-success `HttpResponseMessage` has no associated `RequestMessage`, the default exception factory throws an `InvalidOperationException` whose message explains that a custom `HttpMessageHandler` must set `HttpResponseMessage.RequestMessage`. Closes #1243.

## What is the current behavior?

The factory dereferences `RequestMessage` with a null-forgiving operator and then reads `.Method`, throwing an opaque `NullReferenceException` with no indication of the cause. This commonly happens when a hand-rolled `HttpMessageHandler` (for example in a unit test) returns a response without setting `RequestMessage`.

## What might this PR break?

None. Built-in handlers always populate `RequestMessage`, so this only changes the failure path from an unhelpful `NullReferenceException` to an explanatory `InvalidOperationException`.

## Checklist

- [x] I have read the Contribute guide
- [x] Tests have been added or updated (for bug fixes / features)
- [ ] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the `main` branch
- [x] PR title follows Conventional Commits

## Additional information

A new test drives the default exception factory with a response that has no `RequestMessage` and asserts the clear exception.
