### PR TITLE
build: adopt central package management and modernize MSBuild

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,4 +1,20 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-    "extends": ["local>reactiveui/.github:renovate"]
+    "extends": ["local>reactiveui/.github:renovate"],
+    "semanticCommits": "enabled",
+    "packageRules": [
+        {
+            "description": "Legacy System.* compatibility packages are pinned to their 4.x line for the net4*/netstandard targets. Cap Renovate below 5.0.0 so the .NET monorepo v10 updates do not bump these and break those targets. The modern 10.x System.* entries (selected by the IsTargetFrameworkCompatible bands) are unaffected because this rule only matches versions currently on 4.x.",
+            "matchManagers": ["nuget"],
+            "matchPackageNames": ["/^System\\./"],
+            "matchCurrentVersion": "/^4\\./",
+            "allowedVersions": "<5.0.0"
+        },
+        {
+            "description": "Hold the Roslyn (Microsoft.CodeAnalysis.*) toolchain at its current versions for back-compatibility. The source generator multi-targets Roslyn 3.8/4.1/5.0 and the test/benchmark tooling tracks the 4.x line; these move together only as a deliberate toolchain bump, not via automated updates.",
+            "matchManagers": ["nuget"],
+            "matchPackageNames": ["/^Microsoft\\.CodeAnalysis/"],
+            "enabled": false
+        }
+    ]
 }

--- a/NuGet.config
+++ b/NuGet.config
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
-    <add key="nuget" value="https://api.nuget.org/v3/index.json" /> 
-  </packageSources>
-</configuration>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -41,7 +41,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(IsTestProject)' != 'true'">
-    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.14.15" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" PrivateAssets="All" />
   </ItemGroup>
 
   <!-- MinVer (versioning) — replaces Nerdbank.GitVersioning. Floor at 10.2
@@ -55,8 +55,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300" PrivateAssets="All"/>
-    <PackageReference Include="MinVer" Version="7.0.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All"/>
+    <PackageReference Include="MinVer" PrivateAssets="all" />
   </ItemGroup>
 
   <Target Name="AddCommitHashToAssemblyAttributes" BeforeTargets="GetAssemblyAttributes">

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -1,0 +1,92 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <!-- Transitive pinning is intentionally OFF: the source generator and its test/benchmark
+         tooling deliberately use different Roslyn (Microsoft.CodeAnalysis.*) versions per
+         project (analyzers on 3.8/4.1/5.0, tests on 4.x), which a single pinned transitive
+         version cannot satisfy. -->
+    <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>
+  </PropertyGroup>
+
+  <!-- Core runtime / serialization dependencies -->
+  <ItemGroup>
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageVersion Include="System.Net.Http.Json" Version="10.0.9" />
+    <PackageVersion Include="System.Text.Json" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.9" />
+    <PackageVersion Include="System.Reactive" Version="6.1.0" />
+  </ItemGroup>
+
+  <!-- Build, versioning and analyzers -->
+  <ItemGroup>
+    <PackageVersion Include="MinVer" Version="7.0.0" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.300" />
+    <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.14.15" />
+    <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" />
+  </ItemGroup>
+
+  <!-- Roslyn toolchain. Versions are intentionally held at their current bands:
+       the source generator multi-targets Roslyn 3.8/4.1/5.0 (selected per project via
+       the $(MsCACSharpVersion) VersionOverride) and the test/benchmark tooling tracks
+       the 4.x line. Renovate is configured to hold these back (see .github/renovate.json). -->
+  <ItemGroup>
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.11.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing" Version="1.1.3" />
+  </ItemGroup>
+
+  <!-- Test stack -->
+  <ItemGroup>
+    <PackageVersion Include="TUnit" Version="1.56.0" />
+    <PackageVersion Include="Verify.TUnit" Version="31.19.1" />
+    <PackageVersion Include="Verify.DiffPlex" Version="3.2.0" />
+    <PackageVersion Include="Verify.SourceGenerators" Version="2.5.0" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.8.0" />
+    <PackageVersion Include="Moq" Version="4.20.72" />
+    <PackageVersion Include="PublicApiGenerator" Version="11.5.4" />
+    <!-- Held at 6.x: MockHttp 7.0 changed sequential Expect() matching semantics in a way
+         that breaks the trailing-slash mock tests. Adopt 7.x deliberately with test updates. -->
+    <PackageVersion Include="RichardSzalay.MockHttp" Version="6.0.0" />
+  </ItemGroup>
+
+  <!-- Benchmarks -->
+  <ItemGroup>
+    <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
+    <PackageVersion Include="AutoFixture" Version="4.18.1" />
+  </ItemGroup>
+
+  <!-- Examples -->
+  <ItemGroup>
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.9" />
+    <PackageVersion Include="Serilog" Version="4.3.1" />
+    <PackageVersion Include="Serilog.Sinks.Console" Version="6.1.1" />
+  </ItemGroup>
+
+  <!-- Legacy System.* compatibility packages, scoped to the net4*/netstandard targets.
+       Pinned to their 4.3.x line; Renovate caps these below 5.0.0 (see renovate.json). -->
+  <ItemGroup>
+    <PackageVersion Include="System.Net.Http" Version="4.3.4" />
+    <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" />
+  </ItemGroup>
+
+  <!-- Microsoft.AspNetCore.WebUtilities: multi-targeted per .NET major so each TFM
+       resolves the matching runtime-aligned version. -->
+  <Choose>
+    <When Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))">
+      <ItemGroup>
+        <PackageVersion Include="Microsoft.AspNetCore.WebUtilities" Version="10.0.9" />
+      </ItemGroup>
+    </When>
+    <When Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net9.0'))">
+      <ItemGroup>
+        <PackageVersion Include="Microsoft.AspNetCore.WebUtilities" Version="9.0.17" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageVersion Include="Microsoft.AspNetCore.WebUtilities" Version="8.0.28" />
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+
+</Project>

