### PR TITLE
fix: ValidationApiException propagates ContentHeaders and uses configured serializer

### DIFF
--- a/src/Refit.Tests/API/ApiApprovalTests.Refit.DotNet8_0.verified.txt
+++ b/src/Refit.Tests/API/ApiApprovalTests.Refit.DotNet8_0.verified.txt
@@ -17,7 +17,7 @@ namespace Refit
         protected ApiException(System.Net.Http.HttpRequestMessage message, System.Net.Http.HttpMethod httpMethod, string? content, System.Net.HttpStatusCode statusCode, string? reasonPhrase, System.Net.Http.Headers.HttpResponseHeaders headers, Refit.RefitSettings refitSettings, System.Exception? innerException = null) { }
         protected ApiException(string exceptionMessage, System.Net.Http.HttpRequestMessage message, System.Net.Http.HttpMethod httpMethod, string? content, System.Net.HttpStatusCode statusCode, string? reasonPhrase, System.Net.Http.Headers.HttpResponseHeaders headers, Refit.RefitSettings refitSettings, System.Exception? innerException = null) { }
         public string? Content { get; }
-        public System.Net.Http.Headers.HttpContentHeaders? ContentHeaders { get; }
+        public System.Net.Http.Headers.HttpContentHeaders? ContentHeaders { get; protected set; }
         [System.Diagnostics.CodeAnalysis.MemberNotNullWhen(true, "Content")]
         [get: System.Diagnostics.CodeAnalysis.MemberNotNullWhen(true, "Content")]
         public bool HasContent { get; }

--- a/src/Refit.Tests/API/ApiApprovalTests.Refit.DotNet9_0.verified.txt
+++ b/src/Refit.Tests/API/ApiApprovalTests.Refit.DotNet9_0.verified.txt
@@ -17,7 +17,7 @@ namespace Refit
         protected ApiException(System.Net.Http.HttpRequestMessage message, System.Net.Http.HttpMethod httpMethod, string? content, System.Net.HttpStatusCode statusCode, string? reasonPhrase, System.Net.Http.Headers.HttpResponseHeaders headers, Refit.RefitSettings refitSettings, System.Exception? innerException = null) { }
         protected ApiException(string exceptionMessage, System.Net.Http.HttpRequestMessage message, System.Net.Http.HttpMethod httpMethod, string? content, System.Net.HttpStatusCode statusCode, string? reasonPhrase, System.Net.Http.Headers.HttpResponseHeaders headers, Refit.RefitSettings refitSettings, System.Exception? innerException = null) { }
         public string? Content { get; }
-        public System.Net.Http.Headers.HttpContentHeaders? ContentHeaders { get; }
+        public System.Net.Http.Headers.HttpContentHeaders? ContentHeaders { get; protected set; }
         [System.Diagnostics.CodeAnalysis.MemberNotNullWhen(true, "Content")]
         [get: System.Diagnostics.CodeAnalysis.MemberNotNullWhen(true, "Content")]
         public bool HasContent { get; }

--- a/src/Refit.Tests/API/_snapshots/ApiApprovalTests.Refit.DotNet10_0.verified.txt
+++ b/src/Refit.Tests/API/_snapshots/ApiApprovalTests.Refit.DotNet10_0.verified.txt
@@ -18,7 +18,7 @@ namespace Refit
         protected ApiException(System.Net.Http.HttpRequestMessage message, System.Net.Http.HttpMethod httpMethod, string? content, System.Net.HttpStatusCode statusCode, string? reasonPhrase, System.Net.Http.Headers.HttpResponseHeaders headers, Refit.RefitSettings refitSettings, System.Exception? innerException = null) { }
         protected ApiException(string exceptionMessage, System.Net.Http.HttpRequestMessage message, System.Net.Http.HttpMethod httpMethod, string? content, System.Net.HttpStatusCode statusCode, string? reasonPhrase, System.Net.Http.Headers.HttpResponseHeaders headers, Refit.RefitSettings refitSettings, System.Exception? innerException = null) { }
         public string? Content { get; }
