### PR TITLE
fix: populate ApiException.Content when deserialization fails

### DIFF
--- a/src/Refit.Tests/ResponseTests.cs
+++ b/src/Refit.Tests/ResponseTests.cs
@@ -27,6 +27,18 @@ public class TestAliasObject
     public string ShortNameForJsonProperty { get; set; }
 }
 
+[System.Xml.Serialization.XmlRoot("XmlResponse")]
+public class XmlResponse
+{
+    public string Identifier { get; set; }
+}
+
+public interface IXmlResponseService
+{
+    [Get("/xmlTest")]
+    Task<XmlResponse> GetXmlObject();
+}
+
 public class ResponseTests
 {
     readonly MockHttpMessageHandler mockHandler;
@@ -368,6 +380,86 @@ public class ResponseTests
             result.ShortNameForAlias
         );
         Assert.Equal(nameof(TestAliasObject), result.ShortNameForJsonProperty);
+    }
+
+    [Test]
+    public async Task DeserializationFailureWithNonSeekableStream_PopulatesApiExceptionContent()
+    {
+        // Regression test for #2098: when deserialization fails, ApiException.Content
+        // must still expose the raw response body. With a non-seekable/non-buffered
+        // stream the serializer consumes the content, so ApiException.Create could no
+        // longer re-read it and Content ended up null.
+        const string rawBody = "{ this is not valid json";
+
+        var localHandler = new MockHttpMessageHandler();
+        var settings = new RefitSettings(new SystemTextJsonContentSerializer())
+        {
+            HttpMessageHandlerFactory = () => localHandler
+        };
+
+        using var contentStream = new ThrowOnGetLengthMemoryStream { CanGetLength = true };
+        var bytes = Encoding.UTF8.GetBytes(rawBody);
+        contentStream.Write(bytes, 0, bytes.Length);
+        contentStream.Position = 0;
+        contentStream.CanGetLength = false;
+
+        var httpContent = new StreamContent(contentStream);
+        httpContent.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+
+        var expectedResponse = new HttpResponseMessage(HttpStatusCode.OK) { Content = httpContent };
+
+        localHandler
+            .Expect(HttpMethod.Get, "http://api/aliasTest")
+            .Respond(req => expectedResponse);
+
+        var localFixture = RestService.For<IMyAliasService>("http://api", settings);
+
+        var actualException = await Assert.ThrowsAsync<ApiException>(
+            () => localFixture.GetTestObject()
+        );
+
+        Assert.NotNull(actualException.Content);
+        Assert.Equal(rawBody, actualException.Content);
+    }
+
+    [Test]
+    public async Task XmlDeserializationWithNonSeekableStream_DoesNotThrowStreamConsumed()
+    {
+        // Regression test for #1729: the XML serializer reads the body via
+        // ReadAsStringAsync. The reverted #1705 probed/consumed the stream before
+        // deserializing, which threw "The stream was already consumed" for XML over a
+        // non-seekable network stream. Buffering via LoadIntoBufferAsync must keep this
+        // scenario working.
+        const string xml =
+            "<XmlResponse><Identifier>abc-123</Identifier></XmlResponse>";
+
+        var localHandler = new MockHttpMessageHandler();
+        var settings = new RefitSettings(new Refit.XmlContentSerializer())
+        {
+            HttpMessageHandlerFactory = () => localHandler
+        };
+
+        using var contentStream = new ThrowOnGetLengthMemoryStream { CanGetLength = true };
+        var bytes = Encoding.UTF8.GetBytes(xml);
+        contentStream.Write(bytes, 0, bytes.Length);
+        contentStream.Position = 0;
+        contentStream.CanGetLength = false;
+
+        var httpContent = new StreamContent(contentStream);
+        httpContent.Headers.ContentType = new MediaTypeHeaderValue("application/xml");
+
+        var expectedResponse = new HttpResponseMessage(HttpStatusCode.OK) { Content = httpContent };
+
+        localHandler
+            .Expect(HttpMethod.Get, "http://api/xmlTest")
+            .Respond(req => expectedResponse);
+
+        var localFixture = RestService.For<IXmlResponseService>("http://api", settings);
+
+        var result = await localFixture.GetXmlObject();
+
+        Assert.NotNull(result);
+        Assert.Equal("abc-123", result.Identifier);
     }
 
     [Test]

--- a/src/Refit/RequestBuilderImplementation.cs
+++ b/src/Refit/RequestBuilderImplementation.cs
@@ -816,6 +816,30 @@ namespace Refit
                     return default;
                 }
 
+                // Buffer the content into memory before deserializing so that, if the
+                // serializer throws, ApiException.Create can still re-read the raw body
+                // (see #2098). We deliberately do NOT probe the stream via
+                // ReadAsStreamAsync first: that consumes non-seekable network streams and
+                // breaks serializers that re-read via ReadAsStringAsync, e.g. XML (#1729,
+                // which reverted #1705). LoadIntoBufferAsync is a no-op for the already
+                // buffered content that HttpClient produces by default.
+#pragma warning disable CA1031 // Do not catch general exception types
+                try
+                {
+#if NET8_0_OR_GREATER
+                    await content.LoadIntoBufferAsync(cancellationToken).ConfigureAwait(false);
+#else
+                    await content.LoadIntoBufferAsync().ConfigureAwait(false);
+#endif
+                }
+                catch
+                {
+                    // Best-effort: if the content cannot be buffered we fall back to
+                    // streaming deserialization. The only downside is that the raw body
+                    // may be unavailable on failure, which is the pre-existing behavior.
+                }
+#pragma warning restore CA1031 // Do not catch general exception types
+
                 result = await serializer
                     .FromHttpContentAsync<T>(content, cancellationToken)
                     .ConfigureAwait(false);


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix / diagnostics improvement.

## What is the new behavior?

When a response fails to deserialize, `ApiException.Content` now contains the raw response body even when the content was delivered over a non-seekable or non-buffered stream. The content is buffered with `LoadIntoBufferAsync` before deserialization so the error path can re-read it. Closes #2098.

## What is the current behavior?

If the underlying content stream was non-seekable or non-buffered, the serializer consumed it during deserialization and `ApiException.Create` could no longer read the body, leaving `ApiException.Content` null. This is a re-opening of #1384.

## What might this PR break?

Nothing expected. Buffering only happens on the object deserialization path (not for `Stream` or `HttpContent` return types) and is a no-op for the already buffered content that `HttpClient` produces by default. Buffering is best-effort and wrapped in a guard, so a content that cannot be buffered simply falls back to the previous streaming behavior.

This deliberately avoids the approach that was reverted before. The previous fix (#1705) probed the stream via `ReadAsStreamAsync` before deserializing, which consumed non-seekable streams and broke serializers that re-read via `ReadAsStringAsync` such as XML, causing "The stream was already consumed" (#1729). This change never reads the stream itself; it only asks the content to buffer.

## Checklist

- [x] I have read the Contribute guide
- [x] Tests have been added or updated (for bug fixes / features)
- [ ] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the `main` branch
- [x] PR title follows Conventional Commits

## Additional information

Two tests are added: one reproduces the null `Content` on a deserialization failure over a non-seekable stream, and one is a regression guard asserting XML still deserializes over a non-seekable stream (the #1729 scenario).