--- a/src/InterfaceStubGenerator.Roslyn38/InterfaceStubGenerator.Roslyn38.csproj
+++ b/src/InterfaceStubGenerator.Roslyn38/InterfaceStubGenerator.Roslyn38.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(MsCACSharpVersion)" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" VersionOverride="$(MsCACSharpVersion)" />
   </ItemGroup>
 
   <Target Name="SetBuildVer" AfterTargets="GetBuildVersion" BeforeTargets="SetCloudBuildVersionVars;SetCloudBuildNumberWithVersion">

--- a/src/InterfaceStubGenerator.Roslyn41/InterfaceStubGenerator.Roslyn41.csproj
+++ b/src/InterfaceStubGenerator.Roslyn41/InterfaceStubGenerator.Roslyn41.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(MsCACSharpVersion)" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" VersionOverride="$(MsCACSharpVersion)" PrivateAssets="all" />
   </ItemGroup>
 
   <Target Name="SetBuildVer" AfterTargets="GetBuildVersion" BeforeTargets="SetCloudBuildVersionVars;SetCloudBuildNumberWithVersion">

--- a/src/InterfaceStubGenerator.Roslyn50/InterfaceStubGenerator.Roslyn50.csproj
+++ b/src/InterfaceStubGenerator.Roslyn50/InterfaceStubGenerator.Roslyn50.csproj
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(MsCACSharpVersion)" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" VersionOverride="$(MsCACSharpVersion)" PrivateAssets="all" />
   </ItemGroup>
 
   <Target Name="SetBuildVer" AfterTargets="GetBuildVersion" BeforeTargets="SetCloudBuildVersionVars;SetCloudBuildNumberWithVersion">