-        public System.Net.Http.Headers.HttpContentHeaders? ContentHeaders { get; }
+        public System.Net.Http.Headers.HttpContentHeaders? ContentHeaders { get; protected set; }
         [System.Diagnostics.CodeAnalysis.MemberNotNullWhen(true, "Content")]
         [get: System.Diagnostics.CodeAnalysis.MemberNotNullWhen(true, "Content")]
         public bool HasContent { get; }

--- a/src/Refit.Tests/API/_snapshots/ApiApprovalTests.Refit.DotNet8_0.verified.txt
+++ b/src/Refit.Tests/API/_snapshots/ApiApprovalTests.Refit.DotNet8_0.verified.txt
@@ -17,7 +17,7 @@ namespace Refit
         protected ApiException(System.Net.Http.HttpRequestMessage message, System.Net.Http.HttpMethod httpMethod, string? content, System.Net.HttpStatusCode statusCode, string? reasonPhrase, System.Net.Http.Headers.HttpResponseHeaders headers, Refit.RefitSettings refitSettings, System.Exception? innerException = null) { }
         protected ApiException(string exceptionMessage, System.Net.Http.HttpRequestMessage message, System.Net.Http.HttpMethod httpMethod, string? content, System.Net.HttpStatusCode statusCode, string? reasonPhrase, System.Net.Http.Headers.HttpResponseHeaders headers, Refit.RefitSettings refitSettings, System.Exception? innerException = null) { }
         public string? Content { get; }
-        public System.Net.Http.Headers.HttpContentHeaders? ContentHeaders { get; }
+        public System.Net.Http.Headers.HttpContentHeaders? ContentHeaders { get; protected set; }
         [System.Diagnostics.CodeAnalysis.MemberNotNullWhen(true, "Content")]
         [get: System.Diagnostics.CodeAnalysis.MemberNotNullWhen(true, "Content")]
         public bool HasContent { get; }

--- a/src/Refit.Tests/API/_snapshots/ApiApprovalTests.Refit.DotNet9_0.verified.txt
+++ b/src/Refit.Tests/API/_snapshots/ApiApprovalTests.Refit.DotNet9_0.verified.txt
@@ -17,7 +17,7 @@ namespace Refit
         protected ApiException(System.Net.Http.HttpRequestMessage message, System.Net.Http.HttpMethod httpMethod, string? content, System.Net.HttpStatusCode statusCode, string? reasonPhrase, System.Net.Http.Headers.HttpResponseHeaders headers, Refit.RefitSettings refitSettings, System.Exception? innerException = null) { }
         protected ApiException(string exceptionMessage, System.Net.Http.HttpRequestMessage message, System.Net.Http.HttpMethod httpMethod, string? content, System.Net.HttpStatusCode statusCode, string? reasonPhrase, System.Net.Http.Headers.HttpResponseHeaders headers, Refit.RefitSettings refitSettings, System.Exception? innerException = null) { }
         public string? Content { get; }
-        public System.Net.Http.Headers.HttpContentHeaders? ContentHeaders { get; }
+        public System.Net.Http.Headers.HttpContentHeaders? ContentHeaders { get; protected set; }
         [System.Diagnostics.CodeAnalysis.MemberNotNullWhen(true, "Content")]
         [get: System.Diagnostics.CodeAnalysis.MemberNotNullWhen(true, "Content")]
         public bool HasContent { get; }

--- a/src/Refit.Tests/ResponseTests.cs
+++ b/src/Refit.Tests/ResponseTests.cs
@@ -131,6 +131,76 @@ public class ResponseTests
     }
 
     /// <summary>
