### PR TITLE
docs: Fix Refit 10 typo that should be Refit 11

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ to `Refit.Xml`.
 
 #### Breaking changes in 11.x
 
-Refit 10 introduces `ApiRequestException` to represent requests that fail before receiving a response from the server.
+Refit 11 introduces `ApiRequestException` to represent requests that fail before receiving a response from the server.
 This exception will now wrap previous exceptions such as `HttpRequestException` and `TaskCanceledException` when they occur during request execution.
 
 * If you were not wrapping responses with `IApiResponse` and were catching these exceptions directly, you will need to update your code to catch `ApiRequestException` instead.


### PR DESCRIPTION
## What kind of change does this PR introduce?
Docs update. Fixes #2135 

## What is the new behavior?
Fixes a typo in the readme that says Refit 10 introduces `ApiRequestException`, when it's actually introduced in Refit 11

## What might this PR break?
None

## Checklist
- [x] I have read the [Contribute guide](https://www.reactiveui.net/contribute/index.html)
- [ ] Tests have been added or updated (for bug fixes / features)
- [x] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the `main` branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional information
Typo was caused by me working on #2052 during Refit 9 when 10 would've been the next major release, and I missed updating it after Refit 10 came out