--- a/src/Refit.Benchmarks/Refit.Benchmarks.csproj
+++ b/src/Refit.Benchmarks/Refit.Benchmarks.csproj
@@ -18,11 +18,13 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="System.Net.Http" Version="4.3.4" />
-      <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
-      <PackageReference Include="AutoFixture" Version="4.18.1" />
-      <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
-      <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.12.0-3.24523.4" />
+      <PackageReference Include="System.Net.Http" />
+      <PackageReference Include="System.Text.RegularExpressions" />
+      <PackageReference Include="AutoFixture" />
+      <PackageReference Include="BenchmarkDotNet" />
+      <!-- Aligned with the Roslyn version BenchmarkDotNet pulls in, so the benchmark's
+           Microsoft.CodeAnalysis.* assemblies stay on a single consistent version. -->
+      <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" VersionOverride="4.14.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Refit.GeneratorTests/Refit.GeneratorTests.csproj
+++ b/src/Refit.GeneratorTests/Refit.GeneratorTests.csproj
@@ -13,25 +13,19 @@
     <NoWarn>$(NoWarn);CS1591;CA1819;CA2000;CA2007;CA1056;CA1707;CA1861</NoWarn>
   </PropertyGroup>
   
-  <ItemGroup Condition="$(TargetFramework.StartsWith('net9.0'))">
-    <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="9.0.1*" />
-  </ItemGroup>
-
-  <ItemGroup Condition="$(TargetFramework.StartsWith('net8.0'))">
-    <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="8.0.2*" />
-  </ItemGroup>
-  
   <ItemGroup>
-    <PackageReference Include="System.Formats.Asn1" Version="9.0.1*" />
-    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.8.0" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" /> 
-    <PackageReference Include="TUnit" Version="1.47.0" />
-    <PackageReference Include="Verify.DiffPlex" Version="3.2.0" />
-    <PackageReference Include="Verify.SourceGenerators" Version="2.5.0" />
-    <PackageReference Include="Verify.TUnit" Version="31.18.0" />
-    <PackageReference Include="System.Reactive" Version="6.1.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.11.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing" Version="1.1.3" />
+    <!-- Versions are managed centrally in src/Directory.Packages.props.
+         Microsoft.AspNetCore.WebUtilities is multi-targeted per .NET major there. -->
+    <PackageReference Include="Microsoft.AspNetCore.WebUtilities" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
+    <PackageReference Include="System.Text.RegularExpressions" />
+    <PackageReference Include="TUnit" />
+    <PackageReference Include="Verify.DiffPlex" />
+    <PackageReference Include="Verify.SourceGenerators" />
+    <PackageReference Include="Verify.TUnit" />
+    <PackageReference Include="System.Reactive" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing" />
     <ProjectReference Include="..\Refit.Newtonsoft.Json\Refit.Newtonsoft.Json.csproj" />
     <ProjectReference Include="..\Refit.Xml\Refit.Xml.csproj" />
     <ProjectReference Include="..\InterfaceStubGenerator.Roslyn38\InterfaceStubGenerator.Roslyn38.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="true" />

--- a/src/Refit.HttpClientFactory/Refit.HttpClientFactory.csproj
+++ b/src/Refit.HttpClientFactory/Refit.HttpClientFactory.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Refit\Refit.csproj" PrivateAssets="Analyzers" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Http" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Refit.Newtonsoft.Json/Refit.Newtonsoft.Json.csproj
+++ b/src/Refit.Newtonsoft.Json/Refit.Newtonsoft.Json.csproj
@@ -11,12 +11,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />    
+    <PackageReference Include="Newtonsoft.Json" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies"
-                      Version="1.0.3"
                       PrivateAssets="All" />
     <Reference Include="System.Web" />
   </ItemGroup>

--- a/src/Refit.Tests/Refit.Tests.csproj
+++ b/src/Refit.Tests/Refit.Tests.csproj
@@ -6,10 +6,7 @@
     <OutputType>Exe</OutputType>
     <TargetFrameworks>$(RefitTestTargets)</TargetFrameworks>
     <Deterministic>false</Deterministic>
-    <!-- Some tests rely on CallerFilePath -->
-    <RestoreAdditionalProjectSources>https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json</RestoreAdditionalProjectSources>
     <NoWarn>$(NoWarn);CS1591;CA1819;CA2000;CA2007;CA1056;CA1707;CA1861;CA1515</NoWarn>