+    /// #1945: ValidationApiException should expose the ContentHeaders of the
+    /// originating ApiException rather than leaving them null.
+    /// </summary>
+    [Test]
+    public async Task ValidationApiExceptionPropagatesContentHeaders()
+    {
+        var expectedContent = new ProblemDetails { Detail = "detail", Title = "title" };
+        var expectedResponse = new HttpResponseMessage(HttpStatusCode.BadRequest)
+        {
+            Content = new StringContent(JsonConvert.SerializeObject(expectedContent))
+        };
+        expectedResponse.Content.Headers.ContentType = new MediaTypeHeaderValue(
+            "application/problem+json"
+        );
+        mockHandler.Expect(HttpMethod.Get, "http://api/aliasTest").Respond(req => expectedResponse);
+
+        var actualException = await Assert.ThrowsAsync<ValidationApiException>(
+            () => fixture.GetTestObject()
+        );
+
+        Assert.NotNull(actualException.ContentHeaders);
+        Assert.Equal(
+            "application/problem+json",
+            actualException.ContentHeaders.ContentType?.MediaType
+        );
+    }
+
+    /// <summary>
+    /// #1197: ValidationApiException must deserialize ProblemDetails with the configured
+    /// IHttpContentSerializer instead of a hardcoded System.Text.Json instance. A
+    /// case-sensitive serializer is used here, so the camelCase "detail" key must not map
+    /// to the PascalCase Detail property the way the old camelCase/case-insensitive
+    /// hardcoded options would have.
+    /// </summary>
+    [Test]
+    public async Task ValidationApiExceptionUsesConfiguredContentSerializer()
+    {
+        var localHandler = new MockHttpMessageHandler();
+        var settings = new RefitSettings(
+            new SystemTextJsonContentSerializer(
+                new JsonSerializerOptions { PropertyNameCaseInsensitive = false }
+            )
+        )
+        {
+            HttpMessageHandlerFactory = () => localHandler
+        };
+
+        var expectedResponse = new HttpResponseMessage(HttpStatusCode.BadRequest)
+        {
+            Content = new StringContent("{\"Title\":\"mapped\",\"detail\":\"unmapped\"}")
+        };
+        expectedResponse.Content.Headers.ContentType = new MediaTypeHeaderValue(
+            "application/problem+json"
+        );
+        localHandler
+            .Expect(HttpMethod.Get, "http://api/aliasTest")
+            .Respond(req => expectedResponse);
+
+        var localFixture = RestService.For<IMyAliasService>("http://api", settings);
+
+        var actualException = await Assert.ThrowsAsync<ValidationApiException>(
+            () => localFixture.GetTestObject()
+        );
+
+        Assert.NotNull(actualException.Content);
+        Assert.Equal("mapped", actualException.Content.Title);
+        Assert.Null(actualException.Content.Detail);
+    }
+
+    /// <summary>
     /// Test to verify if EnsureSuccessStatusCodeAsync throws a ValidationApiException for a Bad Request in terms of RFC 7807
     /// </summary>
     [Test]

--- a/src/Refit/ApiException.cs
+++ b/src/Refit/ApiException.cs
@@ -31,7 +31,7 @@ namespace Refit
         /// <summary>
         /// HTTP response content headers as defined in RFC 2616.
         /// </summary>
-        public HttpContentHeaders? ContentHeaders { get; private set; }
+        public HttpContentHeaders? ContentHeaders { get; protected set; }
 
         /// <summary>
         /// HTTP Response content as string.
@@ -214,7 +214,9 @@ namespace Refit
                         ?.Equals("application/problem+json") ?? false
                 )
                 {
-                    exception = ValidationApiException.Create(exception);
+                    exception = await ValidationApiException
+                        .CreateAsync(exception)
+                        .ConfigureAwait(false);
                 }
 
                 response.Content.Dispose();

--- a/src/Refit/ValidationApiException.cs
+++ b/src/Refit/ValidationApiException.cs
@@ -1,4 +1,6 @@
-﻿using System.Text.Json;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
 
 namespace Refit
 {
@@ -26,7 +28,12 @@ namespace Refit
                 apiException.ReasonPhrase,
                 apiException.Headers,
                 apiException.RefitSettings
-            ) { }
+            )
+        {
+            // Carry over the content headers from the originating ApiException so callers
+            // can inspect them on the validation exception too (#1945).
+            ContentHeaders = apiException.ContentHeaders;
+        }
 
         /// <summary>
         /// Creates a new instance of a ValidationException from an existing ApiException.
