### PR TITLE
fix: honor parameter-level CollectionFormat for inner collections

### DIFF
--- a/src/Refit.Tests/RequestBuilder.cs
+++ b/src/Refit.Tests/RequestBuilder.cs
@@ -750,6 +750,39 @@ namespace Refit.Tests
         }
 
         [Test]
+        public void ObjectQueryParameterWithoutQueryAttributeHonorsMultiCollectionFormat()
+        {
+            var fixture = new RequestBuilderImplementation<IDummyHttpApi>();
+            var factory = fixture.BuildRequestFactoryForMethod(
+                nameof(IDummyHttpApi.ComplexTypeQueryWithoutQueryAttribute)
+            );
+
+            var param = new ComplexQueryObject
+            {
+                EnumCollectionMulti = new List<TestEnum> { TestEnum.A, TestEnum.B }
+            };
+            var output = factory(new object[] { param });
+            var uri = new Uri(new Uri("http://api"), output.RequestUri);
+
+            Assert.Equal("/foo?listOfEnumMulti=A&listOfEnumMulti=B", uri.PathAndQuery);
+        }
+
+        [Test]
+        public void ParameterLevelCollectionFormatAppliesToInnerCollectionsWithoutOwnQueryAttribute()
+        {
+            var fixture = new RequestBuilderImplementation<IDummyHttpApi>();
+            var factory = fixture.BuildRequestFactoryForMethod(
+                nameof(IDummyHttpApi.ComplexTypeQueryParameterLevelMulti)
+            );
+
+            var param = new ComplexQueryObject { TestCollection = new[] { 1, 2, 3 } };
+            var output = factory(new object[] { param });
+            var uri = new Uri(new Uri("http://api"), output.RequestUri);
+
+            Assert.Equal("/foo?TestCollection=1&TestCollection=2&TestCollection=3", uri.PathAndQuery);
+        }
+
+        [Test]
         public void MultipleQueryAttributesWithNulls()
         {
             var input = typeof(IRestMethodInfoTests);
@@ -2210,6 +2243,14 @@ namespace Refit.Tests
 
         [Get("/foo")]
         Task ComplexTypeQueryWithInnerCollection([Query] ComplexQueryObject queryParams);
+
+        [Get("/foo")]
+        Task ComplexTypeQueryWithoutQueryAttribute(ComplexQueryObject queryParams);
+
+        [Get("/foo")]
+        Task ComplexTypeQueryParameterLevelMulti(
+            [Query(CollectionFormat.Multi)] ComplexQueryObject queryParams
+        );
 
         [Get("/api/{obj.someProperty}")]
         Task QueryWithOptionalParametersPathBoundObject(

--- a/src/Refit/RequestBuilderImplementation.cs
+++ b/src/Refit/RequestBuilderImplementation.cs
@@ -826,12 +826,13 @@ namespace Refit
         List<KeyValuePair<string, object?>> BuildQueryMap(
             object? @object,
             string? delimiter = null,
-            RestMethodParameterInfo? parameterInfo = null
+            RestMethodParameterInfo? parameterInfo = null,
+            CollectionFormat? collectionFormat = null
         )
         {
             if (@object is IDictionary idictionary)
             {
-                return BuildQueryMap(idictionary, delimiter);
+                return BuildQueryMap(idictionary, delimiter, collectionFormat);
             }
 
             var kvps = new List<KeyValuePair<string, object?>>();
@@ -888,7 +889,8 @@ namespace Refit
                             ienu,
                             propertyInfo,
                             propertyInfo.PropertyType,
-                            queryAttribute
+                            queryAttribute,
+                            collectionFormat
                         )
                     )
                     {
@@ -907,7 +909,7 @@ namespace Refit
                 switch (obj)
                 {
                     case IDictionary idict:
-                        foreach (var keyValuePair in BuildQueryMap(idict, delimiter))
+                        foreach (var keyValuePair in BuildQueryMap(idict, delimiter, collectionFormat))
                         {
                             kvps.Add(
                                 new KeyValuePair<string, object?>(
@@ -920,7 +922,7 @@ namespace Refit
                         break;
 
                     default:
-                        foreach (var keyValuePair in BuildQueryMap(obj, delimiter))
+                        foreach (var keyValuePair in BuildQueryMap(obj, delimiter, null, collectionFormat))
                         {
                             kvps.Add(
                                 new KeyValuePair<string, object?>(
@@ -939,7 +941,8 @@ namespace Refit
 
         List<KeyValuePair<string, object?>> BuildQueryMap(
             IDictionary dictionary,
-            string? delimiter = null
+            string? delimiter = null,
+            CollectionFormat? collectionFormat = null
         )
         {
             var kvps = new List<KeyValuePair<string, object?>>();
@@ -964,7 +967,7 @@ namespace Refit
                 }
                 else
                 {
-                    foreach (var keyValuePair in BuildQueryMap(obj, delimiter))
+                    foreach (var keyValuePair in BuildQueryMap(obj, delimiter, null, collectionFormat))
                     {
                         kvps.Add(
                             new KeyValuePair<string, object?>(
@@ -1354,7 +1357,10 @@ namespace Refit
             }
             else
             {
-                foreach (var kvp in BuildQueryMap(param, attr.Delimiter, parameterInfo))
+                var parameterCollectionFormat = attr.IsCollectionFormatSpecified
+                    ? attr.CollectionFormat
+                    : (CollectionFormat?)null;
+                foreach (var kvp in BuildQueryMap(param, attr.Delimiter, parameterInfo, parameterCollectionFormat))
                 {
                     var path = !string.IsNullOrWhiteSpace(attr.Prefix)
                         ? $"{attr.Prefix}{attr.Delimiter}{kvp.Key}"
@@ -1551,13 +1557,17 @@ namespace Refit
             IEnumerable paramValues,
             ICustomAttributeProvider customAttributeProvider,
             Type type,
-            QueryAttribute? queryAttribute
+            QueryAttribute? queryAttribute,
+            CollectionFormat? fallbackCollectionFormat = null
         )
         {
+            // Precedence: the property's own [Query] format wins; otherwise the format
+            // supplied by the enclosing parameter's [Query] attribute (if any); finally
+            // the global RefitSettings default.
             var collectionFormat =
                 queryAttribute != null && queryAttribute.IsCollectionFormatSpecified
                     ? queryAttribute.CollectionFormat
-                    : settings.CollectionFormat;
+                    : fallbackCollectionFormat ?? settings.CollectionFormat;
 
             switch (collectionFormat)
             {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the new behavior?

A `[Query(CollectionFormat.Multi)]` attribute on an object query parameter now applies to the object's enumerable properties that do not carry their own `[Query]` attribute. For example, a `string[]` property serializes as `Types=a&Types=b` rather than `Types=a,b`. Closes #1762.

The resolution order for an inner collection is now: the property's own `[Query]` format, then the enclosing parameter's `[Query]` format, then `RefitSettings.CollectionFormat`.

## What is the current behavior?

The parameter-level `CollectionFormat` was dropped when expanding an object into query parameters. Only the property's own `[Query]` attribute or the global `RefitSettings.CollectionFormat` was consulted, so inner collections without an explicit attribute always used the global default (CSV).

## What might this PR break?

Nothing. A property that specifies its own `[Query]` format keeps that format, and when no parameter-level format is set the behavior is unchanged (the global default still applies).

## Checklist

- [x] I have read the Contribute guide
- [x] Tests have been added or updated (for bug fixes / features)
- [ ] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the `main` branch
- [x] PR title follows Conventional Commits

## Additional information

New tests cover an object query parameter both with and without a `[Query]` attribute on the parameter, asserting that the inner collection honors the requested `CollectionFormat.Multi`.