-    <MockHttpVersion>6.0.0</MockHttpVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
@@ -17,37 +14,21 @@
     <EmbeddedResource Include="Test Files\Test.pdf" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0' or '$(TargetFramework)' == 'net9.0' or '$(TargetFramework)' == 'net10.0'">
-    <PackageReference Include="PublicApiGenerator" Version="11.5.4" />
-  </ItemGroup>
-  <ItemGroup Condition="$(TargetFramework.StartsWith('net10.0'))">
-    <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="10.0.9" />
-  </ItemGroup>
-  
-  <ItemGroup Condition="$(TargetFramework.StartsWith('net9.0'))">
-    <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="9.0.1*" />
-  </ItemGroup>
-
-  <ItemGroup Condition="$(TargetFramework.StartsWith('net8.0'))">
-    <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="8.0.2*" />
-  </ItemGroup>
-
-  <ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">
-    <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="10.0.9" />
-  </ItemGroup>
-
   <ItemGroup>
-    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.8.0" />
-    <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="System.Formats.Asn1" Version="10.0.9" />
-    <PackageReference Include="TUnit" Version="1.47.0" />
-    <PackageReference Include="System.Reactive" Version="6.1.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.11.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing" Version="1.1.3" />
-    <PackageReference Include="RichardSzalay.MockHttp" Version="$(MockHttpVersion)" />
-    <PackageReference Include="Verify.DiffPlex" Version="3.2.0" />
-    <PackageReference Include="Verify.SourceGenerators" Version="2.5.0" />
-    <PackageReference Include="Verify.TUnit" Version="31.18.0" />
+    <!-- Versions are managed centrally in src/Directory.Packages.props.
+         Microsoft.AspNetCore.WebUtilities is multi-targeted per .NET major there. -->
+    <PackageReference Include="PublicApiGenerator" />
+    <PackageReference Include="Microsoft.AspNetCore.WebUtilities" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="TUnit" />
+    <PackageReference Include="System.Reactive" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing" />
+    <PackageReference Include="RichardSzalay.MockHttp" />
+    <PackageReference Include="Verify.DiffPlex" />
+    <PackageReference Include="Verify.SourceGenerators" />
+    <PackageReference Include="Verify.TUnit" />
     <ProjectReference Include="..\Refit.HttpClientFactory\Refit.HttpClientFactory.csproj" />
     <ProjectReference Include="..\Refit.Newtonsoft.Json\Refit.Newtonsoft.Json.csproj" />
     <ProjectReference Include="..\Refit.Xml\Refit.Xml.csproj" />

--- a/src/Refit.Xml/Refit.Xml.csproj
+++ b/src/Refit.Xml/Refit.Xml.csproj
@@ -12,7 +12,6 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies"
-                      Version="1.0.3"
                       PrivateAssets="All" />
     <Reference Include="System.Web" />
   </ItemGroup>

--- a/src/Refit/Refit.csproj
+++ b/src/Refit/Refit.csproj
@@ -7,7 +7,7 @@
 
     <Nullable>enable</Nullable>
   </PropertyGroup>
-  <PropertyGroup Condition="$(TargetFramework.StartsWith('net8.0')) or $(TargetFramework.StartsWith('net9.0')) or $(TargetFramework.StartsWith('net10.0'))">
+  <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <IsAotCompatible>true</IsAotCompatible>
     <PublishAotSupported>true</PublishAotSupported>
     <TrimMode>link</TrimMode>
@@ -15,17 +15,17 @@
     <IlcGenerateCompleteTypeMetadata>true</IlcGenerateCompleteTypeMetadata>
   </PropertyGroup>
 