@@ -35,6 +42,42 @@ namespace Refit
         /// <returns>ValidationApiException</returns>
         public static ValidationApiException Create(ApiException exception)
         {
+            var ex = CreateCore(exception);
+            ex.Content = JsonSerializer.Deserialize<ProblemDetails>(
+                exception.Content!,
+                SerializerOptions
+            );
+            return ex;
+        }
+
+        /// <summary>
+        /// Creates a new instance of a ValidationException from an existing ApiException,
+        /// deserializing the problem details with the serializer configured in
+        /// <see cref="RefitSettings"/>.
+        /// </summary>
+        /// <param name="exception">An instance of an ApiException to use to build a ValidationException.</param>
+        /// <returns>ValidationApiException</returns>
+        internal static async Task<ValidationApiException> CreateAsync(ApiException exception)
+        {
+            var ex = CreateCore(exception);
+
+            // Deserialize through the configured IHttpContentSerializer rather than a
+            // hardcoded System.Text.Json instance, so problem details honor the user's
+            // serializer (e.g. Newtonsoft) and its settings (#1197).
+            using var content = new StringContent(
+                exception.Content!,
+                Encoding.UTF8,
+                "application/problem+json"
+            );
+            ex.Content = await exception
+                .RefitSettings.ContentSerializer.FromHttpContentAsync<ProblemDetails>(content)
+                .ConfigureAwait(false);
+
+            return ex;
+        }
+
+        static ValidationApiException CreateCore(ApiException exception)
+        {
             if (exception is null)
                 throw new ArgumentNullException(nameof(exception));
             if (string.IsNullOrWhiteSpace(exception.Content))
@@ -42,17 +85,7 @@ namespace Refit
                     "Content must be an 'application/problem+json' compliant json string."
                 );
 
-            var ex = new ValidationApiException(exception);
-
-            if (!string.IsNullOrWhiteSpace(exception.Content))
-            {
-                ex.Content = JsonSerializer.Deserialize<ProblemDetails>(
-                    exception.Content!,
-                    SerializerOptions
-                );
-            }
-
-            return ex;
+            return new ValidationApiException(exception);
         }
 
         /// <summary>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the new behavior?

- `ValidationApiException` now exposes the `ContentHeaders` of the originating `ApiException` instead of leaving them null. The `ApiException.ContentHeaders` setter is widened to `protected` so exceptions derived from `ApiException` can set it as well. Closes #1945.
- Problem details are deserialized with the `IHttpContentSerializer` configured in `RefitSettings` rather than a hardcoded `System.Text.Json` instance, so a configured serializer such as Newtonsoft (and its settings) is honored. Closes #1197 (also addresses the #1234 symptom for non System.Text.Json serializers).

## What is the current behavior?

- `ValidationApiException.Create` never copied `ContentHeaders`, and the setter was `private` so it could not be set by derived types.
- `ValidationApiException.Create` always used a hardcoded `System.Text.Json.JsonSerializer.Deserialize<ProblemDetails>` call, bypassing the configured serializer. Newtonsoft users got `System.Text.Json.JsonElement` values in `Extensions` and other System.Text.Json specific behavior.

## What might this PR break?

Nothing expected. The default serializer is `SystemTextJsonContentSerializer`, whose default options (case-insensitive, camelCase, `ObjectToInferredTypesConverter`) match the previously hardcoded options, so default behavior is unchanged. The public synchronous `Create(ApiException)` overload is kept as-is for back compatibility; only the automatic `application/problem+json` path uses the new async factory that goes through the configured serializer.

## Checklist

- [x] I have read the Contribute guide
- [x] Tests have been added or updated (for bug fixes / features)
- [ ] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the `main` branch
- [x] PR title follows Conventional Commits

## Additional information

Two tests are added: one asserts the thrown `ValidationApiException` carries the `application/problem+json` content headers, and one configures a case-sensitive `System.Text.Json` serializer and asserts the camelCase `detail` key does not map (proving the configured serializer is used rather than the old camelCase, case-insensitive hardcoded options). The public API approval snapshots are updated for the now `protected` `ContentHeaders` setter.