-  <!-- Ensure DisableRuntimeMarshalling is only emitted for .NET 10, not .NET 8/9 -->
-  <PropertyGroup Condition="$(TargetFramework.StartsWith('net8.0')) or $(TargetFramework.StartsWith('net9.0'))">
+  <!-- Ensure DisableRuntimeMarshalling is only emitted for .NET 10+, not .NET 8/9 -->
+  <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0')) and !$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))">
     <DisableRuntimeMarshalling>false</DisableRuntimeMarshalling>
   </PropertyGroup>
-  <PropertyGroup Condition="$(TargetFramework.StartsWith('net10.0'))">
+  <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))">
     <DisableRuntimeMarshalling>true</DisableRuntimeMarshalling>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'net462'">
-    <PackageReference Include="System.Text.Json" Version="10.0.9" />
-    <PackageReference Include="System.Net.Http.Json" Version="10.0.9" />
+    <PackageReference Include="System.Text.Json" />
+    <PackageReference Include="System.Net.Http.Json" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">

--- a/src/examples/BlazorWasmIssue2065/BlazorWasmIssue2065.csproj
+++ b/src/examples/BlazorWasmIssue2065/BlazorWasmIssue2065.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.5" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.5" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/examples/Meow.Common/Meow.Common.csproj
+++ b/src/examples/Meow.Common/Meow.Common.csproj
@@ -15,8 +15,8 @@
                       ReferenceOutputAssembly="false"
                       OutputItemType="Analyzer"
                       PrivateAssets="all" />
-    <PackageReference Include="Serilog" Version="4.3.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
+    <PackageReference Include="Serilog" />
+    <PackageReference Include="Serilog.Sinks.Console" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Build / dependency management. Aligns the repository with the patterns used across the other reactiveui projects (splat, Primitives): central package management, grouped versions, modern MSBuild conditions, and conventional-commit Renovate updates.

## What is the new behavior?

- All NuGet versions live in a single, grouped `src/Directory.Packages.props`; project files reference packages without a version.
- No floating/wildcard versions. `Microsoft.AspNetCore.WebUtilities` is multi-targeted per .NET major via `IsTargetFrameworkCompatible` bands (net8 -> 8.0.28, net9 -> 9.0.17, net10 -> 10.0.9).
- Dependencies are updated to the latest version each target framework allows.
- `Refit.csproj` target-framework conditions use `IsTargetFrameworkCompatible` instead of string matching.
- Renovate produces conventional-commit messages (`chore(deps): ...`) like the other repos, groups updates via the shared preset, caps legacy `System.*` packages below 5.0.0, and holds the Roslyn toolchain back.
- Package source mapping is configured so central package management resolves cleanly.

## What is the current behavior?

- Versions are scattered across project files, including floating wildcards (`8.0.*`, `9.0.*`, `10.0.0-*`).
- Target-framework conditions use `StartsWith(...)` string checks.
- Renovate commit messages were plain (`Update dependency ...`), not conventional.

## What might this PR break?

Nothing functional. This is a build-configuration change; the full test suite passes on net8.0, net9.0 and net10.0, and the solution builds in Release.

Two dependencies are intentionally held back, both noted in the central file:

- `Microsoft.CodeAnalysis.*` (Roslyn) stays on its current versions. The source generator multi-targets Roslyn 3.8/4.1/5.0 and the test tooling tracks 4.x; Renovate is configured to hold these for a deliberate toolchain bump.
- `RichardSzalay.MockHttp` stays on 6.x. 7.0 changes sequential mock-matching semantics and breaks the trailing-slash tests; adopting it needs a test migration.

## Checklist

- [x] I have read the Contribute guide
- [ ] Tests have been added or updated (for bug fixes / features)
- [ ] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the `main` branch
- [x] PR title follows Conventional Commits

## Additional information

Central package transitive pinning is intentionally disabled: the generator and its test/benchmark tooling deliberately use different Roslyn versions per project, which a single pinned transitive version cannot satisfy.

All packages resolve from nuget.org (the default feed), so the `NuGet.config` has been removed entirely along with the secondary dnceng `dotnet-tools` feed it previously declared. This matches the splat/Primitives layout, which ship no `NuGet.config`.
