### PR TITLE
break: add IAsyncEnumerable streaming and opt-in URL, route and JSON serialization modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,7 @@ construction for request shapes the generator can safely model. It currently cov
 * `[Property]` interface properties
 * cancellation tokens
 * `Task`, `Task<T>`, `Task<ApiResponse<T>>`, and related response wrappers
+* `IAsyncEnumerable<T>` for streamed responses
 
 If a method uses a shape the generator cannot safely emit yet, Refit falls back to the existing runtime request-builder
 path for that method.
@@ -343,6 +344,39 @@ Task<List<Page>> Search(string page);
 
 Search("admin/products");
 >>> "/search/admin/products"
+```
+
+By default Refit throws if a route template contains a placeholder with no matching method argument. If you want to
+resolve a placeholder later yourself (for example an API-versioning token rewritten inside a `DelegatingHandler`), set
+`AllowUnmatchedRouteParameters` on `RefitSettings`. The unmatched `{token}` is then left in the URL verbatim instead of
+throwing.
+
+```csharp
+var settings = new RefitSettings { AllowUnmatchedRouteParameters = true };
+var api = RestService.For<IVersionedApi>("https://api.example.com", settings);
+
+// [Get("/api/{version:apiVersion}/values")]
+// the {version:apiVersion} token is left in the path for a DelegatingHandler to replace.
+```
+
+#### Base address and URL resolution
+
+By default Refit requires relative paths to start with `/`, prepends the base address path itself, and trims a trailing
+slash from the base address. If you would rather have the base address and relative URL combined the same way
+`HttpClient` and `System.Uri` do (RFC 3986), set `UrlResolution` on `RefitSettings`:
+
+```csharp
+var settings = new RefitSettings { UrlResolution = UrlResolutionMode.Rfc3986 };
+var api = RestService.For<IMyApi>("https://api.example.com/api/v1/", settings);
+```
+
+Under `UrlResolutionMode.Rfc3986` the leading-slash requirement is relaxed and the trailing slash on the base address is
+significant, exactly as with `HttpClient`:
+
+```csharp
+// base address "https://api.example.com/api/v1/"
+[Get("values")]   // -> https://api.example.com/api/v1/values  (appended)
+[Get("/values")]  // -> https://api.example.com/values         (leading slash replaces the base path)
 ```
 
 ### Querystrings
@@ -669,6 +703,66 @@ performance and low memory usage, while the latter uses the known `Newtonsoft.Js
 customizable. You can read more about the two serializers and the main differences between the
 two [at this link](https://docs.microsoft.com/dotnet/standard/serialization/system-text-json-migrate-from-newtonsoft-how-to).
 
+The default `System.Text.Json` serializer uses camelCase property names, case-insensitive matching, and reads numbers
+from JSON strings (`NumberHandling = AllowReadingFromString`). Override any of these by starting from Refit's defaults,
+tweaking the `JsonSerializerOptions`, and passing them in:
+
+```csharp
+var options = SystemTextJsonContentSerializer.GetDefaultJsonSerializerOptions();
+options.NumberHandling = JsonNumberHandling.Strict; // opt out of reading numbers from strings
+
+var settings = new RefitSettings(new SystemTextJsonContentSerializer(options));
+```
+
+##### Fast-path source-generated serialization
+
+The default options add custom converters and set `NumberHandling`, which the System.Text.Json source generator does
+not support on its serialization [fast-path](https://learn.microsoft.com/dotnet/standard/serialization/system-text-json/source-generation-modes#serialization-optimization-fast-path-mode),
+so the default serializer always uses the (slower) metadata logic. If you want the fast-path, start from
+`GetFastPathJsonSerializerOptions()` instead — it omits the converters and `NumberHandling` so the options stay
+fast-path eligible — and assign a source-generated `TypeInfoResolver`:
+
+```csharp
+var options = SystemTextJsonContentSerializer.GetFastPathJsonSerializerOptions();
+options.TypeInfoResolver = MyJsonContext.Default; // a JsonSerializerContext you declare
+
+var settings = new RefitSettings(new SystemTextJsonContentSerializer(options));
+```
+
+```csharp
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
+[JsonSerializable(typeof(MyRequest))]
+internal partial class MyJsonContext : JsonSerializerContext;
+```
+
+Two caveats: dropping the converters means `object`-typed members are no longer inferred and enums are no longer written
+as camelCase strings (add your own converters only if you accept losing the fast-path); and the fast-path runs through
+the **synchronous** serialization primitives (`SerializeToUtf8Bytes`, `Serialize(Utf8JsonWriter, ...)`) — the one API
+that bypasses it is the built-in `JsonSerializer.SerializeAsync(Stream, ...)`.
+
+By default Refit serializes request bodies with `JsonContent`, which uses exactly that `SerializeAsync(Stream)` path, so
+the fast-path is not used even with fast-path-eligible options. To opt in, set `RequestBodySerialization` on
+`RefitSettings` to one of the synchronous modes, which serialize through the fast-path:
+
+- `RequestBodySerializationMode.Buffered` — serialize synchronously to UTF-8 bytes up front and send as a
+  `ByteArrayContent`. Sets a `Content-Length` header; best for small-to-medium bodies.
+- `RequestBodySerializationMode.Streamed` — serialize through a `Utf8JsonWriter` written to the request stream and
+  flushed asynchronously. No `Content-Length`, but peak memory is bounded (pooled writer chunks rather than the whole
+  body); best for large uploads.
+
+```csharp
+var options = SystemTextJsonContentSerializer.GetFastPathJsonSerializerOptions();
+options.TypeInfoResolver = MyJsonContext.Default;
+
+var settings = new RefitSettings(new SystemTextJsonContentSerializer(options))
+{
+    RequestBodySerialization = RequestBodySerializationMode.Buffered, // or .Streamed for large uploads
+};
+```
+
+Both modes require the content serializer to implement `ISynchronousContentSerializer` (the default
+`SystemTextJsonContentSerializer` does); otherwise the body falls back to the default asynchronous serialization.
+
 For instance, here is how to create a new `RefitSettings` instance using the `Newtonsoft.Json`-based serializer (you'll
 also need to add a `PackageReference` to `Refit.Newtonsoft.Json`):
 
@@ -762,6 +856,33 @@ public interface IDocumentApi
 The request body is streamed (one serialized element per line, separated by `\n`) with a content type of
 `application/x-ndjson`. A non-enumerable value is sent as a single line. If you need a different content type (for
 example `text/plain`), set it with a [static header](#static-headers) or a [dynamic header](#dynamic-headers).
+
+#### Streaming responses with `IAsyncEnumerable<T>`
+
+Declare a method that returns `IAsyncEnumerable<T>` to consume a large response without buffering the whole body. Refit
+reads the response with `HttpCompletionOption.ResponseHeadersRead` and yields each element as it is deserialized:
+
+```csharp
+public interface IDocumentApi
+{
+    [Get("/documents")]
+    IAsyncEnumerable<Company> GetDocuments();
+}
+
+await foreach (var company in api.GetDocuments())
+{
+    // each item is yielded as soon as it is read off the wire
+}
+```
+
+The frame format is auto-detected from the response content type: a content type of `application/jsonl`,
+`application/x-ndjson`, or `application/x-jsonlines` is read as JSON Lines (one value per line); anything else is read
+as a single streamed JSON array. To observe cancellation, add a `CancellationToken` parameter, or use
+`WithCancellation(token)` on the enumerable.
+
+Streaming requires the configured `ContentSerializer` to implement `IStreamingContentSerializer`. The default
+`SystemTextJsonContentSerializer` does; a serializer that does not will throw `NotSupportedException` when the sequence
+is enumerated.
 
 #### XML Content
 

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -18,7 +18,7 @@
     <SystemTextJsonVersion>10.0.9</SystemTextJsonVersion>
 
     <MicrosoftCodeAnalysisAnalyzersVersion>5.3.0</MicrosoftCodeAnalysisAnalyzersVersion>
-    <MicrosoftCodeAnalysisWorkspacesVersion>4.11.0</MicrosoftCodeAnalysisWorkspacesVersion>
+    <MicrosoftCodeAnalysisWorkspacesVersion>4.14.0</MicrosoftCodeAnalysisWorkspacesVersion>
 
     <SourceLinkVersion>10.0.300</SourceLinkVersion>
     <ThreadingAnalyzersVersion>17.14.15</ThreadingAnalyzersVersion>

--- a/src/InterfaceStubGenerator.Shared/Emitter.Helpers.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.Helpers.cs
@@ -93,6 +93,7 @@ internal static partial class Emitter
         {
             ReturnTypeInfo.AsyncVoid => (true, "await (", ").ConfigureAwait(false)"),
             ReturnTypeInfo.AsyncResult => (true, "return await (", ").ConfigureAwait(false)"),
+            ReturnTypeInfo.AsyncEnumerable => (false, "return ", string.Empty),
             ReturnTypeInfo.Return => (false, "return ", string.Empty),
             ReturnTypeInfo.SyncVoid => (false, string.Empty, string.Empty),
             _ => throw new ArgumentOutOfRangeException(

--- a/src/InterfaceStubGenerator.Shared/Emitter.Inline.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.Inline.cs
@@ -77,7 +77,7 @@ internal static partial class Emitter
         var cancellationTokenExpression = BuildCancellationTokenExpression(request);
         var bufferBodyExpression = BuildBufferBodyExpression(bodyParameter);
         var requestUriExpression =
-            $"new global::System.Uri(refitBasePath + {ToCSharpStringLiteral(request.Path)}, global::System.UriKind.Relative)";
+            $"global::Refit.GeneratedRequestRunner.BuildRelativeUri(this.Client, {ToCSharpStringLiteral(request.Path)}, refitSettings.UrlResolution)";
         var contentSource = bodyParameter is null ? string.Empty : BuildInlineContent(bodyParameter);
         var headerSource = BuildInlineHeaders(request);
         var requestPropertySource = BuildInlineRequestProperties(request, interfaceModel);
@@ -87,8 +87,6 @@ internal static partial class Emitter
 
         return $$"""
             {{BuildMethodOpening(methodModel, isExplicit, isExplicit, interfaceModel.SupportsNullable)}}{{bodyIndent}}var refitSettings = {{settingsFieldName}};
-            {{bodyIndent}}var refitBasePath = this.Client.BaseAddress?.AbsolutePath ?? throw new global::System.InvalidOperationException("BaseAddress must be set on the HttpClient instance");
-            {{bodyIndent}}refitBasePath = refitBasePath == "/" ? string.Empty : refitBasePath.TrimEnd('/');
             {{bodyIndent}}var refitRequest = new global::System.Net.Http.HttpRequestMessage({{ToHttpMethodExpression(request.HttpMethod)}}, {{requestUriExpression}});
             {{bodyIndent}}#if NET6_0_OR_GREATER
             {{bodyIndent}}refitRequest.Version = refitSettings.Version;

--- a/src/InterfaceStubGenerator.Shared/Emitter.Inline.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.Inline.cs
@@ -162,6 +162,18 @@ internal static partial class Emitter
                 """;
         }
 
+        if (methodModel.ReturnTypeMetadata == ReturnTypeInfo.AsyncEnumerable)
+        {
+            return $$"""
+                {{bodyIndent}}return global::Refit.GeneratedRequestRunner.StreamAsync<{{request.ResultType}}>(
+                {{bodyIndent}}    this.Client,
+                {{bodyIndent}}    refitRequest,
+                {{bodyIndent}}    refitSettings,
+                {{bodyIndent}}    {{cancellationTokenExpression}});
+
+                """;
+        }
+
         return methodModel.ReturnType.StartsWith("global::System.Threading.Tasks.ValueTask<", StringComparison.Ordinal)
             ? $$"""
                 {{bodyIndent}}return new {{methodModel.ReturnType}}(global::Refit.GeneratedRequestRunner.SendAsync<{{request.ResultType}}, {{request.DeserializedResultType}}>(

--- a/src/InterfaceStubGenerator.Shared/Models/ReturnTypeInfo.cs
+++ b/src/InterfaceStubGenerator.Shared/Models/ReturnTypeInfo.cs
@@ -15,6 +15,9 @@ internal enum ReturnTypeInfo
     /// <summary>The method returns an awaitable with a result.</summary>
     AsyncResult,
 
+    /// <summary>The method returns an IAsyncEnumerable stream.</summary>
+    AsyncEnumerable,
+
     /// <summary>The method returns void synchronously.</summary>
     SyncVoid
 }

--- a/src/InterfaceStubGenerator.Shared/Parser.Request.cs
+++ b/src/InterfaceStubGenerator.Shared/Parser.Request.cs
@@ -38,7 +38,7 @@ internal static partial class Parser
 
         var canGenerateInline =
             parameterEligibility
-            && returnTypeInfo is ReturnTypeInfo.AsyncVoid or ReturnTypeInfo.AsyncResult
+            && returnTypeInfo is ReturnTypeInfo.AsyncVoid or ReturnTypeInfo.AsyncResult or ReturnTypeInfo.AsyncEnumerable
             && methodSymbol.TypeParameters.Length == 0
             && httpMethod.Length > 0
             && IsConstantPathSupported(path)
@@ -573,15 +573,24 @@ internal static partial class Parser
     /// <summary>Gets the result type wrapped by Task or ValueTask.</summary>
     /// <param name="returnType">The declared return type.</param>
     /// <returns>The result type.</returns>
-    private static ITypeSymbol GetReturnResultType(ITypeSymbol returnType) =>
-        returnType is INamedTypeSymbol
+    private static ITypeSymbol GetReturnResultType(ITypeSymbol returnType)
+    {
+        if (returnType is INamedTypeSymbol { TypeArguments.Length: 1 } namedType)
         {
-            MetadataName: "Task`1" or "ValueTask`1",
-            TypeArguments.Length: 1
-        } namedType
-        && namedType.ContainingNamespace.ToDisplayString() == "System.Threading.Tasks"
-            ? namedType.TypeArguments[0]
-            : returnType;
+            var ns = namedType.ContainingNamespace.ToDisplayString();
+            if (namedType.MetadataName is "Task`1" or "ValueTask`1" && ns == "System.Threading.Tasks")
+            {
+                return namedType.TypeArguments[0];
+            }
+
+            if (namedType.MetadataName == "IAsyncEnumerable`1" && ns == "System.Collections.Generic")
+            {
+                return namedType.TypeArguments[0];
+            }
+        }
+
+        return returnType;
+    }
 
     /// <summary>Determines whether a type is one of Refit's API response wrappers.</summary>
     /// <param name="type">The type to inspect.</param>

--- a/src/InterfaceStubGenerator.Shared/Parser.cs
+++ b/src/InterfaceStubGenerator.Shared/Parser.cs
@@ -849,6 +849,7 @@ internal static partial class Parser
         {
             "Task" => ReturnTypeInfo.AsyncVoid,
             "Task`1" or "ValueTask`1" => ReturnTypeInfo.AsyncResult,
+            "IAsyncEnumerable`1" => ReturnTypeInfo.AsyncEnumerable,
             "Void" => ReturnTypeInfo.SyncVoid,
             _ => ReturnTypeInfo.Return
         };

--- a/src/Refit/FormValueMultimap.cs
+++ b/src/Refit/FormValueMultimap.cs
@@ -83,7 +83,7 @@ internal sealed class FormValueMultimap : IEnumerable<KeyValuePair<string?, stri
         TSource source,
         RefitSettings settings) =>
         source is null or IDictionary
-            ? new FormValueMultimap(source!, settings)
+            ? new(source!, settings)
             : new FormValueMultimap(
                 source,
                 settings,

--- a/src/Refit/GeneratedRequestRunner.cs
+++ b/src/Refit/GeneratedRequestRunner.cs
@@ -13,6 +13,25 @@ public static class GeneratedRequestRunner
     /// <summary>The underlying value of the obsolete <c>BodySerializationMethod.Json</c> member.</summary>
     private const int ObsoleteJsonBodySerializationMethodValue = 1;
 
+    /// <summary>Builds the relative request URI for a generated request, joining the client base address with the method path.</summary>
+    /// <param name="client">The HTTP client whose base address is used under legacy resolution.</param>
+    /// <param name="relativePath">The method's relative path, including any leading slash and query string.</param>
+    /// <param name="urlResolution">The configured URL resolution mode.</param>
+    /// <returns>A relative <see cref="Uri"/> to assign to the request, which the client merges with its base address.</returns>
+    public static Uri BuildRelativeUri(HttpClient client, string relativePath, UrlResolutionMode urlResolution)
+    {
+        if (urlResolution == UrlResolutionMode.Rfc3986)
+        {
+            // Let the HttpClient merge the base address with the relative path per RFC 3986; emit the path verbatim.
+            return new(relativePath, UriKind.Relative);
+        }
+
+        var basePath = client.BaseAddress?.AbsolutePath
+            ?? throw new InvalidOperationException("BaseAddress must be set on the HttpClient instance");
+        basePath = basePath == "/" ? string.Empty : basePath.TrimEnd('/');
+        return new(basePath + relativePath, UriKind.Relative);
+    }
+
     /// <summary>Sends a generated request with no response body, throwing on HTTP errors.</summary>
     /// <param name="client">The HTTP client to send with.</param>
     /// <param name="request">The generated request message.</param>
@@ -74,7 +93,7 @@ public static class GeneratedRequestRunner
                     client,
                     request,
                     settings,
-                    new RequestExecutionOptions(
+                    new(
                         isApiResponse,
                         shouldDisposeResponse,
                         bufferBody,
@@ -122,7 +141,8 @@ public static class GeneratedRequestRunner
 
         var content = CreateSerializedBodyContent(settings, body, serializationMethod);
 
-        return streamBody
+        // A synchronously-serialized body is already a buffer (and lets the fast-path engage), so never re-stream it.
+        return streamBody && !UsesSynchronousSerialization(settings)
             ? new PushStreamContent(
                 async (stream, _, _) =>
                 {
@@ -315,11 +335,29 @@ public static class GeneratedRequestRunner
         if (serializationMethod is BodySerializationMethod.Default or BodySerializationMethod.Serialized
             || IsObsoleteJsonSerializationMethod(serializationMethod))
         {
+            if (settings.ContentSerializer is ISynchronousContentSerializer synchronousSerializer)
+            {
+                switch (settings.RequestBodySerialization)
+                {
+                    case RequestBodySerializationMode.Buffered:
+                        return synchronousSerializer.ToHttpContentSynchronous(body);
+                    case RequestBodySerializationMode.Streamed:
+                        return synchronousSerializer.ToStreamingHttpContent(body);
+                }
+            }
+
             return settings.ContentSerializer.ToHttpContent(body);
         }
 
         throw new ArgumentOutOfRangeException(nameof(serializationMethod), serializationMethod, null);
     }
+
+    /// <summary>Determines whether request bodies should be serialized synchronously through the configured serializer.</summary>
+    /// <param name="settings">The Refit settings to inspect.</param>
+    /// <returns><see langword="true"/> when synchronous body serialization is enabled and supported.</returns>
+    private static bool UsesSynchronousSerialization(RefitSettings settings) =>
+        settings.RequestBodySerialization != RequestBodySerializationMode.Default
+        && settings.ContentSerializer is ISynchronousContentSerializer;
 
     /// <summary>Determines whether the body should use the legacy JSON enum member.</summary>
     /// <param name="serializationMethod">The body serialization method.</param>

--- a/src/Refit/GeneratedRequestRunner.cs
+++ b/src/Refit/GeneratedRequestRunner.cs
@@ -2,6 +2,7 @@
 // ReactiveUI and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using System.Text;
 
 namespace Refit;
@@ -100,6 +101,40 @@ public static class GeneratedRequestRunner
                         true),
                     cancellationToken)
                 .ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>Sends a generated request and streams the response as an <see cref="IAsyncEnumerable{T}"/>.</summary>
+    /// <typeparam name="T">The element type yielded to the caller.</typeparam>
+    /// <param name="client">The HTTP client to send with.</param>
+    /// <param name="request">The generated request message; disposed when streaming completes.</param>
+    /// <param name="settings">The Refit settings to use.</param>
+    /// <param name="methodCancellationToken">The cancellation token supplied as a method argument, if any.</param>
+    /// <param name="cancellationToken">The token supplied by the consumer's enumeration.</param>
+    /// <returns>An asynchronous sequence of deserialized elements.</returns>
+    [SuppressMessage(
+        "Major Code Smell",
+        "S4018:Generic methods should provide type parameters",
+        Justification = "Type parameter intentionally specified explicitly by generated callers.")]
+    [SuppressMessage(
+        "Major Code Smell",
+        "S2360:Optional parameters should not be used",
+        Justification = "The optional CancellationToken carries the [EnumeratorCancellation] token for the await-foreach WithCancellation pattern.")]
+    public static async IAsyncEnumerable<T?> StreamAsync<T>(
+        HttpClient client,
+        HttpRequestMessage request,
+        RefitSettings settings,
+        CancellationToken methodCancellationToken,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        RequestExecutionHelpers.ThrowIfBaseAddressMissing(client);
+
+        using var linked = CancellationTokenSource.CreateLinkedTokenSource(methodCancellationToken, cancellationToken);
+        await foreach (var item in RequestExecutionHelpers
+            .StreamResponseAsync<T>(client, request, settings, true, linked.Token)
+            .ConfigureAwait(false))
+        {
+            yield return item;
         }
     }
 

--- a/src/Refit/IStreamingContentSerializer.cs
+++ b/src/Refit/IStreamingContentSerializer.cs
@@ -1,0 +1,31 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Refit;
+
+/// <summary>
+/// An optional capability for an <see cref="IHttpContentSerializer"/> that can deserialize a response body
+/// incrementally into an <see cref="IAsyncEnumerable{T}"/>. Refit uses this for interface methods that return
+/// <see cref="IAsyncEnumerable{T}"/>, reading items as they arrive instead of buffering the whole response.
+/// </summary>
+public interface IStreamingContentSerializer
+{
+    /// <summary>Deserializes a response <paramref name="stream"/> into a sequence of <typeparamref name="T"/> values.</summary>
+    /// <typeparam name="T">The element type to deserialize.</typeparam>
+    /// <param name="stream">The response body stream to read.</param>
+    /// <param name="format">How the body is framed (a single JSON array or newline-delimited JSON).</param>
+    /// <param name="cancellationToken">A token to cancel enumeration.</param>
+    /// <returns>An asynchronous sequence of deserialized values.</returns>
+    [SuppressMessage("Major Code Smell", "S4018:Generic methods should provide type parameters", Justification = "Type parameter intentionally specified explicitly by callers.")]
+    [SuppressMessage(
+        "Major Code Smell",
+        "S2360:Optional parameters should not be used",
+        Justification = "Optional CancellationToken is part of the published interface contract; overloads need default interface methods unavailable on netstandard2.0/net4x.")]
+    IAsyncEnumerable<T?> DeserializeStreamAsync<T>(
+        Stream stream,
+        StreamingContentFormat format,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Refit/ISynchronousContentSerializer.cs
+++ b/src/Refit/ISynchronousContentSerializer.cs
@@ -1,0 +1,35 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Refit;
+
+/// <summary>
+/// An optional capability for an <see cref="IHttpContentSerializer"/> that can serialize a request body
+/// synchronously (buffered or streamed). Refit uses this when <see cref="RefitSettings.RequestBodySerialization"/>
+/// is <see cref="RequestBodySerializationMode.Buffered"/> or <see cref="RequestBodySerializationMode.Streamed"/>,
+/// allowing the System.Text.Json source-generated fast-path to engage. The fast-path runs through the synchronous serialization primitives
+/// (<c>SerializeToUtf8Bytes</c> / <c>Serialize(Utf8JsonWriter, ...)</c>); the built-in <c>SerializeAsync(Stream)</c>
+/// used by <c>JsonContent</c> bypasses it and uses the metadata logic instead.
+/// </summary>
+public interface ISynchronousContentSerializer
+{
+    /// <summary>Serializes <paramref name="item"/> synchronously into a buffered <see cref="HttpContent"/>.</summary>
+    /// <typeparam name="T">The type of the object to serialize.</typeparam>
+    /// <param name="item">The object to serialize.</param>
+    /// <returns>A buffered <see cref="HttpContent"/> (for example a <c>ByteArrayContent</c>) containing the serialized object.</returns>
+    [SuppressMessage("Major Code Smell", "S4018:Generic methods should provide type parameters", Justification = "Type parameter intentionally specified explicitly by callers.")]
+    HttpContent ToHttpContentSynchronous<T>(T item);
+
+    /// <summary>
+    /// Creates an <see cref="HttpContent"/> that serializes <paramref name="item"/> through the synchronous fast-path
+    /// onto the request stream, flushing asynchronously, without buffering the whole body. Best for large uploads.
+    /// </summary>
+    /// <typeparam name="T">The type of the object to serialize.</typeparam>
+    /// <param name="item">The object to serialize.</param>
+    /// <returns>A streaming <see cref="HttpContent"/> that writes the serialized object when sent.</returns>
+    [SuppressMessage("Major Code Smell", "S4018:Generic methods should provide type parameters", Justification = "Type parameter intentionally specified explicitly by callers.")]
+    HttpContent ToStreamingHttpContent<T>(T item);
+}

--- a/src/Refit/PublicAPI/net10.0/PublicAPI.Shipped.txt
+++ b/src/Refit/PublicAPI/net10.0/PublicAPI.Shipped.txt
@@ -1,12 +1,37 @@
 #nullable enable
+abstract Refit.HttpMethodAttribute.Method.get -> System.Net.Http.HttpMethod!
+abstract Refit.MultipartItem.CreateContent() -> System.Net.Http.HttpContent!
+override Refit.ByteArrayPart.CreateContent() -> System.Net.Http.HttpContent!
+override Refit.DeleteAttribute.Method.get -> System.Net.Http.HttpMethod!
+override Refit.FileInfoPart.CreateContent() -> System.Net.Http.HttpContent!
+override Refit.GetAttribute.Method.get -> System.Net.Http.HttpMethod!
+override Refit.HeadAttribute.Method.get -> System.Net.Http.HttpMethod!
+override Refit.ObjectToInferredTypesConverter.Read(ref System.Text.Json.Utf8JsonReader reader, System.Type! typeToConvert, System.Text.Json.JsonSerializerOptions! options) -> object?
+override Refit.ObjectToInferredTypesConverter.Write(System.Text.Json.Utf8JsonWriter! writer, object! value, System.Text.Json.JsonSerializerOptions! options) -> void
+override Refit.OptionsAttribute.Method.get -> System.Net.Http.HttpMethod!
+override Refit.PatchAttribute.Method.get -> System.Net.Http.HttpMethod!
+override Refit.PostAttribute.Method.get -> System.Net.Http.HttpMethod!
+override Refit.PutAttribute.Method.get -> System.Net.Http.HttpMethod!
+override Refit.RestMethodInfo.Equals(object? obj) -> bool
+override Refit.RestMethodInfo.GetHashCode() -> int
+override Refit.RestMethodInfo.ToString() -> string!
+override Refit.StreamPart.CreateContent() -> System.Net.Http.HttpContent!
 Refit.AliasAsAttribute
 Refit.AliasAsAttribute.AliasAsAttribute(string! name) -> void
 Refit.AliasAsAttribute.Name.get -> string!
 Refit.ApiException
-Refit.ApiException.ApiException(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, string? content, System.Net.HttpStatusCode statusCode, string? reasonPhrase, System.Net.Http.Headers.HttpResponseHeaders! headers, Refit.RefitSettings! refitSettings) -> void
-Refit.ApiException.ApiException(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, string? content, System.Net.HttpStatusCode statusCode, string? reasonPhrase, System.Net.Http.Headers.HttpResponseHeaders! headers, Refit.RefitSettings! refitSettings, System.Exception? innerException) -> void
-Refit.ApiException.ApiException(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, string? content, System.Net.HttpStatusCode statusCode, string? reasonPhrase, System.Net.Http.Headers.HttpResponseHeaders! headers, Refit.RefitSettings! refitSettings) -> void
 Refit.ApiException.ApiException(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, string? content, System.Net.HttpStatusCode statusCode, string? reasonPhrase, System.Net.Http.Headers.HttpResponseHeaders! headers, Refit.RefitSettings! refitSettings, System.Exception? innerException) -> void
+Refit.ApiException.ApiException(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, string? content, System.Net.HttpStatusCode statusCode, string? reasonPhrase, System.Net.Http.Headers.HttpResponseHeaders! headers, Refit.RefitSettings! refitSettings) -> void
+Refit.ApiException.ApiException(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, string? content, System.Net.HttpStatusCode statusCode, string? reasonPhrase, System.Net.Http.Headers.HttpResponseHeaders! headers, Refit.RefitSettings! refitSettings, System.Exception? innerException) -> void
+Refit.ApiException.ApiException(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, string? content, System.Net.HttpStatusCode statusCode, string? reasonPhrase, System.Net.Http.Headers.HttpResponseHeaders! headers, Refit.RefitSettings! refitSettings) -> void
+Refit.ApiExceptionBase
+Refit.ApiExceptionBase.ApiExceptionBase(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings, System.Exception? innerException) -> void
+Refit.ApiExceptionBase.ApiExceptionBase(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings) -> void
+Refit.ApiExceptionBase.ApiExceptionBase(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings, System.Exception! innerException) -> void
+Refit.ApiExceptionBase.HttpMethod.get -> System.Net.Http.HttpMethod!
+Refit.ApiExceptionBase.RefitSettings.get -> Refit.RefitSettings!
+Refit.ApiExceptionBase.RequestMessage.get -> System.Net.Http.HttpRequestMessage!
+Refit.ApiExceptionBase.Uri.get -> System.Uri?
 Refit.ApiException.Content.get -> string?
 Refit.ApiException.ContentHeaders.get -> System.Net.Http.Headers.HttpContentHeaders?
 Refit.ApiException.ContentHeaders.set -> void
@@ -15,44 +40,36 @@ Refit.ApiException.HasContent.get -> bool
 Refit.ApiException.Headers.get -> System.Net.Http.Headers.HttpResponseHeaders!
 Refit.ApiException.ReasonPhrase.get -> string?
 Refit.ApiException.StatusCode.get -> System.Net.HttpStatusCode
-Refit.ApiExceptionBase
-Refit.ApiExceptionBase.ApiExceptionBase(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings, System.Exception! innerException) -> void
-Refit.ApiExceptionBase.ApiExceptionBase(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings) -> void
-Refit.ApiExceptionBase.ApiExceptionBase(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings, System.Exception? innerException) -> void
-Refit.ApiExceptionBase.HttpMethod.get -> System.Net.Http.HttpMethod!
-Refit.ApiExceptionBase.RefitSettings.get -> Refit.RefitSettings!
-Refit.ApiExceptionBase.RequestMessage.get -> System.Net.Http.HttpRequestMessage!
-Refit.ApiExceptionBase.Uri.get -> System.Uri?
 Refit.ApiRequestException
-Refit.ApiRequestException.ApiRequestException(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings, System.Exception! innerException) -> void
-Refit.ApiRequestException.ApiRequestException(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings) -> void
 Refit.ApiRequestException.ApiRequestException(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings, System.Exception? innerException) -> void
+Refit.ApiRequestException.ApiRequestException(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings) -> void
+Refit.ApiRequestException.ApiRequestException(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings, System.Exception! innerException) -> void
+Refit.ApiResponseExtensions
+Refit.ApiResponseExtensions.extension<T>(Refit.IApiResponse<T>!)
+Refit.ApiResponseExtensions.extension<T>(Refit.IApiResponse<T>!).EnsureSuccessfulAsync() -> System.Threading.Tasks.Task<Refit.IApiResponse<T>!>!
+Refit.ApiResponseExtensions.extension<T>(Refit.IApiResponse<T>!).EnsureSuccessStatusCodeAsync() -> System.Threading.Tasks.Task<Refit.IApiResponse<T>!>!
 Refit.ApiResponse<T>
 Refit.ApiResponse<T>.ApiResponse(System.Net.Http.HttpRequestMessage! request, System.Net.Http.HttpResponseMessage? response, T? content, Refit.RefitSettings! settings, Refit.ApiExceptionBase? error = null) -> void
-Refit.ApiResponse<T>.ApiResponse(System.Net.Http.HttpResponseMessage! response, T? content, Refit.RefitSettings! settings) -> void
 Refit.ApiResponse<T>.ApiResponse(System.Net.Http.HttpResponseMessage! response, T? content, Refit.RefitSettings! settings, Refit.ApiExceptionBase? error) -> void
+Refit.ApiResponse<T>.ApiResponse(System.Net.Http.HttpResponseMessage! response, T? content, Refit.RefitSettings! settings) -> void
 Refit.ApiResponse<T>.Content.get -> T?
 Refit.ApiResponse<T>.ContentHeaders.get -> System.Net.Http.Headers.HttpContentHeaders?
 Refit.ApiResponse<T>.Dispose() -> void
-Refit.ApiResponse<T>.EnsureSuccessStatusCodeAsync() -> System.Threading.Tasks.Task<Refit.ApiResponse<T>!>!
 Refit.ApiResponse<T>.EnsureSuccessfulAsync() -> System.Threading.Tasks.Task<Refit.ApiResponse<T>!>!
+Refit.ApiResponse<T>.EnsureSuccessStatusCodeAsync() -> System.Threading.Tasks.Task<Refit.ApiResponse<T>!>!
 Refit.ApiResponse<T>.Error.get -> Refit.ApiExceptionBase?
 Refit.ApiResponse<T>.HasContent.get -> bool
 Refit.ApiResponse<T>.HasRequestError(out Refit.ApiRequestException? error) -> bool
 Refit.ApiResponse<T>.HasResponseError(out Refit.ApiException? error) -> bool
 Refit.ApiResponse<T>.Headers.get -> System.Net.Http.Headers.HttpResponseHeaders?
 Refit.ApiResponse<T>.IsReceived.get -> bool
-Refit.ApiResponse<T>.IsSuccessStatusCode.get -> bool
 Refit.ApiResponse<T>.IsSuccessful.get -> bool
+Refit.ApiResponse<T>.IsSuccessStatusCode.get -> bool
 Refit.ApiResponse<T>.ReasonPhrase.get -> string?
 Refit.ApiResponse<T>.RequestMessage.get -> System.Net.Http.HttpRequestMessage!
 Refit.ApiResponse<T>.Settings.get -> Refit.RefitSettings!
 Refit.ApiResponse<T>.StatusCode.get -> System.Net.HttpStatusCode?
 Refit.ApiResponse<T>.Version.get -> System.Version?
-Refit.ApiResponseExtensions
-Refit.ApiResponseExtensions.extension<T>(Refit.IApiResponse<T>!)
-Refit.ApiResponseExtensions.extension<T>(Refit.IApiResponse<T>!).EnsureSuccessStatusCodeAsync() -> System.Threading.Tasks.Task<Refit.IApiResponse<T>!>!
-Refit.ApiResponseExtensions.extension<T>(Refit.IApiResponse<T>!).EnsureSuccessfulAsync() -> System.Threading.Tasks.Task<Refit.IApiResponse<T>!>!
 Refit.AttachmentNameAttribute
 Refit.AttachmentNameAttribute.AttachmentNameAttribute(string! name) -> void
 Refit.AttachmentNameAttribute.Name.get -> string!
@@ -60,10 +77,10 @@ Refit.AuthorizeAttribute
 Refit.AuthorizeAttribute.AuthorizeAttribute(string! scheme = "Bearer") -> void
 Refit.AuthorizeAttribute.Scheme.get -> string!
 Refit.BodyAttribute
-Refit.BodyAttribute.BodyAttribute() -> void
-Refit.BodyAttribute.BodyAttribute(Refit.BodySerializationMethod serializationMethod) -> void
-Refit.BodyAttribute.BodyAttribute(Refit.BodySerializationMethod serializationMethod, bool buffered) -> void
 Refit.BodyAttribute.BodyAttribute(bool buffered) -> void
+Refit.BodyAttribute.BodyAttribute(Refit.BodySerializationMethod serializationMethod, bool buffered) -> void
+Refit.BodyAttribute.BodyAttribute(Refit.BodySerializationMethod serializationMethod) -> void
+Refit.BodyAttribute.BodyAttribute() -> void
 Refit.BodyAttribute.Buffered.get -> bool?
 Refit.BodyAttribute.SerializationMethod.get -> Refit.BodySerializationMethod
 Refit.BodySerializationMethod
@@ -107,13 +124,13 @@ Refit.GetAttribute.GetAttribute(string! path) -> void
 Refit.HeadAttribute
 Refit.HeadAttribute.HeadAttribute(string! path) -> void
 Refit.HeaderAttribute
-Refit.HeaderAttribute.Header.get -> string!
 Refit.HeaderAttribute.HeaderAttribute(string! header) -> void
+Refit.HeaderAttribute.Header.get -> string!
 Refit.HeaderCollectionAttribute
 Refit.HeaderCollectionAttribute.HeaderCollectionAttribute() -> void
 Refit.HeadersAttribute
-Refit.HeadersAttribute.Headers.get -> string![]!
 Refit.HeadersAttribute.HeadersAttribute(params string![]! headers) -> void
+Refit.HeadersAttribute.Headers.get -> string![]!
 Refit.HttpMethodAttribute
 Refit.HttpMethodAttribute.HttpMethodAttribute(string! path) -> void
 Refit.HttpRequestMessageOptions
@@ -124,15 +141,15 @@ Refit.IApiResponse.HasRequestError(out Refit.ApiRequestException? error) -> bool
 Refit.IApiResponse.HasResponseError(out Refit.ApiException? error) -> bool
 Refit.IApiResponse.Headers.get -> System.Net.Http.Headers.HttpResponseHeaders?
 Refit.IApiResponse.IsReceived.get -> bool
-Refit.IApiResponse.IsSuccessStatusCode.get -> bool
 Refit.IApiResponse.IsSuccessful.get -> bool
+Refit.IApiResponse.IsSuccessStatusCode.get -> bool
 Refit.IApiResponse.ReasonPhrase.get -> string?
 Refit.IApiResponse.RequestMessage.get -> System.Net.Http.HttpRequestMessage?
 Refit.IApiResponse.StatusCode.get -> System.Net.HttpStatusCode?
-Refit.IApiResponse.Version.get -> System.Version?
 Refit.IApiResponse<T>
 Refit.IApiResponse<T>.Content.get -> T?
 Refit.IApiResponse<T>.HasContent.get -> bool
+Refit.IApiResponse.Version.get -> System.Version?
 Refit.IFormUrlEncodedParameterFormatter
 Refit.IFormUrlEncodedParameterFormatter.Format(object? value, string? formatString) -> string?
 Refit.IHttpContentSerializer
@@ -143,6 +160,11 @@ Refit.IRequestBuilder
 Refit.IRequestBuilder.BuildRestResultFuncForMethod(string! methodName, System.Type![]? parameterTypes = null, System.Type![]? genericArgumentTypes = null) -> System.Func<System.Net.Http.HttpClient!, object![]!, object?>!
 Refit.IRequestBuilder.Settings.get -> Refit.RefitSettings!
 Refit.IRequestBuilder<T>
+Refit.IStreamingContentSerializer
+Refit.IStreamingContentSerializer.DeserializeStreamAsync<T>(System.IO.Stream! stream, Refit.StreamingContentFormat format, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<T?>!
+Refit.ISynchronousContentSerializer
+Refit.ISynchronousContentSerializer.ToHttpContentSynchronous<T>(T item) -> System.Net.Http.HttpContent!
+Refit.ISynchronousContentSerializer.ToStreamingHttpContent<T>(T item) -> System.Net.Http.HttpContent!
 Refit.IUrlParameterFormatter
 Refit.IUrlParameterFormatter.Format(object? value, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string?
 Refit.IUrlParameterKeyFormatter
@@ -163,8 +185,8 @@ Refit.MultipartAttribute.MultipartAttribute(string! boundaryText = "----MyGreatB
 Refit.MultipartItem
 Refit.MultipartItem.ContentType.get -> string?
 Refit.MultipartItem.FileName.get -> string!
-Refit.MultipartItem.MultipartItem(string! fileName, string? contentType) -> void
 Refit.MultipartItem.MultipartItem(string! fileName, string? contentType, string? name) -> void
+Refit.MultipartItem.MultipartItem(string! fileName, string? contentType) -> void
 Refit.MultipartItem.Name.get -> string?
 Refit.MultipartItem.ToContent() -> System.Net.Http.HttpContent!
 Refit.ObjectToInferredTypesConverter
@@ -196,8 +218,8 @@ Refit.ProblemDetails.Type.get -> string?
 Refit.ProblemDetails.Type.set -> void
 Refit.PropertyAttribute
 Refit.PropertyAttribute.Key.get -> string?
-Refit.PropertyAttribute.PropertyAttribute() -> void
 Refit.PropertyAttribute.PropertyAttribute(string! key) -> void
+Refit.PropertyAttribute.PropertyAttribute() -> void
 Refit.PutAttribute
 Refit.PutAttribute.PutAttribute(string! path) -> void
 Refit.QueryAttribute
@@ -208,17 +230,19 @@ Refit.QueryAttribute.Format.get -> string?
 Refit.QueryAttribute.Format.set -> void
 Refit.QueryAttribute.IsCollectionFormatSpecified.get -> bool
 Refit.QueryAttribute.Prefix.get -> string?
-Refit.QueryAttribute.QueryAttribute() -> void
 Refit.QueryAttribute.QueryAttribute(Refit.CollectionFormat collectionFormat) -> void
-Refit.QueryAttribute.QueryAttribute(string! delimiter) -> void
-Refit.QueryAttribute.QueryAttribute(string! delimiter, string! prefix) -> void
 Refit.QueryAttribute.QueryAttribute(string! delimiter, string! prefix, string! format) -> void
+Refit.QueryAttribute.QueryAttribute(string! delimiter, string! prefix) -> void
+Refit.QueryAttribute.QueryAttribute(string! delimiter) -> void
+Refit.QueryAttribute.QueryAttribute() -> void
 Refit.QueryAttribute.TreatAsString.get -> bool
 Refit.QueryAttribute.TreatAsString.set -> void
 Refit.QueryUriFormatAttribute
 Refit.QueryUriFormatAttribute.QueryUriFormatAttribute(System.UriFormat uriFormat) -> void
 Refit.QueryUriFormatAttribute.UriFormat.get -> System.UriFormat
 Refit.RefitSettings
+Refit.RefitSettings.AllowUnmatchedRouteParameters.get -> bool
+Refit.RefitSettings.AllowUnmatchedRouteParameters.set -> void
 Refit.RefitSettings.AuthorizationHeaderValueGetter.get -> System.Func<System.Net.Http.HttpRequestMessage!, System.Threading.CancellationToken, System.Threading.Tasks.Task<string!>!>?
 Refit.RefitSettings.AuthorizationHeaderValueGetter.set -> void
 Refit.RefitSettings.Buffered.get -> bool
@@ -237,19 +261,27 @@ Refit.RefitSettings.HttpMessageHandlerFactory.get -> System.Func<System.Net.Http
 Refit.RefitSettings.HttpMessageHandlerFactory.set -> void
 Refit.RefitSettings.HttpRequestMessageOptions.get -> System.Collections.Generic.Dictionary<string!, object!>?
 Refit.RefitSettings.HttpRequestMessageOptions.init -> void
-Refit.RefitSettings.RefitSettings() -> void
-Refit.RefitSettings.RefitSettings(Refit.IHttpContentSerializer! contentSerializer) -> void
-Refit.RefitSettings.RefitSettings(Refit.IHttpContentSerializer! contentSerializer, Refit.IUrlParameterFormatter? urlParameterFormatter) -> void
-Refit.RefitSettings.RefitSettings(Refit.IHttpContentSerializer! contentSerializer, Refit.IUrlParameterFormatter? urlParameterFormatter, Refit.IFormUrlEncodedParameterFormatter? formUrlEncodedParameterFormatter) -> void
 Refit.RefitSettings.RefitSettings(Refit.IHttpContentSerializer! contentSerializer, Refit.IUrlParameterFormatter? urlParameterFormatter, Refit.IFormUrlEncodedParameterFormatter? formUrlEncodedParameterFormatter, Refit.IUrlParameterKeyFormatter? urlParameterKeyFormatter) -> void
+Refit.RefitSettings.RefitSettings(Refit.IHttpContentSerializer! contentSerializer, Refit.IUrlParameterFormatter? urlParameterFormatter, Refit.IFormUrlEncodedParameterFormatter? formUrlEncodedParameterFormatter) -> void
+Refit.RefitSettings.RefitSettings(Refit.IHttpContentSerializer! contentSerializer, Refit.IUrlParameterFormatter? urlParameterFormatter) -> void
+Refit.RefitSettings.RefitSettings(Refit.IHttpContentSerializer! contentSerializer) -> void
+Refit.RefitSettings.RefitSettings() -> void
+Refit.RefitSettings.RequestBodySerialization.get -> Refit.RequestBodySerializationMode
+Refit.RefitSettings.RequestBodySerialization.set -> void
 Refit.RefitSettings.UrlParameterFormatter.get -> Refit.IUrlParameterFormatter!
 Refit.RefitSettings.UrlParameterFormatter.set -> void
 Refit.RefitSettings.UrlParameterKeyFormatter.get -> Refit.IUrlParameterKeyFormatter!
 Refit.RefitSettings.UrlParameterKeyFormatter.set -> void
+Refit.RefitSettings.UrlResolution.get -> Refit.UrlResolutionMode
+Refit.RefitSettings.UrlResolution.set -> void
 Refit.RefitSettings.Version.get -> System.Version!
-Refit.RefitSettings.Version.set -> void
 Refit.RefitSettings.VersionPolicy.get -> System.Net.Http.HttpVersionPolicy
 Refit.RefitSettings.VersionPolicy.set -> void
+Refit.RefitSettings.Version.set -> void
+Refit.RequestBodySerializationMode
+Refit.RequestBodySerializationMode.Buffered = 1 -> Refit.RequestBodySerializationMode
+Refit.RequestBodySerializationMode.Default = 0 -> Refit.RequestBodySerializationMode
+Refit.RequestBodySerializationMode.Streamed = 2 -> Refit.RequestBodySerializationMode
 Refit.RequestBuilder
 Refit.RestMethodInfo
 Refit.RestMethodInfo.<Clone>$() -> Refit.RestMethodInfo!
@@ -289,45 +321,38 @@ Refit.RestService
 Refit.SnakeCaseUrlParameterKeyFormatter
 Refit.SnakeCaseUrlParameterKeyFormatter.Format(string! key) -> string!
 Refit.SnakeCaseUrlParameterKeyFormatter.SnakeCaseUrlParameterKeyFormatter() -> void
+Refit.StreamingContentFormat
+Refit.StreamingContentFormat.JsonArray = 0 -> Refit.StreamingContentFormat
+Refit.StreamingContentFormat.JsonLines = 1 -> Refit.StreamingContentFormat
 Refit.StreamPart
 Refit.StreamPart.StreamPart(System.IO.Stream! value, string! fileName, string? contentType = null, string? name = null) -> void
 Refit.StreamPart.Value.get -> System.IO.Stream!
 Refit.SystemTextJsonContentSerializer
+Refit.SystemTextJsonContentSerializer.DeserializeStreamAsync<T>(System.IO.Stream! stream, Refit.StreamingContentFormat format, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<T?>!
 Refit.SystemTextJsonContentSerializer.FromHttpContentAsync<T>(System.Net.Http.HttpContent! content, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<T?>!
 Refit.SystemTextJsonContentSerializer.GetFieldNameForProperty(System.Reflection.PropertyInfo! propertyInfo) -> string?
-Refit.SystemTextJsonContentSerializer.SystemTextJsonContentSerializer() -> void
 Refit.SystemTextJsonContentSerializer.SystemTextJsonContentSerializer(System.Text.Json.JsonSerializerOptions! jsonSerializerOptions) -> void
+Refit.SystemTextJsonContentSerializer.SystemTextJsonContentSerializer() -> void
+Refit.SystemTextJsonContentSerializer.ToHttpContentSynchronous<T>(T item) -> System.Net.Http.HttpContent!
 Refit.SystemTextJsonContentSerializer.ToHttpContent<T>(T item) -> System.Net.Http.HttpContent!
+Refit.SystemTextJsonContentSerializer.ToStreamingHttpContent<T>(T item) -> System.Net.Http.HttpContent!
+Refit.UrlResolutionMode
+Refit.UrlResolutionMode.RefitLegacy = 0 -> Refit.UrlResolutionMode
+Refit.UrlResolutionMode.Rfc3986 = 1 -> Refit.UrlResolutionMode
 Refit.ValidationApiException
 Refit.ValidationApiException.Content.get -> Refit.ProblemDetails?
-Refit.ValidationApiException.ValidationApiException(string! message) -> void
 Refit.ValidationApiException.ValidationApiException(string! message, System.Exception! innerException) -> void
-abstract Refit.HttpMethodAttribute.Method.get -> System.Net.Http.HttpMethod!
-abstract Refit.MultipartItem.CreateContent() -> System.Net.Http.HttpContent!
-override Refit.ByteArrayPart.CreateContent() -> System.Net.Http.HttpContent!
-override Refit.DeleteAttribute.Method.get -> System.Net.Http.HttpMethod!
-override Refit.FileInfoPart.CreateContent() -> System.Net.Http.HttpContent!
-override Refit.GetAttribute.Method.get -> System.Net.Http.HttpMethod!
-override Refit.HeadAttribute.Method.get -> System.Net.Http.HttpMethod!
-override Refit.ObjectToInferredTypesConverter.Read(ref System.Text.Json.Utf8JsonReader reader, System.Type! typeToConvert, System.Text.Json.JsonSerializerOptions! options) -> object?
-override Refit.ObjectToInferredTypesConverter.Write(System.Text.Json.Utf8JsonWriter! writer, object! value, System.Text.Json.JsonSerializerOptions! options) -> void
-override Refit.OptionsAttribute.Method.get -> System.Net.Http.HttpMethod!
-override Refit.PatchAttribute.Method.get -> System.Net.Http.HttpMethod!
-override Refit.PostAttribute.Method.get -> System.Net.Http.HttpMethod!
-override Refit.PutAttribute.Method.get -> System.Net.Http.HttpMethod!
-override Refit.RestMethodInfo.Equals(object? obj) -> bool
-override Refit.RestMethodInfo.GetHashCode() -> int
-override Refit.RestMethodInfo.ToString() -> string!
-override Refit.StreamPart.CreateContent() -> System.Net.Http.HttpContent!
-static Refit.ApiException.Create(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, System.Net.Http.HttpResponseMessage! response, Refit.RefitSettings! refitSettings) -> System.Threading.Tasks.Task<Refit.ApiException!>!
-static Refit.ApiException.Create(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, System.Net.Http.HttpResponseMessage! response, Refit.RefitSettings! refitSettings, System.Exception? innerException) -> System.Threading.Tasks.Task<Refit.ApiException!>!
-static Refit.ApiException.Create(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, System.Net.Http.HttpResponseMessage! response, Refit.RefitSettings! refitSettings) -> System.Threading.Tasks.Task<Refit.ApiException!>!
+Refit.ValidationApiException.ValidationApiException(string! message) -> void
 static Refit.ApiException.Create(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, System.Net.Http.HttpResponseMessage! response, Refit.RefitSettings! refitSettings, System.Exception? innerException) -> System.Threading.Tasks.Task<Refit.ApiException!>!
-static Refit.ApiResponseExtensions.EnsureSuccessStatusCodeAsync<T>(this Refit.IApiResponse<T>! response) -> System.Threading.Tasks.Task<Refit.IApiResponse<T>!>!
+static Refit.ApiException.Create(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, System.Net.Http.HttpResponseMessage! response, Refit.RefitSettings! refitSettings) -> System.Threading.Tasks.Task<Refit.ApiException!>!
+static Refit.ApiException.Create(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, System.Net.Http.HttpResponseMessage! response, Refit.RefitSettings! refitSettings, System.Exception? innerException) -> System.Threading.Tasks.Task<Refit.ApiException!>!
+static Refit.ApiException.Create(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, System.Net.Http.HttpResponseMessage! response, Refit.RefitSettings! refitSettings) -> System.Threading.Tasks.Task<Refit.ApiException!>!
 static Refit.ApiResponseExtensions.EnsureSuccessfulAsync<T>(this Refit.IApiResponse<T>! response) -> System.Threading.Tasks.Task<Refit.IApiResponse<T>!>!
+static Refit.ApiResponseExtensions.EnsureSuccessStatusCodeAsync<T>(this Refit.IApiResponse<T>! response) -> System.Threading.Tasks.Task<Refit.IApiResponse<T>!>!
 static Refit.GeneratedRequestRunner.AddConfiguredRequestOptions(System.Net.Http.HttpRequestMessage! request, Refit.RefitSettings! settings, System.Type! interfaceType) -> void
 static Refit.GeneratedRequestRunner.AddHeaderCollection(System.Net.Http.HttpRequestMessage! request, System.Collections.Generic.IDictionary<string!, string!>? headers) -> void
 static Refit.GeneratedRequestRunner.AddRequestProperty<TValue>(System.Net.Http.HttpRequestMessage! request, string! key, TValue value) -> void
+static Refit.GeneratedRequestRunner.BuildRelativeUri(System.Net.Http.HttpClient! client, string! relativePath, Refit.UrlResolutionMode urlResolution) -> System.Uri!
 static Refit.GeneratedRequestRunner.CreateBodyContent<TBody>(Refit.RefitSettings! settings, TBody body, Refit.BodySerializationMethod serializationMethod, bool streamBody) -> System.Net.Http.HttpContent!
 static Refit.GeneratedRequestRunner.CreateJsonLinesBodyContent<TBody>(Refit.RefitSettings! settings, TBody body) -> System.Net.Http.HttpContent!
 static Refit.GeneratedRequestRunner.CreateUrlEncodedBodyContent<TBody>(Refit.RefitSettings! settings, TBody body) -> System.Net.Http.HttpContent!
@@ -347,26 +372,27 @@ static Refit.RequestBuilder.ForType<T>(Refit.RefitSettings? settings) -> Refit.I
 static Refit.RestMethodInfo.operator !=(Refit.RestMethodInfo? left, Refit.RestMethodInfo? right) -> bool
 static Refit.RestMethodInfo.operator ==(Refit.RestMethodInfo? left, Refit.RestMethodInfo? right) -> bool
 static Refit.RestService.CreateHttpClient(string! hostUrl, Refit.RefitSettings? settings) -> System.Net.Http.HttpClient!
+static Refit.RestService.ForGenerated(System.Type! refitInterfaceType, string! hostUrl, Refit.RefitSettings! settings) -> object!
+static Refit.RestService.ForGenerated(System.Type! refitInterfaceType, System.Net.Http.HttpClient! client, Refit.RefitSettings! settings) -> object!
+static Refit.RestService.ForGenerated<T>(string! hostUrl, Refit.RefitSettings! settings) -> T
+static Refit.RestService.ForGenerated<T>(string! hostUrl) -> T
+static Refit.RestService.ForGenerated<T>(System.Net.Http.HttpClient! client, Refit.RefitSettings! settings) -> T
+static Refit.RestService.ForGenerated<T>(System.Net.Http.HttpClient! client) -> T
+static Refit.RestService.For(System.Type! refitInterfaceType, string! hostUrl) -> object!
+static Refit.RestService.For(System.Type! refitInterfaceType, string! hostUrl, Refit.RefitSettings? settings) -> object!
 static Refit.RestService.For(System.Type! refitInterfaceType, System.Net.Http.HttpClient! client) -> object!
 static Refit.RestService.For(System.Type! refitInterfaceType, System.Net.Http.HttpClient! client, Refit.IRequestBuilder! builder) -> object!
 static Refit.RestService.For(System.Type! refitInterfaceType, System.Net.Http.HttpClient! client, Refit.RefitSettings? settings) -> object!
-static Refit.RestService.For(System.Type! refitInterfaceType, string! hostUrl) -> object!
-static Refit.RestService.For(System.Type! refitInterfaceType, string! hostUrl, Refit.RefitSettings? settings) -> object!
-static Refit.RestService.For<T>(System.Net.Http.HttpClient! client) -> T
+static Refit.RestService.For<T>(string! hostUrl, Refit.RefitSettings? settings) -> T
+static Refit.RestService.For<T>(string! hostUrl) -> T
 static Refit.RestService.For<T>(System.Net.Http.HttpClient! client, Refit.IRequestBuilder<T>! builder) -> T
 static Refit.RestService.For<T>(System.Net.Http.HttpClient! client, Refit.RefitSettings? settings) -> T
-static Refit.RestService.For<T>(string! hostUrl) -> T
-static Refit.RestService.For<T>(string! hostUrl, Refit.RefitSettings? settings) -> T
-static Refit.RestService.ForGenerated(System.Type! refitInterfaceType, System.Net.Http.HttpClient! client, Refit.RefitSettings! settings) -> object!
-static Refit.RestService.ForGenerated(System.Type! refitInterfaceType, string! hostUrl, Refit.RefitSettings! settings) -> object!
-static Refit.RestService.ForGenerated<T>(System.Net.Http.HttpClient! client) -> T
-static Refit.RestService.ForGenerated<T>(System.Net.Http.HttpClient! client, Refit.RefitSettings! settings) -> T
-static Refit.RestService.ForGenerated<T>(string! hostUrl) -> T
-static Refit.RestService.ForGenerated<T>(string! hostUrl, Refit.RefitSettings! settings) -> T
+static Refit.RestService.For<T>(System.Net.Http.HttpClient! client) -> T
 static Refit.RestService.RegisterGeneratedFactory(System.Type! refitInterfaceType, System.Func<System.Net.Http.HttpClient!, Refit.IRequestBuilder!, object!>! factory) -> void
 static Refit.RestService.RegisterGeneratedFactory<T>(System.Func<System.Net.Http.HttpClient!, Refit.IRequestBuilder!, T>! factory) -> void
 static Refit.RestService.RegisterGeneratedSettingsFactory<T>(System.Func<System.Net.Http.HttpClient!, Refit.RefitSettings!, T>! factory) -> void
 static Refit.SystemTextJsonContentSerializer.GetDefaultJsonSerializerOptions() -> System.Text.Json.JsonSerializerOptions!
+static Refit.SystemTextJsonContentSerializer.GetFastPathJsonSerializerOptions() -> System.Text.Json.JsonSerializerOptions!
 static Refit.ValidationApiException.Create(Refit.ApiException! exception) -> Refit.ValidationApiException!
 virtual Refit.DefaultFormUrlEncodedParameterFormatter.Format(object? value, string? formatString) -> string?
 virtual Refit.DefaultUrlParameterFormatter.Format(object? value, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string?

--- a/src/Refit/PublicAPI/net10.0/PublicAPI.Shipped.txt
+++ b/src/Refit/PublicAPI/net10.0/PublicAPI.Shipped.txt
@@ -359,6 +359,7 @@ static Refit.GeneratedRequestRunner.CreateUrlEncodedBodyContent<TBody>(Refit.Ref
 static Refit.GeneratedRequestRunner.SendAsync<T, TBody>(System.Net.Http.HttpClient! client, System.Net.Http.HttpRequestMessage! request, Refit.RefitSettings! settings, bool isApiResponse, bool shouldDisposeResponse, bool bufferBody, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<T?>!
 static Refit.GeneratedRequestRunner.SendVoidAsync(System.Net.Http.HttpClient! client, System.Net.Http.HttpRequestMessage! request, Refit.RefitSettings! settings, bool bufferBody, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 static Refit.GeneratedRequestRunner.SetHeader(System.Net.Http.HttpRequestMessage! request, string! name, string? value) -> void
+static Refit.GeneratedRequestRunner.StreamAsync<T>(System.Net.Http.HttpClient! client, System.Net.Http.HttpRequestMessage! request, Refit.RefitSettings! settings, System.Threading.CancellationToken methodCancellationToken, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<T?>!
 static Refit.HttpRequestMessageOptions.InterfaceType.get -> string!
 static Refit.HttpRequestMessageOptions.RestMethodInfo.get -> string!
 static Refit.JsonLinesContent.JsonLinesMediaType.get -> string!

--- a/src/Refit/PublicAPI/net11.0/PublicAPI.Shipped.txt
+++ b/src/Refit/PublicAPI/net11.0/PublicAPI.Shipped.txt
@@ -1,12 +1,37 @@
 #nullable enable
+abstract Refit.HttpMethodAttribute.Method.get -> System.Net.Http.HttpMethod!
+abstract Refit.MultipartItem.CreateContent() -> System.Net.Http.HttpContent!
+override Refit.ByteArrayPart.CreateContent() -> System.Net.Http.HttpContent!
+override Refit.DeleteAttribute.Method.get -> System.Net.Http.HttpMethod!
+override Refit.FileInfoPart.CreateContent() -> System.Net.Http.HttpContent!
+override Refit.GetAttribute.Method.get -> System.Net.Http.HttpMethod!
+override Refit.HeadAttribute.Method.get -> System.Net.Http.HttpMethod!
+override Refit.ObjectToInferredTypesConverter.Read(ref System.Text.Json.Utf8JsonReader reader, System.Type! typeToConvert, System.Text.Json.JsonSerializerOptions! options) -> object?
+override Refit.ObjectToInferredTypesConverter.Write(System.Text.Json.Utf8JsonWriter! writer, object! value, System.Text.Json.JsonSerializerOptions! options) -> void
+override Refit.OptionsAttribute.Method.get -> System.Net.Http.HttpMethod!
+override Refit.PatchAttribute.Method.get -> System.Net.Http.HttpMethod!
+override Refit.PostAttribute.Method.get -> System.Net.Http.HttpMethod!
+override Refit.PutAttribute.Method.get -> System.Net.Http.HttpMethod!
+override Refit.RestMethodInfo.Equals(object? obj) -> bool
+override Refit.RestMethodInfo.GetHashCode() -> int
+override Refit.RestMethodInfo.ToString() -> string!
+override Refit.StreamPart.CreateContent() -> System.Net.Http.HttpContent!
 Refit.AliasAsAttribute
 Refit.AliasAsAttribute.AliasAsAttribute(string! name) -> void
 Refit.AliasAsAttribute.Name.get -> string!
 Refit.ApiException
-Refit.ApiException.ApiException(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, string? content, System.Net.HttpStatusCode statusCode, string? reasonPhrase, System.Net.Http.Headers.HttpResponseHeaders! headers, Refit.RefitSettings! refitSettings) -> void
-Refit.ApiException.ApiException(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, string? content, System.Net.HttpStatusCode statusCode, string? reasonPhrase, System.Net.Http.Headers.HttpResponseHeaders! headers, Refit.RefitSettings! refitSettings, System.Exception? innerException) -> void
-Refit.ApiException.ApiException(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, string? content, System.Net.HttpStatusCode statusCode, string? reasonPhrase, System.Net.Http.Headers.HttpResponseHeaders! headers, Refit.RefitSettings! refitSettings) -> void
 Refit.ApiException.ApiException(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, string? content, System.Net.HttpStatusCode statusCode, string? reasonPhrase, System.Net.Http.Headers.HttpResponseHeaders! headers, Refit.RefitSettings! refitSettings, System.Exception? innerException) -> void
+Refit.ApiException.ApiException(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, string? content, System.Net.HttpStatusCode statusCode, string? reasonPhrase, System.Net.Http.Headers.HttpResponseHeaders! headers, Refit.RefitSettings! refitSettings) -> void
+Refit.ApiException.ApiException(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, string? content, System.Net.HttpStatusCode statusCode, string? reasonPhrase, System.Net.Http.Headers.HttpResponseHeaders! headers, Refit.RefitSettings! refitSettings, System.Exception? innerException) -> void
+Refit.ApiException.ApiException(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, string? content, System.Net.HttpStatusCode statusCode, string? reasonPhrase, System.Net.Http.Headers.HttpResponseHeaders! headers, Refit.RefitSettings! refitSettings) -> void
+Refit.ApiExceptionBase
+Refit.ApiExceptionBase.ApiExceptionBase(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings, System.Exception? innerException) -> void
+Refit.ApiExceptionBase.ApiExceptionBase(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings) -> void
+Refit.ApiExceptionBase.ApiExceptionBase(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings, System.Exception! innerException) -> void
+Refit.ApiExceptionBase.HttpMethod.get -> System.Net.Http.HttpMethod!
+Refit.ApiExceptionBase.RefitSettings.get -> Refit.RefitSettings!
+Refit.ApiExceptionBase.RequestMessage.get -> System.Net.Http.HttpRequestMessage!
+Refit.ApiExceptionBase.Uri.get -> System.Uri?
 Refit.ApiException.Content.get -> string?
 Refit.ApiException.ContentHeaders.get -> System.Net.Http.Headers.HttpContentHeaders?
 Refit.ApiException.ContentHeaders.set -> void
@@ -15,44 +40,36 @@ Refit.ApiException.HasContent.get -> bool
 Refit.ApiException.Headers.get -> System.Net.Http.Headers.HttpResponseHeaders!
 Refit.ApiException.ReasonPhrase.get -> string?
 Refit.ApiException.StatusCode.get -> System.Net.HttpStatusCode
-Refit.ApiExceptionBase
-Refit.ApiExceptionBase.ApiExceptionBase(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings, System.Exception! innerException) -> void
-Refit.ApiExceptionBase.ApiExceptionBase(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings) -> void
-Refit.ApiExceptionBase.ApiExceptionBase(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings, System.Exception? innerException) -> void
-Refit.ApiExceptionBase.HttpMethod.get -> System.Net.Http.HttpMethod!
-Refit.ApiExceptionBase.RefitSettings.get -> Refit.RefitSettings!
-Refit.ApiExceptionBase.RequestMessage.get -> System.Net.Http.HttpRequestMessage!
-Refit.ApiExceptionBase.Uri.get -> System.Uri?
 Refit.ApiRequestException
-Refit.ApiRequestException.ApiRequestException(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings, System.Exception! innerException) -> void
-Refit.ApiRequestException.ApiRequestException(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings) -> void
 Refit.ApiRequestException.ApiRequestException(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings, System.Exception? innerException) -> void
+Refit.ApiRequestException.ApiRequestException(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings) -> void
+Refit.ApiRequestException.ApiRequestException(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings, System.Exception! innerException) -> void
+Refit.ApiResponseExtensions
+Refit.ApiResponseExtensions.extension<T>(Refit.IApiResponse<T>!)
+Refit.ApiResponseExtensions.extension<T>(Refit.IApiResponse<T>!).EnsureSuccessfulAsync() -> System.Threading.Tasks.Task<Refit.IApiResponse<T>!>!
+Refit.ApiResponseExtensions.extension<T>(Refit.IApiResponse<T>!).EnsureSuccessStatusCodeAsync() -> System.Threading.Tasks.Task<Refit.IApiResponse<T>!>!
 Refit.ApiResponse<T>
 Refit.ApiResponse<T>.ApiResponse(System.Net.Http.HttpRequestMessage! request, System.Net.Http.HttpResponseMessage? response, T? content, Refit.RefitSettings! settings, Refit.ApiExceptionBase? error = null) -> void
-Refit.ApiResponse<T>.ApiResponse(System.Net.Http.HttpResponseMessage! response, T? content, Refit.RefitSettings! settings) -> void
 Refit.ApiResponse<T>.ApiResponse(System.Net.Http.HttpResponseMessage! response, T? content, Refit.RefitSettings! settings, Refit.ApiExceptionBase? error) -> void
+Refit.ApiResponse<T>.ApiResponse(System.Net.Http.HttpResponseMessage! response, T? content, Refit.RefitSettings! settings) -> void
 Refit.ApiResponse<T>.Content.get -> T?
 Refit.ApiResponse<T>.ContentHeaders.get -> System.Net.Http.Headers.HttpContentHeaders?
 Refit.ApiResponse<T>.Dispose() -> void
-Refit.ApiResponse<T>.EnsureSuccessStatusCodeAsync() -> System.Threading.Tasks.Task<Refit.ApiResponse<T>!>!
 Refit.ApiResponse<T>.EnsureSuccessfulAsync() -> System.Threading.Tasks.Task<Refit.ApiResponse<T>!>!
+Refit.ApiResponse<T>.EnsureSuccessStatusCodeAsync() -> System.Threading.Tasks.Task<Refit.ApiResponse<T>!>!
 Refit.ApiResponse<T>.Error.get -> Refit.ApiExceptionBase?
 Refit.ApiResponse<T>.HasContent.get -> bool
 Refit.ApiResponse<T>.HasRequestError(out Refit.ApiRequestException? error) -> bool
 Refit.ApiResponse<T>.HasResponseError(out Refit.ApiException? error) -> bool
 Refit.ApiResponse<T>.Headers.get -> System.Net.Http.Headers.HttpResponseHeaders?
 Refit.ApiResponse<T>.IsReceived.get -> bool
-Refit.ApiResponse<T>.IsSuccessStatusCode.get -> bool
 Refit.ApiResponse<T>.IsSuccessful.get -> bool
+Refit.ApiResponse<T>.IsSuccessStatusCode.get -> bool
 Refit.ApiResponse<T>.ReasonPhrase.get -> string?
 Refit.ApiResponse<T>.RequestMessage.get -> System.Net.Http.HttpRequestMessage!
 Refit.ApiResponse<T>.Settings.get -> Refit.RefitSettings!
 Refit.ApiResponse<T>.StatusCode.get -> System.Net.HttpStatusCode?
 Refit.ApiResponse<T>.Version.get -> System.Version?
-Refit.ApiResponseExtensions
-Refit.ApiResponseExtensions.extension<T>(Refit.IApiResponse<T>!)
-Refit.ApiResponseExtensions.extension<T>(Refit.IApiResponse<T>!).EnsureSuccessStatusCodeAsync() -> System.Threading.Tasks.Task<Refit.IApiResponse<T>!>!
-Refit.ApiResponseExtensions.extension<T>(Refit.IApiResponse<T>!).EnsureSuccessfulAsync() -> System.Threading.Tasks.Task<Refit.IApiResponse<T>!>!
 Refit.AttachmentNameAttribute
 Refit.AttachmentNameAttribute.AttachmentNameAttribute(string! name) -> void
 Refit.AttachmentNameAttribute.Name.get -> string!
@@ -60,10 +77,10 @@ Refit.AuthorizeAttribute
 Refit.AuthorizeAttribute.AuthorizeAttribute(string! scheme = "Bearer") -> void
 Refit.AuthorizeAttribute.Scheme.get -> string!
 Refit.BodyAttribute
-Refit.BodyAttribute.BodyAttribute() -> void
-Refit.BodyAttribute.BodyAttribute(Refit.BodySerializationMethod serializationMethod) -> void
-Refit.BodyAttribute.BodyAttribute(Refit.BodySerializationMethod serializationMethod, bool buffered) -> void
 Refit.BodyAttribute.BodyAttribute(bool buffered) -> void
+Refit.BodyAttribute.BodyAttribute(Refit.BodySerializationMethod serializationMethod, bool buffered) -> void
+Refit.BodyAttribute.BodyAttribute(Refit.BodySerializationMethod serializationMethod) -> void
+Refit.BodyAttribute.BodyAttribute() -> void
 Refit.BodyAttribute.Buffered.get -> bool?
 Refit.BodyAttribute.SerializationMethod.get -> Refit.BodySerializationMethod
 Refit.BodySerializationMethod
@@ -107,13 +124,13 @@ Refit.GetAttribute.GetAttribute(string! path) -> void
 Refit.HeadAttribute
 Refit.HeadAttribute.HeadAttribute(string! path) -> void
 Refit.HeaderAttribute
-Refit.HeaderAttribute.Header.get -> string!
 Refit.HeaderAttribute.HeaderAttribute(string! header) -> void
+Refit.HeaderAttribute.Header.get -> string!
 Refit.HeaderCollectionAttribute
 Refit.HeaderCollectionAttribute.HeaderCollectionAttribute() -> void
 Refit.HeadersAttribute
-Refit.HeadersAttribute.Headers.get -> string![]!
 Refit.HeadersAttribute.HeadersAttribute(params string![]! headers) -> void
+Refit.HeadersAttribute.Headers.get -> string![]!
 Refit.HttpMethodAttribute
 Refit.HttpMethodAttribute.HttpMethodAttribute(string! path) -> void
 Refit.HttpRequestMessageOptions
@@ -124,15 +141,15 @@ Refit.IApiResponse.HasRequestError(out Refit.ApiRequestException? error) -> bool
 Refit.IApiResponse.HasResponseError(out Refit.ApiException? error) -> bool
 Refit.IApiResponse.Headers.get -> System.Net.Http.Headers.HttpResponseHeaders?
 Refit.IApiResponse.IsReceived.get -> bool
-Refit.IApiResponse.IsSuccessStatusCode.get -> bool
 Refit.IApiResponse.IsSuccessful.get -> bool
+Refit.IApiResponse.IsSuccessStatusCode.get -> bool
 Refit.IApiResponse.ReasonPhrase.get -> string?
 Refit.IApiResponse.RequestMessage.get -> System.Net.Http.HttpRequestMessage?
 Refit.IApiResponse.StatusCode.get -> System.Net.HttpStatusCode?
-Refit.IApiResponse.Version.get -> System.Version?
 Refit.IApiResponse<T>
 Refit.IApiResponse<T>.Content.get -> T?
 Refit.IApiResponse<T>.HasContent.get -> bool
+Refit.IApiResponse.Version.get -> System.Version?
 Refit.IFormUrlEncodedParameterFormatter
 Refit.IFormUrlEncodedParameterFormatter.Format(object? value, string? formatString) -> string?
 Refit.IHttpContentSerializer
@@ -143,6 +160,11 @@ Refit.IRequestBuilder
 Refit.IRequestBuilder.BuildRestResultFuncForMethod(string! methodName, System.Type![]? parameterTypes = null, System.Type![]? genericArgumentTypes = null) -> System.Func<System.Net.Http.HttpClient!, object![]!, object?>!
 Refit.IRequestBuilder.Settings.get -> Refit.RefitSettings!
 Refit.IRequestBuilder<T>
+Refit.IStreamingContentSerializer
+Refit.IStreamingContentSerializer.DeserializeStreamAsync<T>(System.IO.Stream! stream, Refit.StreamingContentFormat format, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<T?>!
+Refit.ISynchronousContentSerializer
+Refit.ISynchronousContentSerializer.ToHttpContentSynchronous<T>(T item) -> System.Net.Http.HttpContent!
+Refit.ISynchronousContentSerializer.ToStreamingHttpContent<T>(T item) -> System.Net.Http.HttpContent!
 Refit.IUrlParameterFormatter
 Refit.IUrlParameterFormatter.Format(object? value, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string?
 Refit.IUrlParameterKeyFormatter
@@ -163,8 +185,8 @@ Refit.MultipartAttribute.MultipartAttribute(string! boundaryText = "----MyGreatB
 Refit.MultipartItem
 Refit.MultipartItem.ContentType.get -> string?
 Refit.MultipartItem.FileName.get -> string!
-Refit.MultipartItem.MultipartItem(string! fileName, string? contentType) -> void
 Refit.MultipartItem.MultipartItem(string! fileName, string? contentType, string? name) -> void
+Refit.MultipartItem.MultipartItem(string! fileName, string? contentType) -> void
 Refit.MultipartItem.Name.get -> string?
 Refit.MultipartItem.ToContent() -> System.Net.Http.HttpContent!
 Refit.ObjectToInferredTypesConverter
@@ -196,8 +218,8 @@ Refit.ProblemDetails.Type.get -> string?
 Refit.ProblemDetails.Type.set -> void
 Refit.PropertyAttribute
 Refit.PropertyAttribute.Key.get -> string?
-Refit.PropertyAttribute.PropertyAttribute() -> void
 Refit.PropertyAttribute.PropertyAttribute(string! key) -> void
+Refit.PropertyAttribute.PropertyAttribute() -> void
 Refit.PutAttribute
 Refit.PutAttribute.PutAttribute(string! path) -> void
 Refit.QueryAttribute
@@ -208,17 +230,19 @@ Refit.QueryAttribute.Format.get -> string?
 Refit.QueryAttribute.Format.set -> void
 Refit.QueryAttribute.IsCollectionFormatSpecified.get -> bool
 Refit.QueryAttribute.Prefix.get -> string?
-Refit.QueryAttribute.QueryAttribute() -> void
 Refit.QueryAttribute.QueryAttribute(Refit.CollectionFormat collectionFormat) -> void
-Refit.QueryAttribute.QueryAttribute(string! delimiter) -> void
-Refit.QueryAttribute.QueryAttribute(string! delimiter, string! prefix) -> void
 Refit.QueryAttribute.QueryAttribute(string! delimiter, string! prefix, string! format) -> void
+Refit.QueryAttribute.QueryAttribute(string! delimiter, string! prefix) -> void
+Refit.QueryAttribute.QueryAttribute(string! delimiter) -> void
+Refit.QueryAttribute.QueryAttribute() -> void
 Refit.QueryAttribute.TreatAsString.get -> bool
 Refit.QueryAttribute.TreatAsString.set -> void
 Refit.QueryUriFormatAttribute
 Refit.QueryUriFormatAttribute.QueryUriFormatAttribute(System.UriFormat uriFormat) -> void
 Refit.QueryUriFormatAttribute.UriFormat.get -> System.UriFormat
 Refit.RefitSettings
+Refit.RefitSettings.AllowUnmatchedRouteParameters.get -> bool
+Refit.RefitSettings.AllowUnmatchedRouteParameters.set -> void
 Refit.RefitSettings.AuthorizationHeaderValueGetter.get -> System.Func<System.Net.Http.HttpRequestMessage!, System.Threading.CancellationToken, System.Threading.Tasks.Task<string!>!>?
 Refit.RefitSettings.AuthorizationHeaderValueGetter.set -> void
 Refit.RefitSettings.Buffered.get -> bool
@@ -237,19 +261,27 @@ Refit.RefitSettings.HttpMessageHandlerFactory.get -> System.Func<System.Net.Http
 Refit.RefitSettings.HttpMessageHandlerFactory.set -> void
 Refit.RefitSettings.HttpRequestMessageOptions.get -> System.Collections.Generic.Dictionary<string!, object!>?
 Refit.RefitSettings.HttpRequestMessageOptions.init -> void
-Refit.RefitSettings.RefitSettings() -> void
-Refit.RefitSettings.RefitSettings(Refit.IHttpContentSerializer! contentSerializer) -> void
-Refit.RefitSettings.RefitSettings(Refit.IHttpContentSerializer! contentSerializer, Refit.IUrlParameterFormatter? urlParameterFormatter) -> void
-Refit.RefitSettings.RefitSettings(Refit.IHttpContentSerializer! contentSerializer, Refit.IUrlParameterFormatter? urlParameterFormatter, Refit.IFormUrlEncodedParameterFormatter? formUrlEncodedParameterFormatter) -> void
 Refit.RefitSettings.RefitSettings(Refit.IHttpContentSerializer! contentSerializer, Refit.IUrlParameterFormatter? urlParameterFormatter, Refit.IFormUrlEncodedParameterFormatter? formUrlEncodedParameterFormatter, Refit.IUrlParameterKeyFormatter? urlParameterKeyFormatter) -> void
+Refit.RefitSettings.RefitSettings(Refit.IHttpContentSerializer! contentSerializer, Refit.IUrlParameterFormatter? urlParameterFormatter, Refit.IFormUrlEncodedParameterFormatter? formUrlEncodedParameterFormatter) -> void
+Refit.RefitSettings.RefitSettings(Refit.IHttpContentSerializer! contentSerializer, Refit.IUrlParameterFormatter? urlParameterFormatter) -> void
+Refit.RefitSettings.RefitSettings(Refit.IHttpContentSerializer! contentSerializer) -> void
+Refit.RefitSettings.RefitSettings() -> void
+Refit.RefitSettings.RequestBodySerialization.get -> Refit.RequestBodySerializationMode
+Refit.RefitSettings.RequestBodySerialization.set -> void
 Refit.RefitSettings.UrlParameterFormatter.get -> Refit.IUrlParameterFormatter!
 Refit.RefitSettings.UrlParameterFormatter.set -> void
 Refit.RefitSettings.UrlParameterKeyFormatter.get -> Refit.IUrlParameterKeyFormatter!
 Refit.RefitSettings.UrlParameterKeyFormatter.set -> void
+Refit.RefitSettings.UrlResolution.get -> Refit.UrlResolutionMode
+Refit.RefitSettings.UrlResolution.set -> void
 Refit.RefitSettings.Version.get -> System.Version!
-Refit.RefitSettings.Version.set -> void
 Refit.RefitSettings.VersionPolicy.get -> System.Net.Http.HttpVersionPolicy
 Refit.RefitSettings.VersionPolicy.set -> void
+Refit.RefitSettings.Version.set -> void
+Refit.RequestBodySerializationMode
+Refit.RequestBodySerializationMode.Buffered = 1 -> Refit.RequestBodySerializationMode
+Refit.RequestBodySerializationMode.Default = 0 -> Refit.RequestBodySerializationMode
+Refit.RequestBodySerializationMode.Streamed = 2 -> Refit.RequestBodySerializationMode
 Refit.RequestBuilder
 Refit.RestMethodInfo
 Refit.RestMethodInfo.<Clone>$() -> Refit.RestMethodInfo!
@@ -289,45 +321,38 @@ Refit.RestService
 Refit.SnakeCaseUrlParameterKeyFormatter
 Refit.SnakeCaseUrlParameterKeyFormatter.Format(string! key) -> string!
 Refit.SnakeCaseUrlParameterKeyFormatter.SnakeCaseUrlParameterKeyFormatter() -> void
+Refit.StreamingContentFormat
+Refit.StreamingContentFormat.JsonArray = 0 -> Refit.StreamingContentFormat
+Refit.StreamingContentFormat.JsonLines = 1 -> Refit.StreamingContentFormat
 Refit.StreamPart
 Refit.StreamPart.StreamPart(System.IO.Stream! value, string! fileName, string? contentType = null, string? name = null) -> void
 Refit.StreamPart.Value.get -> System.IO.Stream!
 Refit.SystemTextJsonContentSerializer
+Refit.SystemTextJsonContentSerializer.DeserializeStreamAsync<T>(System.IO.Stream! stream, Refit.StreamingContentFormat format, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<T?>!
 Refit.SystemTextJsonContentSerializer.FromHttpContentAsync<T>(System.Net.Http.HttpContent! content, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<T?>!
 Refit.SystemTextJsonContentSerializer.GetFieldNameForProperty(System.Reflection.PropertyInfo! propertyInfo) -> string?
-Refit.SystemTextJsonContentSerializer.SystemTextJsonContentSerializer() -> void
 Refit.SystemTextJsonContentSerializer.SystemTextJsonContentSerializer(System.Text.Json.JsonSerializerOptions! jsonSerializerOptions) -> void
+Refit.SystemTextJsonContentSerializer.SystemTextJsonContentSerializer() -> void
+Refit.SystemTextJsonContentSerializer.ToHttpContentSynchronous<T>(T item) -> System.Net.Http.HttpContent!
 Refit.SystemTextJsonContentSerializer.ToHttpContent<T>(T item) -> System.Net.Http.HttpContent!
+Refit.SystemTextJsonContentSerializer.ToStreamingHttpContent<T>(T item) -> System.Net.Http.HttpContent!
+Refit.UrlResolutionMode
+Refit.UrlResolutionMode.RefitLegacy = 0 -> Refit.UrlResolutionMode
+Refit.UrlResolutionMode.Rfc3986 = 1 -> Refit.UrlResolutionMode
 Refit.ValidationApiException
 Refit.ValidationApiException.Content.get -> Refit.ProblemDetails?
-Refit.ValidationApiException.ValidationApiException(string! message) -> void
 Refit.ValidationApiException.ValidationApiException(string! message, System.Exception! innerException) -> void
-abstract Refit.HttpMethodAttribute.Method.get -> System.Net.Http.HttpMethod!
-abstract Refit.MultipartItem.CreateContent() -> System.Net.Http.HttpContent!
-override Refit.ByteArrayPart.CreateContent() -> System.Net.Http.HttpContent!
-override Refit.DeleteAttribute.Method.get -> System.Net.Http.HttpMethod!
-override Refit.FileInfoPart.CreateContent() -> System.Net.Http.HttpContent!
-override Refit.GetAttribute.Method.get -> System.Net.Http.HttpMethod!
-override Refit.HeadAttribute.Method.get -> System.Net.Http.HttpMethod!
-override Refit.ObjectToInferredTypesConverter.Read(ref System.Text.Json.Utf8JsonReader reader, System.Type! typeToConvert, System.Text.Json.JsonSerializerOptions! options) -> object?
-override Refit.ObjectToInferredTypesConverter.Write(System.Text.Json.Utf8JsonWriter! writer, object! value, System.Text.Json.JsonSerializerOptions! options) -> void
-override Refit.OptionsAttribute.Method.get -> System.Net.Http.HttpMethod!
-override Refit.PatchAttribute.Method.get -> System.Net.Http.HttpMethod!
-override Refit.PostAttribute.Method.get -> System.Net.Http.HttpMethod!
-override Refit.PutAttribute.Method.get -> System.Net.Http.HttpMethod!
-override Refit.RestMethodInfo.Equals(object? obj) -> bool
-override Refit.RestMethodInfo.GetHashCode() -> int
-override Refit.RestMethodInfo.ToString() -> string!
-override Refit.StreamPart.CreateContent() -> System.Net.Http.HttpContent!
-static Refit.ApiException.Create(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, System.Net.Http.HttpResponseMessage! response, Refit.RefitSettings! refitSettings) -> System.Threading.Tasks.Task<Refit.ApiException!>!
-static Refit.ApiException.Create(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, System.Net.Http.HttpResponseMessage! response, Refit.RefitSettings! refitSettings, System.Exception? innerException) -> System.Threading.Tasks.Task<Refit.ApiException!>!
-static Refit.ApiException.Create(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, System.Net.Http.HttpResponseMessage! response, Refit.RefitSettings! refitSettings) -> System.Threading.Tasks.Task<Refit.ApiException!>!
+Refit.ValidationApiException.ValidationApiException(string! message) -> void
 static Refit.ApiException.Create(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, System.Net.Http.HttpResponseMessage! response, Refit.RefitSettings! refitSettings, System.Exception? innerException) -> System.Threading.Tasks.Task<Refit.ApiException!>!
-static Refit.ApiResponseExtensions.EnsureSuccessStatusCodeAsync<T>(this Refit.IApiResponse<T>! response) -> System.Threading.Tasks.Task<Refit.IApiResponse<T>!>!
+static Refit.ApiException.Create(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, System.Net.Http.HttpResponseMessage! response, Refit.RefitSettings! refitSettings) -> System.Threading.Tasks.Task<Refit.ApiException!>!
+static Refit.ApiException.Create(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, System.Net.Http.HttpResponseMessage! response, Refit.RefitSettings! refitSettings, System.Exception? innerException) -> System.Threading.Tasks.Task<Refit.ApiException!>!
+static Refit.ApiException.Create(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, System.Net.Http.HttpResponseMessage! response, Refit.RefitSettings! refitSettings) -> System.Threading.Tasks.Task<Refit.ApiException!>!
 static Refit.ApiResponseExtensions.EnsureSuccessfulAsync<T>(this Refit.IApiResponse<T>! response) -> System.Threading.Tasks.Task<Refit.IApiResponse<T>!>!
+static Refit.ApiResponseExtensions.EnsureSuccessStatusCodeAsync<T>(this Refit.IApiResponse<T>! response) -> System.Threading.Tasks.Task<Refit.IApiResponse<T>!>!
 static Refit.GeneratedRequestRunner.AddConfiguredRequestOptions(System.Net.Http.HttpRequestMessage! request, Refit.RefitSettings! settings, System.Type! interfaceType) -> void
 static Refit.GeneratedRequestRunner.AddHeaderCollection(System.Net.Http.HttpRequestMessage! request, System.Collections.Generic.IDictionary<string!, string!>? headers) -> void
 static Refit.GeneratedRequestRunner.AddRequestProperty<TValue>(System.Net.Http.HttpRequestMessage! request, string! key, TValue value) -> void
+static Refit.GeneratedRequestRunner.BuildRelativeUri(System.Net.Http.HttpClient! client, string! relativePath, Refit.UrlResolutionMode urlResolution) -> System.Uri!
 static Refit.GeneratedRequestRunner.CreateBodyContent<TBody>(Refit.RefitSettings! settings, TBody body, Refit.BodySerializationMethod serializationMethod, bool streamBody) -> System.Net.Http.HttpContent!
 static Refit.GeneratedRequestRunner.CreateJsonLinesBodyContent<TBody>(Refit.RefitSettings! settings, TBody body) -> System.Net.Http.HttpContent!
 static Refit.GeneratedRequestRunner.CreateUrlEncodedBodyContent<TBody>(Refit.RefitSettings! settings, TBody body) -> System.Net.Http.HttpContent!
@@ -347,26 +372,27 @@ static Refit.RequestBuilder.ForType<T>(Refit.RefitSettings? settings) -> Refit.I
 static Refit.RestMethodInfo.operator !=(Refit.RestMethodInfo? left, Refit.RestMethodInfo? right) -> bool
 static Refit.RestMethodInfo.operator ==(Refit.RestMethodInfo? left, Refit.RestMethodInfo? right) -> bool
 static Refit.RestService.CreateHttpClient(string! hostUrl, Refit.RefitSettings? settings) -> System.Net.Http.HttpClient!
+static Refit.RestService.ForGenerated(System.Type! refitInterfaceType, string! hostUrl, Refit.RefitSettings! settings) -> object!
+static Refit.RestService.ForGenerated(System.Type! refitInterfaceType, System.Net.Http.HttpClient! client, Refit.RefitSettings! settings) -> object!
+static Refit.RestService.ForGenerated<T>(string! hostUrl, Refit.RefitSettings! settings) -> T
+static Refit.RestService.ForGenerated<T>(string! hostUrl) -> T
+static Refit.RestService.ForGenerated<T>(System.Net.Http.HttpClient! client, Refit.RefitSettings! settings) -> T
+static Refit.RestService.ForGenerated<T>(System.Net.Http.HttpClient! client) -> T
+static Refit.RestService.For(System.Type! refitInterfaceType, string! hostUrl) -> object!
+static Refit.RestService.For(System.Type! refitInterfaceType, string! hostUrl, Refit.RefitSettings? settings) -> object!
 static Refit.RestService.For(System.Type! refitInterfaceType, System.Net.Http.HttpClient! client) -> object!
 static Refit.RestService.For(System.Type! refitInterfaceType, System.Net.Http.HttpClient! client, Refit.IRequestBuilder! builder) -> object!
 static Refit.RestService.For(System.Type! refitInterfaceType, System.Net.Http.HttpClient! client, Refit.RefitSettings? settings) -> object!
-static Refit.RestService.For(System.Type! refitInterfaceType, string! hostUrl) -> object!
-static Refit.RestService.For(System.Type! refitInterfaceType, string! hostUrl, Refit.RefitSettings? settings) -> object!
-static Refit.RestService.For<T>(System.Net.Http.HttpClient! client) -> T
+static Refit.RestService.For<T>(string! hostUrl, Refit.RefitSettings? settings) -> T
+static Refit.RestService.For<T>(string! hostUrl) -> T
 static Refit.RestService.For<T>(System.Net.Http.HttpClient! client, Refit.IRequestBuilder<T>! builder) -> T
 static Refit.RestService.For<T>(System.Net.Http.HttpClient! client, Refit.RefitSettings? settings) -> T
-static Refit.RestService.For<T>(string! hostUrl) -> T
-static Refit.RestService.For<T>(string! hostUrl, Refit.RefitSettings? settings) -> T
-static Refit.RestService.ForGenerated(System.Type! refitInterfaceType, System.Net.Http.HttpClient! client, Refit.RefitSettings! settings) -> object!
-static Refit.RestService.ForGenerated(System.Type! refitInterfaceType, string! hostUrl, Refit.RefitSettings! settings) -> object!
-static Refit.RestService.ForGenerated<T>(System.Net.Http.HttpClient! client) -> T
-static Refit.RestService.ForGenerated<T>(System.Net.Http.HttpClient! client, Refit.RefitSettings! settings) -> T
-static Refit.RestService.ForGenerated<T>(string! hostUrl) -> T
-static Refit.RestService.ForGenerated<T>(string! hostUrl, Refit.RefitSettings! settings) -> T
+static Refit.RestService.For<T>(System.Net.Http.HttpClient! client) -> T
 static Refit.RestService.RegisterGeneratedFactory(System.Type! refitInterfaceType, System.Func<System.Net.Http.HttpClient!, Refit.IRequestBuilder!, object!>! factory) -> void
 static Refit.RestService.RegisterGeneratedFactory<T>(System.Func<System.Net.Http.HttpClient!, Refit.IRequestBuilder!, T>! factory) -> void
 static Refit.RestService.RegisterGeneratedSettingsFactory<T>(System.Func<System.Net.Http.HttpClient!, Refit.RefitSettings!, T>! factory) -> void
 static Refit.SystemTextJsonContentSerializer.GetDefaultJsonSerializerOptions() -> System.Text.Json.JsonSerializerOptions!
+static Refit.SystemTextJsonContentSerializer.GetFastPathJsonSerializerOptions() -> System.Text.Json.JsonSerializerOptions!
 static Refit.ValidationApiException.Create(Refit.ApiException! exception) -> Refit.ValidationApiException!
 virtual Refit.DefaultFormUrlEncodedParameterFormatter.Format(object? value, string? formatString) -> string?
 virtual Refit.DefaultUrlParameterFormatter.Format(object? value, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string?

--- a/src/Refit/PublicAPI/net11.0/PublicAPI.Shipped.txt
+++ b/src/Refit/PublicAPI/net11.0/PublicAPI.Shipped.txt
@@ -359,6 +359,7 @@ static Refit.GeneratedRequestRunner.CreateUrlEncodedBodyContent<TBody>(Refit.Ref
 static Refit.GeneratedRequestRunner.SendAsync<T, TBody>(System.Net.Http.HttpClient! client, System.Net.Http.HttpRequestMessage! request, Refit.RefitSettings! settings, bool isApiResponse, bool shouldDisposeResponse, bool bufferBody, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<T?>!
 static Refit.GeneratedRequestRunner.SendVoidAsync(System.Net.Http.HttpClient! client, System.Net.Http.HttpRequestMessage! request, Refit.RefitSettings! settings, bool bufferBody, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 static Refit.GeneratedRequestRunner.SetHeader(System.Net.Http.HttpRequestMessage! request, string! name, string? value) -> void
+static Refit.GeneratedRequestRunner.StreamAsync<T>(System.Net.Http.HttpClient! client, System.Net.Http.HttpRequestMessage! request, Refit.RefitSettings! settings, System.Threading.CancellationToken methodCancellationToken, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<T?>!
 static Refit.HttpRequestMessageOptions.InterfaceType.get -> string!
 static Refit.HttpRequestMessageOptions.RestMethodInfo.get -> string!
 static Refit.JsonLinesContent.JsonLinesMediaType.get -> string!

--- a/src/Refit/PublicAPI/net462/PublicAPI.Shipped.txt
+++ b/src/Refit/PublicAPI/net462/PublicAPI.Shipped.txt
@@ -355,6 +355,7 @@ static Refit.GeneratedRequestRunner.CreateUrlEncodedBodyContent<TBody>(Refit.Ref
 static Refit.GeneratedRequestRunner.SendAsync<T, TBody>(System.Net.Http.HttpClient! client, System.Net.Http.HttpRequestMessage! request, Refit.RefitSettings! settings, bool isApiResponse, bool shouldDisposeResponse, bool bufferBody, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<T?>!
 static Refit.GeneratedRequestRunner.SendVoidAsync(System.Net.Http.HttpClient! client, System.Net.Http.HttpRequestMessage! request, Refit.RefitSettings! settings, bool bufferBody, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 static Refit.GeneratedRequestRunner.SetHeader(System.Net.Http.HttpRequestMessage! request, string! name, string? value) -> void
+static Refit.GeneratedRequestRunner.StreamAsync<T>(System.Net.Http.HttpClient! client, System.Net.Http.HttpRequestMessage! request, Refit.RefitSettings! settings, System.Threading.CancellationToken methodCancellationToken, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<T?>!
 static Refit.HttpRequestMessageOptions.InterfaceType.get -> string!
 static Refit.HttpRequestMessageOptions.RestMethodInfo.get -> string!
 static Refit.JsonLinesContent.JsonLinesMediaType.get -> string!

--- a/src/Refit/PublicAPI/net462/PublicAPI.Shipped.txt
+++ b/src/Refit/PublicAPI/net462/PublicAPI.Shipped.txt
@@ -1,12 +1,37 @@
 #nullable enable
+abstract Refit.HttpMethodAttribute.Method.get -> System.Net.Http.HttpMethod!
+abstract Refit.MultipartItem.CreateContent() -> System.Net.Http.HttpContent!
+override Refit.ByteArrayPart.CreateContent() -> System.Net.Http.HttpContent!
+override Refit.DeleteAttribute.Method.get -> System.Net.Http.HttpMethod!
+override Refit.FileInfoPart.CreateContent() -> System.Net.Http.HttpContent!
+override Refit.GetAttribute.Method.get -> System.Net.Http.HttpMethod!
+override Refit.HeadAttribute.Method.get -> System.Net.Http.HttpMethod!
+override Refit.ObjectToInferredTypesConverter.Read(ref System.Text.Json.Utf8JsonReader reader, System.Type! typeToConvert, System.Text.Json.JsonSerializerOptions! options) -> object?
+override Refit.ObjectToInferredTypesConverter.Write(System.Text.Json.Utf8JsonWriter! writer, object! value, System.Text.Json.JsonSerializerOptions! options) -> void
+override Refit.OptionsAttribute.Method.get -> System.Net.Http.HttpMethod!
+override Refit.PatchAttribute.Method.get -> System.Net.Http.HttpMethod!
+override Refit.PostAttribute.Method.get -> System.Net.Http.HttpMethod!
+override Refit.PutAttribute.Method.get -> System.Net.Http.HttpMethod!
+override Refit.RestMethodInfo.Equals(object? obj) -> bool
+override Refit.RestMethodInfo.GetHashCode() -> int
+override Refit.RestMethodInfo.ToString() -> string!
+override Refit.StreamPart.CreateContent() -> System.Net.Http.HttpContent!
 Refit.AliasAsAttribute
 Refit.AliasAsAttribute.AliasAsAttribute(string! name) -> void
 Refit.AliasAsAttribute.Name.get -> string!
 Refit.ApiException
-Refit.ApiException.ApiException(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, string? content, System.Net.HttpStatusCode statusCode, string? reasonPhrase, System.Net.Http.Headers.HttpResponseHeaders! headers, Refit.RefitSettings! refitSettings) -> void
-Refit.ApiException.ApiException(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, string? content, System.Net.HttpStatusCode statusCode, string? reasonPhrase, System.Net.Http.Headers.HttpResponseHeaders! headers, Refit.RefitSettings! refitSettings, System.Exception? innerException) -> void
-Refit.ApiException.ApiException(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, string? content, System.Net.HttpStatusCode statusCode, string? reasonPhrase, System.Net.Http.Headers.HttpResponseHeaders! headers, Refit.RefitSettings! refitSettings) -> void
 Refit.ApiException.ApiException(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, string? content, System.Net.HttpStatusCode statusCode, string? reasonPhrase, System.Net.Http.Headers.HttpResponseHeaders! headers, Refit.RefitSettings! refitSettings, System.Exception? innerException) -> void
+Refit.ApiException.ApiException(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, string? content, System.Net.HttpStatusCode statusCode, string? reasonPhrase, System.Net.Http.Headers.HttpResponseHeaders! headers, Refit.RefitSettings! refitSettings) -> void
+Refit.ApiException.ApiException(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, string? content, System.Net.HttpStatusCode statusCode, string? reasonPhrase, System.Net.Http.Headers.HttpResponseHeaders! headers, Refit.RefitSettings! refitSettings, System.Exception? innerException) -> void
+Refit.ApiException.ApiException(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, string? content, System.Net.HttpStatusCode statusCode, string? reasonPhrase, System.Net.Http.Headers.HttpResponseHeaders! headers, Refit.RefitSettings! refitSettings) -> void
+Refit.ApiExceptionBase
+Refit.ApiExceptionBase.ApiExceptionBase(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings, System.Exception? innerException) -> void
+Refit.ApiExceptionBase.ApiExceptionBase(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings) -> void
+Refit.ApiExceptionBase.ApiExceptionBase(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings, System.Exception! innerException) -> void
+Refit.ApiExceptionBase.HttpMethod.get -> System.Net.Http.HttpMethod!
+Refit.ApiExceptionBase.RefitSettings.get -> Refit.RefitSettings!
+Refit.ApiExceptionBase.RequestMessage.get -> System.Net.Http.HttpRequestMessage!
+Refit.ApiExceptionBase.Uri.get -> System.Uri?
 Refit.ApiException.Content.get -> string?
 Refit.ApiException.ContentHeaders.get -> System.Net.Http.Headers.HttpContentHeaders?
 Refit.ApiException.ContentHeaders.set -> void
@@ -15,44 +40,36 @@ Refit.ApiException.HasContent.get -> bool
 Refit.ApiException.Headers.get -> System.Net.Http.Headers.HttpResponseHeaders!
 Refit.ApiException.ReasonPhrase.get -> string?
 Refit.ApiException.StatusCode.get -> System.Net.HttpStatusCode
-Refit.ApiExceptionBase
-Refit.ApiExceptionBase.ApiExceptionBase(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings, System.Exception! innerException) -> void
-Refit.ApiExceptionBase.ApiExceptionBase(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings) -> void
-Refit.ApiExceptionBase.ApiExceptionBase(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings, System.Exception? innerException) -> void
-Refit.ApiExceptionBase.HttpMethod.get -> System.Net.Http.HttpMethod!
-Refit.ApiExceptionBase.RefitSettings.get -> Refit.RefitSettings!
-Refit.ApiExceptionBase.RequestMessage.get -> System.Net.Http.HttpRequestMessage!
-Refit.ApiExceptionBase.Uri.get -> System.Uri?
 Refit.ApiRequestException
-Refit.ApiRequestException.ApiRequestException(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings, System.Exception! innerException) -> void
-Refit.ApiRequestException.ApiRequestException(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings) -> void
 Refit.ApiRequestException.ApiRequestException(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings, System.Exception? innerException) -> void
+Refit.ApiRequestException.ApiRequestException(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings) -> void
+Refit.ApiRequestException.ApiRequestException(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings, System.Exception! innerException) -> void
+Refit.ApiResponseExtensions
+Refit.ApiResponseExtensions.extension<T>(Refit.IApiResponse<T>!)
+Refit.ApiResponseExtensions.extension<T>(Refit.IApiResponse<T>!).EnsureSuccessfulAsync() -> System.Threading.Tasks.Task<Refit.IApiResponse<T>!>!
+Refit.ApiResponseExtensions.extension<T>(Refit.IApiResponse<T>!).EnsureSuccessStatusCodeAsync() -> System.Threading.Tasks.Task<Refit.IApiResponse<T>!>!
 Refit.ApiResponse<T>
 Refit.ApiResponse<T>.ApiResponse(System.Net.Http.HttpRequestMessage! request, System.Net.Http.HttpResponseMessage? response, T? content, Refit.RefitSettings! settings, Refit.ApiExceptionBase? error = null) -> void
-Refit.ApiResponse<T>.ApiResponse(System.Net.Http.HttpResponseMessage! response, T? content, Refit.RefitSettings! settings) -> void
 Refit.ApiResponse<T>.ApiResponse(System.Net.Http.HttpResponseMessage! response, T? content, Refit.RefitSettings! settings, Refit.ApiExceptionBase? error) -> void
+Refit.ApiResponse<T>.ApiResponse(System.Net.Http.HttpResponseMessage! response, T? content, Refit.RefitSettings! settings) -> void
 Refit.ApiResponse<T>.Content.get -> T?
 Refit.ApiResponse<T>.ContentHeaders.get -> System.Net.Http.Headers.HttpContentHeaders?
 Refit.ApiResponse<T>.Dispose() -> void
-Refit.ApiResponse<T>.EnsureSuccessStatusCodeAsync() -> System.Threading.Tasks.Task<Refit.ApiResponse<T>!>!
 Refit.ApiResponse<T>.EnsureSuccessfulAsync() -> System.Threading.Tasks.Task<Refit.ApiResponse<T>!>!
+Refit.ApiResponse<T>.EnsureSuccessStatusCodeAsync() -> System.Threading.Tasks.Task<Refit.ApiResponse<T>!>!
 Refit.ApiResponse<T>.Error.get -> Refit.ApiExceptionBase?
 Refit.ApiResponse<T>.HasContent.get -> bool
 Refit.ApiResponse<T>.HasRequestError(out Refit.ApiRequestException? error) -> bool
 Refit.ApiResponse<T>.HasResponseError(out Refit.ApiException? error) -> bool
 Refit.ApiResponse<T>.Headers.get -> System.Net.Http.Headers.HttpResponseHeaders?
 Refit.ApiResponse<T>.IsReceived.get -> bool
-Refit.ApiResponse<T>.IsSuccessStatusCode.get -> bool
 Refit.ApiResponse<T>.IsSuccessful.get -> bool
+Refit.ApiResponse<T>.IsSuccessStatusCode.get -> bool
 Refit.ApiResponse<T>.ReasonPhrase.get -> string?
 Refit.ApiResponse<T>.RequestMessage.get -> System.Net.Http.HttpRequestMessage!
 Refit.ApiResponse<T>.Settings.get -> Refit.RefitSettings!
 Refit.ApiResponse<T>.StatusCode.get -> System.Net.HttpStatusCode?
 Refit.ApiResponse<T>.Version.get -> System.Version?
-Refit.ApiResponseExtensions
-Refit.ApiResponseExtensions.extension<T>(Refit.IApiResponse<T>!)
-Refit.ApiResponseExtensions.extension<T>(Refit.IApiResponse<T>!).EnsureSuccessStatusCodeAsync() -> System.Threading.Tasks.Task<Refit.IApiResponse<T>!>!
-Refit.ApiResponseExtensions.extension<T>(Refit.IApiResponse<T>!).EnsureSuccessfulAsync() -> System.Threading.Tasks.Task<Refit.IApiResponse<T>!>!
 Refit.AttachmentNameAttribute
 Refit.AttachmentNameAttribute.AttachmentNameAttribute(string! name) -> void
 Refit.AttachmentNameAttribute.Name.get -> string!
@@ -60,10 +77,10 @@ Refit.AuthorizeAttribute
 Refit.AuthorizeAttribute.AuthorizeAttribute(string! scheme = "Bearer") -> void
 Refit.AuthorizeAttribute.Scheme.get -> string!
 Refit.BodyAttribute
-Refit.BodyAttribute.BodyAttribute() -> void
-Refit.BodyAttribute.BodyAttribute(Refit.BodySerializationMethod serializationMethod) -> void
-Refit.BodyAttribute.BodyAttribute(Refit.BodySerializationMethod serializationMethod, bool buffered) -> void
 Refit.BodyAttribute.BodyAttribute(bool buffered) -> void
+Refit.BodyAttribute.BodyAttribute(Refit.BodySerializationMethod serializationMethod, bool buffered) -> void
+Refit.BodyAttribute.BodyAttribute(Refit.BodySerializationMethod serializationMethod) -> void
+Refit.BodyAttribute.BodyAttribute() -> void
 Refit.BodyAttribute.Buffered.get -> bool?
 Refit.BodyAttribute.SerializationMethod.get -> Refit.BodySerializationMethod
 Refit.BodySerializationMethod
@@ -107,13 +124,13 @@ Refit.GetAttribute.GetAttribute(string! path) -> void
 Refit.HeadAttribute
 Refit.HeadAttribute.HeadAttribute(string! path) -> void
 Refit.HeaderAttribute
-Refit.HeaderAttribute.Header.get -> string!
 Refit.HeaderAttribute.HeaderAttribute(string! header) -> void
+Refit.HeaderAttribute.Header.get -> string!
 Refit.HeaderCollectionAttribute
 Refit.HeaderCollectionAttribute.HeaderCollectionAttribute() -> void
 Refit.HeadersAttribute
-Refit.HeadersAttribute.Headers.get -> string![]!
 Refit.HeadersAttribute.HeadersAttribute(params string![]! headers) -> void
+Refit.HeadersAttribute.Headers.get -> string![]!
 Refit.HttpMethodAttribute
 Refit.HttpMethodAttribute.HttpMethodAttribute(string! path) -> void
 Refit.HttpRequestMessageOptions
@@ -124,15 +141,15 @@ Refit.IApiResponse.HasRequestError(out Refit.ApiRequestException? error) -> bool
 Refit.IApiResponse.HasResponseError(out Refit.ApiException? error) -> bool
 Refit.IApiResponse.Headers.get -> System.Net.Http.Headers.HttpResponseHeaders?
 Refit.IApiResponse.IsReceived.get -> bool
-Refit.IApiResponse.IsSuccessStatusCode.get -> bool
 Refit.IApiResponse.IsSuccessful.get -> bool
+Refit.IApiResponse.IsSuccessStatusCode.get -> bool
 Refit.IApiResponse.ReasonPhrase.get -> string?
 Refit.IApiResponse.RequestMessage.get -> System.Net.Http.HttpRequestMessage?
 Refit.IApiResponse.StatusCode.get -> System.Net.HttpStatusCode?
-Refit.IApiResponse.Version.get -> System.Version?
 Refit.IApiResponse<T>
 Refit.IApiResponse<T>.Content.get -> T?
 Refit.IApiResponse<T>.HasContent.get -> bool
+Refit.IApiResponse.Version.get -> System.Version?
 Refit.IFormUrlEncodedParameterFormatter
 Refit.IFormUrlEncodedParameterFormatter.Format(object? value, string? formatString) -> string?
 Refit.IHttpContentSerializer
@@ -143,6 +160,11 @@ Refit.IRequestBuilder
 Refit.IRequestBuilder.BuildRestResultFuncForMethod(string! methodName, System.Type![]? parameterTypes = null, System.Type![]? genericArgumentTypes = null) -> System.Func<System.Net.Http.HttpClient!, object![]!, object?>!
 Refit.IRequestBuilder.Settings.get -> Refit.RefitSettings!
 Refit.IRequestBuilder<T>
+Refit.IStreamingContentSerializer
+Refit.IStreamingContentSerializer.DeserializeStreamAsync<T>(System.IO.Stream! stream, Refit.StreamingContentFormat format, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<T?>!
+Refit.ISynchronousContentSerializer
+Refit.ISynchronousContentSerializer.ToHttpContentSynchronous<T>(T item) -> System.Net.Http.HttpContent!
+Refit.ISynchronousContentSerializer.ToStreamingHttpContent<T>(T item) -> System.Net.Http.HttpContent!
 Refit.IUrlParameterFormatter
 Refit.IUrlParameterFormatter.Format(object? value, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string?
 Refit.IUrlParameterKeyFormatter
@@ -163,8 +185,8 @@ Refit.MultipartAttribute.MultipartAttribute(string! boundaryText = "----MyGreatB
 Refit.MultipartItem
 Refit.MultipartItem.ContentType.get -> string?
 Refit.MultipartItem.FileName.get -> string!
-Refit.MultipartItem.MultipartItem(string! fileName, string? contentType) -> void
 Refit.MultipartItem.MultipartItem(string! fileName, string? contentType, string? name) -> void
+Refit.MultipartItem.MultipartItem(string! fileName, string? contentType) -> void
 Refit.MultipartItem.Name.get -> string?
 Refit.MultipartItem.ToContent() -> System.Net.Http.HttpContent!
 Refit.ObjectToInferredTypesConverter
@@ -196,8 +218,8 @@ Refit.ProblemDetails.Type.get -> string?
 Refit.ProblemDetails.Type.set -> void
 Refit.PropertyAttribute
 Refit.PropertyAttribute.Key.get -> string?
-Refit.PropertyAttribute.PropertyAttribute() -> void
 Refit.PropertyAttribute.PropertyAttribute(string! key) -> void
+Refit.PropertyAttribute.PropertyAttribute() -> void
 Refit.PutAttribute
 Refit.PutAttribute.PutAttribute(string! path) -> void
 Refit.QueryAttribute
@@ -208,17 +230,19 @@ Refit.QueryAttribute.Format.get -> string?
 Refit.QueryAttribute.Format.set -> void
 Refit.QueryAttribute.IsCollectionFormatSpecified.get -> bool
 Refit.QueryAttribute.Prefix.get -> string?
-Refit.QueryAttribute.QueryAttribute() -> void
 Refit.QueryAttribute.QueryAttribute(Refit.CollectionFormat collectionFormat) -> void
-Refit.QueryAttribute.QueryAttribute(string! delimiter) -> void
-Refit.QueryAttribute.QueryAttribute(string! delimiter, string! prefix) -> void
 Refit.QueryAttribute.QueryAttribute(string! delimiter, string! prefix, string! format) -> void
+Refit.QueryAttribute.QueryAttribute(string! delimiter, string! prefix) -> void
+Refit.QueryAttribute.QueryAttribute(string! delimiter) -> void
+Refit.QueryAttribute.QueryAttribute() -> void
 Refit.QueryAttribute.TreatAsString.get -> bool
 Refit.QueryAttribute.TreatAsString.set -> void
 Refit.QueryUriFormatAttribute
 Refit.QueryUriFormatAttribute.QueryUriFormatAttribute(System.UriFormat uriFormat) -> void
 Refit.QueryUriFormatAttribute.UriFormat.get -> System.UriFormat
 Refit.RefitSettings
+Refit.RefitSettings.AllowUnmatchedRouteParameters.get -> bool
+Refit.RefitSettings.AllowUnmatchedRouteParameters.set -> void
 Refit.RefitSettings.AuthorizationHeaderValueGetter.get -> System.Func<System.Net.Http.HttpRequestMessage!, System.Threading.CancellationToken, System.Threading.Tasks.Task<string!>!>?
 Refit.RefitSettings.AuthorizationHeaderValueGetter.set -> void
 Refit.RefitSettings.Buffered.get -> bool
@@ -237,15 +261,23 @@ Refit.RefitSettings.HttpMessageHandlerFactory.get -> System.Func<System.Net.Http
 Refit.RefitSettings.HttpMessageHandlerFactory.set -> void
 Refit.RefitSettings.HttpRequestMessageOptions.get -> System.Collections.Generic.Dictionary<string!, object!>?
 Refit.RefitSettings.HttpRequestMessageOptions.init -> void
-Refit.RefitSettings.RefitSettings() -> void
-Refit.RefitSettings.RefitSettings(Refit.IHttpContentSerializer! contentSerializer) -> void
-Refit.RefitSettings.RefitSettings(Refit.IHttpContentSerializer! contentSerializer, Refit.IUrlParameterFormatter? urlParameterFormatter) -> void
-Refit.RefitSettings.RefitSettings(Refit.IHttpContentSerializer! contentSerializer, Refit.IUrlParameterFormatter? urlParameterFormatter, Refit.IFormUrlEncodedParameterFormatter? formUrlEncodedParameterFormatter) -> void
 Refit.RefitSettings.RefitSettings(Refit.IHttpContentSerializer! contentSerializer, Refit.IUrlParameterFormatter? urlParameterFormatter, Refit.IFormUrlEncodedParameterFormatter? formUrlEncodedParameterFormatter, Refit.IUrlParameterKeyFormatter? urlParameterKeyFormatter) -> void
+Refit.RefitSettings.RefitSettings(Refit.IHttpContentSerializer! contentSerializer, Refit.IUrlParameterFormatter? urlParameterFormatter, Refit.IFormUrlEncodedParameterFormatter? formUrlEncodedParameterFormatter) -> void
+Refit.RefitSettings.RefitSettings(Refit.IHttpContentSerializer! contentSerializer, Refit.IUrlParameterFormatter? urlParameterFormatter) -> void
+Refit.RefitSettings.RefitSettings(Refit.IHttpContentSerializer! contentSerializer) -> void
+Refit.RefitSettings.RefitSettings() -> void
+Refit.RefitSettings.RequestBodySerialization.get -> Refit.RequestBodySerializationMode
+Refit.RefitSettings.RequestBodySerialization.set -> void
 Refit.RefitSettings.UrlParameterFormatter.get -> Refit.IUrlParameterFormatter!
 Refit.RefitSettings.UrlParameterFormatter.set -> void
 Refit.RefitSettings.UrlParameterKeyFormatter.get -> Refit.IUrlParameterKeyFormatter!
 Refit.RefitSettings.UrlParameterKeyFormatter.set -> void
+Refit.RefitSettings.UrlResolution.get -> Refit.UrlResolutionMode
+Refit.RefitSettings.UrlResolution.set -> void
+Refit.RequestBodySerializationMode
+Refit.RequestBodySerializationMode.Buffered = 1 -> Refit.RequestBodySerializationMode
+Refit.RequestBodySerializationMode.Default = 0 -> Refit.RequestBodySerializationMode
+Refit.RequestBodySerializationMode.Streamed = 2 -> Refit.RequestBodySerializationMode
 Refit.RequestBuilder
 Refit.RestMethodInfo
 Refit.RestMethodInfo.<Clone>$() -> Refit.RestMethodInfo!
@@ -285,45 +317,38 @@ Refit.RestService
 Refit.SnakeCaseUrlParameterKeyFormatter
 Refit.SnakeCaseUrlParameterKeyFormatter.Format(string! key) -> string!
 Refit.SnakeCaseUrlParameterKeyFormatter.SnakeCaseUrlParameterKeyFormatter() -> void
+Refit.StreamingContentFormat
+Refit.StreamingContentFormat.JsonArray = 0 -> Refit.StreamingContentFormat
+Refit.StreamingContentFormat.JsonLines = 1 -> Refit.StreamingContentFormat
 Refit.StreamPart
 Refit.StreamPart.StreamPart(System.IO.Stream! value, string! fileName, string? contentType = null, string? name = null) -> void
 Refit.StreamPart.Value.get -> System.IO.Stream!
 Refit.SystemTextJsonContentSerializer
+Refit.SystemTextJsonContentSerializer.DeserializeStreamAsync<T>(System.IO.Stream! stream, Refit.StreamingContentFormat format, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<T?>!
 Refit.SystemTextJsonContentSerializer.FromHttpContentAsync<T>(System.Net.Http.HttpContent! content, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<T?>!
 Refit.SystemTextJsonContentSerializer.GetFieldNameForProperty(System.Reflection.PropertyInfo! propertyInfo) -> string?
-Refit.SystemTextJsonContentSerializer.SystemTextJsonContentSerializer() -> void
 Refit.SystemTextJsonContentSerializer.SystemTextJsonContentSerializer(System.Text.Json.JsonSerializerOptions! jsonSerializerOptions) -> void
+Refit.SystemTextJsonContentSerializer.SystemTextJsonContentSerializer() -> void
+Refit.SystemTextJsonContentSerializer.ToHttpContentSynchronous<T>(T item) -> System.Net.Http.HttpContent!
 Refit.SystemTextJsonContentSerializer.ToHttpContent<T>(T item) -> System.Net.Http.HttpContent!
+Refit.SystemTextJsonContentSerializer.ToStreamingHttpContent<T>(T item) -> System.Net.Http.HttpContent!
+Refit.UrlResolutionMode
+Refit.UrlResolutionMode.RefitLegacy = 0 -> Refit.UrlResolutionMode
+Refit.UrlResolutionMode.Rfc3986 = 1 -> Refit.UrlResolutionMode
 Refit.ValidationApiException
 Refit.ValidationApiException.Content.get -> Refit.ProblemDetails?
-Refit.ValidationApiException.ValidationApiException(string! message) -> void
 Refit.ValidationApiException.ValidationApiException(string! message, System.Exception! innerException) -> void
-abstract Refit.HttpMethodAttribute.Method.get -> System.Net.Http.HttpMethod!
-abstract Refit.MultipartItem.CreateContent() -> System.Net.Http.HttpContent!
-override Refit.ByteArrayPart.CreateContent() -> System.Net.Http.HttpContent!
-override Refit.DeleteAttribute.Method.get -> System.Net.Http.HttpMethod!
-override Refit.FileInfoPart.CreateContent() -> System.Net.Http.HttpContent!
-override Refit.GetAttribute.Method.get -> System.Net.Http.HttpMethod!
-override Refit.HeadAttribute.Method.get -> System.Net.Http.HttpMethod!
-override Refit.ObjectToInferredTypesConverter.Read(ref System.Text.Json.Utf8JsonReader reader, System.Type! typeToConvert, System.Text.Json.JsonSerializerOptions! options) -> object?
-override Refit.ObjectToInferredTypesConverter.Write(System.Text.Json.Utf8JsonWriter! writer, object! value, System.Text.Json.JsonSerializerOptions! options) -> void
-override Refit.OptionsAttribute.Method.get -> System.Net.Http.HttpMethod!
-override Refit.PatchAttribute.Method.get -> System.Net.Http.HttpMethod!
-override Refit.PostAttribute.Method.get -> System.Net.Http.HttpMethod!
-override Refit.PutAttribute.Method.get -> System.Net.Http.HttpMethod!
-override Refit.RestMethodInfo.Equals(object? obj) -> bool
-override Refit.RestMethodInfo.GetHashCode() -> int
-override Refit.RestMethodInfo.ToString() -> string!
-override Refit.StreamPart.CreateContent() -> System.Net.Http.HttpContent!
-static Refit.ApiException.Create(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, System.Net.Http.HttpResponseMessage! response, Refit.RefitSettings! refitSettings) -> System.Threading.Tasks.Task<Refit.ApiException!>!
-static Refit.ApiException.Create(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, System.Net.Http.HttpResponseMessage! response, Refit.RefitSettings! refitSettings, System.Exception? innerException) -> System.Threading.Tasks.Task<Refit.ApiException!>!
-static Refit.ApiException.Create(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, System.Net.Http.HttpResponseMessage! response, Refit.RefitSettings! refitSettings) -> System.Threading.Tasks.Task<Refit.ApiException!>!
+Refit.ValidationApiException.ValidationApiException(string! message) -> void
 static Refit.ApiException.Create(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, System.Net.Http.HttpResponseMessage! response, Refit.RefitSettings! refitSettings, System.Exception? innerException) -> System.Threading.Tasks.Task<Refit.ApiException!>!
-static Refit.ApiResponseExtensions.EnsureSuccessStatusCodeAsync<T>(this Refit.IApiResponse<T>! response) -> System.Threading.Tasks.Task<Refit.IApiResponse<T>!>!
+static Refit.ApiException.Create(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, System.Net.Http.HttpResponseMessage! response, Refit.RefitSettings! refitSettings) -> System.Threading.Tasks.Task<Refit.ApiException!>!
+static Refit.ApiException.Create(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, System.Net.Http.HttpResponseMessage! response, Refit.RefitSettings! refitSettings, System.Exception? innerException) -> System.Threading.Tasks.Task<Refit.ApiException!>!
+static Refit.ApiException.Create(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, System.Net.Http.HttpResponseMessage! response, Refit.RefitSettings! refitSettings) -> System.Threading.Tasks.Task<Refit.ApiException!>!
 static Refit.ApiResponseExtensions.EnsureSuccessfulAsync<T>(this Refit.IApiResponse<T>! response) -> System.Threading.Tasks.Task<Refit.IApiResponse<T>!>!
+static Refit.ApiResponseExtensions.EnsureSuccessStatusCodeAsync<T>(this Refit.IApiResponse<T>! response) -> System.Threading.Tasks.Task<Refit.IApiResponse<T>!>!
 static Refit.GeneratedRequestRunner.AddConfiguredRequestOptions(System.Net.Http.HttpRequestMessage! request, Refit.RefitSettings! settings, System.Type! interfaceType) -> void
 static Refit.GeneratedRequestRunner.AddHeaderCollection(System.Net.Http.HttpRequestMessage! request, System.Collections.Generic.IDictionary<string!, string!>? headers) -> void
 static Refit.GeneratedRequestRunner.AddRequestProperty<TValue>(System.Net.Http.HttpRequestMessage! request, string! key, TValue value) -> void
+static Refit.GeneratedRequestRunner.BuildRelativeUri(System.Net.Http.HttpClient! client, string! relativePath, Refit.UrlResolutionMode urlResolution) -> System.Uri!
 static Refit.GeneratedRequestRunner.CreateBodyContent<TBody>(Refit.RefitSettings! settings, TBody body, Refit.BodySerializationMethod serializationMethod, bool streamBody) -> System.Net.Http.HttpContent!
 static Refit.GeneratedRequestRunner.CreateJsonLinesBodyContent<TBody>(Refit.RefitSettings! settings, TBody body) -> System.Net.Http.HttpContent!
 static Refit.GeneratedRequestRunner.CreateUrlEncodedBodyContent<TBody>(Refit.RefitSettings! settings, TBody body) -> System.Net.Http.HttpContent!
@@ -343,26 +368,27 @@ static Refit.RequestBuilder.ForType<T>(Refit.RefitSettings? settings) -> Refit.I
 static Refit.RestMethodInfo.operator !=(Refit.RestMethodInfo? left, Refit.RestMethodInfo? right) -> bool
 static Refit.RestMethodInfo.operator ==(Refit.RestMethodInfo? left, Refit.RestMethodInfo? right) -> bool
 static Refit.RestService.CreateHttpClient(string! hostUrl, Refit.RefitSettings? settings) -> System.Net.Http.HttpClient!
+static Refit.RestService.ForGenerated(System.Type! refitInterfaceType, string! hostUrl, Refit.RefitSettings! settings) -> object!
+static Refit.RestService.ForGenerated(System.Type! refitInterfaceType, System.Net.Http.HttpClient! client, Refit.RefitSettings! settings) -> object!
+static Refit.RestService.ForGenerated<T>(string! hostUrl, Refit.RefitSettings! settings) -> T
+static Refit.RestService.ForGenerated<T>(string! hostUrl) -> T
+static Refit.RestService.ForGenerated<T>(System.Net.Http.HttpClient! client, Refit.RefitSettings! settings) -> T
+static Refit.RestService.ForGenerated<T>(System.Net.Http.HttpClient! client) -> T
+static Refit.RestService.For(System.Type! refitInterfaceType, string! hostUrl) -> object!
+static Refit.RestService.For(System.Type! refitInterfaceType, string! hostUrl, Refit.RefitSettings? settings) -> object!
 static Refit.RestService.For(System.Type! refitInterfaceType, System.Net.Http.HttpClient! client) -> object!
 static Refit.RestService.For(System.Type! refitInterfaceType, System.Net.Http.HttpClient! client, Refit.IRequestBuilder! builder) -> object!
 static Refit.RestService.For(System.Type! refitInterfaceType, System.Net.Http.HttpClient! client, Refit.RefitSettings? settings) -> object!
-static Refit.RestService.For(System.Type! refitInterfaceType, string! hostUrl) -> object!
-static Refit.RestService.For(System.Type! refitInterfaceType, string! hostUrl, Refit.RefitSettings? settings) -> object!
-static Refit.RestService.For<T>(System.Net.Http.HttpClient! client) -> T
+static Refit.RestService.For<T>(string! hostUrl, Refit.RefitSettings? settings) -> T
+static Refit.RestService.For<T>(string! hostUrl) -> T
 static Refit.RestService.For<T>(System.Net.Http.HttpClient! client, Refit.IRequestBuilder<T>! builder) -> T
 static Refit.RestService.For<T>(System.Net.Http.HttpClient! client, Refit.RefitSettings? settings) -> T
-static Refit.RestService.For<T>(string! hostUrl) -> T
-static Refit.RestService.For<T>(string! hostUrl, Refit.RefitSettings? settings) -> T
-static Refit.RestService.ForGenerated(System.Type! refitInterfaceType, System.Net.Http.HttpClient! client, Refit.RefitSettings! settings) -> object!
-static Refit.RestService.ForGenerated(System.Type! refitInterfaceType, string! hostUrl, Refit.RefitSettings! settings) -> object!
-static Refit.RestService.ForGenerated<T>(System.Net.Http.HttpClient! client) -> T
-static Refit.RestService.ForGenerated<T>(System.Net.Http.HttpClient! client, Refit.RefitSettings! settings) -> T
-static Refit.RestService.ForGenerated<T>(string! hostUrl) -> T
-static Refit.RestService.ForGenerated<T>(string! hostUrl, Refit.RefitSettings! settings) -> T
+static Refit.RestService.For<T>(System.Net.Http.HttpClient! client) -> T
 static Refit.RestService.RegisterGeneratedFactory(System.Type! refitInterfaceType, System.Func<System.Net.Http.HttpClient!, Refit.IRequestBuilder!, object!>! factory) -> void
 static Refit.RestService.RegisterGeneratedFactory<T>(System.Func<System.Net.Http.HttpClient!, Refit.IRequestBuilder!, T>! factory) -> void
 static Refit.RestService.RegisterGeneratedSettingsFactory<T>(System.Func<System.Net.Http.HttpClient!, Refit.RefitSettings!, T>! factory) -> void
 static Refit.SystemTextJsonContentSerializer.GetDefaultJsonSerializerOptions() -> System.Text.Json.JsonSerializerOptions!
+static Refit.SystemTextJsonContentSerializer.GetFastPathJsonSerializerOptions() -> System.Text.Json.JsonSerializerOptions!
 static Refit.ValidationApiException.Create(Refit.ApiException! exception) -> Refit.ValidationApiException!
 virtual Refit.DefaultFormUrlEncodedParameterFormatter.Format(object? value, string? formatString) -> string?
 virtual Refit.DefaultUrlParameterFormatter.Format(object? value, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string?

--- a/src/Refit/PublicAPI/net470/PublicAPI.Shipped.txt
+++ b/src/Refit/PublicAPI/net470/PublicAPI.Shipped.txt
@@ -355,6 +355,7 @@ static Refit.GeneratedRequestRunner.CreateUrlEncodedBodyContent<TBody>(Refit.Ref
 static Refit.GeneratedRequestRunner.SendAsync<T, TBody>(System.Net.Http.HttpClient! client, System.Net.Http.HttpRequestMessage! request, Refit.RefitSettings! settings, bool isApiResponse, bool shouldDisposeResponse, bool bufferBody, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<T?>!
 static Refit.GeneratedRequestRunner.SendVoidAsync(System.Net.Http.HttpClient! client, System.Net.Http.HttpRequestMessage! request, Refit.RefitSettings! settings, bool bufferBody, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 static Refit.GeneratedRequestRunner.SetHeader(System.Net.Http.HttpRequestMessage! request, string! name, string? value) -> void
+static Refit.GeneratedRequestRunner.StreamAsync<T>(System.Net.Http.HttpClient! client, System.Net.Http.HttpRequestMessage! request, Refit.RefitSettings! settings, System.Threading.CancellationToken methodCancellationToken, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<T?>!
 static Refit.HttpRequestMessageOptions.InterfaceType.get -> string!
 static Refit.HttpRequestMessageOptions.RestMethodInfo.get -> string!
 static Refit.JsonLinesContent.JsonLinesMediaType.get -> string!

--- a/src/Refit/PublicAPI/net470/PublicAPI.Shipped.txt
+++ b/src/Refit/PublicAPI/net470/PublicAPI.Shipped.txt
@@ -1,12 +1,37 @@
 #nullable enable
+abstract Refit.HttpMethodAttribute.Method.get -> System.Net.Http.HttpMethod!
+abstract Refit.MultipartItem.CreateContent() -> System.Net.Http.HttpContent!
+override Refit.ByteArrayPart.CreateContent() -> System.Net.Http.HttpContent!
+override Refit.DeleteAttribute.Method.get -> System.Net.Http.HttpMethod!
+override Refit.FileInfoPart.CreateContent() -> System.Net.Http.HttpContent!
+override Refit.GetAttribute.Method.get -> System.Net.Http.HttpMethod!
+override Refit.HeadAttribute.Method.get -> System.Net.Http.HttpMethod!
+override Refit.ObjectToInferredTypesConverter.Read(ref System.Text.Json.Utf8JsonReader reader, System.Type! typeToConvert, System.Text.Json.JsonSerializerOptions! options) -> object?
+override Refit.ObjectToInferredTypesConverter.Write(System.Text.Json.Utf8JsonWriter! writer, object! value, System.Text.Json.JsonSerializerOptions! options) -> void
+override Refit.OptionsAttribute.Method.get -> System.Net.Http.HttpMethod!
+override Refit.PatchAttribute.Method.get -> System.Net.Http.HttpMethod!
+override Refit.PostAttribute.Method.get -> System.Net.Http.HttpMethod!
+override Refit.PutAttribute.Method.get -> System.Net.Http.HttpMethod!
+override Refit.RestMethodInfo.Equals(object? obj) -> bool
+override Refit.RestMethodInfo.GetHashCode() -> int
+override Refit.RestMethodInfo.ToString() -> string!
+override Refit.StreamPart.CreateContent() -> System.Net.Http.HttpContent!
 Refit.AliasAsAttribute
 Refit.AliasAsAttribute.AliasAsAttribute(string! name) -> void
 Refit.AliasAsAttribute.Name.get -> string!
 Refit.ApiException
-Refit.ApiException.ApiException(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, string? content, System.Net.HttpStatusCode statusCode, string? reasonPhrase, System.Net.Http.Headers.HttpResponseHeaders! headers, Refit.RefitSettings! refitSettings) -> void
-Refit.ApiException.ApiException(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, string? content, System.Net.HttpStatusCode statusCode, string? reasonPhrase, System.Net.Http.Headers.HttpResponseHeaders! headers, Refit.RefitSettings! refitSettings, System.Exception? innerException) -> void
-Refit.ApiException.ApiException(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, string? content, System.Net.HttpStatusCode statusCode, string? reasonPhrase, System.Net.Http.Headers.HttpResponseHeaders! headers, Refit.RefitSettings! refitSettings) -> void
 Refit.ApiException.ApiException(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, string? content, System.Net.HttpStatusCode statusCode, string? reasonPhrase, System.Net.Http.Headers.HttpResponseHeaders! headers, Refit.RefitSettings! refitSettings, System.Exception? innerException) -> void
+Refit.ApiException.ApiException(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, string? content, System.Net.HttpStatusCode statusCode, string? reasonPhrase, System.Net.Http.Headers.HttpResponseHeaders! headers, Refit.RefitSettings! refitSettings) -> void
+Refit.ApiException.ApiException(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, string? content, System.Net.HttpStatusCode statusCode, string? reasonPhrase, System.Net.Http.Headers.HttpResponseHeaders! headers, Refit.RefitSettings! refitSettings, System.Exception? innerException) -> void
+Refit.ApiException.ApiException(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, string? content, System.Net.HttpStatusCode statusCode, string? reasonPhrase, System.Net.Http.Headers.HttpResponseHeaders! headers, Refit.RefitSettings! refitSettings) -> void
+Refit.ApiExceptionBase
+Refit.ApiExceptionBase.ApiExceptionBase(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings, System.Exception? innerException) -> void
+Refit.ApiExceptionBase.ApiExceptionBase(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings) -> void
+Refit.ApiExceptionBase.ApiExceptionBase(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings, System.Exception! innerException) -> void
+Refit.ApiExceptionBase.HttpMethod.get -> System.Net.Http.HttpMethod!
+Refit.ApiExceptionBase.RefitSettings.get -> Refit.RefitSettings!
+Refit.ApiExceptionBase.RequestMessage.get -> System.Net.Http.HttpRequestMessage!
+Refit.ApiExceptionBase.Uri.get -> System.Uri?
 Refit.ApiException.Content.get -> string?
 Refit.ApiException.ContentHeaders.get -> System.Net.Http.Headers.HttpContentHeaders?
 Refit.ApiException.ContentHeaders.set -> void
@@ -15,44 +40,36 @@ Refit.ApiException.HasContent.get -> bool
 Refit.ApiException.Headers.get -> System.Net.Http.Headers.HttpResponseHeaders!
 Refit.ApiException.ReasonPhrase.get -> string?
 Refit.ApiException.StatusCode.get -> System.Net.HttpStatusCode
-Refit.ApiExceptionBase
-Refit.ApiExceptionBase.ApiExceptionBase(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings, System.Exception! innerException) -> void
-Refit.ApiExceptionBase.ApiExceptionBase(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings) -> void
-Refit.ApiExceptionBase.ApiExceptionBase(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings, System.Exception? innerException) -> void
-Refit.ApiExceptionBase.HttpMethod.get -> System.Net.Http.HttpMethod!
-Refit.ApiExceptionBase.RefitSettings.get -> Refit.RefitSettings!
-Refit.ApiExceptionBase.RequestMessage.get -> System.Net.Http.HttpRequestMessage!
-Refit.ApiExceptionBase.Uri.get -> System.Uri?
 Refit.ApiRequestException
-Refit.ApiRequestException.ApiRequestException(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings, System.Exception! innerException) -> void
-Refit.ApiRequestException.ApiRequestException(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings) -> void
 Refit.ApiRequestException.ApiRequestException(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings, System.Exception? innerException) -> void
+Refit.ApiRequestException.ApiRequestException(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings) -> void
+Refit.ApiRequestException.ApiRequestException(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings, System.Exception! innerException) -> void
+Refit.ApiResponseExtensions
+Refit.ApiResponseExtensions.extension<T>(Refit.IApiResponse<T>!)
+Refit.ApiResponseExtensions.extension<T>(Refit.IApiResponse<T>!).EnsureSuccessfulAsync() -> System.Threading.Tasks.Task<Refit.IApiResponse<T>!>!
+Refit.ApiResponseExtensions.extension<T>(Refit.IApiResponse<T>!).EnsureSuccessStatusCodeAsync() -> System.Threading.Tasks.Task<Refit.IApiResponse<T>!>!
 Refit.ApiResponse<T>
 Refit.ApiResponse<T>.ApiResponse(System.Net.Http.HttpRequestMessage! request, System.Net.Http.HttpResponseMessage? response, T? content, Refit.RefitSettings! settings, Refit.ApiExceptionBase? error = null) -> void
-Refit.ApiResponse<T>.ApiResponse(System.Net.Http.HttpResponseMessage! response, T? content, Refit.RefitSettings! settings) -> void
 Refit.ApiResponse<T>.ApiResponse(System.Net.Http.HttpResponseMessage! response, T? content, Refit.RefitSettings! settings, Refit.ApiExceptionBase? error) -> void
+Refit.ApiResponse<T>.ApiResponse(System.Net.Http.HttpResponseMessage! response, T? content, Refit.RefitSettings! settings) -> void
 Refit.ApiResponse<T>.Content.get -> T?
 Refit.ApiResponse<T>.ContentHeaders.get -> System.Net.Http.Headers.HttpContentHeaders?
 Refit.ApiResponse<T>.Dispose() -> void
-Refit.ApiResponse<T>.EnsureSuccessStatusCodeAsync() -> System.Threading.Tasks.Task<Refit.ApiResponse<T>!>!
 Refit.ApiResponse<T>.EnsureSuccessfulAsync() -> System.Threading.Tasks.Task<Refit.ApiResponse<T>!>!
+Refit.ApiResponse<T>.EnsureSuccessStatusCodeAsync() -> System.Threading.Tasks.Task<Refit.ApiResponse<T>!>!
 Refit.ApiResponse<T>.Error.get -> Refit.ApiExceptionBase?
 Refit.ApiResponse<T>.HasContent.get -> bool
 Refit.ApiResponse<T>.HasRequestError(out Refit.ApiRequestException? error) -> bool
 Refit.ApiResponse<T>.HasResponseError(out Refit.ApiException? error) -> bool
 Refit.ApiResponse<T>.Headers.get -> System.Net.Http.Headers.HttpResponseHeaders?
 Refit.ApiResponse<T>.IsReceived.get -> bool
-Refit.ApiResponse<T>.IsSuccessStatusCode.get -> bool
 Refit.ApiResponse<T>.IsSuccessful.get -> bool
+Refit.ApiResponse<T>.IsSuccessStatusCode.get -> bool
 Refit.ApiResponse<T>.ReasonPhrase.get -> string?
 Refit.ApiResponse<T>.RequestMessage.get -> System.Net.Http.HttpRequestMessage!
 Refit.ApiResponse<T>.Settings.get -> Refit.RefitSettings!
 Refit.ApiResponse<T>.StatusCode.get -> System.Net.HttpStatusCode?
 Refit.ApiResponse<T>.Version.get -> System.Version?
-Refit.ApiResponseExtensions
-Refit.ApiResponseExtensions.extension<T>(Refit.IApiResponse<T>!)
-Refit.ApiResponseExtensions.extension<T>(Refit.IApiResponse<T>!).EnsureSuccessStatusCodeAsync() -> System.Threading.Tasks.Task<Refit.IApiResponse<T>!>!
-Refit.ApiResponseExtensions.extension<T>(Refit.IApiResponse<T>!).EnsureSuccessfulAsync() -> System.Threading.Tasks.Task<Refit.IApiResponse<T>!>!
 Refit.AttachmentNameAttribute
 Refit.AttachmentNameAttribute.AttachmentNameAttribute(string! name) -> void
 Refit.AttachmentNameAttribute.Name.get -> string!
@@ -60,10 +77,10 @@ Refit.AuthorizeAttribute
 Refit.AuthorizeAttribute.AuthorizeAttribute(string! scheme = "Bearer") -> void
 Refit.AuthorizeAttribute.Scheme.get -> string!
 Refit.BodyAttribute
-Refit.BodyAttribute.BodyAttribute() -> void
-Refit.BodyAttribute.BodyAttribute(Refit.BodySerializationMethod serializationMethod) -> void
-Refit.BodyAttribute.BodyAttribute(Refit.BodySerializationMethod serializationMethod, bool buffered) -> void
 Refit.BodyAttribute.BodyAttribute(bool buffered) -> void
+Refit.BodyAttribute.BodyAttribute(Refit.BodySerializationMethod serializationMethod, bool buffered) -> void
+Refit.BodyAttribute.BodyAttribute(Refit.BodySerializationMethod serializationMethod) -> void
+Refit.BodyAttribute.BodyAttribute() -> void
 Refit.BodyAttribute.Buffered.get -> bool?
 Refit.BodyAttribute.SerializationMethod.get -> Refit.BodySerializationMethod
 Refit.BodySerializationMethod
@@ -107,13 +124,13 @@ Refit.GetAttribute.GetAttribute(string! path) -> void
 Refit.HeadAttribute
 Refit.HeadAttribute.HeadAttribute(string! path) -> void
 Refit.HeaderAttribute
-Refit.HeaderAttribute.Header.get -> string!
 Refit.HeaderAttribute.HeaderAttribute(string! header) -> void
+Refit.HeaderAttribute.Header.get -> string!
 Refit.HeaderCollectionAttribute
 Refit.HeaderCollectionAttribute.HeaderCollectionAttribute() -> void
 Refit.HeadersAttribute
-Refit.HeadersAttribute.Headers.get -> string![]!
 Refit.HeadersAttribute.HeadersAttribute(params string![]! headers) -> void
+Refit.HeadersAttribute.Headers.get -> string![]!
 Refit.HttpMethodAttribute
 Refit.HttpMethodAttribute.HttpMethodAttribute(string! path) -> void
 Refit.HttpRequestMessageOptions
@@ -124,15 +141,15 @@ Refit.IApiResponse.HasRequestError(out Refit.ApiRequestException? error) -> bool
 Refit.IApiResponse.HasResponseError(out Refit.ApiException? error) -> bool
 Refit.IApiResponse.Headers.get -> System.Net.Http.Headers.HttpResponseHeaders?
 Refit.IApiResponse.IsReceived.get -> bool
-Refit.IApiResponse.IsSuccessStatusCode.get -> bool
 Refit.IApiResponse.IsSuccessful.get -> bool
+Refit.IApiResponse.IsSuccessStatusCode.get -> bool
 Refit.IApiResponse.ReasonPhrase.get -> string?
 Refit.IApiResponse.RequestMessage.get -> System.Net.Http.HttpRequestMessage?
 Refit.IApiResponse.StatusCode.get -> System.Net.HttpStatusCode?
-Refit.IApiResponse.Version.get -> System.Version?
 Refit.IApiResponse<T>
 Refit.IApiResponse<T>.Content.get -> T?
 Refit.IApiResponse<T>.HasContent.get -> bool
+Refit.IApiResponse.Version.get -> System.Version?
 Refit.IFormUrlEncodedParameterFormatter
 Refit.IFormUrlEncodedParameterFormatter.Format(object? value, string? formatString) -> string?
 Refit.IHttpContentSerializer
@@ -143,6 +160,11 @@ Refit.IRequestBuilder
 Refit.IRequestBuilder.BuildRestResultFuncForMethod(string! methodName, System.Type![]? parameterTypes = null, System.Type![]? genericArgumentTypes = null) -> System.Func<System.Net.Http.HttpClient!, object![]!, object?>!
 Refit.IRequestBuilder.Settings.get -> Refit.RefitSettings!
 Refit.IRequestBuilder<T>
+Refit.IStreamingContentSerializer
+Refit.IStreamingContentSerializer.DeserializeStreamAsync<T>(System.IO.Stream! stream, Refit.StreamingContentFormat format, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<T?>!
+Refit.ISynchronousContentSerializer
+Refit.ISynchronousContentSerializer.ToHttpContentSynchronous<T>(T item) -> System.Net.Http.HttpContent!
+Refit.ISynchronousContentSerializer.ToStreamingHttpContent<T>(T item) -> System.Net.Http.HttpContent!
 Refit.IUrlParameterFormatter
 Refit.IUrlParameterFormatter.Format(object? value, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string?
 Refit.IUrlParameterKeyFormatter
@@ -163,8 +185,8 @@ Refit.MultipartAttribute.MultipartAttribute(string! boundaryText = "----MyGreatB
 Refit.MultipartItem
 Refit.MultipartItem.ContentType.get -> string?
 Refit.MultipartItem.FileName.get -> string!
-Refit.MultipartItem.MultipartItem(string! fileName, string? contentType) -> void
 Refit.MultipartItem.MultipartItem(string! fileName, string? contentType, string? name) -> void
+Refit.MultipartItem.MultipartItem(string! fileName, string? contentType) -> void
 Refit.MultipartItem.Name.get -> string?
 Refit.MultipartItem.ToContent() -> System.Net.Http.HttpContent!
 Refit.ObjectToInferredTypesConverter
@@ -196,8 +218,8 @@ Refit.ProblemDetails.Type.get -> string?
 Refit.ProblemDetails.Type.set -> void
 Refit.PropertyAttribute
 Refit.PropertyAttribute.Key.get -> string?
-Refit.PropertyAttribute.PropertyAttribute() -> void
 Refit.PropertyAttribute.PropertyAttribute(string! key) -> void
+Refit.PropertyAttribute.PropertyAttribute() -> void
 Refit.PutAttribute
 Refit.PutAttribute.PutAttribute(string! path) -> void
 Refit.QueryAttribute
@@ -208,17 +230,19 @@ Refit.QueryAttribute.Format.get -> string?
 Refit.QueryAttribute.Format.set -> void
 Refit.QueryAttribute.IsCollectionFormatSpecified.get -> bool
 Refit.QueryAttribute.Prefix.get -> string?
-Refit.QueryAttribute.QueryAttribute() -> void
 Refit.QueryAttribute.QueryAttribute(Refit.CollectionFormat collectionFormat) -> void
-Refit.QueryAttribute.QueryAttribute(string! delimiter) -> void
-Refit.QueryAttribute.QueryAttribute(string! delimiter, string! prefix) -> void
 Refit.QueryAttribute.QueryAttribute(string! delimiter, string! prefix, string! format) -> void
+Refit.QueryAttribute.QueryAttribute(string! delimiter, string! prefix) -> void
+Refit.QueryAttribute.QueryAttribute(string! delimiter) -> void
+Refit.QueryAttribute.QueryAttribute() -> void
 Refit.QueryAttribute.TreatAsString.get -> bool
 Refit.QueryAttribute.TreatAsString.set -> void
 Refit.QueryUriFormatAttribute
 Refit.QueryUriFormatAttribute.QueryUriFormatAttribute(System.UriFormat uriFormat) -> void
 Refit.QueryUriFormatAttribute.UriFormat.get -> System.UriFormat
 Refit.RefitSettings
+Refit.RefitSettings.AllowUnmatchedRouteParameters.get -> bool
+Refit.RefitSettings.AllowUnmatchedRouteParameters.set -> void
 Refit.RefitSettings.AuthorizationHeaderValueGetter.get -> System.Func<System.Net.Http.HttpRequestMessage!, System.Threading.CancellationToken, System.Threading.Tasks.Task<string!>!>?
 Refit.RefitSettings.AuthorizationHeaderValueGetter.set -> void
 Refit.RefitSettings.Buffered.get -> bool
@@ -237,15 +261,23 @@ Refit.RefitSettings.HttpMessageHandlerFactory.get -> System.Func<System.Net.Http
 Refit.RefitSettings.HttpMessageHandlerFactory.set -> void
 Refit.RefitSettings.HttpRequestMessageOptions.get -> System.Collections.Generic.Dictionary<string!, object!>?
 Refit.RefitSettings.HttpRequestMessageOptions.init -> void
-Refit.RefitSettings.RefitSettings() -> void
-Refit.RefitSettings.RefitSettings(Refit.IHttpContentSerializer! contentSerializer) -> void
-Refit.RefitSettings.RefitSettings(Refit.IHttpContentSerializer! contentSerializer, Refit.IUrlParameterFormatter? urlParameterFormatter) -> void
-Refit.RefitSettings.RefitSettings(Refit.IHttpContentSerializer! contentSerializer, Refit.IUrlParameterFormatter? urlParameterFormatter, Refit.IFormUrlEncodedParameterFormatter? formUrlEncodedParameterFormatter) -> void
 Refit.RefitSettings.RefitSettings(Refit.IHttpContentSerializer! contentSerializer, Refit.IUrlParameterFormatter? urlParameterFormatter, Refit.IFormUrlEncodedParameterFormatter? formUrlEncodedParameterFormatter, Refit.IUrlParameterKeyFormatter? urlParameterKeyFormatter) -> void
+Refit.RefitSettings.RefitSettings(Refit.IHttpContentSerializer! contentSerializer, Refit.IUrlParameterFormatter? urlParameterFormatter, Refit.IFormUrlEncodedParameterFormatter? formUrlEncodedParameterFormatter) -> void
+Refit.RefitSettings.RefitSettings(Refit.IHttpContentSerializer! contentSerializer, Refit.IUrlParameterFormatter? urlParameterFormatter) -> void
+Refit.RefitSettings.RefitSettings(Refit.IHttpContentSerializer! contentSerializer) -> void
+Refit.RefitSettings.RefitSettings() -> void
+Refit.RefitSettings.RequestBodySerialization.get -> Refit.RequestBodySerializationMode
+Refit.RefitSettings.RequestBodySerialization.set -> void
 Refit.RefitSettings.UrlParameterFormatter.get -> Refit.IUrlParameterFormatter!
 Refit.RefitSettings.UrlParameterFormatter.set -> void
 Refit.RefitSettings.UrlParameterKeyFormatter.get -> Refit.IUrlParameterKeyFormatter!
 Refit.RefitSettings.UrlParameterKeyFormatter.set -> void
+Refit.RefitSettings.UrlResolution.get -> Refit.UrlResolutionMode
+Refit.RefitSettings.UrlResolution.set -> void
+Refit.RequestBodySerializationMode
+Refit.RequestBodySerializationMode.Buffered = 1 -> Refit.RequestBodySerializationMode
+Refit.RequestBodySerializationMode.Default = 0 -> Refit.RequestBodySerializationMode
+Refit.RequestBodySerializationMode.Streamed = 2 -> Refit.RequestBodySerializationMode
 Refit.RequestBuilder
 Refit.RestMethodInfo
 Refit.RestMethodInfo.<Clone>$() -> Refit.RestMethodInfo!
@@ -285,45 +317,38 @@ Refit.RestService
 Refit.SnakeCaseUrlParameterKeyFormatter
 Refit.SnakeCaseUrlParameterKeyFormatter.Format(string! key) -> string!
 Refit.SnakeCaseUrlParameterKeyFormatter.SnakeCaseUrlParameterKeyFormatter() -> void
+Refit.StreamingContentFormat
+Refit.StreamingContentFormat.JsonArray = 0 -> Refit.StreamingContentFormat
+Refit.StreamingContentFormat.JsonLines = 1 -> Refit.StreamingContentFormat
 Refit.StreamPart
 Refit.StreamPart.StreamPart(System.IO.Stream! value, string! fileName, string? contentType = null, string? name = null) -> void
 Refit.StreamPart.Value.get -> System.IO.Stream!
 Refit.SystemTextJsonContentSerializer
+Refit.SystemTextJsonContentSerializer.DeserializeStreamAsync<T>(System.IO.Stream! stream, Refit.StreamingContentFormat format, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<T?>!
 Refit.SystemTextJsonContentSerializer.FromHttpContentAsync<T>(System.Net.Http.HttpContent! content, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<T?>!
 Refit.SystemTextJsonContentSerializer.GetFieldNameForProperty(System.Reflection.PropertyInfo! propertyInfo) -> string?
-Refit.SystemTextJsonContentSerializer.SystemTextJsonContentSerializer() -> void
 Refit.SystemTextJsonContentSerializer.SystemTextJsonContentSerializer(System.Text.Json.JsonSerializerOptions! jsonSerializerOptions) -> void
+Refit.SystemTextJsonContentSerializer.SystemTextJsonContentSerializer() -> void
+Refit.SystemTextJsonContentSerializer.ToHttpContentSynchronous<T>(T item) -> System.Net.Http.HttpContent!
 Refit.SystemTextJsonContentSerializer.ToHttpContent<T>(T item) -> System.Net.Http.HttpContent!
+Refit.SystemTextJsonContentSerializer.ToStreamingHttpContent<T>(T item) -> System.Net.Http.HttpContent!
+Refit.UrlResolutionMode
+Refit.UrlResolutionMode.RefitLegacy = 0 -> Refit.UrlResolutionMode
+Refit.UrlResolutionMode.Rfc3986 = 1 -> Refit.UrlResolutionMode
 Refit.ValidationApiException
 Refit.ValidationApiException.Content.get -> Refit.ProblemDetails?
-Refit.ValidationApiException.ValidationApiException(string! message) -> void
 Refit.ValidationApiException.ValidationApiException(string! message, System.Exception! innerException) -> void
-abstract Refit.HttpMethodAttribute.Method.get -> System.Net.Http.HttpMethod!
-abstract Refit.MultipartItem.CreateContent() -> System.Net.Http.HttpContent!
-override Refit.ByteArrayPart.CreateContent() -> System.Net.Http.HttpContent!
-override Refit.DeleteAttribute.Method.get -> System.Net.Http.HttpMethod!
-override Refit.FileInfoPart.CreateContent() -> System.Net.Http.HttpContent!
-override Refit.GetAttribute.Method.get -> System.Net.Http.HttpMethod!
-override Refit.HeadAttribute.Method.get -> System.Net.Http.HttpMethod!
-override Refit.ObjectToInferredTypesConverter.Read(ref System.Text.Json.Utf8JsonReader reader, System.Type! typeToConvert, System.Text.Json.JsonSerializerOptions! options) -> object?
-override Refit.ObjectToInferredTypesConverter.Write(System.Text.Json.Utf8JsonWriter! writer, object! value, System.Text.Json.JsonSerializerOptions! options) -> void
-override Refit.OptionsAttribute.Method.get -> System.Net.Http.HttpMethod!
-override Refit.PatchAttribute.Method.get -> System.Net.Http.HttpMethod!
-override Refit.PostAttribute.Method.get -> System.Net.Http.HttpMethod!
-override Refit.PutAttribute.Method.get -> System.Net.Http.HttpMethod!
-override Refit.RestMethodInfo.Equals(object? obj) -> bool
-override Refit.RestMethodInfo.GetHashCode() -> int
-override Refit.RestMethodInfo.ToString() -> string!
-override Refit.StreamPart.CreateContent() -> System.Net.Http.HttpContent!
-static Refit.ApiException.Create(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, System.Net.Http.HttpResponseMessage! response, Refit.RefitSettings! refitSettings) -> System.Threading.Tasks.Task<Refit.ApiException!>!
-static Refit.ApiException.Create(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, System.Net.Http.HttpResponseMessage! response, Refit.RefitSettings! refitSettings, System.Exception? innerException) -> System.Threading.Tasks.Task<Refit.ApiException!>!
-static Refit.ApiException.Create(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, System.Net.Http.HttpResponseMessage! response, Refit.RefitSettings! refitSettings) -> System.Threading.Tasks.Task<Refit.ApiException!>!
+Refit.ValidationApiException.ValidationApiException(string! message) -> void
 static Refit.ApiException.Create(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, System.Net.Http.HttpResponseMessage! response, Refit.RefitSettings! refitSettings, System.Exception? innerException) -> System.Threading.Tasks.Task<Refit.ApiException!>!
-static Refit.ApiResponseExtensions.EnsureSuccessStatusCodeAsync<T>(this Refit.IApiResponse<T>! response) -> System.Threading.Tasks.Task<Refit.IApiResponse<T>!>!
+static Refit.ApiException.Create(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, System.Net.Http.HttpResponseMessage! response, Refit.RefitSettings! refitSettings) -> System.Threading.Tasks.Task<Refit.ApiException!>!
+static Refit.ApiException.Create(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, System.Net.Http.HttpResponseMessage! response, Refit.RefitSettings! refitSettings, System.Exception? innerException) -> System.Threading.Tasks.Task<Refit.ApiException!>!
+static Refit.ApiException.Create(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, System.Net.Http.HttpResponseMessage! response, Refit.RefitSettings! refitSettings) -> System.Threading.Tasks.Task<Refit.ApiException!>!
 static Refit.ApiResponseExtensions.EnsureSuccessfulAsync<T>(this Refit.IApiResponse<T>! response) -> System.Threading.Tasks.Task<Refit.IApiResponse<T>!>!
+static Refit.ApiResponseExtensions.EnsureSuccessStatusCodeAsync<T>(this Refit.IApiResponse<T>! response) -> System.Threading.Tasks.Task<Refit.IApiResponse<T>!>!
 static Refit.GeneratedRequestRunner.AddConfiguredRequestOptions(System.Net.Http.HttpRequestMessage! request, Refit.RefitSettings! settings, System.Type! interfaceType) -> void
 static Refit.GeneratedRequestRunner.AddHeaderCollection(System.Net.Http.HttpRequestMessage! request, System.Collections.Generic.IDictionary<string!, string!>? headers) -> void
 static Refit.GeneratedRequestRunner.AddRequestProperty<TValue>(System.Net.Http.HttpRequestMessage! request, string! key, TValue value) -> void
+static Refit.GeneratedRequestRunner.BuildRelativeUri(System.Net.Http.HttpClient! client, string! relativePath, Refit.UrlResolutionMode urlResolution) -> System.Uri!
 static Refit.GeneratedRequestRunner.CreateBodyContent<TBody>(Refit.RefitSettings! settings, TBody body, Refit.BodySerializationMethod serializationMethod, bool streamBody) -> System.Net.Http.HttpContent!
 static Refit.GeneratedRequestRunner.CreateJsonLinesBodyContent<TBody>(Refit.RefitSettings! settings, TBody body) -> System.Net.Http.HttpContent!
 static Refit.GeneratedRequestRunner.CreateUrlEncodedBodyContent<TBody>(Refit.RefitSettings! settings, TBody body) -> System.Net.Http.HttpContent!
@@ -343,26 +368,27 @@ static Refit.RequestBuilder.ForType<T>(Refit.RefitSettings? settings) -> Refit.I
 static Refit.RestMethodInfo.operator !=(Refit.RestMethodInfo? left, Refit.RestMethodInfo? right) -> bool
 static Refit.RestMethodInfo.operator ==(Refit.RestMethodInfo? left, Refit.RestMethodInfo? right) -> bool
 static Refit.RestService.CreateHttpClient(string! hostUrl, Refit.RefitSettings? settings) -> System.Net.Http.HttpClient!
+static Refit.RestService.ForGenerated(System.Type! refitInterfaceType, string! hostUrl, Refit.RefitSettings! settings) -> object!
+static Refit.RestService.ForGenerated(System.Type! refitInterfaceType, System.Net.Http.HttpClient! client, Refit.RefitSettings! settings) -> object!
+static Refit.RestService.ForGenerated<T>(string! hostUrl, Refit.RefitSettings! settings) -> T
+static Refit.RestService.ForGenerated<T>(string! hostUrl) -> T
+static Refit.RestService.ForGenerated<T>(System.Net.Http.HttpClient! client, Refit.RefitSettings! settings) -> T
+static Refit.RestService.ForGenerated<T>(System.Net.Http.HttpClient! client) -> T
+static Refit.RestService.For(System.Type! refitInterfaceType, string! hostUrl) -> object!
+static Refit.RestService.For(System.Type! refitInterfaceType, string! hostUrl, Refit.RefitSettings? settings) -> object!
 static Refit.RestService.For(System.Type! refitInterfaceType, System.Net.Http.HttpClient! client) -> object!
 static Refit.RestService.For(System.Type! refitInterfaceType, System.Net.Http.HttpClient! client, Refit.IRequestBuilder! builder) -> object!
 static Refit.RestService.For(System.Type! refitInterfaceType, System.Net.Http.HttpClient! client, Refit.RefitSettings? settings) -> object!
-static Refit.RestService.For(System.Type! refitInterfaceType, string! hostUrl) -> object!
-static Refit.RestService.For(System.Type! refitInterfaceType, string! hostUrl, Refit.RefitSettings? settings) -> object!
-static Refit.RestService.For<T>(System.Net.Http.HttpClient! client) -> T
+static Refit.RestService.For<T>(string! hostUrl, Refit.RefitSettings? settings) -> T
+static Refit.RestService.For<T>(string! hostUrl) -> T
 static Refit.RestService.For<T>(System.Net.Http.HttpClient! client, Refit.IRequestBuilder<T>! builder) -> T
 static Refit.RestService.For<T>(System.Net.Http.HttpClient! client, Refit.RefitSettings? settings) -> T
-static Refit.RestService.For<T>(string! hostUrl) -> T
-static Refit.RestService.For<T>(string! hostUrl, Refit.RefitSettings? settings) -> T
-static Refit.RestService.ForGenerated(System.Type! refitInterfaceType, System.Net.Http.HttpClient! client, Refit.RefitSettings! settings) -> object!
-static Refit.RestService.ForGenerated(System.Type! refitInterfaceType, string! hostUrl, Refit.RefitSettings! settings) -> object!
-static Refit.RestService.ForGenerated<T>(System.Net.Http.HttpClient! client) -> T
-static Refit.RestService.ForGenerated<T>(System.Net.Http.HttpClient! client, Refit.RefitSettings! settings) -> T
-static Refit.RestService.ForGenerated<T>(string! hostUrl) -> T
-static Refit.RestService.ForGenerated<T>(string! hostUrl, Refit.RefitSettings! settings) -> T
+static Refit.RestService.For<T>(System.Net.Http.HttpClient! client) -> T
 static Refit.RestService.RegisterGeneratedFactory(System.Type! refitInterfaceType, System.Func<System.Net.Http.HttpClient!, Refit.IRequestBuilder!, object!>! factory) -> void
 static Refit.RestService.RegisterGeneratedFactory<T>(System.Func<System.Net.Http.HttpClient!, Refit.IRequestBuilder!, T>! factory) -> void
 static Refit.RestService.RegisterGeneratedSettingsFactory<T>(System.Func<System.Net.Http.HttpClient!, Refit.RefitSettings!, T>! factory) -> void
 static Refit.SystemTextJsonContentSerializer.GetDefaultJsonSerializerOptions() -> System.Text.Json.JsonSerializerOptions!
+static Refit.SystemTextJsonContentSerializer.GetFastPathJsonSerializerOptions() -> System.Text.Json.JsonSerializerOptions!
 static Refit.ValidationApiException.Create(Refit.ApiException! exception) -> Refit.ValidationApiException!
 virtual Refit.DefaultFormUrlEncodedParameterFormatter.Format(object? value, string? formatString) -> string?
 virtual Refit.DefaultUrlParameterFormatter.Format(object? value, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string?

--- a/src/Refit/PublicAPI/net471/PublicAPI.Shipped.txt
+++ b/src/Refit/PublicAPI/net471/PublicAPI.Shipped.txt
@@ -355,6 +355,7 @@ static Refit.GeneratedRequestRunner.CreateUrlEncodedBodyContent<TBody>(Refit.Ref
 static Refit.GeneratedRequestRunner.SendAsync<T, TBody>(System.Net.Http.HttpClient! client, System.Net.Http.HttpRequestMessage! request, Refit.RefitSettings! settings, bool isApiResponse, bool shouldDisposeResponse, bool bufferBody, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<T?>!
 static Refit.GeneratedRequestRunner.SendVoidAsync(System.Net.Http.HttpClient! client, System.Net.Http.HttpRequestMessage! request, Refit.RefitSettings! settings, bool bufferBody, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 static Refit.GeneratedRequestRunner.SetHeader(System.Net.Http.HttpRequestMessage! request, string! name, string? value) -> void
+static Refit.GeneratedRequestRunner.StreamAsync<T>(System.Net.Http.HttpClient! client, System.Net.Http.HttpRequestMessage! request, Refit.RefitSettings! settings, System.Threading.CancellationToken methodCancellationToken, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<T?>!
 static Refit.HttpRequestMessageOptions.InterfaceType.get -> string!
 static Refit.HttpRequestMessageOptions.RestMethodInfo.get -> string!
 static Refit.JsonLinesContent.JsonLinesMediaType.get -> string!

--- a/src/Refit/PublicAPI/net471/PublicAPI.Shipped.txt
+++ b/src/Refit/PublicAPI/net471/PublicAPI.Shipped.txt
@@ -1,12 +1,37 @@
 #nullable enable
+abstract Refit.HttpMethodAttribute.Method.get -> System.Net.Http.HttpMethod!
+abstract Refit.MultipartItem.CreateContent() -> System.Net.Http.HttpContent!
+override Refit.ByteArrayPart.CreateContent() -> System.Net.Http.HttpContent!
+override Refit.DeleteAttribute.Method.get -> System.Net.Http.HttpMethod!
+override Refit.FileInfoPart.CreateContent() -> System.Net.Http.HttpContent!
+override Refit.GetAttribute.Method.get -> System.Net.Http.HttpMethod!
+override Refit.HeadAttribute.Method.get -> System.Net.Http.HttpMethod!
+override Refit.ObjectToInferredTypesConverter.Read(ref System.Text.Json.Utf8JsonReader reader, System.Type! typeToConvert, System.Text.Json.JsonSerializerOptions! options) -> object?
+override Refit.ObjectToInferredTypesConverter.Write(System.Text.Json.Utf8JsonWriter! writer, object! value, System.Text.Json.JsonSerializerOptions! options) -> void
+override Refit.OptionsAttribute.Method.get -> System.Net.Http.HttpMethod!
+override Refit.PatchAttribute.Method.get -> System.Net.Http.HttpMethod!
+override Refit.PostAttribute.Method.get -> System.Net.Http.HttpMethod!
+override Refit.PutAttribute.Method.get -> System.Net.Http.HttpMethod!
+override Refit.RestMethodInfo.Equals(object? obj) -> bool
+override Refit.RestMethodInfo.GetHashCode() -> int
+override Refit.RestMethodInfo.ToString() -> string!
+override Refit.StreamPart.CreateContent() -> System.Net.Http.HttpContent!
 Refit.AliasAsAttribute
 Refit.AliasAsAttribute.AliasAsAttribute(string! name) -> void
 Refit.AliasAsAttribute.Name.get -> string!
 Refit.ApiException
-Refit.ApiException.ApiException(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, string? content, System.Net.HttpStatusCode statusCode, string? reasonPhrase, System.Net.Http.Headers.HttpResponseHeaders! headers, Refit.RefitSettings! refitSettings) -> void
-Refit.ApiException.ApiException(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, string? content, System.Net.HttpStatusCode statusCode, string? reasonPhrase, System.Net.Http.Headers.HttpResponseHeaders! headers, Refit.RefitSettings! refitSettings, System.Exception? innerException) -> void
-Refit.ApiException.ApiException(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, string? content, System.Net.HttpStatusCode statusCode, string? reasonPhrase, System.Net.Http.Headers.HttpResponseHeaders! headers, Refit.RefitSettings! refitSettings) -> void
 Refit.ApiException.ApiException(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, string? content, System.Net.HttpStatusCode statusCode, string? reasonPhrase, System.Net.Http.Headers.HttpResponseHeaders! headers, Refit.RefitSettings! refitSettings, System.Exception? innerException) -> void
+Refit.ApiException.ApiException(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, string? content, System.Net.HttpStatusCode statusCode, string? reasonPhrase, System.Net.Http.Headers.HttpResponseHeaders! headers, Refit.RefitSettings! refitSettings) -> void
+Refit.ApiException.ApiException(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, string? content, System.Net.HttpStatusCode statusCode, string? reasonPhrase, System.Net.Http.Headers.HttpResponseHeaders! headers, Refit.RefitSettings! refitSettings, System.Exception? innerException) -> void
+Refit.ApiException.ApiException(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, string? content, System.Net.HttpStatusCode statusCode, string? reasonPhrase, System.Net.Http.Headers.HttpResponseHeaders! headers, Refit.RefitSettings! refitSettings) -> void
+Refit.ApiExceptionBase
+Refit.ApiExceptionBase.ApiExceptionBase(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings, System.Exception? innerException) -> void
+Refit.ApiExceptionBase.ApiExceptionBase(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings) -> void
+Refit.ApiExceptionBase.ApiExceptionBase(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings, System.Exception! innerException) -> void
+Refit.ApiExceptionBase.HttpMethod.get -> System.Net.Http.HttpMethod!
+Refit.ApiExceptionBase.RefitSettings.get -> Refit.RefitSettings!
+Refit.ApiExceptionBase.RequestMessage.get -> System.Net.Http.HttpRequestMessage!
+Refit.ApiExceptionBase.Uri.get -> System.Uri?
 Refit.ApiException.Content.get -> string?
 Refit.ApiException.ContentHeaders.get -> System.Net.Http.Headers.HttpContentHeaders?
 Refit.ApiException.ContentHeaders.set -> void
@@ -15,44 +40,36 @@ Refit.ApiException.HasContent.get -> bool
 Refit.ApiException.Headers.get -> System.Net.Http.Headers.HttpResponseHeaders!
 Refit.ApiException.ReasonPhrase.get -> string?
 Refit.ApiException.StatusCode.get -> System.Net.HttpStatusCode
-Refit.ApiExceptionBase
-Refit.ApiExceptionBase.ApiExceptionBase(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings, System.Exception! innerException) -> void
-Refit.ApiExceptionBase.ApiExceptionBase(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings) -> void
-Refit.ApiExceptionBase.ApiExceptionBase(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings, System.Exception? innerException) -> void
-Refit.ApiExceptionBase.HttpMethod.get -> System.Net.Http.HttpMethod!
-Refit.ApiExceptionBase.RefitSettings.get -> Refit.RefitSettings!
-Refit.ApiExceptionBase.RequestMessage.get -> System.Net.Http.HttpRequestMessage!
-Refit.ApiExceptionBase.Uri.get -> System.Uri?
 Refit.ApiRequestException
-Refit.ApiRequestException.ApiRequestException(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings, System.Exception! innerException) -> void
-Refit.ApiRequestException.ApiRequestException(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings) -> void
 Refit.ApiRequestException.ApiRequestException(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings, System.Exception? innerException) -> void
+Refit.ApiRequestException.ApiRequestException(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings) -> void
+Refit.ApiRequestException.ApiRequestException(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings, System.Exception! innerException) -> void
+Refit.ApiResponseExtensions
+Refit.ApiResponseExtensions.extension<T>(Refit.IApiResponse<T>!)
+Refit.ApiResponseExtensions.extension<T>(Refit.IApiResponse<T>!).EnsureSuccessfulAsync() -> System.Threading.Tasks.Task<Refit.IApiResponse<T>!>!
+Refit.ApiResponseExtensions.extension<T>(Refit.IApiResponse<T>!).EnsureSuccessStatusCodeAsync() -> System.Threading.Tasks.Task<Refit.IApiResponse<T>!>!
 Refit.ApiResponse<T>
 Refit.ApiResponse<T>.ApiResponse(System.Net.Http.HttpRequestMessage! request, System.Net.Http.HttpResponseMessage? response, T? content, Refit.RefitSettings! settings, Refit.ApiExceptionBase? error = null) -> void
-Refit.ApiResponse<T>.ApiResponse(System.Net.Http.HttpResponseMessage! response, T? content, Refit.RefitSettings! settings) -> void
 Refit.ApiResponse<T>.ApiResponse(System.Net.Http.HttpResponseMessage! response, T? content, Refit.RefitSettings! settings, Refit.ApiExceptionBase? error) -> void
+Refit.ApiResponse<T>.ApiResponse(System.Net.Http.HttpResponseMessage! response, T? content, Refit.RefitSettings! settings) -> void
 Refit.ApiResponse<T>.Content.get -> T?
 Refit.ApiResponse<T>.ContentHeaders.get -> System.Net.Http.Headers.HttpContentHeaders?
 Refit.ApiResponse<T>.Dispose() -> void
-Refit.ApiResponse<T>.EnsureSuccessStatusCodeAsync() -> System.Threading.Tasks.Task<Refit.ApiResponse<T>!>!
 Refit.ApiResponse<T>.EnsureSuccessfulAsync() -> System.Threading.Tasks.Task<Refit.ApiResponse<T>!>!
+Refit.ApiResponse<T>.EnsureSuccessStatusCodeAsync() -> System.Threading.Tasks.Task<Refit.ApiResponse<T>!>!
 Refit.ApiResponse<T>.Error.get -> Refit.ApiExceptionBase?
 Refit.ApiResponse<T>.HasContent.get -> bool
 Refit.ApiResponse<T>.HasRequestError(out Refit.ApiRequestException? error) -> bool
 Refit.ApiResponse<T>.HasResponseError(out Refit.ApiException? error) -> bool
 Refit.ApiResponse<T>.Headers.get -> System.Net.Http.Headers.HttpResponseHeaders?
 Refit.ApiResponse<T>.IsReceived.get -> bool
-Refit.ApiResponse<T>.IsSuccessStatusCode.get -> bool
 Refit.ApiResponse<T>.IsSuccessful.get -> bool
+Refit.ApiResponse<T>.IsSuccessStatusCode.get -> bool
 Refit.ApiResponse<T>.ReasonPhrase.get -> string?
 Refit.ApiResponse<T>.RequestMessage.get -> System.Net.Http.HttpRequestMessage!
 Refit.ApiResponse<T>.Settings.get -> Refit.RefitSettings!
 Refit.ApiResponse<T>.StatusCode.get -> System.Net.HttpStatusCode?
 Refit.ApiResponse<T>.Version.get -> System.Version?
-Refit.ApiResponseExtensions
-Refit.ApiResponseExtensions.extension<T>(Refit.IApiResponse<T>!)
-Refit.ApiResponseExtensions.extension<T>(Refit.IApiResponse<T>!).EnsureSuccessStatusCodeAsync() -> System.Threading.Tasks.Task<Refit.IApiResponse<T>!>!
-Refit.ApiResponseExtensions.extension<T>(Refit.IApiResponse<T>!).EnsureSuccessfulAsync() -> System.Threading.Tasks.Task<Refit.IApiResponse<T>!>!
 Refit.AttachmentNameAttribute
 Refit.AttachmentNameAttribute.AttachmentNameAttribute(string! name) -> void
 Refit.AttachmentNameAttribute.Name.get -> string!
@@ -60,10 +77,10 @@ Refit.AuthorizeAttribute
 Refit.AuthorizeAttribute.AuthorizeAttribute(string! scheme = "Bearer") -> void
 Refit.AuthorizeAttribute.Scheme.get -> string!
 Refit.BodyAttribute
-Refit.BodyAttribute.BodyAttribute() -> void
-Refit.BodyAttribute.BodyAttribute(Refit.BodySerializationMethod serializationMethod) -> void
-Refit.BodyAttribute.BodyAttribute(Refit.BodySerializationMethod serializationMethod, bool buffered) -> void
 Refit.BodyAttribute.BodyAttribute(bool buffered) -> void
+Refit.BodyAttribute.BodyAttribute(Refit.BodySerializationMethod serializationMethod, bool buffered) -> void
+Refit.BodyAttribute.BodyAttribute(Refit.BodySerializationMethod serializationMethod) -> void
+Refit.BodyAttribute.BodyAttribute() -> void
 Refit.BodyAttribute.Buffered.get -> bool?
 Refit.BodyAttribute.SerializationMethod.get -> Refit.BodySerializationMethod
 Refit.BodySerializationMethod
@@ -107,13 +124,13 @@ Refit.GetAttribute.GetAttribute(string! path) -> void
 Refit.HeadAttribute
 Refit.HeadAttribute.HeadAttribute(string! path) -> void
 Refit.HeaderAttribute
-Refit.HeaderAttribute.Header.get -> string!
 Refit.HeaderAttribute.HeaderAttribute(string! header) -> void
+Refit.HeaderAttribute.Header.get -> string!
 Refit.HeaderCollectionAttribute
 Refit.HeaderCollectionAttribute.HeaderCollectionAttribute() -> void
 Refit.HeadersAttribute
-Refit.HeadersAttribute.Headers.get -> string![]!
 Refit.HeadersAttribute.HeadersAttribute(params string![]! headers) -> void
+Refit.HeadersAttribute.Headers.get -> string![]!
 Refit.HttpMethodAttribute
 Refit.HttpMethodAttribute.HttpMethodAttribute(string! path) -> void
 Refit.HttpRequestMessageOptions
@@ -124,15 +141,15 @@ Refit.IApiResponse.HasRequestError(out Refit.ApiRequestException? error) -> bool
 Refit.IApiResponse.HasResponseError(out Refit.ApiException? error) -> bool
 Refit.IApiResponse.Headers.get -> System.Net.Http.Headers.HttpResponseHeaders?
 Refit.IApiResponse.IsReceived.get -> bool
-Refit.IApiResponse.IsSuccessStatusCode.get -> bool
 Refit.IApiResponse.IsSuccessful.get -> bool
+Refit.IApiResponse.IsSuccessStatusCode.get -> bool
 Refit.IApiResponse.ReasonPhrase.get -> string?
 Refit.IApiResponse.RequestMessage.get -> System.Net.Http.HttpRequestMessage?
 Refit.IApiResponse.StatusCode.get -> System.Net.HttpStatusCode?
-Refit.IApiResponse.Version.get -> System.Version?
 Refit.IApiResponse<T>
 Refit.IApiResponse<T>.Content.get -> T?
 Refit.IApiResponse<T>.HasContent.get -> bool
+Refit.IApiResponse.Version.get -> System.Version?
 Refit.IFormUrlEncodedParameterFormatter
 Refit.IFormUrlEncodedParameterFormatter.Format(object? value, string? formatString) -> string?
 Refit.IHttpContentSerializer
@@ -143,6 +160,11 @@ Refit.IRequestBuilder
 Refit.IRequestBuilder.BuildRestResultFuncForMethod(string! methodName, System.Type![]? parameterTypes = null, System.Type![]? genericArgumentTypes = null) -> System.Func<System.Net.Http.HttpClient!, object![]!, object?>!
 Refit.IRequestBuilder.Settings.get -> Refit.RefitSettings!
 Refit.IRequestBuilder<T>
+Refit.IStreamingContentSerializer
+Refit.IStreamingContentSerializer.DeserializeStreamAsync<T>(System.IO.Stream! stream, Refit.StreamingContentFormat format, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<T?>!
+Refit.ISynchronousContentSerializer
+Refit.ISynchronousContentSerializer.ToHttpContentSynchronous<T>(T item) -> System.Net.Http.HttpContent!
+Refit.ISynchronousContentSerializer.ToStreamingHttpContent<T>(T item) -> System.Net.Http.HttpContent!
 Refit.IUrlParameterFormatter
 Refit.IUrlParameterFormatter.Format(object? value, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string?
 Refit.IUrlParameterKeyFormatter
@@ -163,8 +185,8 @@ Refit.MultipartAttribute.MultipartAttribute(string! boundaryText = "----MyGreatB
 Refit.MultipartItem
 Refit.MultipartItem.ContentType.get -> string?
 Refit.MultipartItem.FileName.get -> string!
-Refit.MultipartItem.MultipartItem(string! fileName, string? contentType) -> void
 Refit.MultipartItem.MultipartItem(string! fileName, string? contentType, string? name) -> void
+Refit.MultipartItem.MultipartItem(string! fileName, string? contentType) -> void
 Refit.MultipartItem.Name.get -> string?
 Refit.MultipartItem.ToContent() -> System.Net.Http.HttpContent!
 Refit.ObjectToInferredTypesConverter
@@ -196,8 +218,8 @@ Refit.ProblemDetails.Type.get -> string?
 Refit.ProblemDetails.Type.set -> void
 Refit.PropertyAttribute
 Refit.PropertyAttribute.Key.get -> string?
-Refit.PropertyAttribute.PropertyAttribute() -> void
 Refit.PropertyAttribute.PropertyAttribute(string! key) -> void
+Refit.PropertyAttribute.PropertyAttribute() -> void
 Refit.PutAttribute
 Refit.PutAttribute.PutAttribute(string! path) -> void
 Refit.QueryAttribute
@@ -208,17 +230,19 @@ Refit.QueryAttribute.Format.get -> string?
 Refit.QueryAttribute.Format.set -> void
 Refit.QueryAttribute.IsCollectionFormatSpecified.get -> bool
 Refit.QueryAttribute.Prefix.get -> string?
-Refit.QueryAttribute.QueryAttribute() -> void
 Refit.QueryAttribute.QueryAttribute(Refit.CollectionFormat collectionFormat) -> void
-Refit.QueryAttribute.QueryAttribute(string! delimiter) -> void
-Refit.QueryAttribute.QueryAttribute(string! delimiter, string! prefix) -> void
 Refit.QueryAttribute.QueryAttribute(string! delimiter, string! prefix, string! format) -> void
+Refit.QueryAttribute.QueryAttribute(string! delimiter, string! prefix) -> void
+Refit.QueryAttribute.QueryAttribute(string! delimiter) -> void
+Refit.QueryAttribute.QueryAttribute() -> void
 Refit.QueryAttribute.TreatAsString.get -> bool
 Refit.QueryAttribute.TreatAsString.set -> void
 Refit.QueryUriFormatAttribute
 Refit.QueryUriFormatAttribute.QueryUriFormatAttribute(System.UriFormat uriFormat) -> void
 Refit.QueryUriFormatAttribute.UriFormat.get -> System.UriFormat
 Refit.RefitSettings
+Refit.RefitSettings.AllowUnmatchedRouteParameters.get -> bool
+Refit.RefitSettings.AllowUnmatchedRouteParameters.set -> void
 Refit.RefitSettings.AuthorizationHeaderValueGetter.get -> System.Func<System.Net.Http.HttpRequestMessage!, System.Threading.CancellationToken, System.Threading.Tasks.Task<string!>!>?
 Refit.RefitSettings.AuthorizationHeaderValueGetter.set -> void
 Refit.RefitSettings.Buffered.get -> bool
@@ -237,15 +261,23 @@ Refit.RefitSettings.HttpMessageHandlerFactory.get -> System.Func<System.Net.Http
 Refit.RefitSettings.HttpMessageHandlerFactory.set -> void
 Refit.RefitSettings.HttpRequestMessageOptions.get -> System.Collections.Generic.Dictionary<string!, object!>?
 Refit.RefitSettings.HttpRequestMessageOptions.init -> void
-Refit.RefitSettings.RefitSettings() -> void
-Refit.RefitSettings.RefitSettings(Refit.IHttpContentSerializer! contentSerializer) -> void
-Refit.RefitSettings.RefitSettings(Refit.IHttpContentSerializer! contentSerializer, Refit.IUrlParameterFormatter? urlParameterFormatter) -> void
-Refit.RefitSettings.RefitSettings(Refit.IHttpContentSerializer! contentSerializer, Refit.IUrlParameterFormatter? urlParameterFormatter, Refit.IFormUrlEncodedParameterFormatter? formUrlEncodedParameterFormatter) -> void
 Refit.RefitSettings.RefitSettings(Refit.IHttpContentSerializer! contentSerializer, Refit.IUrlParameterFormatter? urlParameterFormatter, Refit.IFormUrlEncodedParameterFormatter? formUrlEncodedParameterFormatter, Refit.IUrlParameterKeyFormatter? urlParameterKeyFormatter) -> void
+Refit.RefitSettings.RefitSettings(Refit.IHttpContentSerializer! contentSerializer, Refit.IUrlParameterFormatter? urlParameterFormatter, Refit.IFormUrlEncodedParameterFormatter? formUrlEncodedParameterFormatter) -> void
+Refit.RefitSettings.RefitSettings(Refit.IHttpContentSerializer! contentSerializer, Refit.IUrlParameterFormatter? urlParameterFormatter) -> void
+Refit.RefitSettings.RefitSettings(Refit.IHttpContentSerializer! contentSerializer) -> void
+Refit.RefitSettings.RefitSettings() -> void
+Refit.RefitSettings.RequestBodySerialization.get -> Refit.RequestBodySerializationMode
+Refit.RefitSettings.RequestBodySerialization.set -> void
 Refit.RefitSettings.UrlParameterFormatter.get -> Refit.IUrlParameterFormatter!
 Refit.RefitSettings.UrlParameterFormatter.set -> void
 Refit.RefitSettings.UrlParameterKeyFormatter.get -> Refit.IUrlParameterKeyFormatter!
 Refit.RefitSettings.UrlParameterKeyFormatter.set -> void
+Refit.RefitSettings.UrlResolution.get -> Refit.UrlResolutionMode
+Refit.RefitSettings.UrlResolution.set -> void
+Refit.RequestBodySerializationMode
+Refit.RequestBodySerializationMode.Buffered = 1 -> Refit.RequestBodySerializationMode
+Refit.RequestBodySerializationMode.Default = 0 -> Refit.RequestBodySerializationMode
+Refit.RequestBodySerializationMode.Streamed = 2 -> Refit.RequestBodySerializationMode
 Refit.RequestBuilder
 Refit.RestMethodInfo
 Refit.RestMethodInfo.<Clone>$() -> Refit.RestMethodInfo!
@@ -285,45 +317,38 @@ Refit.RestService
 Refit.SnakeCaseUrlParameterKeyFormatter
 Refit.SnakeCaseUrlParameterKeyFormatter.Format(string! key) -> string!
 Refit.SnakeCaseUrlParameterKeyFormatter.SnakeCaseUrlParameterKeyFormatter() -> void
+Refit.StreamingContentFormat
+Refit.StreamingContentFormat.JsonArray = 0 -> Refit.StreamingContentFormat
+Refit.StreamingContentFormat.JsonLines = 1 -> Refit.StreamingContentFormat
 Refit.StreamPart
 Refit.StreamPart.StreamPart(System.IO.Stream! value, string! fileName, string? contentType = null, string? name = null) -> void
 Refit.StreamPart.Value.get -> System.IO.Stream!
 Refit.SystemTextJsonContentSerializer
+Refit.SystemTextJsonContentSerializer.DeserializeStreamAsync<T>(System.IO.Stream! stream, Refit.StreamingContentFormat format, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<T?>!
 Refit.SystemTextJsonContentSerializer.FromHttpContentAsync<T>(System.Net.Http.HttpContent! content, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<T?>!
 Refit.SystemTextJsonContentSerializer.GetFieldNameForProperty(System.Reflection.PropertyInfo! propertyInfo) -> string?
-Refit.SystemTextJsonContentSerializer.SystemTextJsonContentSerializer() -> void
 Refit.SystemTextJsonContentSerializer.SystemTextJsonContentSerializer(System.Text.Json.JsonSerializerOptions! jsonSerializerOptions) -> void
+Refit.SystemTextJsonContentSerializer.SystemTextJsonContentSerializer() -> void
+Refit.SystemTextJsonContentSerializer.ToHttpContentSynchronous<T>(T item) -> System.Net.Http.HttpContent!
 Refit.SystemTextJsonContentSerializer.ToHttpContent<T>(T item) -> System.Net.Http.HttpContent!
+Refit.SystemTextJsonContentSerializer.ToStreamingHttpContent<T>(T item) -> System.Net.Http.HttpContent!
+Refit.UrlResolutionMode
+Refit.UrlResolutionMode.RefitLegacy = 0 -> Refit.UrlResolutionMode
+Refit.UrlResolutionMode.Rfc3986 = 1 -> Refit.UrlResolutionMode
 Refit.ValidationApiException
 Refit.ValidationApiException.Content.get -> Refit.ProblemDetails?
-Refit.ValidationApiException.ValidationApiException(string! message) -> void
 Refit.ValidationApiException.ValidationApiException(string! message, System.Exception! innerException) -> void
-abstract Refit.HttpMethodAttribute.Method.get -> System.Net.Http.HttpMethod!
-abstract Refit.MultipartItem.CreateContent() -> System.Net.Http.HttpContent!
-override Refit.ByteArrayPart.CreateContent() -> System.Net.Http.HttpContent!
-override Refit.DeleteAttribute.Method.get -> System.Net.Http.HttpMethod!
-override Refit.FileInfoPart.CreateContent() -> System.Net.Http.HttpContent!
-override Refit.GetAttribute.Method.get -> System.Net.Http.HttpMethod!
-override Refit.HeadAttribute.Method.get -> System.Net.Http.HttpMethod!
-override Refit.ObjectToInferredTypesConverter.Read(ref System.Text.Json.Utf8JsonReader reader, System.Type! typeToConvert, System.Text.Json.JsonSerializerOptions! options) -> object?
-override Refit.ObjectToInferredTypesConverter.Write(System.Text.Json.Utf8JsonWriter! writer, object! value, System.Text.Json.JsonSerializerOptions! options) -> void
-override Refit.OptionsAttribute.Method.get -> System.Net.Http.HttpMethod!
-override Refit.PatchAttribute.Method.get -> System.Net.Http.HttpMethod!
-override Refit.PostAttribute.Method.get -> System.Net.Http.HttpMethod!
-override Refit.PutAttribute.Method.get -> System.Net.Http.HttpMethod!
-override Refit.RestMethodInfo.Equals(object? obj) -> bool
-override Refit.RestMethodInfo.GetHashCode() -> int
-override Refit.RestMethodInfo.ToString() -> string!
-override Refit.StreamPart.CreateContent() -> System.Net.Http.HttpContent!
-static Refit.ApiException.Create(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, System.Net.Http.HttpResponseMessage! response, Refit.RefitSettings! refitSettings) -> System.Threading.Tasks.Task<Refit.ApiException!>!
-static Refit.ApiException.Create(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, System.Net.Http.HttpResponseMessage! response, Refit.RefitSettings! refitSettings, System.Exception? innerException) -> System.Threading.Tasks.Task<Refit.ApiException!>!
-static Refit.ApiException.Create(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, System.Net.Http.HttpResponseMessage! response, Refit.RefitSettings! refitSettings) -> System.Threading.Tasks.Task<Refit.ApiException!>!
+Refit.ValidationApiException.ValidationApiException(string! message) -> void
 static Refit.ApiException.Create(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, System.Net.Http.HttpResponseMessage! response, Refit.RefitSettings! refitSettings, System.Exception? innerException) -> System.Threading.Tasks.Task<Refit.ApiException!>!
-static Refit.ApiResponseExtensions.EnsureSuccessStatusCodeAsync<T>(this Refit.IApiResponse<T>! response) -> System.Threading.Tasks.Task<Refit.IApiResponse<T>!>!
+static Refit.ApiException.Create(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, System.Net.Http.HttpResponseMessage! response, Refit.RefitSettings! refitSettings) -> System.Threading.Tasks.Task<Refit.ApiException!>!
+static Refit.ApiException.Create(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, System.Net.Http.HttpResponseMessage! response, Refit.RefitSettings! refitSettings, System.Exception? innerException) -> System.Threading.Tasks.Task<Refit.ApiException!>!
+static Refit.ApiException.Create(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, System.Net.Http.HttpResponseMessage! response, Refit.RefitSettings! refitSettings) -> System.Threading.Tasks.Task<Refit.ApiException!>!
 static Refit.ApiResponseExtensions.EnsureSuccessfulAsync<T>(this Refit.IApiResponse<T>! response) -> System.Threading.Tasks.Task<Refit.IApiResponse<T>!>!
+static Refit.ApiResponseExtensions.EnsureSuccessStatusCodeAsync<T>(this Refit.IApiResponse<T>! response) -> System.Threading.Tasks.Task<Refit.IApiResponse<T>!>!
 static Refit.GeneratedRequestRunner.AddConfiguredRequestOptions(System.Net.Http.HttpRequestMessage! request, Refit.RefitSettings! settings, System.Type! interfaceType) -> void
 static Refit.GeneratedRequestRunner.AddHeaderCollection(System.Net.Http.HttpRequestMessage! request, System.Collections.Generic.IDictionary<string!, string!>? headers) -> void
 static Refit.GeneratedRequestRunner.AddRequestProperty<TValue>(System.Net.Http.HttpRequestMessage! request, string! key, TValue value) -> void
+static Refit.GeneratedRequestRunner.BuildRelativeUri(System.Net.Http.HttpClient! client, string! relativePath, Refit.UrlResolutionMode urlResolution) -> System.Uri!
 static Refit.GeneratedRequestRunner.CreateBodyContent<TBody>(Refit.RefitSettings! settings, TBody body, Refit.BodySerializationMethod serializationMethod, bool streamBody) -> System.Net.Http.HttpContent!
 static Refit.GeneratedRequestRunner.CreateJsonLinesBodyContent<TBody>(Refit.RefitSettings! settings, TBody body) -> System.Net.Http.HttpContent!
 static Refit.GeneratedRequestRunner.CreateUrlEncodedBodyContent<TBody>(Refit.RefitSettings! settings, TBody body) -> System.Net.Http.HttpContent!
@@ -343,26 +368,27 @@ static Refit.RequestBuilder.ForType<T>(Refit.RefitSettings? settings) -> Refit.I
 static Refit.RestMethodInfo.operator !=(Refit.RestMethodInfo? left, Refit.RestMethodInfo? right) -> bool
 static Refit.RestMethodInfo.operator ==(Refit.RestMethodInfo? left, Refit.RestMethodInfo? right) -> bool
 static Refit.RestService.CreateHttpClient(string! hostUrl, Refit.RefitSettings? settings) -> System.Net.Http.HttpClient!
+static Refit.RestService.ForGenerated(System.Type! refitInterfaceType, string! hostUrl, Refit.RefitSettings! settings) -> object!
+static Refit.RestService.ForGenerated(System.Type! refitInterfaceType, System.Net.Http.HttpClient! client, Refit.RefitSettings! settings) -> object!
+static Refit.RestService.ForGenerated<T>(string! hostUrl, Refit.RefitSettings! settings) -> T
+static Refit.RestService.ForGenerated<T>(string! hostUrl) -> T
+static Refit.RestService.ForGenerated<T>(System.Net.Http.HttpClient! client, Refit.RefitSettings! settings) -> T
+static Refit.RestService.ForGenerated<T>(System.Net.Http.HttpClient! client) -> T
+static Refit.RestService.For(System.Type! refitInterfaceType, string! hostUrl) -> object!
+static Refit.RestService.For(System.Type! refitInterfaceType, string! hostUrl, Refit.RefitSettings? settings) -> object!
 static Refit.RestService.For(System.Type! refitInterfaceType, System.Net.Http.HttpClient! client) -> object!
 static Refit.RestService.For(System.Type! refitInterfaceType, System.Net.Http.HttpClient! client, Refit.IRequestBuilder! builder) -> object!
 static Refit.RestService.For(System.Type! refitInterfaceType, System.Net.Http.HttpClient! client, Refit.RefitSettings? settings) -> object!
-static Refit.RestService.For(System.Type! refitInterfaceType, string! hostUrl) -> object!
-static Refit.RestService.For(System.Type! refitInterfaceType, string! hostUrl, Refit.RefitSettings? settings) -> object!
-static Refit.RestService.For<T>(System.Net.Http.HttpClient! client) -> T
+static Refit.RestService.For<T>(string! hostUrl, Refit.RefitSettings? settings) -> T
+static Refit.RestService.For<T>(string! hostUrl) -> T
 static Refit.RestService.For<T>(System.Net.Http.HttpClient! client, Refit.IRequestBuilder<T>! builder) -> T
 static Refit.RestService.For<T>(System.Net.Http.HttpClient! client, Refit.RefitSettings? settings) -> T
-static Refit.RestService.For<T>(string! hostUrl) -> T
-static Refit.RestService.For<T>(string! hostUrl, Refit.RefitSettings? settings) -> T
-static Refit.RestService.ForGenerated(System.Type! refitInterfaceType, System.Net.Http.HttpClient! client, Refit.RefitSettings! settings) -> object!
-static Refit.RestService.ForGenerated(System.Type! refitInterfaceType, string! hostUrl, Refit.RefitSettings! settings) -> object!
-static Refit.RestService.ForGenerated<T>(System.Net.Http.HttpClient! client) -> T
-static Refit.RestService.ForGenerated<T>(System.Net.Http.HttpClient! client, Refit.RefitSettings! settings) -> T
-static Refit.RestService.ForGenerated<T>(string! hostUrl) -> T
-static Refit.RestService.ForGenerated<T>(string! hostUrl, Refit.RefitSettings! settings) -> T
+static Refit.RestService.For<T>(System.Net.Http.HttpClient! client) -> T
 static Refit.RestService.RegisterGeneratedFactory(System.Type! refitInterfaceType, System.Func<System.Net.Http.HttpClient!, Refit.IRequestBuilder!, object!>! factory) -> void
 static Refit.RestService.RegisterGeneratedFactory<T>(System.Func<System.Net.Http.HttpClient!, Refit.IRequestBuilder!, T>! factory) -> void
 static Refit.RestService.RegisterGeneratedSettingsFactory<T>(System.Func<System.Net.Http.HttpClient!, Refit.RefitSettings!, T>! factory) -> void
 static Refit.SystemTextJsonContentSerializer.GetDefaultJsonSerializerOptions() -> System.Text.Json.JsonSerializerOptions!
+static Refit.SystemTextJsonContentSerializer.GetFastPathJsonSerializerOptions() -> System.Text.Json.JsonSerializerOptions!
 static Refit.ValidationApiException.Create(Refit.ApiException! exception) -> Refit.ValidationApiException!
 virtual Refit.DefaultFormUrlEncodedParameterFormatter.Format(object? value, string? formatString) -> string?
 virtual Refit.DefaultUrlParameterFormatter.Format(object? value, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string?

--- a/src/Refit/PublicAPI/net472/PublicAPI.Shipped.txt
+++ b/src/Refit/PublicAPI/net472/PublicAPI.Shipped.txt
@@ -355,6 +355,7 @@ static Refit.GeneratedRequestRunner.CreateUrlEncodedBodyContent<TBody>(Refit.Ref
 static Refit.GeneratedRequestRunner.SendAsync<T, TBody>(System.Net.Http.HttpClient! client, System.Net.Http.HttpRequestMessage! request, Refit.RefitSettings! settings, bool isApiResponse, bool shouldDisposeResponse, bool bufferBody, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<T?>!
 static Refit.GeneratedRequestRunner.SendVoidAsync(System.Net.Http.HttpClient! client, System.Net.Http.HttpRequestMessage! request, Refit.RefitSettings! settings, bool bufferBody, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 static Refit.GeneratedRequestRunner.SetHeader(System.Net.Http.HttpRequestMessage! request, string! name, string? value) -> void
+static Refit.GeneratedRequestRunner.StreamAsync<T>(System.Net.Http.HttpClient! client, System.Net.Http.HttpRequestMessage! request, Refit.RefitSettings! settings, System.Threading.CancellationToken methodCancellationToken, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<T?>!
 static Refit.HttpRequestMessageOptions.InterfaceType.get -> string!
 static Refit.HttpRequestMessageOptions.RestMethodInfo.get -> string!
 static Refit.JsonLinesContent.JsonLinesMediaType.get -> string!

--- a/src/Refit/PublicAPI/net472/PublicAPI.Shipped.txt
+++ b/src/Refit/PublicAPI/net472/PublicAPI.Shipped.txt
@@ -1,12 +1,37 @@
 #nullable enable
+abstract Refit.HttpMethodAttribute.Method.get -> System.Net.Http.HttpMethod!
+abstract Refit.MultipartItem.CreateContent() -> System.Net.Http.HttpContent!
+override Refit.ByteArrayPart.CreateContent() -> System.Net.Http.HttpContent!
+override Refit.DeleteAttribute.Method.get -> System.Net.Http.HttpMethod!
+override Refit.FileInfoPart.CreateContent() -> System.Net.Http.HttpContent!
+override Refit.GetAttribute.Method.get -> System.Net.Http.HttpMethod!
+override Refit.HeadAttribute.Method.get -> System.Net.Http.HttpMethod!
+override Refit.ObjectToInferredTypesConverter.Read(ref System.Text.Json.Utf8JsonReader reader, System.Type! typeToConvert, System.Text.Json.JsonSerializerOptions! options) -> object?
+override Refit.ObjectToInferredTypesConverter.Write(System.Text.Json.Utf8JsonWriter! writer, object! value, System.Text.Json.JsonSerializerOptions! options) -> void
+override Refit.OptionsAttribute.Method.get -> System.Net.Http.HttpMethod!
+override Refit.PatchAttribute.Method.get -> System.Net.Http.HttpMethod!
+override Refit.PostAttribute.Method.get -> System.Net.Http.HttpMethod!
+override Refit.PutAttribute.Method.get -> System.Net.Http.HttpMethod!
+override Refit.RestMethodInfo.Equals(object? obj) -> bool
+override Refit.RestMethodInfo.GetHashCode() -> int
+override Refit.RestMethodInfo.ToString() -> string!
+override Refit.StreamPart.CreateContent() -> System.Net.Http.HttpContent!
 Refit.AliasAsAttribute
 Refit.AliasAsAttribute.AliasAsAttribute(string! name) -> void
 Refit.AliasAsAttribute.Name.get -> string!
 Refit.ApiException
-Refit.ApiException.ApiException(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, string? content, System.Net.HttpStatusCode statusCode, string? reasonPhrase, System.Net.Http.Headers.HttpResponseHeaders! headers, Refit.RefitSettings! refitSettings) -> void
-Refit.ApiException.ApiException(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, string? content, System.Net.HttpStatusCode statusCode, string? reasonPhrase, System.Net.Http.Headers.HttpResponseHeaders! headers, Refit.RefitSettings! refitSettings, System.Exception? innerException) -> void
-Refit.ApiException.ApiException(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, string? content, System.Net.HttpStatusCode statusCode, string? reasonPhrase, System.Net.Http.Headers.HttpResponseHeaders! headers, Refit.RefitSettings! refitSettings) -> void
 Refit.ApiException.ApiException(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, string? content, System.Net.HttpStatusCode statusCode, string? reasonPhrase, System.Net.Http.Headers.HttpResponseHeaders! headers, Refit.RefitSettings! refitSettings, System.Exception? innerException) -> void
+Refit.ApiException.ApiException(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, string? content, System.Net.HttpStatusCode statusCode, string? reasonPhrase, System.Net.Http.Headers.HttpResponseHeaders! headers, Refit.RefitSettings! refitSettings) -> void
+Refit.ApiException.ApiException(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, string? content, System.Net.HttpStatusCode statusCode, string? reasonPhrase, System.Net.Http.Headers.HttpResponseHeaders! headers, Refit.RefitSettings! refitSettings, System.Exception? innerException) -> void
+Refit.ApiException.ApiException(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, string? content, System.Net.HttpStatusCode statusCode, string? reasonPhrase, System.Net.Http.Headers.HttpResponseHeaders! headers, Refit.RefitSettings! refitSettings) -> void
+Refit.ApiExceptionBase
+Refit.ApiExceptionBase.ApiExceptionBase(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings, System.Exception? innerException) -> void
+Refit.ApiExceptionBase.ApiExceptionBase(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings) -> void
+Refit.ApiExceptionBase.ApiExceptionBase(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings, System.Exception! innerException) -> void
+Refit.ApiExceptionBase.HttpMethod.get -> System.Net.Http.HttpMethod!
+Refit.ApiExceptionBase.RefitSettings.get -> Refit.RefitSettings!
+Refit.ApiExceptionBase.RequestMessage.get -> System.Net.Http.HttpRequestMessage!
+Refit.ApiExceptionBase.Uri.get -> System.Uri?
 Refit.ApiException.Content.get -> string?
 Refit.ApiException.ContentHeaders.get -> System.Net.Http.Headers.HttpContentHeaders?
 Refit.ApiException.ContentHeaders.set -> void
@@ -15,44 +40,36 @@ Refit.ApiException.HasContent.get -> bool
 Refit.ApiException.Headers.get -> System.Net.Http.Headers.HttpResponseHeaders!
 Refit.ApiException.ReasonPhrase.get -> string?
 Refit.ApiException.StatusCode.get -> System.Net.HttpStatusCode
-Refit.ApiExceptionBase
-Refit.ApiExceptionBase.ApiExceptionBase(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings, System.Exception! innerException) -> void
-Refit.ApiExceptionBase.ApiExceptionBase(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings) -> void
-Refit.ApiExceptionBase.ApiExceptionBase(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings, System.Exception? innerException) -> void
-Refit.ApiExceptionBase.HttpMethod.get -> System.Net.Http.HttpMethod!
-Refit.ApiExceptionBase.RefitSettings.get -> Refit.RefitSettings!
-Refit.ApiExceptionBase.RequestMessage.get -> System.Net.Http.HttpRequestMessage!
-Refit.ApiExceptionBase.Uri.get -> System.Uri?
 Refit.ApiRequestException
-Refit.ApiRequestException.ApiRequestException(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings, System.Exception! innerException) -> void
-Refit.ApiRequestException.ApiRequestException(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings) -> void
 Refit.ApiRequestException.ApiRequestException(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings, System.Exception? innerException) -> void
+Refit.ApiRequestException.ApiRequestException(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings) -> void
+Refit.ApiRequestException.ApiRequestException(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings, System.Exception! innerException) -> void
+Refit.ApiResponseExtensions
+Refit.ApiResponseExtensions.extension<T>(Refit.IApiResponse<T>!)
+Refit.ApiResponseExtensions.extension<T>(Refit.IApiResponse<T>!).EnsureSuccessfulAsync() -> System.Threading.Tasks.Task<Refit.IApiResponse<T>!>!
+Refit.ApiResponseExtensions.extension<T>(Refit.IApiResponse<T>!).EnsureSuccessStatusCodeAsync() -> System.Threading.Tasks.Task<Refit.IApiResponse<T>!>!
 Refit.ApiResponse<T>
 Refit.ApiResponse<T>.ApiResponse(System.Net.Http.HttpRequestMessage! request, System.Net.Http.HttpResponseMessage? response, T? content, Refit.RefitSettings! settings, Refit.ApiExceptionBase? error = null) -> void
-Refit.ApiResponse<T>.ApiResponse(System.Net.Http.HttpResponseMessage! response, T? content, Refit.RefitSettings! settings) -> void
 Refit.ApiResponse<T>.ApiResponse(System.Net.Http.HttpResponseMessage! response, T? content, Refit.RefitSettings! settings, Refit.ApiExceptionBase? error) -> void
+Refit.ApiResponse<T>.ApiResponse(System.Net.Http.HttpResponseMessage! response, T? content, Refit.RefitSettings! settings) -> void
 Refit.ApiResponse<T>.Content.get -> T?
 Refit.ApiResponse<T>.ContentHeaders.get -> System.Net.Http.Headers.HttpContentHeaders?
 Refit.ApiResponse<T>.Dispose() -> void
-Refit.ApiResponse<T>.EnsureSuccessStatusCodeAsync() -> System.Threading.Tasks.Task<Refit.ApiResponse<T>!>!
 Refit.ApiResponse<T>.EnsureSuccessfulAsync() -> System.Threading.Tasks.Task<Refit.ApiResponse<T>!>!
+Refit.ApiResponse<T>.EnsureSuccessStatusCodeAsync() -> System.Threading.Tasks.Task<Refit.ApiResponse<T>!>!
 Refit.ApiResponse<T>.Error.get -> Refit.ApiExceptionBase?
 Refit.ApiResponse<T>.HasContent.get -> bool
 Refit.ApiResponse<T>.HasRequestError(out Refit.ApiRequestException? error) -> bool
 Refit.ApiResponse<T>.HasResponseError(out Refit.ApiException? error) -> bool
 Refit.ApiResponse<T>.Headers.get -> System.Net.Http.Headers.HttpResponseHeaders?
 Refit.ApiResponse<T>.IsReceived.get -> bool
-Refit.ApiResponse<T>.IsSuccessStatusCode.get -> bool
 Refit.ApiResponse<T>.IsSuccessful.get -> bool
+Refit.ApiResponse<T>.IsSuccessStatusCode.get -> bool
 Refit.ApiResponse<T>.ReasonPhrase.get -> string?
 Refit.ApiResponse<T>.RequestMessage.get -> System.Net.Http.HttpRequestMessage!
 Refit.ApiResponse<T>.Settings.get -> Refit.RefitSettings!
 Refit.ApiResponse<T>.StatusCode.get -> System.Net.HttpStatusCode?
 Refit.ApiResponse<T>.Version.get -> System.Version?
-Refit.ApiResponseExtensions
-Refit.ApiResponseExtensions.extension<T>(Refit.IApiResponse<T>!)
-Refit.ApiResponseExtensions.extension<T>(Refit.IApiResponse<T>!).EnsureSuccessStatusCodeAsync() -> System.Threading.Tasks.Task<Refit.IApiResponse<T>!>!
-Refit.ApiResponseExtensions.extension<T>(Refit.IApiResponse<T>!).EnsureSuccessfulAsync() -> System.Threading.Tasks.Task<Refit.IApiResponse<T>!>!
 Refit.AttachmentNameAttribute
 Refit.AttachmentNameAttribute.AttachmentNameAttribute(string! name) -> void
 Refit.AttachmentNameAttribute.Name.get -> string!
@@ -60,10 +77,10 @@ Refit.AuthorizeAttribute
 Refit.AuthorizeAttribute.AuthorizeAttribute(string! scheme = "Bearer") -> void
 Refit.AuthorizeAttribute.Scheme.get -> string!
 Refit.BodyAttribute
-Refit.BodyAttribute.BodyAttribute() -> void
-Refit.BodyAttribute.BodyAttribute(Refit.BodySerializationMethod serializationMethod) -> void
-Refit.BodyAttribute.BodyAttribute(Refit.BodySerializationMethod serializationMethod, bool buffered) -> void
 Refit.BodyAttribute.BodyAttribute(bool buffered) -> void
+Refit.BodyAttribute.BodyAttribute(Refit.BodySerializationMethod serializationMethod, bool buffered) -> void
+Refit.BodyAttribute.BodyAttribute(Refit.BodySerializationMethod serializationMethod) -> void
+Refit.BodyAttribute.BodyAttribute() -> void
 Refit.BodyAttribute.Buffered.get -> bool?
 Refit.BodyAttribute.SerializationMethod.get -> Refit.BodySerializationMethod
 Refit.BodySerializationMethod
@@ -107,13 +124,13 @@ Refit.GetAttribute.GetAttribute(string! path) -> void
 Refit.HeadAttribute
 Refit.HeadAttribute.HeadAttribute(string! path) -> void
 Refit.HeaderAttribute
-Refit.HeaderAttribute.Header.get -> string!
 Refit.HeaderAttribute.HeaderAttribute(string! header) -> void
+Refit.HeaderAttribute.Header.get -> string!
 Refit.HeaderCollectionAttribute
 Refit.HeaderCollectionAttribute.HeaderCollectionAttribute() -> void
 Refit.HeadersAttribute
-Refit.HeadersAttribute.Headers.get -> string![]!
 Refit.HeadersAttribute.HeadersAttribute(params string![]! headers) -> void
+Refit.HeadersAttribute.Headers.get -> string![]!
 Refit.HttpMethodAttribute
 Refit.HttpMethodAttribute.HttpMethodAttribute(string! path) -> void
 Refit.HttpRequestMessageOptions
@@ -124,15 +141,15 @@ Refit.IApiResponse.HasRequestError(out Refit.ApiRequestException? error) -> bool
 Refit.IApiResponse.HasResponseError(out Refit.ApiException? error) -> bool
 Refit.IApiResponse.Headers.get -> System.Net.Http.Headers.HttpResponseHeaders?
 Refit.IApiResponse.IsReceived.get -> bool
-Refit.IApiResponse.IsSuccessStatusCode.get -> bool
 Refit.IApiResponse.IsSuccessful.get -> bool
+Refit.IApiResponse.IsSuccessStatusCode.get -> bool
 Refit.IApiResponse.ReasonPhrase.get -> string?
 Refit.IApiResponse.RequestMessage.get -> System.Net.Http.HttpRequestMessage?
 Refit.IApiResponse.StatusCode.get -> System.Net.HttpStatusCode?
-Refit.IApiResponse.Version.get -> System.Version?
 Refit.IApiResponse<T>
 Refit.IApiResponse<T>.Content.get -> T?
 Refit.IApiResponse<T>.HasContent.get -> bool
+Refit.IApiResponse.Version.get -> System.Version?
 Refit.IFormUrlEncodedParameterFormatter
 Refit.IFormUrlEncodedParameterFormatter.Format(object? value, string? formatString) -> string?
 Refit.IHttpContentSerializer
@@ -143,6 +160,11 @@ Refit.IRequestBuilder
 Refit.IRequestBuilder.BuildRestResultFuncForMethod(string! methodName, System.Type![]? parameterTypes = null, System.Type![]? genericArgumentTypes = null) -> System.Func<System.Net.Http.HttpClient!, object![]!, object?>!
 Refit.IRequestBuilder.Settings.get -> Refit.RefitSettings!
 Refit.IRequestBuilder<T>
+Refit.IStreamingContentSerializer
+Refit.IStreamingContentSerializer.DeserializeStreamAsync<T>(System.IO.Stream! stream, Refit.StreamingContentFormat format, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<T?>!
+Refit.ISynchronousContentSerializer
+Refit.ISynchronousContentSerializer.ToHttpContentSynchronous<T>(T item) -> System.Net.Http.HttpContent!
+Refit.ISynchronousContentSerializer.ToStreamingHttpContent<T>(T item) -> System.Net.Http.HttpContent!
 Refit.IUrlParameterFormatter
 Refit.IUrlParameterFormatter.Format(object? value, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string?
 Refit.IUrlParameterKeyFormatter
@@ -163,8 +185,8 @@ Refit.MultipartAttribute.MultipartAttribute(string! boundaryText = "----MyGreatB
 Refit.MultipartItem
 Refit.MultipartItem.ContentType.get -> string?
 Refit.MultipartItem.FileName.get -> string!
-Refit.MultipartItem.MultipartItem(string! fileName, string? contentType) -> void
 Refit.MultipartItem.MultipartItem(string! fileName, string? contentType, string? name) -> void
+Refit.MultipartItem.MultipartItem(string! fileName, string? contentType) -> void
 Refit.MultipartItem.Name.get -> string?
 Refit.MultipartItem.ToContent() -> System.Net.Http.HttpContent!
 Refit.ObjectToInferredTypesConverter
@@ -196,8 +218,8 @@ Refit.ProblemDetails.Type.get -> string?
 Refit.ProblemDetails.Type.set -> void
 Refit.PropertyAttribute
 Refit.PropertyAttribute.Key.get -> string?
-Refit.PropertyAttribute.PropertyAttribute() -> void
 Refit.PropertyAttribute.PropertyAttribute(string! key) -> void
+Refit.PropertyAttribute.PropertyAttribute() -> void
 Refit.PutAttribute
 Refit.PutAttribute.PutAttribute(string! path) -> void
 Refit.QueryAttribute
@@ -208,17 +230,19 @@ Refit.QueryAttribute.Format.get -> string?
 Refit.QueryAttribute.Format.set -> void
 Refit.QueryAttribute.IsCollectionFormatSpecified.get -> bool
 Refit.QueryAttribute.Prefix.get -> string?
-Refit.QueryAttribute.QueryAttribute() -> void
 Refit.QueryAttribute.QueryAttribute(Refit.CollectionFormat collectionFormat) -> void
-Refit.QueryAttribute.QueryAttribute(string! delimiter) -> void
-Refit.QueryAttribute.QueryAttribute(string! delimiter, string! prefix) -> void
 Refit.QueryAttribute.QueryAttribute(string! delimiter, string! prefix, string! format) -> void
+Refit.QueryAttribute.QueryAttribute(string! delimiter, string! prefix) -> void
+Refit.QueryAttribute.QueryAttribute(string! delimiter) -> void
+Refit.QueryAttribute.QueryAttribute() -> void
 Refit.QueryAttribute.TreatAsString.get -> bool
 Refit.QueryAttribute.TreatAsString.set -> void
 Refit.QueryUriFormatAttribute
 Refit.QueryUriFormatAttribute.QueryUriFormatAttribute(System.UriFormat uriFormat) -> void
 Refit.QueryUriFormatAttribute.UriFormat.get -> System.UriFormat
 Refit.RefitSettings
+Refit.RefitSettings.AllowUnmatchedRouteParameters.get -> bool
+Refit.RefitSettings.AllowUnmatchedRouteParameters.set -> void
 Refit.RefitSettings.AuthorizationHeaderValueGetter.get -> System.Func<System.Net.Http.HttpRequestMessage!, System.Threading.CancellationToken, System.Threading.Tasks.Task<string!>!>?
 Refit.RefitSettings.AuthorizationHeaderValueGetter.set -> void
 Refit.RefitSettings.Buffered.get -> bool
@@ -237,15 +261,23 @@ Refit.RefitSettings.HttpMessageHandlerFactory.get -> System.Func<System.Net.Http
 Refit.RefitSettings.HttpMessageHandlerFactory.set -> void
 Refit.RefitSettings.HttpRequestMessageOptions.get -> System.Collections.Generic.Dictionary<string!, object!>?
 Refit.RefitSettings.HttpRequestMessageOptions.init -> void
-Refit.RefitSettings.RefitSettings() -> void
-Refit.RefitSettings.RefitSettings(Refit.IHttpContentSerializer! contentSerializer) -> void
-Refit.RefitSettings.RefitSettings(Refit.IHttpContentSerializer! contentSerializer, Refit.IUrlParameterFormatter? urlParameterFormatter) -> void
-Refit.RefitSettings.RefitSettings(Refit.IHttpContentSerializer! contentSerializer, Refit.IUrlParameterFormatter? urlParameterFormatter, Refit.IFormUrlEncodedParameterFormatter? formUrlEncodedParameterFormatter) -> void
 Refit.RefitSettings.RefitSettings(Refit.IHttpContentSerializer! contentSerializer, Refit.IUrlParameterFormatter? urlParameterFormatter, Refit.IFormUrlEncodedParameterFormatter? formUrlEncodedParameterFormatter, Refit.IUrlParameterKeyFormatter? urlParameterKeyFormatter) -> void
+Refit.RefitSettings.RefitSettings(Refit.IHttpContentSerializer! contentSerializer, Refit.IUrlParameterFormatter? urlParameterFormatter, Refit.IFormUrlEncodedParameterFormatter? formUrlEncodedParameterFormatter) -> void
+Refit.RefitSettings.RefitSettings(Refit.IHttpContentSerializer! contentSerializer, Refit.IUrlParameterFormatter? urlParameterFormatter) -> void
+Refit.RefitSettings.RefitSettings(Refit.IHttpContentSerializer! contentSerializer) -> void
+Refit.RefitSettings.RefitSettings() -> void
+Refit.RefitSettings.RequestBodySerialization.get -> Refit.RequestBodySerializationMode
+Refit.RefitSettings.RequestBodySerialization.set -> void
 Refit.RefitSettings.UrlParameterFormatter.get -> Refit.IUrlParameterFormatter!
 Refit.RefitSettings.UrlParameterFormatter.set -> void
 Refit.RefitSettings.UrlParameterKeyFormatter.get -> Refit.IUrlParameterKeyFormatter!
 Refit.RefitSettings.UrlParameterKeyFormatter.set -> void
+Refit.RefitSettings.UrlResolution.get -> Refit.UrlResolutionMode
+Refit.RefitSettings.UrlResolution.set -> void
+Refit.RequestBodySerializationMode
+Refit.RequestBodySerializationMode.Buffered = 1 -> Refit.RequestBodySerializationMode
+Refit.RequestBodySerializationMode.Default = 0 -> Refit.RequestBodySerializationMode
+Refit.RequestBodySerializationMode.Streamed = 2 -> Refit.RequestBodySerializationMode
 Refit.RequestBuilder
 Refit.RestMethodInfo
 Refit.RestMethodInfo.<Clone>$() -> Refit.RestMethodInfo!
@@ -285,45 +317,38 @@ Refit.RestService
 Refit.SnakeCaseUrlParameterKeyFormatter
 Refit.SnakeCaseUrlParameterKeyFormatter.Format(string! key) -> string!
 Refit.SnakeCaseUrlParameterKeyFormatter.SnakeCaseUrlParameterKeyFormatter() -> void
+Refit.StreamingContentFormat
+Refit.StreamingContentFormat.JsonArray = 0 -> Refit.StreamingContentFormat
+Refit.StreamingContentFormat.JsonLines = 1 -> Refit.StreamingContentFormat
 Refit.StreamPart
 Refit.StreamPart.StreamPart(System.IO.Stream! value, string! fileName, string? contentType = null, string? name = null) -> void
 Refit.StreamPart.Value.get -> System.IO.Stream!
 Refit.SystemTextJsonContentSerializer
+Refit.SystemTextJsonContentSerializer.DeserializeStreamAsync<T>(System.IO.Stream! stream, Refit.StreamingContentFormat format, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<T?>!
 Refit.SystemTextJsonContentSerializer.FromHttpContentAsync<T>(System.Net.Http.HttpContent! content, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<T?>!
 Refit.SystemTextJsonContentSerializer.GetFieldNameForProperty(System.Reflection.PropertyInfo! propertyInfo) -> string?
-Refit.SystemTextJsonContentSerializer.SystemTextJsonContentSerializer() -> void
 Refit.SystemTextJsonContentSerializer.SystemTextJsonContentSerializer(System.Text.Json.JsonSerializerOptions! jsonSerializerOptions) -> void
+Refit.SystemTextJsonContentSerializer.SystemTextJsonContentSerializer() -> void
+Refit.SystemTextJsonContentSerializer.ToHttpContentSynchronous<T>(T item) -> System.Net.Http.HttpContent!
 Refit.SystemTextJsonContentSerializer.ToHttpContent<T>(T item) -> System.Net.Http.HttpContent!
+Refit.SystemTextJsonContentSerializer.ToStreamingHttpContent<T>(T item) -> System.Net.Http.HttpContent!
+Refit.UrlResolutionMode
+Refit.UrlResolutionMode.RefitLegacy = 0 -> Refit.UrlResolutionMode
+Refit.UrlResolutionMode.Rfc3986 = 1 -> Refit.UrlResolutionMode
 Refit.ValidationApiException
 Refit.ValidationApiException.Content.get -> Refit.ProblemDetails?
-Refit.ValidationApiException.ValidationApiException(string! message) -> void
 Refit.ValidationApiException.ValidationApiException(string! message, System.Exception! innerException) -> void
-abstract Refit.HttpMethodAttribute.Method.get -> System.Net.Http.HttpMethod!
-abstract Refit.MultipartItem.CreateContent() -> System.Net.Http.HttpContent!
-override Refit.ByteArrayPart.CreateContent() -> System.Net.Http.HttpContent!
-override Refit.DeleteAttribute.Method.get -> System.Net.Http.HttpMethod!
-override Refit.FileInfoPart.CreateContent() -> System.Net.Http.HttpContent!
-override Refit.GetAttribute.Method.get -> System.Net.Http.HttpMethod!
-override Refit.HeadAttribute.Method.get -> System.Net.Http.HttpMethod!
-override Refit.ObjectToInferredTypesConverter.Read(ref System.Text.Json.Utf8JsonReader reader, System.Type! typeToConvert, System.Text.Json.JsonSerializerOptions! options) -> object?
-override Refit.ObjectToInferredTypesConverter.Write(System.Text.Json.Utf8JsonWriter! writer, object! value, System.Text.Json.JsonSerializerOptions! options) -> void
-override Refit.OptionsAttribute.Method.get -> System.Net.Http.HttpMethod!
-override Refit.PatchAttribute.Method.get -> System.Net.Http.HttpMethod!
-override Refit.PostAttribute.Method.get -> System.Net.Http.HttpMethod!
-override Refit.PutAttribute.Method.get -> System.Net.Http.HttpMethod!
-override Refit.RestMethodInfo.Equals(object? obj) -> bool
-override Refit.RestMethodInfo.GetHashCode() -> int
-override Refit.RestMethodInfo.ToString() -> string!
-override Refit.StreamPart.CreateContent() -> System.Net.Http.HttpContent!
-static Refit.ApiException.Create(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, System.Net.Http.HttpResponseMessage! response, Refit.RefitSettings! refitSettings) -> System.Threading.Tasks.Task<Refit.ApiException!>!
-static Refit.ApiException.Create(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, System.Net.Http.HttpResponseMessage! response, Refit.RefitSettings! refitSettings, System.Exception? innerException) -> System.Threading.Tasks.Task<Refit.ApiException!>!
-static Refit.ApiException.Create(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, System.Net.Http.HttpResponseMessage! response, Refit.RefitSettings! refitSettings) -> System.Threading.Tasks.Task<Refit.ApiException!>!
+Refit.ValidationApiException.ValidationApiException(string! message) -> void
 static Refit.ApiException.Create(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, System.Net.Http.HttpResponseMessage! response, Refit.RefitSettings! refitSettings, System.Exception? innerException) -> System.Threading.Tasks.Task<Refit.ApiException!>!
-static Refit.ApiResponseExtensions.EnsureSuccessStatusCodeAsync<T>(this Refit.IApiResponse<T>! response) -> System.Threading.Tasks.Task<Refit.IApiResponse<T>!>!
+static Refit.ApiException.Create(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, System.Net.Http.HttpResponseMessage! response, Refit.RefitSettings! refitSettings) -> System.Threading.Tasks.Task<Refit.ApiException!>!
+static Refit.ApiException.Create(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, System.Net.Http.HttpResponseMessage! response, Refit.RefitSettings! refitSettings, System.Exception? innerException) -> System.Threading.Tasks.Task<Refit.ApiException!>!
+static Refit.ApiException.Create(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, System.Net.Http.HttpResponseMessage! response, Refit.RefitSettings! refitSettings) -> System.Threading.Tasks.Task<Refit.ApiException!>!
 static Refit.ApiResponseExtensions.EnsureSuccessfulAsync<T>(this Refit.IApiResponse<T>! response) -> System.Threading.Tasks.Task<Refit.IApiResponse<T>!>!
+static Refit.ApiResponseExtensions.EnsureSuccessStatusCodeAsync<T>(this Refit.IApiResponse<T>! response) -> System.Threading.Tasks.Task<Refit.IApiResponse<T>!>!
 static Refit.GeneratedRequestRunner.AddConfiguredRequestOptions(System.Net.Http.HttpRequestMessage! request, Refit.RefitSettings! settings, System.Type! interfaceType) -> void
 static Refit.GeneratedRequestRunner.AddHeaderCollection(System.Net.Http.HttpRequestMessage! request, System.Collections.Generic.IDictionary<string!, string!>? headers) -> void
 static Refit.GeneratedRequestRunner.AddRequestProperty<TValue>(System.Net.Http.HttpRequestMessage! request, string! key, TValue value) -> void
+static Refit.GeneratedRequestRunner.BuildRelativeUri(System.Net.Http.HttpClient! client, string! relativePath, Refit.UrlResolutionMode urlResolution) -> System.Uri!
 static Refit.GeneratedRequestRunner.CreateBodyContent<TBody>(Refit.RefitSettings! settings, TBody body, Refit.BodySerializationMethod serializationMethod, bool streamBody) -> System.Net.Http.HttpContent!
 static Refit.GeneratedRequestRunner.CreateJsonLinesBodyContent<TBody>(Refit.RefitSettings! settings, TBody body) -> System.Net.Http.HttpContent!
 static Refit.GeneratedRequestRunner.CreateUrlEncodedBodyContent<TBody>(Refit.RefitSettings! settings, TBody body) -> System.Net.Http.HttpContent!
@@ -343,26 +368,27 @@ static Refit.RequestBuilder.ForType<T>(Refit.RefitSettings? settings) -> Refit.I
 static Refit.RestMethodInfo.operator !=(Refit.RestMethodInfo? left, Refit.RestMethodInfo? right) -> bool
 static Refit.RestMethodInfo.operator ==(Refit.RestMethodInfo? left, Refit.RestMethodInfo? right) -> bool
 static Refit.RestService.CreateHttpClient(string! hostUrl, Refit.RefitSettings? settings) -> System.Net.Http.HttpClient!
+static Refit.RestService.ForGenerated(System.Type! refitInterfaceType, string! hostUrl, Refit.RefitSettings! settings) -> object!
+static Refit.RestService.ForGenerated(System.Type! refitInterfaceType, System.Net.Http.HttpClient! client, Refit.RefitSettings! settings) -> object!
+static Refit.RestService.ForGenerated<T>(string! hostUrl, Refit.RefitSettings! settings) -> T
+static Refit.RestService.ForGenerated<T>(string! hostUrl) -> T
+static Refit.RestService.ForGenerated<T>(System.Net.Http.HttpClient! client, Refit.RefitSettings! settings) -> T
+static Refit.RestService.ForGenerated<T>(System.Net.Http.HttpClient! client) -> T
+static Refit.RestService.For(System.Type! refitInterfaceType, string! hostUrl) -> object!
+static Refit.RestService.For(System.Type! refitInterfaceType, string! hostUrl, Refit.RefitSettings? settings) -> object!
 static Refit.RestService.For(System.Type! refitInterfaceType, System.Net.Http.HttpClient! client) -> object!
 static Refit.RestService.For(System.Type! refitInterfaceType, System.Net.Http.HttpClient! client, Refit.IRequestBuilder! builder) -> object!
 static Refit.RestService.For(System.Type! refitInterfaceType, System.Net.Http.HttpClient! client, Refit.RefitSettings? settings) -> object!
-static Refit.RestService.For(System.Type! refitInterfaceType, string! hostUrl) -> object!
-static Refit.RestService.For(System.Type! refitInterfaceType, string! hostUrl, Refit.RefitSettings? settings) -> object!
-static Refit.RestService.For<T>(System.Net.Http.HttpClient! client) -> T
+static Refit.RestService.For<T>(string! hostUrl, Refit.RefitSettings? settings) -> T
+static Refit.RestService.For<T>(string! hostUrl) -> T
 static Refit.RestService.For<T>(System.Net.Http.HttpClient! client, Refit.IRequestBuilder<T>! builder) -> T
 static Refit.RestService.For<T>(System.Net.Http.HttpClient! client, Refit.RefitSettings? settings) -> T
-static Refit.RestService.For<T>(string! hostUrl) -> T
-static Refit.RestService.For<T>(string! hostUrl, Refit.RefitSettings? settings) -> T
-static Refit.RestService.ForGenerated(System.Type! refitInterfaceType, System.Net.Http.HttpClient! client, Refit.RefitSettings! settings) -> object!
-static Refit.RestService.ForGenerated(System.Type! refitInterfaceType, string! hostUrl, Refit.RefitSettings! settings) -> object!
-static Refit.RestService.ForGenerated<T>(System.Net.Http.HttpClient! client) -> T
-static Refit.RestService.ForGenerated<T>(System.Net.Http.HttpClient! client, Refit.RefitSettings! settings) -> T
-static Refit.RestService.ForGenerated<T>(string! hostUrl) -> T
-static Refit.RestService.ForGenerated<T>(string! hostUrl, Refit.RefitSettings! settings) -> T
+static Refit.RestService.For<T>(System.Net.Http.HttpClient! client) -> T
 static Refit.RestService.RegisterGeneratedFactory(System.Type! refitInterfaceType, System.Func<System.Net.Http.HttpClient!, Refit.IRequestBuilder!, object!>! factory) -> void
 static Refit.RestService.RegisterGeneratedFactory<T>(System.Func<System.Net.Http.HttpClient!, Refit.IRequestBuilder!, T>! factory) -> void
 static Refit.RestService.RegisterGeneratedSettingsFactory<T>(System.Func<System.Net.Http.HttpClient!, Refit.RefitSettings!, T>! factory) -> void
 static Refit.SystemTextJsonContentSerializer.GetDefaultJsonSerializerOptions() -> System.Text.Json.JsonSerializerOptions!
+static Refit.SystemTextJsonContentSerializer.GetFastPathJsonSerializerOptions() -> System.Text.Json.JsonSerializerOptions!
 static Refit.ValidationApiException.Create(Refit.ApiException! exception) -> Refit.ValidationApiException!
 virtual Refit.DefaultFormUrlEncodedParameterFormatter.Format(object? value, string? formatString) -> string?
 virtual Refit.DefaultUrlParameterFormatter.Format(object? value, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string?

--- a/src/Refit/PublicAPI/net48/PublicAPI.Shipped.txt
+++ b/src/Refit/PublicAPI/net48/PublicAPI.Shipped.txt
@@ -355,6 +355,7 @@ static Refit.GeneratedRequestRunner.CreateUrlEncodedBodyContent<TBody>(Refit.Ref
 static Refit.GeneratedRequestRunner.SendAsync<T, TBody>(System.Net.Http.HttpClient! client, System.Net.Http.HttpRequestMessage! request, Refit.RefitSettings! settings, bool isApiResponse, bool shouldDisposeResponse, bool bufferBody, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<T?>!
 static Refit.GeneratedRequestRunner.SendVoidAsync(System.Net.Http.HttpClient! client, System.Net.Http.HttpRequestMessage! request, Refit.RefitSettings! settings, bool bufferBody, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 static Refit.GeneratedRequestRunner.SetHeader(System.Net.Http.HttpRequestMessage! request, string! name, string? value) -> void
+static Refit.GeneratedRequestRunner.StreamAsync<T>(System.Net.Http.HttpClient! client, System.Net.Http.HttpRequestMessage! request, Refit.RefitSettings! settings, System.Threading.CancellationToken methodCancellationToken, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<T?>!
 static Refit.HttpRequestMessageOptions.InterfaceType.get -> string!
 static Refit.HttpRequestMessageOptions.RestMethodInfo.get -> string!
 static Refit.JsonLinesContent.JsonLinesMediaType.get -> string!

--- a/src/Refit/PublicAPI/net48/PublicAPI.Shipped.txt
+++ b/src/Refit/PublicAPI/net48/PublicAPI.Shipped.txt
@@ -1,12 +1,37 @@
 #nullable enable
+abstract Refit.HttpMethodAttribute.Method.get -> System.Net.Http.HttpMethod!
+abstract Refit.MultipartItem.CreateContent() -> System.Net.Http.HttpContent!
+override Refit.ByteArrayPart.CreateContent() -> System.Net.Http.HttpContent!
+override Refit.DeleteAttribute.Method.get -> System.Net.Http.HttpMethod!
+override Refit.FileInfoPart.CreateContent() -> System.Net.Http.HttpContent!
+override Refit.GetAttribute.Method.get -> System.Net.Http.HttpMethod!
+override Refit.HeadAttribute.Method.get -> System.Net.Http.HttpMethod!
+override Refit.ObjectToInferredTypesConverter.Read(ref System.Text.Json.Utf8JsonReader reader, System.Type! typeToConvert, System.Text.Json.JsonSerializerOptions! options) -> object?
+override Refit.ObjectToInferredTypesConverter.Write(System.Text.Json.Utf8JsonWriter! writer, object! value, System.Text.Json.JsonSerializerOptions! options) -> void
+override Refit.OptionsAttribute.Method.get -> System.Net.Http.HttpMethod!
+override Refit.PatchAttribute.Method.get -> System.Net.Http.HttpMethod!
+override Refit.PostAttribute.Method.get -> System.Net.Http.HttpMethod!
+override Refit.PutAttribute.Method.get -> System.Net.Http.HttpMethod!
+override Refit.RestMethodInfo.Equals(object? obj) -> bool
+override Refit.RestMethodInfo.GetHashCode() -> int
+override Refit.RestMethodInfo.ToString() -> string!
+override Refit.StreamPart.CreateContent() -> System.Net.Http.HttpContent!
 Refit.AliasAsAttribute
 Refit.AliasAsAttribute.AliasAsAttribute(string! name) -> void
 Refit.AliasAsAttribute.Name.get -> string!
 Refit.ApiException
-Refit.ApiException.ApiException(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, string? content, System.Net.HttpStatusCode statusCode, string? reasonPhrase, System.Net.Http.Headers.HttpResponseHeaders! headers, Refit.RefitSettings! refitSettings) -> void
-Refit.ApiException.ApiException(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, string? content, System.Net.HttpStatusCode statusCode, string? reasonPhrase, System.Net.Http.Headers.HttpResponseHeaders! headers, Refit.RefitSettings! refitSettings, System.Exception? innerException) -> void
-Refit.ApiException.ApiException(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, string? content, System.Net.HttpStatusCode statusCode, string? reasonPhrase, System.Net.Http.Headers.HttpResponseHeaders! headers, Refit.RefitSettings! refitSettings) -> void
 Refit.ApiException.ApiException(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, string? content, System.Net.HttpStatusCode statusCode, string? reasonPhrase, System.Net.Http.Headers.HttpResponseHeaders! headers, Refit.RefitSettings! refitSettings, System.Exception? innerException) -> void
+Refit.ApiException.ApiException(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, string? content, System.Net.HttpStatusCode statusCode, string? reasonPhrase, System.Net.Http.Headers.HttpResponseHeaders! headers, Refit.RefitSettings! refitSettings) -> void
+Refit.ApiException.ApiException(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, string? content, System.Net.HttpStatusCode statusCode, string? reasonPhrase, System.Net.Http.Headers.HttpResponseHeaders! headers, Refit.RefitSettings! refitSettings, System.Exception? innerException) -> void
+Refit.ApiException.ApiException(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, string? content, System.Net.HttpStatusCode statusCode, string? reasonPhrase, System.Net.Http.Headers.HttpResponseHeaders! headers, Refit.RefitSettings! refitSettings) -> void
+Refit.ApiExceptionBase
+Refit.ApiExceptionBase.ApiExceptionBase(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings, System.Exception? innerException) -> void
+Refit.ApiExceptionBase.ApiExceptionBase(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings) -> void
+Refit.ApiExceptionBase.ApiExceptionBase(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings, System.Exception! innerException) -> void
+Refit.ApiExceptionBase.HttpMethod.get -> System.Net.Http.HttpMethod!
+Refit.ApiExceptionBase.RefitSettings.get -> Refit.RefitSettings!
+Refit.ApiExceptionBase.RequestMessage.get -> System.Net.Http.HttpRequestMessage!
+Refit.ApiExceptionBase.Uri.get -> System.Uri?
 Refit.ApiException.Content.get -> string?
 Refit.ApiException.ContentHeaders.get -> System.Net.Http.Headers.HttpContentHeaders?
 Refit.ApiException.ContentHeaders.set -> void
@@ -15,44 +40,36 @@ Refit.ApiException.HasContent.get -> bool
 Refit.ApiException.Headers.get -> System.Net.Http.Headers.HttpResponseHeaders!
 Refit.ApiException.ReasonPhrase.get -> string?
 Refit.ApiException.StatusCode.get -> System.Net.HttpStatusCode
-Refit.ApiExceptionBase
-Refit.ApiExceptionBase.ApiExceptionBase(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings, System.Exception! innerException) -> void
-Refit.ApiExceptionBase.ApiExceptionBase(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings) -> void
-Refit.ApiExceptionBase.ApiExceptionBase(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings, System.Exception? innerException) -> void
-Refit.ApiExceptionBase.HttpMethod.get -> System.Net.Http.HttpMethod!
-Refit.ApiExceptionBase.RefitSettings.get -> Refit.RefitSettings!
-Refit.ApiExceptionBase.RequestMessage.get -> System.Net.Http.HttpRequestMessage!
-Refit.ApiExceptionBase.Uri.get -> System.Uri?
 Refit.ApiRequestException
-Refit.ApiRequestException.ApiRequestException(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings, System.Exception! innerException) -> void
-Refit.ApiRequestException.ApiRequestException(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings) -> void
 Refit.ApiRequestException.ApiRequestException(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings, System.Exception? innerException) -> void
+Refit.ApiRequestException.ApiRequestException(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings) -> void
+Refit.ApiRequestException.ApiRequestException(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings, System.Exception! innerException) -> void
+Refit.ApiResponseExtensions
+Refit.ApiResponseExtensions.extension<T>(Refit.IApiResponse<T>!)
+Refit.ApiResponseExtensions.extension<T>(Refit.IApiResponse<T>!).EnsureSuccessfulAsync() -> System.Threading.Tasks.Task<Refit.IApiResponse<T>!>!
+Refit.ApiResponseExtensions.extension<T>(Refit.IApiResponse<T>!).EnsureSuccessStatusCodeAsync() -> System.Threading.Tasks.Task<Refit.IApiResponse<T>!>!
 Refit.ApiResponse<T>
 Refit.ApiResponse<T>.ApiResponse(System.Net.Http.HttpRequestMessage! request, System.Net.Http.HttpResponseMessage? response, T? content, Refit.RefitSettings! settings, Refit.ApiExceptionBase? error = null) -> void
-Refit.ApiResponse<T>.ApiResponse(System.Net.Http.HttpResponseMessage! response, T? content, Refit.RefitSettings! settings) -> void
 Refit.ApiResponse<T>.ApiResponse(System.Net.Http.HttpResponseMessage! response, T? content, Refit.RefitSettings! settings, Refit.ApiExceptionBase? error) -> void
+Refit.ApiResponse<T>.ApiResponse(System.Net.Http.HttpResponseMessage! response, T? content, Refit.RefitSettings! settings) -> void
 Refit.ApiResponse<T>.Content.get -> T?
 Refit.ApiResponse<T>.ContentHeaders.get -> System.Net.Http.Headers.HttpContentHeaders?
 Refit.ApiResponse<T>.Dispose() -> void
-Refit.ApiResponse<T>.EnsureSuccessStatusCodeAsync() -> System.Threading.Tasks.Task<Refit.ApiResponse<T>!>!
 Refit.ApiResponse<T>.EnsureSuccessfulAsync() -> System.Threading.Tasks.Task<Refit.ApiResponse<T>!>!
+Refit.ApiResponse<T>.EnsureSuccessStatusCodeAsync() -> System.Threading.Tasks.Task<Refit.ApiResponse<T>!>!
 Refit.ApiResponse<T>.Error.get -> Refit.ApiExceptionBase?
 Refit.ApiResponse<T>.HasContent.get -> bool
 Refit.ApiResponse<T>.HasRequestError(out Refit.ApiRequestException? error) -> bool
 Refit.ApiResponse<T>.HasResponseError(out Refit.ApiException? error) -> bool
 Refit.ApiResponse<T>.Headers.get -> System.Net.Http.Headers.HttpResponseHeaders?
 Refit.ApiResponse<T>.IsReceived.get -> bool
-Refit.ApiResponse<T>.IsSuccessStatusCode.get -> bool
 Refit.ApiResponse<T>.IsSuccessful.get -> bool
+Refit.ApiResponse<T>.IsSuccessStatusCode.get -> bool
 Refit.ApiResponse<T>.ReasonPhrase.get -> string?
 Refit.ApiResponse<T>.RequestMessage.get -> System.Net.Http.HttpRequestMessage!
 Refit.ApiResponse<T>.Settings.get -> Refit.RefitSettings!
 Refit.ApiResponse<T>.StatusCode.get -> System.Net.HttpStatusCode?
 Refit.ApiResponse<T>.Version.get -> System.Version?
-Refit.ApiResponseExtensions
-Refit.ApiResponseExtensions.extension<T>(Refit.IApiResponse<T>!)
-Refit.ApiResponseExtensions.extension<T>(Refit.IApiResponse<T>!).EnsureSuccessStatusCodeAsync() -> System.Threading.Tasks.Task<Refit.IApiResponse<T>!>!
-Refit.ApiResponseExtensions.extension<T>(Refit.IApiResponse<T>!).EnsureSuccessfulAsync() -> System.Threading.Tasks.Task<Refit.IApiResponse<T>!>!
 Refit.AttachmentNameAttribute
 Refit.AttachmentNameAttribute.AttachmentNameAttribute(string! name) -> void
 Refit.AttachmentNameAttribute.Name.get -> string!
@@ -60,10 +77,10 @@ Refit.AuthorizeAttribute
 Refit.AuthorizeAttribute.AuthorizeAttribute(string! scheme = "Bearer") -> void
 Refit.AuthorizeAttribute.Scheme.get -> string!
 Refit.BodyAttribute
-Refit.BodyAttribute.BodyAttribute() -> void
-Refit.BodyAttribute.BodyAttribute(Refit.BodySerializationMethod serializationMethod) -> void
-Refit.BodyAttribute.BodyAttribute(Refit.BodySerializationMethod serializationMethod, bool buffered) -> void
 Refit.BodyAttribute.BodyAttribute(bool buffered) -> void
+Refit.BodyAttribute.BodyAttribute(Refit.BodySerializationMethod serializationMethod, bool buffered) -> void
+Refit.BodyAttribute.BodyAttribute(Refit.BodySerializationMethod serializationMethod) -> void
+Refit.BodyAttribute.BodyAttribute() -> void
 Refit.BodyAttribute.Buffered.get -> bool?
 Refit.BodyAttribute.SerializationMethod.get -> Refit.BodySerializationMethod
 Refit.BodySerializationMethod
@@ -107,13 +124,13 @@ Refit.GetAttribute.GetAttribute(string! path) -> void
 Refit.HeadAttribute
 Refit.HeadAttribute.HeadAttribute(string! path) -> void
 Refit.HeaderAttribute
-Refit.HeaderAttribute.Header.get -> string!
 Refit.HeaderAttribute.HeaderAttribute(string! header) -> void
+Refit.HeaderAttribute.Header.get -> string!
 Refit.HeaderCollectionAttribute
 Refit.HeaderCollectionAttribute.HeaderCollectionAttribute() -> void
 Refit.HeadersAttribute
-Refit.HeadersAttribute.Headers.get -> string![]!
 Refit.HeadersAttribute.HeadersAttribute(params string![]! headers) -> void
+Refit.HeadersAttribute.Headers.get -> string![]!
 Refit.HttpMethodAttribute
 Refit.HttpMethodAttribute.HttpMethodAttribute(string! path) -> void
 Refit.HttpRequestMessageOptions
@@ -124,15 +141,15 @@ Refit.IApiResponse.HasRequestError(out Refit.ApiRequestException? error) -> bool
 Refit.IApiResponse.HasResponseError(out Refit.ApiException? error) -> bool
 Refit.IApiResponse.Headers.get -> System.Net.Http.Headers.HttpResponseHeaders?
 Refit.IApiResponse.IsReceived.get -> bool
-Refit.IApiResponse.IsSuccessStatusCode.get -> bool
 Refit.IApiResponse.IsSuccessful.get -> bool
+Refit.IApiResponse.IsSuccessStatusCode.get -> bool
 Refit.IApiResponse.ReasonPhrase.get -> string?
 Refit.IApiResponse.RequestMessage.get -> System.Net.Http.HttpRequestMessage?
 Refit.IApiResponse.StatusCode.get -> System.Net.HttpStatusCode?
-Refit.IApiResponse.Version.get -> System.Version?
 Refit.IApiResponse<T>
 Refit.IApiResponse<T>.Content.get -> T?
 Refit.IApiResponse<T>.HasContent.get -> bool
+Refit.IApiResponse.Version.get -> System.Version?
 Refit.IFormUrlEncodedParameterFormatter
 Refit.IFormUrlEncodedParameterFormatter.Format(object? value, string? formatString) -> string?
 Refit.IHttpContentSerializer
@@ -143,6 +160,11 @@ Refit.IRequestBuilder
 Refit.IRequestBuilder.BuildRestResultFuncForMethod(string! methodName, System.Type![]? parameterTypes = null, System.Type![]? genericArgumentTypes = null) -> System.Func<System.Net.Http.HttpClient!, object![]!, object?>!
 Refit.IRequestBuilder.Settings.get -> Refit.RefitSettings!
 Refit.IRequestBuilder<T>
+Refit.IStreamingContentSerializer
+Refit.IStreamingContentSerializer.DeserializeStreamAsync<T>(System.IO.Stream! stream, Refit.StreamingContentFormat format, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<T?>!
+Refit.ISynchronousContentSerializer
+Refit.ISynchronousContentSerializer.ToHttpContentSynchronous<T>(T item) -> System.Net.Http.HttpContent!
+Refit.ISynchronousContentSerializer.ToStreamingHttpContent<T>(T item) -> System.Net.Http.HttpContent!
 Refit.IUrlParameterFormatter
 Refit.IUrlParameterFormatter.Format(object? value, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string?
 Refit.IUrlParameterKeyFormatter
@@ -163,8 +185,8 @@ Refit.MultipartAttribute.MultipartAttribute(string! boundaryText = "----MyGreatB
 Refit.MultipartItem
 Refit.MultipartItem.ContentType.get -> string?
 Refit.MultipartItem.FileName.get -> string!
-Refit.MultipartItem.MultipartItem(string! fileName, string? contentType) -> void
 Refit.MultipartItem.MultipartItem(string! fileName, string? contentType, string? name) -> void
+Refit.MultipartItem.MultipartItem(string! fileName, string? contentType) -> void
 Refit.MultipartItem.Name.get -> string?
 Refit.MultipartItem.ToContent() -> System.Net.Http.HttpContent!
 Refit.ObjectToInferredTypesConverter
@@ -196,8 +218,8 @@ Refit.ProblemDetails.Type.get -> string?
 Refit.ProblemDetails.Type.set -> void
 Refit.PropertyAttribute
 Refit.PropertyAttribute.Key.get -> string?
-Refit.PropertyAttribute.PropertyAttribute() -> void
 Refit.PropertyAttribute.PropertyAttribute(string! key) -> void
+Refit.PropertyAttribute.PropertyAttribute() -> void
 Refit.PutAttribute
 Refit.PutAttribute.PutAttribute(string! path) -> void
 Refit.QueryAttribute
@@ -208,17 +230,19 @@ Refit.QueryAttribute.Format.get -> string?
 Refit.QueryAttribute.Format.set -> void
 Refit.QueryAttribute.IsCollectionFormatSpecified.get -> bool
 Refit.QueryAttribute.Prefix.get -> string?
-Refit.QueryAttribute.QueryAttribute() -> void
 Refit.QueryAttribute.QueryAttribute(Refit.CollectionFormat collectionFormat) -> void
-Refit.QueryAttribute.QueryAttribute(string! delimiter) -> void
-Refit.QueryAttribute.QueryAttribute(string! delimiter, string! prefix) -> void
 Refit.QueryAttribute.QueryAttribute(string! delimiter, string! prefix, string! format) -> void
+Refit.QueryAttribute.QueryAttribute(string! delimiter, string! prefix) -> void
+Refit.QueryAttribute.QueryAttribute(string! delimiter) -> void
+Refit.QueryAttribute.QueryAttribute() -> void
 Refit.QueryAttribute.TreatAsString.get -> bool
 Refit.QueryAttribute.TreatAsString.set -> void
 Refit.QueryUriFormatAttribute
 Refit.QueryUriFormatAttribute.QueryUriFormatAttribute(System.UriFormat uriFormat) -> void
 Refit.QueryUriFormatAttribute.UriFormat.get -> System.UriFormat
 Refit.RefitSettings
+Refit.RefitSettings.AllowUnmatchedRouteParameters.get -> bool
+Refit.RefitSettings.AllowUnmatchedRouteParameters.set -> void
 Refit.RefitSettings.AuthorizationHeaderValueGetter.get -> System.Func<System.Net.Http.HttpRequestMessage!, System.Threading.CancellationToken, System.Threading.Tasks.Task<string!>!>?
 Refit.RefitSettings.AuthorizationHeaderValueGetter.set -> void
 Refit.RefitSettings.Buffered.get -> bool
@@ -237,15 +261,23 @@ Refit.RefitSettings.HttpMessageHandlerFactory.get -> System.Func<System.Net.Http
 Refit.RefitSettings.HttpMessageHandlerFactory.set -> void
 Refit.RefitSettings.HttpRequestMessageOptions.get -> System.Collections.Generic.Dictionary<string!, object!>?
 Refit.RefitSettings.HttpRequestMessageOptions.init -> void
-Refit.RefitSettings.RefitSettings() -> void
-Refit.RefitSettings.RefitSettings(Refit.IHttpContentSerializer! contentSerializer) -> void
-Refit.RefitSettings.RefitSettings(Refit.IHttpContentSerializer! contentSerializer, Refit.IUrlParameterFormatter? urlParameterFormatter) -> void
-Refit.RefitSettings.RefitSettings(Refit.IHttpContentSerializer! contentSerializer, Refit.IUrlParameterFormatter? urlParameterFormatter, Refit.IFormUrlEncodedParameterFormatter? formUrlEncodedParameterFormatter) -> void
 Refit.RefitSettings.RefitSettings(Refit.IHttpContentSerializer! contentSerializer, Refit.IUrlParameterFormatter? urlParameterFormatter, Refit.IFormUrlEncodedParameterFormatter? formUrlEncodedParameterFormatter, Refit.IUrlParameterKeyFormatter? urlParameterKeyFormatter) -> void
+Refit.RefitSettings.RefitSettings(Refit.IHttpContentSerializer! contentSerializer, Refit.IUrlParameterFormatter? urlParameterFormatter, Refit.IFormUrlEncodedParameterFormatter? formUrlEncodedParameterFormatter) -> void
+Refit.RefitSettings.RefitSettings(Refit.IHttpContentSerializer! contentSerializer, Refit.IUrlParameterFormatter? urlParameterFormatter) -> void
+Refit.RefitSettings.RefitSettings(Refit.IHttpContentSerializer! contentSerializer) -> void
+Refit.RefitSettings.RefitSettings() -> void
+Refit.RefitSettings.RequestBodySerialization.get -> Refit.RequestBodySerializationMode
+Refit.RefitSettings.RequestBodySerialization.set -> void
 Refit.RefitSettings.UrlParameterFormatter.get -> Refit.IUrlParameterFormatter!
 Refit.RefitSettings.UrlParameterFormatter.set -> void
 Refit.RefitSettings.UrlParameterKeyFormatter.get -> Refit.IUrlParameterKeyFormatter!
 Refit.RefitSettings.UrlParameterKeyFormatter.set -> void
+Refit.RefitSettings.UrlResolution.get -> Refit.UrlResolutionMode
+Refit.RefitSettings.UrlResolution.set -> void
+Refit.RequestBodySerializationMode
+Refit.RequestBodySerializationMode.Buffered = 1 -> Refit.RequestBodySerializationMode
+Refit.RequestBodySerializationMode.Default = 0 -> Refit.RequestBodySerializationMode
+Refit.RequestBodySerializationMode.Streamed = 2 -> Refit.RequestBodySerializationMode
 Refit.RequestBuilder
 Refit.RestMethodInfo
 Refit.RestMethodInfo.<Clone>$() -> Refit.RestMethodInfo!
@@ -285,45 +317,38 @@ Refit.RestService
 Refit.SnakeCaseUrlParameterKeyFormatter
 Refit.SnakeCaseUrlParameterKeyFormatter.Format(string! key) -> string!
 Refit.SnakeCaseUrlParameterKeyFormatter.SnakeCaseUrlParameterKeyFormatter() -> void
+Refit.StreamingContentFormat
+Refit.StreamingContentFormat.JsonArray = 0 -> Refit.StreamingContentFormat
+Refit.StreamingContentFormat.JsonLines = 1 -> Refit.StreamingContentFormat
 Refit.StreamPart
 Refit.StreamPart.StreamPart(System.IO.Stream! value, string! fileName, string? contentType = null, string? name = null) -> void
 Refit.StreamPart.Value.get -> System.IO.Stream!
 Refit.SystemTextJsonContentSerializer
+Refit.SystemTextJsonContentSerializer.DeserializeStreamAsync<T>(System.IO.Stream! stream, Refit.StreamingContentFormat format, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<T?>!
 Refit.SystemTextJsonContentSerializer.FromHttpContentAsync<T>(System.Net.Http.HttpContent! content, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<T?>!
 Refit.SystemTextJsonContentSerializer.GetFieldNameForProperty(System.Reflection.PropertyInfo! propertyInfo) -> string?
-Refit.SystemTextJsonContentSerializer.SystemTextJsonContentSerializer() -> void
 Refit.SystemTextJsonContentSerializer.SystemTextJsonContentSerializer(System.Text.Json.JsonSerializerOptions! jsonSerializerOptions) -> void
+Refit.SystemTextJsonContentSerializer.SystemTextJsonContentSerializer() -> void
+Refit.SystemTextJsonContentSerializer.ToHttpContentSynchronous<T>(T item) -> System.Net.Http.HttpContent!
 Refit.SystemTextJsonContentSerializer.ToHttpContent<T>(T item) -> System.Net.Http.HttpContent!
+Refit.SystemTextJsonContentSerializer.ToStreamingHttpContent<T>(T item) -> System.Net.Http.HttpContent!
+Refit.UrlResolutionMode
+Refit.UrlResolutionMode.RefitLegacy = 0 -> Refit.UrlResolutionMode
+Refit.UrlResolutionMode.Rfc3986 = 1 -> Refit.UrlResolutionMode
 Refit.ValidationApiException
 Refit.ValidationApiException.Content.get -> Refit.ProblemDetails?
-Refit.ValidationApiException.ValidationApiException(string! message) -> void
 Refit.ValidationApiException.ValidationApiException(string! message, System.Exception! innerException) -> void
-abstract Refit.HttpMethodAttribute.Method.get -> System.Net.Http.HttpMethod!
-abstract Refit.MultipartItem.CreateContent() -> System.Net.Http.HttpContent!
-override Refit.ByteArrayPart.CreateContent() -> System.Net.Http.HttpContent!
-override Refit.DeleteAttribute.Method.get -> System.Net.Http.HttpMethod!
-override Refit.FileInfoPart.CreateContent() -> System.Net.Http.HttpContent!
-override Refit.GetAttribute.Method.get -> System.Net.Http.HttpMethod!
-override Refit.HeadAttribute.Method.get -> System.Net.Http.HttpMethod!
-override Refit.ObjectToInferredTypesConverter.Read(ref System.Text.Json.Utf8JsonReader reader, System.Type! typeToConvert, System.Text.Json.JsonSerializerOptions! options) -> object?
-override Refit.ObjectToInferredTypesConverter.Write(System.Text.Json.Utf8JsonWriter! writer, object! value, System.Text.Json.JsonSerializerOptions! options) -> void
-override Refit.OptionsAttribute.Method.get -> System.Net.Http.HttpMethod!
-override Refit.PatchAttribute.Method.get -> System.Net.Http.HttpMethod!
-override Refit.PostAttribute.Method.get -> System.Net.Http.HttpMethod!
-override Refit.PutAttribute.Method.get -> System.Net.Http.HttpMethod!
-override Refit.RestMethodInfo.Equals(object? obj) -> bool
-override Refit.RestMethodInfo.GetHashCode() -> int
-override Refit.RestMethodInfo.ToString() -> string!
-override Refit.StreamPart.CreateContent() -> System.Net.Http.HttpContent!
-static Refit.ApiException.Create(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, System.Net.Http.HttpResponseMessage! response, Refit.RefitSettings! refitSettings) -> System.Threading.Tasks.Task<Refit.ApiException!>!
-static Refit.ApiException.Create(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, System.Net.Http.HttpResponseMessage! response, Refit.RefitSettings! refitSettings, System.Exception? innerException) -> System.Threading.Tasks.Task<Refit.ApiException!>!
-static Refit.ApiException.Create(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, System.Net.Http.HttpResponseMessage! response, Refit.RefitSettings! refitSettings) -> System.Threading.Tasks.Task<Refit.ApiException!>!
+Refit.ValidationApiException.ValidationApiException(string! message) -> void
 static Refit.ApiException.Create(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, System.Net.Http.HttpResponseMessage! response, Refit.RefitSettings! refitSettings, System.Exception? innerException) -> System.Threading.Tasks.Task<Refit.ApiException!>!
-static Refit.ApiResponseExtensions.EnsureSuccessStatusCodeAsync<T>(this Refit.IApiResponse<T>! response) -> System.Threading.Tasks.Task<Refit.IApiResponse<T>!>!
+static Refit.ApiException.Create(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, System.Net.Http.HttpResponseMessage! response, Refit.RefitSettings! refitSettings) -> System.Threading.Tasks.Task<Refit.ApiException!>!
+static Refit.ApiException.Create(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, System.Net.Http.HttpResponseMessage! response, Refit.RefitSettings! refitSettings, System.Exception? innerException) -> System.Threading.Tasks.Task<Refit.ApiException!>!
+static Refit.ApiException.Create(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, System.Net.Http.HttpResponseMessage! response, Refit.RefitSettings! refitSettings) -> System.Threading.Tasks.Task<Refit.ApiException!>!
 static Refit.ApiResponseExtensions.EnsureSuccessfulAsync<T>(this Refit.IApiResponse<T>! response) -> System.Threading.Tasks.Task<Refit.IApiResponse<T>!>!
+static Refit.ApiResponseExtensions.EnsureSuccessStatusCodeAsync<T>(this Refit.IApiResponse<T>! response) -> System.Threading.Tasks.Task<Refit.IApiResponse<T>!>!
 static Refit.GeneratedRequestRunner.AddConfiguredRequestOptions(System.Net.Http.HttpRequestMessage! request, Refit.RefitSettings! settings, System.Type! interfaceType) -> void
 static Refit.GeneratedRequestRunner.AddHeaderCollection(System.Net.Http.HttpRequestMessage! request, System.Collections.Generic.IDictionary<string!, string!>? headers) -> void
 static Refit.GeneratedRequestRunner.AddRequestProperty<TValue>(System.Net.Http.HttpRequestMessage! request, string! key, TValue value) -> void
+static Refit.GeneratedRequestRunner.BuildRelativeUri(System.Net.Http.HttpClient! client, string! relativePath, Refit.UrlResolutionMode urlResolution) -> System.Uri!
 static Refit.GeneratedRequestRunner.CreateBodyContent<TBody>(Refit.RefitSettings! settings, TBody body, Refit.BodySerializationMethod serializationMethod, bool streamBody) -> System.Net.Http.HttpContent!
 static Refit.GeneratedRequestRunner.CreateJsonLinesBodyContent<TBody>(Refit.RefitSettings! settings, TBody body) -> System.Net.Http.HttpContent!
 static Refit.GeneratedRequestRunner.CreateUrlEncodedBodyContent<TBody>(Refit.RefitSettings! settings, TBody body) -> System.Net.Http.HttpContent!
@@ -343,26 +368,27 @@ static Refit.RequestBuilder.ForType<T>(Refit.RefitSettings? settings) -> Refit.I
 static Refit.RestMethodInfo.operator !=(Refit.RestMethodInfo? left, Refit.RestMethodInfo? right) -> bool
 static Refit.RestMethodInfo.operator ==(Refit.RestMethodInfo? left, Refit.RestMethodInfo? right) -> bool
 static Refit.RestService.CreateHttpClient(string! hostUrl, Refit.RefitSettings? settings) -> System.Net.Http.HttpClient!
+static Refit.RestService.ForGenerated(System.Type! refitInterfaceType, string! hostUrl, Refit.RefitSettings! settings) -> object!
+static Refit.RestService.ForGenerated(System.Type! refitInterfaceType, System.Net.Http.HttpClient! client, Refit.RefitSettings! settings) -> object!
+static Refit.RestService.ForGenerated<T>(string! hostUrl, Refit.RefitSettings! settings) -> T
+static Refit.RestService.ForGenerated<T>(string! hostUrl) -> T
+static Refit.RestService.ForGenerated<T>(System.Net.Http.HttpClient! client, Refit.RefitSettings! settings) -> T
+static Refit.RestService.ForGenerated<T>(System.Net.Http.HttpClient! client) -> T
+static Refit.RestService.For(System.Type! refitInterfaceType, string! hostUrl) -> object!
+static Refit.RestService.For(System.Type! refitInterfaceType, string! hostUrl, Refit.RefitSettings? settings) -> object!
 static Refit.RestService.For(System.Type! refitInterfaceType, System.Net.Http.HttpClient! client) -> object!
 static Refit.RestService.For(System.Type! refitInterfaceType, System.Net.Http.HttpClient! client, Refit.IRequestBuilder! builder) -> object!
 static Refit.RestService.For(System.Type! refitInterfaceType, System.Net.Http.HttpClient! client, Refit.RefitSettings? settings) -> object!
-static Refit.RestService.For(System.Type! refitInterfaceType, string! hostUrl) -> object!
-static Refit.RestService.For(System.Type! refitInterfaceType, string! hostUrl, Refit.RefitSettings? settings) -> object!
-static Refit.RestService.For<T>(System.Net.Http.HttpClient! client) -> T
+static Refit.RestService.For<T>(string! hostUrl, Refit.RefitSettings? settings) -> T
+static Refit.RestService.For<T>(string! hostUrl) -> T
 static Refit.RestService.For<T>(System.Net.Http.HttpClient! client, Refit.IRequestBuilder<T>! builder) -> T
 static Refit.RestService.For<T>(System.Net.Http.HttpClient! client, Refit.RefitSettings? settings) -> T
-static Refit.RestService.For<T>(string! hostUrl) -> T
-static Refit.RestService.For<T>(string! hostUrl, Refit.RefitSettings? settings) -> T
-static Refit.RestService.ForGenerated(System.Type! refitInterfaceType, System.Net.Http.HttpClient! client, Refit.RefitSettings! settings) -> object!
-static Refit.RestService.ForGenerated(System.Type! refitInterfaceType, string! hostUrl, Refit.RefitSettings! settings) -> object!
-static Refit.RestService.ForGenerated<T>(System.Net.Http.HttpClient! client) -> T
-static Refit.RestService.ForGenerated<T>(System.Net.Http.HttpClient! client, Refit.RefitSettings! settings) -> T
-static Refit.RestService.ForGenerated<T>(string! hostUrl) -> T
-static Refit.RestService.ForGenerated<T>(string! hostUrl, Refit.RefitSettings! settings) -> T
+static Refit.RestService.For<T>(System.Net.Http.HttpClient! client) -> T
 static Refit.RestService.RegisterGeneratedFactory(System.Type! refitInterfaceType, System.Func<System.Net.Http.HttpClient!, Refit.IRequestBuilder!, object!>! factory) -> void
 static Refit.RestService.RegisterGeneratedFactory<T>(System.Func<System.Net.Http.HttpClient!, Refit.IRequestBuilder!, T>! factory) -> void
 static Refit.RestService.RegisterGeneratedSettingsFactory<T>(System.Func<System.Net.Http.HttpClient!, Refit.RefitSettings!, T>! factory) -> void
 static Refit.SystemTextJsonContentSerializer.GetDefaultJsonSerializerOptions() -> System.Text.Json.JsonSerializerOptions!
+static Refit.SystemTextJsonContentSerializer.GetFastPathJsonSerializerOptions() -> System.Text.Json.JsonSerializerOptions!
 static Refit.ValidationApiException.Create(Refit.ApiException! exception) -> Refit.ValidationApiException!
 virtual Refit.DefaultFormUrlEncodedParameterFormatter.Format(object? value, string? formatString) -> string?
 virtual Refit.DefaultUrlParameterFormatter.Format(object? value, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string?

--- a/src/Refit/PublicAPI/net481/PublicAPI.Shipped.txt
+++ b/src/Refit/PublicAPI/net481/PublicAPI.Shipped.txt
@@ -355,6 +355,7 @@ static Refit.GeneratedRequestRunner.CreateUrlEncodedBodyContent<TBody>(Refit.Ref
 static Refit.GeneratedRequestRunner.SendAsync<T, TBody>(System.Net.Http.HttpClient! client, System.Net.Http.HttpRequestMessage! request, Refit.RefitSettings! settings, bool isApiResponse, bool shouldDisposeResponse, bool bufferBody, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<T?>!
 static Refit.GeneratedRequestRunner.SendVoidAsync(System.Net.Http.HttpClient! client, System.Net.Http.HttpRequestMessage! request, Refit.RefitSettings! settings, bool bufferBody, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 static Refit.GeneratedRequestRunner.SetHeader(System.Net.Http.HttpRequestMessage! request, string! name, string? value) -> void
+static Refit.GeneratedRequestRunner.StreamAsync<T>(System.Net.Http.HttpClient! client, System.Net.Http.HttpRequestMessage! request, Refit.RefitSettings! settings, System.Threading.CancellationToken methodCancellationToken, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<T?>!
 static Refit.HttpRequestMessageOptions.InterfaceType.get -> string!
 static Refit.HttpRequestMessageOptions.RestMethodInfo.get -> string!
 static Refit.JsonLinesContent.JsonLinesMediaType.get -> string!

--- a/src/Refit/PublicAPI/net481/PublicAPI.Shipped.txt
+++ b/src/Refit/PublicAPI/net481/PublicAPI.Shipped.txt
@@ -1,12 +1,37 @@
 #nullable enable
+abstract Refit.HttpMethodAttribute.Method.get -> System.Net.Http.HttpMethod!
+abstract Refit.MultipartItem.CreateContent() -> System.Net.Http.HttpContent!
+override Refit.ByteArrayPart.CreateContent() -> System.Net.Http.HttpContent!
+override Refit.DeleteAttribute.Method.get -> System.Net.Http.HttpMethod!
+override Refit.FileInfoPart.CreateContent() -> System.Net.Http.HttpContent!
+override Refit.GetAttribute.Method.get -> System.Net.Http.HttpMethod!
+override Refit.HeadAttribute.Method.get -> System.Net.Http.HttpMethod!
+override Refit.ObjectToInferredTypesConverter.Read(ref System.Text.Json.Utf8JsonReader reader, System.Type! typeToConvert, System.Text.Json.JsonSerializerOptions! options) -> object?
+override Refit.ObjectToInferredTypesConverter.Write(System.Text.Json.Utf8JsonWriter! writer, object! value, System.Text.Json.JsonSerializerOptions! options) -> void
+override Refit.OptionsAttribute.Method.get -> System.Net.Http.HttpMethod!
+override Refit.PatchAttribute.Method.get -> System.Net.Http.HttpMethod!
+override Refit.PostAttribute.Method.get -> System.Net.Http.HttpMethod!
+override Refit.PutAttribute.Method.get -> System.Net.Http.HttpMethod!
+override Refit.RestMethodInfo.Equals(object? obj) -> bool
+override Refit.RestMethodInfo.GetHashCode() -> int
+override Refit.RestMethodInfo.ToString() -> string!
+override Refit.StreamPart.CreateContent() -> System.Net.Http.HttpContent!
 Refit.AliasAsAttribute
 Refit.AliasAsAttribute.AliasAsAttribute(string! name) -> void
 Refit.AliasAsAttribute.Name.get -> string!
 Refit.ApiException
-Refit.ApiException.ApiException(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, string? content, System.Net.HttpStatusCode statusCode, string? reasonPhrase, System.Net.Http.Headers.HttpResponseHeaders! headers, Refit.RefitSettings! refitSettings) -> void
-Refit.ApiException.ApiException(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, string? content, System.Net.HttpStatusCode statusCode, string? reasonPhrase, System.Net.Http.Headers.HttpResponseHeaders! headers, Refit.RefitSettings! refitSettings, System.Exception? innerException) -> void
-Refit.ApiException.ApiException(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, string? content, System.Net.HttpStatusCode statusCode, string? reasonPhrase, System.Net.Http.Headers.HttpResponseHeaders! headers, Refit.RefitSettings! refitSettings) -> void
 Refit.ApiException.ApiException(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, string? content, System.Net.HttpStatusCode statusCode, string? reasonPhrase, System.Net.Http.Headers.HttpResponseHeaders! headers, Refit.RefitSettings! refitSettings, System.Exception? innerException) -> void
+Refit.ApiException.ApiException(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, string? content, System.Net.HttpStatusCode statusCode, string? reasonPhrase, System.Net.Http.Headers.HttpResponseHeaders! headers, Refit.RefitSettings! refitSettings) -> void
+Refit.ApiException.ApiException(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, string? content, System.Net.HttpStatusCode statusCode, string? reasonPhrase, System.Net.Http.Headers.HttpResponseHeaders! headers, Refit.RefitSettings! refitSettings, System.Exception? innerException) -> void
+Refit.ApiException.ApiException(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, string? content, System.Net.HttpStatusCode statusCode, string? reasonPhrase, System.Net.Http.Headers.HttpResponseHeaders! headers, Refit.RefitSettings! refitSettings) -> void
+Refit.ApiExceptionBase
+Refit.ApiExceptionBase.ApiExceptionBase(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings, System.Exception? innerException) -> void
+Refit.ApiExceptionBase.ApiExceptionBase(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings) -> void
+Refit.ApiExceptionBase.ApiExceptionBase(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings, System.Exception! innerException) -> void
+Refit.ApiExceptionBase.HttpMethod.get -> System.Net.Http.HttpMethod!
+Refit.ApiExceptionBase.RefitSettings.get -> Refit.RefitSettings!
+Refit.ApiExceptionBase.RequestMessage.get -> System.Net.Http.HttpRequestMessage!
+Refit.ApiExceptionBase.Uri.get -> System.Uri?
 Refit.ApiException.Content.get -> string?
 Refit.ApiException.ContentHeaders.get -> System.Net.Http.Headers.HttpContentHeaders?
 Refit.ApiException.ContentHeaders.set -> void
@@ -15,44 +40,36 @@ Refit.ApiException.HasContent.get -> bool
 Refit.ApiException.Headers.get -> System.Net.Http.Headers.HttpResponseHeaders!
 Refit.ApiException.ReasonPhrase.get -> string?
 Refit.ApiException.StatusCode.get -> System.Net.HttpStatusCode
-Refit.ApiExceptionBase
-Refit.ApiExceptionBase.ApiExceptionBase(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings, System.Exception! innerException) -> void
-Refit.ApiExceptionBase.ApiExceptionBase(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings) -> void
-Refit.ApiExceptionBase.ApiExceptionBase(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings, System.Exception? innerException) -> void
-Refit.ApiExceptionBase.HttpMethod.get -> System.Net.Http.HttpMethod!
-Refit.ApiExceptionBase.RefitSettings.get -> Refit.RefitSettings!
-Refit.ApiExceptionBase.RequestMessage.get -> System.Net.Http.HttpRequestMessage!
-Refit.ApiExceptionBase.Uri.get -> System.Uri?
 Refit.ApiRequestException
-Refit.ApiRequestException.ApiRequestException(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings, System.Exception! innerException) -> void
-Refit.ApiRequestException.ApiRequestException(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings) -> void
 Refit.ApiRequestException.ApiRequestException(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings, System.Exception? innerException) -> void
+Refit.ApiRequestException.ApiRequestException(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings) -> void
+Refit.ApiRequestException.ApiRequestException(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings, System.Exception! innerException) -> void
+Refit.ApiResponseExtensions
+Refit.ApiResponseExtensions.extension<T>(Refit.IApiResponse<T>!)
+Refit.ApiResponseExtensions.extension<T>(Refit.IApiResponse<T>!).EnsureSuccessfulAsync() -> System.Threading.Tasks.Task<Refit.IApiResponse<T>!>!
+Refit.ApiResponseExtensions.extension<T>(Refit.IApiResponse<T>!).EnsureSuccessStatusCodeAsync() -> System.Threading.Tasks.Task<Refit.IApiResponse<T>!>!
 Refit.ApiResponse<T>
 Refit.ApiResponse<T>.ApiResponse(System.Net.Http.HttpRequestMessage! request, System.Net.Http.HttpResponseMessage? response, T? content, Refit.RefitSettings! settings, Refit.ApiExceptionBase? error = null) -> void
-Refit.ApiResponse<T>.ApiResponse(System.Net.Http.HttpResponseMessage! response, T? content, Refit.RefitSettings! settings) -> void
 Refit.ApiResponse<T>.ApiResponse(System.Net.Http.HttpResponseMessage! response, T? content, Refit.RefitSettings! settings, Refit.ApiExceptionBase? error) -> void
+Refit.ApiResponse<T>.ApiResponse(System.Net.Http.HttpResponseMessage! response, T? content, Refit.RefitSettings! settings) -> void
 Refit.ApiResponse<T>.Content.get -> T?
 Refit.ApiResponse<T>.ContentHeaders.get -> System.Net.Http.Headers.HttpContentHeaders?
 Refit.ApiResponse<T>.Dispose() -> void
-Refit.ApiResponse<T>.EnsureSuccessStatusCodeAsync() -> System.Threading.Tasks.Task<Refit.ApiResponse<T>!>!
 Refit.ApiResponse<T>.EnsureSuccessfulAsync() -> System.Threading.Tasks.Task<Refit.ApiResponse<T>!>!
+Refit.ApiResponse<T>.EnsureSuccessStatusCodeAsync() -> System.Threading.Tasks.Task<Refit.ApiResponse<T>!>!
 Refit.ApiResponse<T>.Error.get -> Refit.ApiExceptionBase?
 Refit.ApiResponse<T>.HasContent.get -> bool
 Refit.ApiResponse<T>.HasRequestError(out Refit.ApiRequestException? error) -> bool
 Refit.ApiResponse<T>.HasResponseError(out Refit.ApiException? error) -> bool
 Refit.ApiResponse<T>.Headers.get -> System.Net.Http.Headers.HttpResponseHeaders?
 Refit.ApiResponse<T>.IsReceived.get -> bool
-Refit.ApiResponse<T>.IsSuccessStatusCode.get -> bool
 Refit.ApiResponse<T>.IsSuccessful.get -> bool
+Refit.ApiResponse<T>.IsSuccessStatusCode.get -> bool
 Refit.ApiResponse<T>.ReasonPhrase.get -> string?
 Refit.ApiResponse<T>.RequestMessage.get -> System.Net.Http.HttpRequestMessage!
 Refit.ApiResponse<T>.Settings.get -> Refit.RefitSettings!
 Refit.ApiResponse<T>.StatusCode.get -> System.Net.HttpStatusCode?
 Refit.ApiResponse<T>.Version.get -> System.Version?
-Refit.ApiResponseExtensions
-Refit.ApiResponseExtensions.extension<T>(Refit.IApiResponse<T>!)
-Refit.ApiResponseExtensions.extension<T>(Refit.IApiResponse<T>!).EnsureSuccessStatusCodeAsync() -> System.Threading.Tasks.Task<Refit.IApiResponse<T>!>!
-Refit.ApiResponseExtensions.extension<T>(Refit.IApiResponse<T>!).EnsureSuccessfulAsync() -> System.Threading.Tasks.Task<Refit.IApiResponse<T>!>!
 Refit.AttachmentNameAttribute
 Refit.AttachmentNameAttribute.AttachmentNameAttribute(string! name) -> void
 Refit.AttachmentNameAttribute.Name.get -> string!
@@ -60,10 +77,10 @@ Refit.AuthorizeAttribute
 Refit.AuthorizeAttribute.AuthorizeAttribute(string! scheme = "Bearer") -> void
 Refit.AuthorizeAttribute.Scheme.get -> string!
 Refit.BodyAttribute
-Refit.BodyAttribute.BodyAttribute() -> void
-Refit.BodyAttribute.BodyAttribute(Refit.BodySerializationMethod serializationMethod) -> void
-Refit.BodyAttribute.BodyAttribute(Refit.BodySerializationMethod serializationMethod, bool buffered) -> void
 Refit.BodyAttribute.BodyAttribute(bool buffered) -> void
+Refit.BodyAttribute.BodyAttribute(Refit.BodySerializationMethod serializationMethod, bool buffered) -> void
+Refit.BodyAttribute.BodyAttribute(Refit.BodySerializationMethod serializationMethod) -> void
+Refit.BodyAttribute.BodyAttribute() -> void
 Refit.BodyAttribute.Buffered.get -> bool?
 Refit.BodyAttribute.SerializationMethod.get -> Refit.BodySerializationMethod
 Refit.BodySerializationMethod
@@ -107,13 +124,13 @@ Refit.GetAttribute.GetAttribute(string! path) -> void
 Refit.HeadAttribute
 Refit.HeadAttribute.HeadAttribute(string! path) -> void
 Refit.HeaderAttribute
-Refit.HeaderAttribute.Header.get -> string!
 Refit.HeaderAttribute.HeaderAttribute(string! header) -> void
+Refit.HeaderAttribute.Header.get -> string!
 Refit.HeaderCollectionAttribute
 Refit.HeaderCollectionAttribute.HeaderCollectionAttribute() -> void
 Refit.HeadersAttribute
-Refit.HeadersAttribute.Headers.get -> string![]!
 Refit.HeadersAttribute.HeadersAttribute(params string![]! headers) -> void
+Refit.HeadersAttribute.Headers.get -> string![]!
 Refit.HttpMethodAttribute
 Refit.HttpMethodAttribute.HttpMethodAttribute(string! path) -> void
 Refit.HttpRequestMessageOptions
@@ -124,15 +141,15 @@ Refit.IApiResponse.HasRequestError(out Refit.ApiRequestException? error) -> bool
 Refit.IApiResponse.HasResponseError(out Refit.ApiException? error) -> bool
 Refit.IApiResponse.Headers.get -> System.Net.Http.Headers.HttpResponseHeaders?
 Refit.IApiResponse.IsReceived.get -> bool
-Refit.IApiResponse.IsSuccessStatusCode.get -> bool
 Refit.IApiResponse.IsSuccessful.get -> bool
+Refit.IApiResponse.IsSuccessStatusCode.get -> bool
 Refit.IApiResponse.ReasonPhrase.get -> string?
 Refit.IApiResponse.RequestMessage.get -> System.Net.Http.HttpRequestMessage?
 Refit.IApiResponse.StatusCode.get -> System.Net.HttpStatusCode?
-Refit.IApiResponse.Version.get -> System.Version?
 Refit.IApiResponse<T>
 Refit.IApiResponse<T>.Content.get -> T?
 Refit.IApiResponse<T>.HasContent.get -> bool
+Refit.IApiResponse.Version.get -> System.Version?
 Refit.IFormUrlEncodedParameterFormatter
 Refit.IFormUrlEncodedParameterFormatter.Format(object? value, string? formatString) -> string?
 Refit.IHttpContentSerializer
@@ -143,6 +160,11 @@ Refit.IRequestBuilder
 Refit.IRequestBuilder.BuildRestResultFuncForMethod(string! methodName, System.Type![]? parameterTypes = null, System.Type![]? genericArgumentTypes = null) -> System.Func<System.Net.Http.HttpClient!, object![]!, object?>!
 Refit.IRequestBuilder.Settings.get -> Refit.RefitSettings!
 Refit.IRequestBuilder<T>
+Refit.IStreamingContentSerializer
+Refit.IStreamingContentSerializer.DeserializeStreamAsync<T>(System.IO.Stream! stream, Refit.StreamingContentFormat format, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<T?>!
+Refit.ISynchronousContentSerializer
+Refit.ISynchronousContentSerializer.ToHttpContentSynchronous<T>(T item) -> System.Net.Http.HttpContent!
+Refit.ISynchronousContentSerializer.ToStreamingHttpContent<T>(T item) -> System.Net.Http.HttpContent!
 Refit.IUrlParameterFormatter
 Refit.IUrlParameterFormatter.Format(object? value, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string?
 Refit.IUrlParameterKeyFormatter
@@ -163,8 +185,8 @@ Refit.MultipartAttribute.MultipartAttribute(string! boundaryText = "----MyGreatB
 Refit.MultipartItem
 Refit.MultipartItem.ContentType.get -> string?
 Refit.MultipartItem.FileName.get -> string!
-Refit.MultipartItem.MultipartItem(string! fileName, string? contentType) -> void
 Refit.MultipartItem.MultipartItem(string! fileName, string? contentType, string? name) -> void
+Refit.MultipartItem.MultipartItem(string! fileName, string? contentType) -> void
 Refit.MultipartItem.Name.get -> string?
 Refit.MultipartItem.ToContent() -> System.Net.Http.HttpContent!
 Refit.ObjectToInferredTypesConverter
@@ -196,8 +218,8 @@ Refit.ProblemDetails.Type.get -> string?
 Refit.ProblemDetails.Type.set -> void
 Refit.PropertyAttribute
 Refit.PropertyAttribute.Key.get -> string?
-Refit.PropertyAttribute.PropertyAttribute() -> void
 Refit.PropertyAttribute.PropertyAttribute(string! key) -> void
+Refit.PropertyAttribute.PropertyAttribute() -> void
 Refit.PutAttribute
 Refit.PutAttribute.PutAttribute(string! path) -> void
 Refit.QueryAttribute
@@ -208,17 +230,19 @@ Refit.QueryAttribute.Format.get -> string?
 Refit.QueryAttribute.Format.set -> void
 Refit.QueryAttribute.IsCollectionFormatSpecified.get -> bool
 Refit.QueryAttribute.Prefix.get -> string?
-Refit.QueryAttribute.QueryAttribute() -> void
 Refit.QueryAttribute.QueryAttribute(Refit.CollectionFormat collectionFormat) -> void
-Refit.QueryAttribute.QueryAttribute(string! delimiter) -> void
-Refit.QueryAttribute.QueryAttribute(string! delimiter, string! prefix) -> void
 Refit.QueryAttribute.QueryAttribute(string! delimiter, string! prefix, string! format) -> void
+Refit.QueryAttribute.QueryAttribute(string! delimiter, string! prefix) -> void
+Refit.QueryAttribute.QueryAttribute(string! delimiter) -> void
+Refit.QueryAttribute.QueryAttribute() -> void
 Refit.QueryAttribute.TreatAsString.get -> bool
 Refit.QueryAttribute.TreatAsString.set -> void
 Refit.QueryUriFormatAttribute
 Refit.QueryUriFormatAttribute.QueryUriFormatAttribute(System.UriFormat uriFormat) -> void
 Refit.QueryUriFormatAttribute.UriFormat.get -> System.UriFormat
 Refit.RefitSettings
+Refit.RefitSettings.AllowUnmatchedRouteParameters.get -> bool
+Refit.RefitSettings.AllowUnmatchedRouteParameters.set -> void
 Refit.RefitSettings.AuthorizationHeaderValueGetter.get -> System.Func<System.Net.Http.HttpRequestMessage!, System.Threading.CancellationToken, System.Threading.Tasks.Task<string!>!>?
 Refit.RefitSettings.AuthorizationHeaderValueGetter.set -> void
 Refit.RefitSettings.Buffered.get -> bool
@@ -237,15 +261,23 @@ Refit.RefitSettings.HttpMessageHandlerFactory.get -> System.Func<System.Net.Http
 Refit.RefitSettings.HttpMessageHandlerFactory.set -> void
 Refit.RefitSettings.HttpRequestMessageOptions.get -> System.Collections.Generic.Dictionary<string!, object!>?
 Refit.RefitSettings.HttpRequestMessageOptions.init -> void
-Refit.RefitSettings.RefitSettings() -> void
-Refit.RefitSettings.RefitSettings(Refit.IHttpContentSerializer! contentSerializer) -> void
-Refit.RefitSettings.RefitSettings(Refit.IHttpContentSerializer! contentSerializer, Refit.IUrlParameterFormatter? urlParameterFormatter) -> void
-Refit.RefitSettings.RefitSettings(Refit.IHttpContentSerializer! contentSerializer, Refit.IUrlParameterFormatter? urlParameterFormatter, Refit.IFormUrlEncodedParameterFormatter? formUrlEncodedParameterFormatter) -> void
 Refit.RefitSettings.RefitSettings(Refit.IHttpContentSerializer! contentSerializer, Refit.IUrlParameterFormatter? urlParameterFormatter, Refit.IFormUrlEncodedParameterFormatter? formUrlEncodedParameterFormatter, Refit.IUrlParameterKeyFormatter? urlParameterKeyFormatter) -> void
+Refit.RefitSettings.RefitSettings(Refit.IHttpContentSerializer! contentSerializer, Refit.IUrlParameterFormatter? urlParameterFormatter, Refit.IFormUrlEncodedParameterFormatter? formUrlEncodedParameterFormatter) -> void
+Refit.RefitSettings.RefitSettings(Refit.IHttpContentSerializer! contentSerializer, Refit.IUrlParameterFormatter? urlParameterFormatter) -> void
+Refit.RefitSettings.RefitSettings(Refit.IHttpContentSerializer! contentSerializer) -> void
+Refit.RefitSettings.RefitSettings() -> void
+Refit.RefitSettings.RequestBodySerialization.get -> Refit.RequestBodySerializationMode
+Refit.RefitSettings.RequestBodySerialization.set -> void
 Refit.RefitSettings.UrlParameterFormatter.get -> Refit.IUrlParameterFormatter!
 Refit.RefitSettings.UrlParameterFormatter.set -> void
 Refit.RefitSettings.UrlParameterKeyFormatter.get -> Refit.IUrlParameterKeyFormatter!
 Refit.RefitSettings.UrlParameterKeyFormatter.set -> void
+Refit.RefitSettings.UrlResolution.get -> Refit.UrlResolutionMode
+Refit.RefitSettings.UrlResolution.set -> void
+Refit.RequestBodySerializationMode
+Refit.RequestBodySerializationMode.Buffered = 1 -> Refit.RequestBodySerializationMode
+Refit.RequestBodySerializationMode.Default = 0 -> Refit.RequestBodySerializationMode
+Refit.RequestBodySerializationMode.Streamed = 2 -> Refit.RequestBodySerializationMode
 Refit.RequestBuilder
 Refit.RestMethodInfo
 Refit.RestMethodInfo.<Clone>$() -> Refit.RestMethodInfo!
@@ -285,45 +317,38 @@ Refit.RestService
 Refit.SnakeCaseUrlParameterKeyFormatter
 Refit.SnakeCaseUrlParameterKeyFormatter.Format(string! key) -> string!
 Refit.SnakeCaseUrlParameterKeyFormatter.SnakeCaseUrlParameterKeyFormatter() -> void
+Refit.StreamingContentFormat
+Refit.StreamingContentFormat.JsonArray = 0 -> Refit.StreamingContentFormat
+Refit.StreamingContentFormat.JsonLines = 1 -> Refit.StreamingContentFormat
 Refit.StreamPart
 Refit.StreamPart.StreamPart(System.IO.Stream! value, string! fileName, string? contentType = null, string? name = null) -> void
 Refit.StreamPart.Value.get -> System.IO.Stream!
 Refit.SystemTextJsonContentSerializer
+Refit.SystemTextJsonContentSerializer.DeserializeStreamAsync<T>(System.IO.Stream! stream, Refit.StreamingContentFormat format, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<T?>!
 Refit.SystemTextJsonContentSerializer.FromHttpContentAsync<T>(System.Net.Http.HttpContent! content, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<T?>!
 Refit.SystemTextJsonContentSerializer.GetFieldNameForProperty(System.Reflection.PropertyInfo! propertyInfo) -> string?
-Refit.SystemTextJsonContentSerializer.SystemTextJsonContentSerializer() -> void
 Refit.SystemTextJsonContentSerializer.SystemTextJsonContentSerializer(System.Text.Json.JsonSerializerOptions! jsonSerializerOptions) -> void
+Refit.SystemTextJsonContentSerializer.SystemTextJsonContentSerializer() -> void
+Refit.SystemTextJsonContentSerializer.ToHttpContentSynchronous<T>(T item) -> System.Net.Http.HttpContent!
 Refit.SystemTextJsonContentSerializer.ToHttpContent<T>(T item) -> System.Net.Http.HttpContent!
+Refit.SystemTextJsonContentSerializer.ToStreamingHttpContent<T>(T item) -> System.Net.Http.HttpContent!
+Refit.UrlResolutionMode
+Refit.UrlResolutionMode.RefitLegacy = 0 -> Refit.UrlResolutionMode
+Refit.UrlResolutionMode.Rfc3986 = 1 -> Refit.UrlResolutionMode
 Refit.ValidationApiException
 Refit.ValidationApiException.Content.get -> Refit.ProblemDetails?
-Refit.ValidationApiException.ValidationApiException(string! message) -> void
 Refit.ValidationApiException.ValidationApiException(string! message, System.Exception! innerException) -> void
-abstract Refit.HttpMethodAttribute.Method.get -> System.Net.Http.HttpMethod!
-abstract Refit.MultipartItem.CreateContent() -> System.Net.Http.HttpContent!
-override Refit.ByteArrayPart.CreateContent() -> System.Net.Http.HttpContent!
-override Refit.DeleteAttribute.Method.get -> System.Net.Http.HttpMethod!
-override Refit.FileInfoPart.CreateContent() -> System.Net.Http.HttpContent!
-override Refit.GetAttribute.Method.get -> System.Net.Http.HttpMethod!
-override Refit.HeadAttribute.Method.get -> System.Net.Http.HttpMethod!
-override Refit.ObjectToInferredTypesConverter.Read(ref System.Text.Json.Utf8JsonReader reader, System.Type! typeToConvert, System.Text.Json.JsonSerializerOptions! options) -> object?
-override Refit.ObjectToInferredTypesConverter.Write(System.Text.Json.Utf8JsonWriter! writer, object! value, System.Text.Json.JsonSerializerOptions! options) -> void
-override Refit.OptionsAttribute.Method.get -> System.Net.Http.HttpMethod!
-override Refit.PatchAttribute.Method.get -> System.Net.Http.HttpMethod!
-override Refit.PostAttribute.Method.get -> System.Net.Http.HttpMethod!
-override Refit.PutAttribute.Method.get -> System.Net.Http.HttpMethod!
-override Refit.RestMethodInfo.Equals(object? obj) -> bool
-override Refit.RestMethodInfo.GetHashCode() -> int
-override Refit.RestMethodInfo.ToString() -> string!
-override Refit.StreamPart.CreateContent() -> System.Net.Http.HttpContent!
-static Refit.ApiException.Create(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, System.Net.Http.HttpResponseMessage! response, Refit.RefitSettings! refitSettings) -> System.Threading.Tasks.Task<Refit.ApiException!>!
-static Refit.ApiException.Create(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, System.Net.Http.HttpResponseMessage! response, Refit.RefitSettings! refitSettings, System.Exception? innerException) -> System.Threading.Tasks.Task<Refit.ApiException!>!
-static Refit.ApiException.Create(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, System.Net.Http.HttpResponseMessage! response, Refit.RefitSettings! refitSettings) -> System.Threading.Tasks.Task<Refit.ApiException!>!
+Refit.ValidationApiException.ValidationApiException(string! message) -> void
 static Refit.ApiException.Create(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, System.Net.Http.HttpResponseMessage! response, Refit.RefitSettings! refitSettings, System.Exception? innerException) -> System.Threading.Tasks.Task<Refit.ApiException!>!
-static Refit.ApiResponseExtensions.EnsureSuccessStatusCodeAsync<T>(this Refit.IApiResponse<T>! response) -> System.Threading.Tasks.Task<Refit.IApiResponse<T>!>!
+static Refit.ApiException.Create(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, System.Net.Http.HttpResponseMessage! response, Refit.RefitSettings! refitSettings) -> System.Threading.Tasks.Task<Refit.ApiException!>!
+static Refit.ApiException.Create(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, System.Net.Http.HttpResponseMessage! response, Refit.RefitSettings! refitSettings, System.Exception? innerException) -> System.Threading.Tasks.Task<Refit.ApiException!>!
+static Refit.ApiException.Create(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, System.Net.Http.HttpResponseMessage! response, Refit.RefitSettings! refitSettings) -> System.Threading.Tasks.Task<Refit.ApiException!>!
 static Refit.ApiResponseExtensions.EnsureSuccessfulAsync<T>(this Refit.IApiResponse<T>! response) -> System.Threading.Tasks.Task<Refit.IApiResponse<T>!>!
+static Refit.ApiResponseExtensions.EnsureSuccessStatusCodeAsync<T>(this Refit.IApiResponse<T>! response) -> System.Threading.Tasks.Task<Refit.IApiResponse<T>!>!
 static Refit.GeneratedRequestRunner.AddConfiguredRequestOptions(System.Net.Http.HttpRequestMessage! request, Refit.RefitSettings! settings, System.Type! interfaceType) -> void
 static Refit.GeneratedRequestRunner.AddHeaderCollection(System.Net.Http.HttpRequestMessage! request, System.Collections.Generic.IDictionary<string!, string!>? headers) -> void
 static Refit.GeneratedRequestRunner.AddRequestProperty<TValue>(System.Net.Http.HttpRequestMessage! request, string! key, TValue value) -> void
+static Refit.GeneratedRequestRunner.BuildRelativeUri(System.Net.Http.HttpClient! client, string! relativePath, Refit.UrlResolutionMode urlResolution) -> System.Uri!
 static Refit.GeneratedRequestRunner.CreateBodyContent<TBody>(Refit.RefitSettings! settings, TBody body, Refit.BodySerializationMethod serializationMethod, bool streamBody) -> System.Net.Http.HttpContent!
 static Refit.GeneratedRequestRunner.CreateJsonLinesBodyContent<TBody>(Refit.RefitSettings! settings, TBody body) -> System.Net.Http.HttpContent!
 static Refit.GeneratedRequestRunner.CreateUrlEncodedBodyContent<TBody>(Refit.RefitSettings! settings, TBody body) -> System.Net.Http.HttpContent!
@@ -343,26 +368,27 @@ static Refit.RequestBuilder.ForType<T>(Refit.RefitSettings? settings) -> Refit.I
 static Refit.RestMethodInfo.operator !=(Refit.RestMethodInfo? left, Refit.RestMethodInfo? right) -> bool
 static Refit.RestMethodInfo.operator ==(Refit.RestMethodInfo? left, Refit.RestMethodInfo? right) -> bool
 static Refit.RestService.CreateHttpClient(string! hostUrl, Refit.RefitSettings? settings) -> System.Net.Http.HttpClient!
+static Refit.RestService.ForGenerated(System.Type! refitInterfaceType, string! hostUrl, Refit.RefitSettings! settings) -> object!
+static Refit.RestService.ForGenerated(System.Type! refitInterfaceType, System.Net.Http.HttpClient! client, Refit.RefitSettings! settings) -> object!
+static Refit.RestService.ForGenerated<T>(string! hostUrl, Refit.RefitSettings! settings) -> T
+static Refit.RestService.ForGenerated<T>(string! hostUrl) -> T
+static Refit.RestService.ForGenerated<T>(System.Net.Http.HttpClient! client, Refit.RefitSettings! settings) -> T
+static Refit.RestService.ForGenerated<T>(System.Net.Http.HttpClient! client) -> T
+static Refit.RestService.For(System.Type! refitInterfaceType, string! hostUrl) -> object!
+static Refit.RestService.For(System.Type! refitInterfaceType, string! hostUrl, Refit.RefitSettings? settings) -> object!
 static Refit.RestService.For(System.Type! refitInterfaceType, System.Net.Http.HttpClient! client) -> object!
 static Refit.RestService.For(System.Type! refitInterfaceType, System.Net.Http.HttpClient! client, Refit.IRequestBuilder! builder) -> object!
 static Refit.RestService.For(System.Type! refitInterfaceType, System.Net.Http.HttpClient! client, Refit.RefitSettings? settings) -> object!
-static Refit.RestService.For(System.Type! refitInterfaceType, string! hostUrl) -> object!
-static Refit.RestService.For(System.Type! refitInterfaceType, string! hostUrl, Refit.RefitSettings? settings) -> object!
-static Refit.RestService.For<T>(System.Net.Http.HttpClient! client) -> T
+static Refit.RestService.For<T>(string! hostUrl, Refit.RefitSettings? settings) -> T
+static Refit.RestService.For<T>(string! hostUrl) -> T
 static Refit.RestService.For<T>(System.Net.Http.HttpClient! client, Refit.IRequestBuilder<T>! builder) -> T
 static Refit.RestService.For<T>(System.Net.Http.HttpClient! client, Refit.RefitSettings? settings) -> T
-static Refit.RestService.For<T>(string! hostUrl) -> T
-static Refit.RestService.For<T>(string! hostUrl, Refit.RefitSettings? settings) -> T
-static Refit.RestService.ForGenerated(System.Type! refitInterfaceType, System.Net.Http.HttpClient! client, Refit.RefitSettings! settings) -> object!
-static Refit.RestService.ForGenerated(System.Type! refitInterfaceType, string! hostUrl, Refit.RefitSettings! settings) -> object!
-static Refit.RestService.ForGenerated<T>(System.Net.Http.HttpClient! client) -> T
-static Refit.RestService.ForGenerated<T>(System.Net.Http.HttpClient! client, Refit.RefitSettings! settings) -> T
-static Refit.RestService.ForGenerated<T>(string! hostUrl) -> T
-static Refit.RestService.ForGenerated<T>(string! hostUrl, Refit.RefitSettings! settings) -> T
+static Refit.RestService.For<T>(System.Net.Http.HttpClient! client) -> T
 static Refit.RestService.RegisterGeneratedFactory(System.Type! refitInterfaceType, System.Func<System.Net.Http.HttpClient!, Refit.IRequestBuilder!, object!>! factory) -> void
 static Refit.RestService.RegisterGeneratedFactory<T>(System.Func<System.Net.Http.HttpClient!, Refit.IRequestBuilder!, T>! factory) -> void
 static Refit.RestService.RegisterGeneratedSettingsFactory<T>(System.Func<System.Net.Http.HttpClient!, Refit.RefitSettings!, T>! factory) -> void
 static Refit.SystemTextJsonContentSerializer.GetDefaultJsonSerializerOptions() -> System.Text.Json.JsonSerializerOptions!
+static Refit.SystemTextJsonContentSerializer.GetFastPathJsonSerializerOptions() -> System.Text.Json.JsonSerializerOptions!
 static Refit.ValidationApiException.Create(Refit.ApiException! exception) -> Refit.ValidationApiException!
 virtual Refit.DefaultFormUrlEncodedParameterFormatter.Format(object? value, string? formatString) -> string?
 virtual Refit.DefaultUrlParameterFormatter.Format(object? value, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string?

--- a/src/Refit/PublicAPI/net8.0/PublicAPI.Shipped.txt
+++ b/src/Refit/PublicAPI/net8.0/PublicAPI.Shipped.txt
@@ -1,12 +1,37 @@
 #nullable enable
+abstract Refit.HttpMethodAttribute.Method.get -> System.Net.Http.HttpMethod!
+abstract Refit.MultipartItem.CreateContent() -> System.Net.Http.HttpContent!
+override Refit.ByteArrayPart.CreateContent() -> System.Net.Http.HttpContent!
+override Refit.DeleteAttribute.Method.get -> System.Net.Http.HttpMethod!
+override Refit.FileInfoPart.CreateContent() -> System.Net.Http.HttpContent!
+override Refit.GetAttribute.Method.get -> System.Net.Http.HttpMethod!
+override Refit.HeadAttribute.Method.get -> System.Net.Http.HttpMethod!
+override Refit.ObjectToInferredTypesConverter.Read(ref System.Text.Json.Utf8JsonReader reader, System.Type! typeToConvert, System.Text.Json.JsonSerializerOptions! options) -> object?
+override Refit.ObjectToInferredTypesConverter.Write(System.Text.Json.Utf8JsonWriter! writer, object! value, System.Text.Json.JsonSerializerOptions! options) -> void
+override Refit.OptionsAttribute.Method.get -> System.Net.Http.HttpMethod!
+override Refit.PatchAttribute.Method.get -> System.Net.Http.HttpMethod!
+override Refit.PostAttribute.Method.get -> System.Net.Http.HttpMethod!
+override Refit.PutAttribute.Method.get -> System.Net.Http.HttpMethod!
+override Refit.RestMethodInfo.Equals(object? obj) -> bool
+override Refit.RestMethodInfo.GetHashCode() -> int
+override Refit.RestMethodInfo.ToString() -> string!
+override Refit.StreamPart.CreateContent() -> System.Net.Http.HttpContent!
 Refit.AliasAsAttribute
 Refit.AliasAsAttribute.AliasAsAttribute(string! name) -> void
 Refit.AliasAsAttribute.Name.get -> string!
 Refit.ApiException
-Refit.ApiException.ApiException(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, string? content, System.Net.HttpStatusCode statusCode, string? reasonPhrase, System.Net.Http.Headers.HttpResponseHeaders! headers, Refit.RefitSettings! refitSettings) -> void
-Refit.ApiException.ApiException(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, string? content, System.Net.HttpStatusCode statusCode, string? reasonPhrase, System.Net.Http.Headers.HttpResponseHeaders! headers, Refit.RefitSettings! refitSettings, System.Exception? innerException) -> void
-Refit.ApiException.ApiException(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, string? content, System.Net.HttpStatusCode statusCode, string? reasonPhrase, System.Net.Http.Headers.HttpResponseHeaders! headers, Refit.RefitSettings! refitSettings) -> void
 Refit.ApiException.ApiException(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, string? content, System.Net.HttpStatusCode statusCode, string? reasonPhrase, System.Net.Http.Headers.HttpResponseHeaders! headers, Refit.RefitSettings! refitSettings, System.Exception? innerException) -> void
+Refit.ApiException.ApiException(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, string? content, System.Net.HttpStatusCode statusCode, string? reasonPhrase, System.Net.Http.Headers.HttpResponseHeaders! headers, Refit.RefitSettings! refitSettings) -> void
+Refit.ApiException.ApiException(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, string? content, System.Net.HttpStatusCode statusCode, string? reasonPhrase, System.Net.Http.Headers.HttpResponseHeaders! headers, Refit.RefitSettings! refitSettings, System.Exception? innerException) -> void
+Refit.ApiException.ApiException(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, string? content, System.Net.HttpStatusCode statusCode, string? reasonPhrase, System.Net.Http.Headers.HttpResponseHeaders! headers, Refit.RefitSettings! refitSettings) -> void
+Refit.ApiExceptionBase
+Refit.ApiExceptionBase.ApiExceptionBase(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings, System.Exception? innerException) -> void
+Refit.ApiExceptionBase.ApiExceptionBase(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings) -> void
+Refit.ApiExceptionBase.ApiExceptionBase(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings, System.Exception! innerException) -> void
+Refit.ApiExceptionBase.HttpMethod.get -> System.Net.Http.HttpMethod!
+Refit.ApiExceptionBase.RefitSettings.get -> Refit.RefitSettings!
+Refit.ApiExceptionBase.RequestMessage.get -> System.Net.Http.HttpRequestMessage!
+Refit.ApiExceptionBase.Uri.get -> System.Uri?
 Refit.ApiException.Content.get -> string?
 Refit.ApiException.ContentHeaders.get -> System.Net.Http.Headers.HttpContentHeaders?
 Refit.ApiException.ContentHeaders.set -> void
@@ -15,44 +40,36 @@ Refit.ApiException.HasContent.get -> bool
 Refit.ApiException.Headers.get -> System.Net.Http.Headers.HttpResponseHeaders!
 Refit.ApiException.ReasonPhrase.get -> string?
 Refit.ApiException.StatusCode.get -> System.Net.HttpStatusCode
-Refit.ApiExceptionBase
-Refit.ApiExceptionBase.ApiExceptionBase(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings, System.Exception! innerException) -> void
-Refit.ApiExceptionBase.ApiExceptionBase(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings) -> void
-Refit.ApiExceptionBase.ApiExceptionBase(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings, System.Exception? innerException) -> void
-Refit.ApiExceptionBase.HttpMethod.get -> System.Net.Http.HttpMethod!
-Refit.ApiExceptionBase.RefitSettings.get -> Refit.RefitSettings!
-Refit.ApiExceptionBase.RequestMessage.get -> System.Net.Http.HttpRequestMessage!
-Refit.ApiExceptionBase.Uri.get -> System.Uri?
 Refit.ApiRequestException
-Refit.ApiRequestException.ApiRequestException(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings, System.Exception! innerException) -> void
-Refit.ApiRequestException.ApiRequestException(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings) -> void
 Refit.ApiRequestException.ApiRequestException(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings, System.Exception? innerException) -> void
+Refit.ApiRequestException.ApiRequestException(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings) -> void
+Refit.ApiRequestException.ApiRequestException(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings, System.Exception! innerException) -> void
+Refit.ApiResponseExtensions
+Refit.ApiResponseExtensions.extension<T>(Refit.IApiResponse<T>!)
+Refit.ApiResponseExtensions.extension<T>(Refit.IApiResponse<T>!).EnsureSuccessfulAsync() -> System.Threading.Tasks.Task<Refit.IApiResponse<T>!>!
+Refit.ApiResponseExtensions.extension<T>(Refit.IApiResponse<T>!).EnsureSuccessStatusCodeAsync() -> System.Threading.Tasks.Task<Refit.IApiResponse<T>!>!
 Refit.ApiResponse<T>
 Refit.ApiResponse<T>.ApiResponse(System.Net.Http.HttpRequestMessage! request, System.Net.Http.HttpResponseMessage? response, T? content, Refit.RefitSettings! settings, Refit.ApiExceptionBase? error = null) -> void
-Refit.ApiResponse<T>.ApiResponse(System.Net.Http.HttpResponseMessage! response, T? content, Refit.RefitSettings! settings) -> void
 Refit.ApiResponse<T>.ApiResponse(System.Net.Http.HttpResponseMessage! response, T? content, Refit.RefitSettings! settings, Refit.ApiExceptionBase? error) -> void
+Refit.ApiResponse<T>.ApiResponse(System.Net.Http.HttpResponseMessage! response, T? content, Refit.RefitSettings! settings) -> void
 Refit.ApiResponse<T>.Content.get -> T?
 Refit.ApiResponse<T>.ContentHeaders.get -> System.Net.Http.Headers.HttpContentHeaders?
 Refit.ApiResponse<T>.Dispose() -> void
-Refit.ApiResponse<T>.EnsureSuccessStatusCodeAsync() -> System.Threading.Tasks.Task<Refit.ApiResponse<T>!>!
 Refit.ApiResponse<T>.EnsureSuccessfulAsync() -> System.Threading.Tasks.Task<Refit.ApiResponse<T>!>!
+Refit.ApiResponse<T>.EnsureSuccessStatusCodeAsync() -> System.Threading.Tasks.Task<Refit.ApiResponse<T>!>!
 Refit.ApiResponse<T>.Error.get -> Refit.ApiExceptionBase?
 Refit.ApiResponse<T>.HasContent.get -> bool
 Refit.ApiResponse<T>.HasRequestError(out Refit.ApiRequestException? error) -> bool
 Refit.ApiResponse<T>.HasResponseError(out Refit.ApiException? error) -> bool
 Refit.ApiResponse<T>.Headers.get -> System.Net.Http.Headers.HttpResponseHeaders?
 Refit.ApiResponse<T>.IsReceived.get -> bool
-Refit.ApiResponse<T>.IsSuccessStatusCode.get -> bool
 Refit.ApiResponse<T>.IsSuccessful.get -> bool
+Refit.ApiResponse<T>.IsSuccessStatusCode.get -> bool
 Refit.ApiResponse<T>.ReasonPhrase.get -> string?
 Refit.ApiResponse<T>.RequestMessage.get -> System.Net.Http.HttpRequestMessage!
 Refit.ApiResponse<T>.Settings.get -> Refit.RefitSettings!
 Refit.ApiResponse<T>.StatusCode.get -> System.Net.HttpStatusCode?
 Refit.ApiResponse<T>.Version.get -> System.Version?
-Refit.ApiResponseExtensions
-Refit.ApiResponseExtensions.extension<T>(Refit.IApiResponse<T>!)
-Refit.ApiResponseExtensions.extension<T>(Refit.IApiResponse<T>!).EnsureSuccessStatusCodeAsync() -> System.Threading.Tasks.Task<Refit.IApiResponse<T>!>!
-Refit.ApiResponseExtensions.extension<T>(Refit.IApiResponse<T>!).EnsureSuccessfulAsync() -> System.Threading.Tasks.Task<Refit.IApiResponse<T>!>!
 Refit.AttachmentNameAttribute
 Refit.AttachmentNameAttribute.AttachmentNameAttribute(string! name) -> void
 Refit.AttachmentNameAttribute.Name.get -> string!
@@ -60,10 +77,10 @@ Refit.AuthorizeAttribute
 Refit.AuthorizeAttribute.AuthorizeAttribute(string! scheme = "Bearer") -> void
 Refit.AuthorizeAttribute.Scheme.get -> string!
 Refit.BodyAttribute
-Refit.BodyAttribute.BodyAttribute() -> void
-Refit.BodyAttribute.BodyAttribute(Refit.BodySerializationMethod serializationMethod) -> void
-Refit.BodyAttribute.BodyAttribute(Refit.BodySerializationMethod serializationMethod, bool buffered) -> void
 Refit.BodyAttribute.BodyAttribute(bool buffered) -> void
+Refit.BodyAttribute.BodyAttribute(Refit.BodySerializationMethod serializationMethod, bool buffered) -> void
+Refit.BodyAttribute.BodyAttribute(Refit.BodySerializationMethod serializationMethod) -> void
+Refit.BodyAttribute.BodyAttribute() -> void
 Refit.BodyAttribute.Buffered.get -> bool?
 Refit.BodyAttribute.SerializationMethod.get -> Refit.BodySerializationMethod
 Refit.BodySerializationMethod
@@ -107,13 +124,13 @@ Refit.GetAttribute.GetAttribute(string! path) -> void
 Refit.HeadAttribute
 Refit.HeadAttribute.HeadAttribute(string! path) -> void
 Refit.HeaderAttribute
-Refit.HeaderAttribute.Header.get -> string!
 Refit.HeaderAttribute.HeaderAttribute(string! header) -> void
+Refit.HeaderAttribute.Header.get -> string!
 Refit.HeaderCollectionAttribute
 Refit.HeaderCollectionAttribute.HeaderCollectionAttribute() -> void
 Refit.HeadersAttribute
-Refit.HeadersAttribute.Headers.get -> string![]!
 Refit.HeadersAttribute.HeadersAttribute(params string![]! headers) -> void
+Refit.HeadersAttribute.Headers.get -> string![]!
 Refit.HttpMethodAttribute
 Refit.HttpMethodAttribute.HttpMethodAttribute(string! path) -> void
 Refit.HttpRequestMessageOptions
@@ -124,15 +141,15 @@ Refit.IApiResponse.HasRequestError(out Refit.ApiRequestException? error) -> bool
 Refit.IApiResponse.HasResponseError(out Refit.ApiException? error) -> bool
 Refit.IApiResponse.Headers.get -> System.Net.Http.Headers.HttpResponseHeaders?
 Refit.IApiResponse.IsReceived.get -> bool
-Refit.IApiResponse.IsSuccessStatusCode.get -> bool
 Refit.IApiResponse.IsSuccessful.get -> bool
+Refit.IApiResponse.IsSuccessStatusCode.get -> bool
 Refit.IApiResponse.ReasonPhrase.get -> string?
 Refit.IApiResponse.RequestMessage.get -> System.Net.Http.HttpRequestMessage?
 Refit.IApiResponse.StatusCode.get -> System.Net.HttpStatusCode?
-Refit.IApiResponse.Version.get -> System.Version?
 Refit.IApiResponse<T>
 Refit.IApiResponse<T>.Content.get -> T?
 Refit.IApiResponse<T>.HasContent.get -> bool
+Refit.IApiResponse.Version.get -> System.Version?
 Refit.IFormUrlEncodedParameterFormatter
 Refit.IFormUrlEncodedParameterFormatter.Format(object? value, string? formatString) -> string?
 Refit.IHttpContentSerializer
@@ -143,6 +160,11 @@ Refit.IRequestBuilder
 Refit.IRequestBuilder.BuildRestResultFuncForMethod(string! methodName, System.Type![]? parameterTypes = null, System.Type![]? genericArgumentTypes = null) -> System.Func<System.Net.Http.HttpClient!, object![]!, object?>!
 Refit.IRequestBuilder.Settings.get -> Refit.RefitSettings!
 Refit.IRequestBuilder<T>
+Refit.IStreamingContentSerializer
+Refit.IStreamingContentSerializer.DeserializeStreamAsync<T>(System.IO.Stream! stream, Refit.StreamingContentFormat format, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<T?>!
+Refit.ISynchronousContentSerializer
+Refit.ISynchronousContentSerializer.ToHttpContentSynchronous<T>(T item) -> System.Net.Http.HttpContent!
+Refit.ISynchronousContentSerializer.ToStreamingHttpContent<T>(T item) -> System.Net.Http.HttpContent!
 Refit.IUrlParameterFormatter
 Refit.IUrlParameterFormatter.Format(object? value, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string?
 Refit.IUrlParameterKeyFormatter
@@ -163,8 +185,8 @@ Refit.MultipartAttribute.MultipartAttribute(string! boundaryText = "----MyGreatB
 Refit.MultipartItem
 Refit.MultipartItem.ContentType.get -> string?
 Refit.MultipartItem.FileName.get -> string!
-Refit.MultipartItem.MultipartItem(string! fileName, string? contentType) -> void
 Refit.MultipartItem.MultipartItem(string! fileName, string? contentType, string? name) -> void
+Refit.MultipartItem.MultipartItem(string! fileName, string? contentType) -> void
 Refit.MultipartItem.Name.get -> string?
 Refit.MultipartItem.ToContent() -> System.Net.Http.HttpContent!
 Refit.ObjectToInferredTypesConverter
@@ -196,8 +218,8 @@ Refit.ProblemDetails.Type.get -> string?
 Refit.ProblemDetails.Type.set -> void
 Refit.PropertyAttribute
 Refit.PropertyAttribute.Key.get -> string?
-Refit.PropertyAttribute.PropertyAttribute() -> void
 Refit.PropertyAttribute.PropertyAttribute(string! key) -> void
+Refit.PropertyAttribute.PropertyAttribute() -> void
 Refit.PutAttribute
 Refit.PutAttribute.PutAttribute(string! path) -> void
 Refit.QueryAttribute
@@ -208,17 +230,19 @@ Refit.QueryAttribute.Format.get -> string?
 Refit.QueryAttribute.Format.set -> void
 Refit.QueryAttribute.IsCollectionFormatSpecified.get -> bool
 Refit.QueryAttribute.Prefix.get -> string?
-Refit.QueryAttribute.QueryAttribute() -> void
 Refit.QueryAttribute.QueryAttribute(Refit.CollectionFormat collectionFormat) -> void
-Refit.QueryAttribute.QueryAttribute(string! delimiter) -> void
-Refit.QueryAttribute.QueryAttribute(string! delimiter, string! prefix) -> void
 Refit.QueryAttribute.QueryAttribute(string! delimiter, string! prefix, string! format) -> void
+Refit.QueryAttribute.QueryAttribute(string! delimiter, string! prefix) -> void
+Refit.QueryAttribute.QueryAttribute(string! delimiter) -> void
+Refit.QueryAttribute.QueryAttribute() -> void
 Refit.QueryAttribute.TreatAsString.get -> bool
 Refit.QueryAttribute.TreatAsString.set -> void
 Refit.QueryUriFormatAttribute
 Refit.QueryUriFormatAttribute.QueryUriFormatAttribute(System.UriFormat uriFormat) -> void
 Refit.QueryUriFormatAttribute.UriFormat.get -> System.UriFormat
 Refit.RefitSettings
+Refit.RefitSettings.AllowUnmatchedRouteParameters.get -> bool
+Refit.RefitSettings.AllowUnmatchedRouteParameters.set -> void
 Refit.RefitSettings.AuthorizationHeaderValueGetter.get -> System.Func<System.Net.Http.HttpRequestMessage!, System.Threading.CancellationToken, System.Threading.Tasks.Task<string!>!>?
 Refit.RefitSettings.AuthorizationHeaderValueGetter.set -> void
 Refit.RefitSettings.Buffered.get -> bool
@@ -237,19 +261,27 @@ Refit.RefitSettings.HttpMessageHandlerFactory.get -> System.Func<System.Net.Http
 Refit.RefitSettings.HttpMessageHandlerFactory.set -> void
 Refit.RefitSettings.HttpRequestMessageOptions.get -> System.Collections.Generic.Dictionary<string!, object!>?
 Refit.RefitSettings.HttpRequestMessageOptions.init -> void
-Refit.RefitSettings.RefitSettings() -> void
-Refit.RefitSettings.RefitSettings(Refit.IHttpContentSerializer! contentSerializer) -> void
-Refit.RefitSettings.RefitSettings(Refit.IHttpContentSerializer! contentSerializer, Refit.IUrlParameterFormatter? urlParameterFormatter) -> void
-Refit.RefitSettings.RefitSettings(Refit.IHttpContentSerializer! contentSerializer, Refit.IUrlParameterFormatter? urlParameterFormatter, Refit.IFormUrlEncodedParameterFormatter? formUrlEncodedParameterFormatter) -> void
 Refit.RefitSettings.RefitSettings(Refit.IHttpContentSerializer! contentSerializer, Refit.IUrlParameterFormatter? urlParameterFormatter, Refit.IFormUrlEncodedParameterFormatter? formUrlEncodedParameterFormatter, Refit.IUrlParameterKeyFormatter? urlParameterKeyFormatter) -> void
+Refit.RefitSettings.RefitSettings(Refit.IHttpContentSerializer! contentSerializer, Refit.IUrlParameterFormatter? urlParameterFormatter, Refit.IFormUrlEncodedParameterFormatter? formUrlEncodedParameterFormatter) -> void
+Refit.RefitSettings.RefitSettings(Refit.IHttpContentSerializer! contentSerializer, Refit.IUrlParameterFormatter? urlParameterFormatter) -> void
+Refit.RefitSettings.RefitSettings(Refit.IHttpContentSerializer! contentSerializer) -> void
+Refit.RefitSettings.RefitSettings() -> void
+Refit.RefitSettings.RequestBodySerialization.get -> Refit.RequestBodySerializationMode
+Refit.RefitSettings.RequestBodySerialization.set -> void
 Refit.RefitSettings.UrlParameterFormatter.get -> Refit.IUrlParameterFormatter!
 Refit.RefitSettings.UrlParameterFormatter.set -> void
 Refit.RefitSettings.UrlParameterKeyFormatter.get -> Refit.IUrlParameterKeyFormatter!
 Refit.RefitSettings.UrlParameterKeyFormatter.set -> void
+Refit.RefitSettings.UrlResolution.get -> Refit.UrlResolutionMode
+Refit.RefitSettings.UrlResolution.set -> void
 Refit.RefitSettings.Version.get -> System.Version!
-Refit.RefitSettings.Version.set -> void
 Refit.RefitSettings.VersionPolicy.get -> System.Net.Http.HttpVersionPolicy
 Refit.RefitSettings.VersionPolicy.set -> void
+Refit.RefitSettings.Version.set -> void
+Refit.RequestBodySerializationMode
+Refit.RequestBodySerializationMode.Buffered = 1 -> Refit.RequestBodySerializationMode
+Refit.RequestBodySerializationMode.Default = 0 -> Refit.RequestBodySerializationMode
+Refit.RequestBodySerializationMode.Streamed = 2 -> Refit.RequestBodySerializationMode
 Refit.RequestBuilder
 Refit.RestMethodInfo
 Refit.RestMethodInfo.<Clone>$() -> Refit.RestMethodInfo!
@@ -289,45 +321,38 @@ Refit.RestService
 Refit.SnakeCaseUrlParameterKeyFormatter
 Refit.SnakeCaseUrlParameterKeyFormatter.Format(string! key) -> string!
 Refit.SnakeCaseUrlParameterKeyFormatter.SnakeCaseUrlParameterKeyFormatter() -> void
+Refit.StreamingContentFormat
+Refit.StreamingContentFormat.JsonArray = 0 -> Refit.StreamingContentFormat
+Refit.StreamingContentFormat.JsonLines = 1 -> Refit.StreamingContentFormat
 Refit.StreamPart
 Refit.StreamPart.StreamPart(System.IO.Stream! value, string! fileName, string? contentType = null, string? name = null) -> void
 Refit.StreamPart.Value.get -> System.IO.Stream!
 Refit.SystemTextJsonContentSerializer
+Refit.SystemTextJsonContentSerializer.DeserializeStreamAsync<T>(System.IO.Stream! stream, Refit.StreamingContentFormat format, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<T?>!
 Refit.SystemTextJsonContentSerializer.FromHttpContentAsync<T>(System.Net.Http.HttpContent! content, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<T?>!
 Refit.SystemTextJsonContentSerializer.GetFieldNameForProperty(System.Reflection.PropertyInfo! propertyInfo) -> string?
-Refit.SystemTextJsonContentSerializer.SystemTextJsonContentSerializer() -> void
 Refit.SystemTextJsonContentSerializer.SystemTextJsonContentSerializer(System.Text.Json.JsonSerializerOptions! jsonSerializerOptions) -> void
+Refit.SystemTextJsonContentSerializer.SystemTextJsonContentSerializer() -> void
+Refit.SystemTextJsonContentSerializer.ToHttpContentSynchronous<T>(T item) -> System.Net.Http.HttpContent!
 Refit.SystemTextJsonContentSerializer.ToHttpContent<T>(T item) -> System.Net.Http.HttpContent!
+Refit.SystemTextJsonContentSerializer.ToStreamingHttpContent<T>(T item) -> System.Net.Http.HttpContent!
+Refit.UrlResolutionMode
+Refit.UrlResolutionMode.RefitLegacy = 0 -> Refit.UrlResolutionMode
+Refit.UrlResolutionMode.Rfc3986 = 1 -> Refit.UrlResolutionMode
 Refit.ValidationApiException
 Refit.ValidationApiException.Content.get -> Refit.ProblemDetails?
-Refit.ValidationApiException.ValidationApiException(string! message) -> void
 Refit.ValidationApiException.ValidationApiException(string! message, System.Exception! innerException) -> void
-abstract Refit.HttpMethodAttribute.Method.get -> System.Net.Http.HttpMethod!
-abstract Refit.MultipartItem.CreateContent() -> System.Net.Http.HttpContent!
-override Refit.ByteArrayPart.CreateContent() -> System.Net.Http.HttpContent!
-override Refit.DeleteAttribute.Method.get -> System.Net.Http.HttpMethod!
-override Refit.FileInfoPart.CreateContent() -> System.Net.Http.HttpContent!
-override Refit.GetAttribute.Method.get -> System.Net.Http.HttpMethod!
-override Refit.HeadAttribute.Method.get -> System.Net.Http.HttpMethod!
-override Refit.ObjectToInferredTypesConverter.Read(ref System.Text.Json.Utf8JsonReader reader, System.Type! typeToConvert, System.Text.Json.JsonSerializerOptions! options) -> object?
-override Refit.ObjectToInferredTypesConverter.Write(System.Text.Json.Utf8JsonWriter! writer, object! value, System.Text.Json.JsonSerializerOptions! options) -> void
-override Refit.OptionsAttribute.Method.get -> System.Net.Http.HttpMethod!
-override Refit.PatchAttribute.Method.get -> System.Net.Http.HttpMethod!
-override Refit.PostAttribute.Method.get -> System.Net.Http.HttpMethod!
-override Refit.PutAttribute.Method.get -> System.Net.Http.HttpMethod!
-override Refit.RestMethodInfo.Equals(object? obj) -> bool
-override Refit.RestMethodInfo.GetHashCode() -> int
-override Refit.RestMethodInfo.ToString() -> string!
-override Refit.StreamPart.CreateContent() -> System.Net.Http.HttpContent!
-static Refit.ApiException.Create(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, System.Net.Http.HttpResponseMessage! response, Refit.RefitSettings! refitSettings) -> System.Threading.Tasks.Task<Refit.ApiException!>!
-static Refit.ApiException.Create(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, System.Net.Http.HttpResponseMessage! response, Refit.RefitSettings! refitSettings, System.Exception? innerException) -> System.Threading.Tasks.Task<Refit.ApiException!>!
-static Refit.ApiException.Create(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, System.Net.Http.HttpResponseMessage! response, Refit.RefitSettings! refitSettings) -> System.Threading.Tasks.Task<Refit.ApiException!>!
+Refit.ValidationApiException.ValidationApiException(string! message) -> void
 static Refit.ApiException.Create(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, System.Net.Http.HttpResponseMessage! response, Refit.RefitSettings! refitSettings, System.Exception? innerException) -> System.Threading.Tasks.Task<Refit.ApiException!>!
-static Refit.ApiResponseExtensions.EnsureSuccessStatusCodeAsync<T>(this Refit.IApiResponse<T>! response) -> System.Threading.Tasks.Task<Refit.IApiResponse<T>!>!
+static Refit.ApiException.Create(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, System.Net.Http.HttpResponseMessage! response, Refit.RefitSettings! refitSettings) -> System.Threading.Tasks.Task<Refit.ApiException!>!
+static Refit.ApiException.Create(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, System.Net.Http.HttpResponseMessage! response, Refit.RefitSettings! refitSettings, System.Exception? innerException) -> System.Threading.Tasks.Task<Refit.ApiException!>!
+static Refit.ApiException.Create(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, System.Net.Http.HttpResponseMessage! response, Refit.RefitSettings! refitSettings) -> System.Threading.Tasks.Task<Refit.ApiException!>!
 static Refit.ApiResponseExtensions.EnsureSuccessfulAsync<T>(this Refit.IApiResponse<T>! response) -> System.Threading.Tasks.Task<Refit.IApiResponse<T>!>!
+static Refit.ApiResponseExtensions.EnsureSuccessStatusCodeAsync<T>(this Refit.IApiResponse<T>! response) -> System.Threading.Tasks.Task<Refit.IApiResponse<T>!>!
 static Refit.GeneratedRequestRunner.AddConfiguredRequestOptions(System.Net.Http.HttpRequestMessage! request, Refit.RefitSettings! settings, System.Type! interfaceType) -> void
 static Refit.GeneratedRequestRunner.AddHeaderCollection(System.Net.Http.HttpRequestMessage! request, System.Collections.Generic.IDictionary<string!, string!>? headers) -> void
 static Refit.GeneratedRequestRunner.AddRequestProperty<TValue>(System.Net.Http.HttpRequestMessage! request, string! key, TValue value) -> void
+static Refit.GeneratedRequestRunner.BuildRelativeUri(System.Net.Http.HttpClient! client, string! relativePath, Refit.UrlResolutionMode urlResolution) -> System.Uri!
 static Refit.GeneratedRequestRunner.CreateBodyContent<TBody>(Refit.RefitSettings! settings, TBody body, Refit.BodySerializationMethod serializationMethod, bool streamBody) -> System.Net.Http.HttpContent!
 static Refit.GeneratedRequestRunner.CreateJsonLinesBodyContent<TBody>(Refit.RefitSettings! settings, TBody body) -> System.Net.Http.HttpContent!
 static Refit.GeneratedRequestRunner.CreateUrlEncodedBodyContent<TBody>(Refit.RefitSettings! settings, TBody body) -> System.Net.Http.HttpContent!
@@ -347,26 +372,27 @@ static Refit.RequestBuilder.ForType<T>(Refit.RefitSettings? settings) -> Refit.I
 static Refit.RestMethodInfo.operator !=(Refit.RestMethodInfo? left, Refit.RestMethodInfo? right) -> bool
 static Refit.RestMethodInfo.operator ==(Refit.RestMethodInfo? left, Refit.RestMethodInfo? right) -> bool
 static Refit.RestService.CreateHttpClient(string! hostUrl, Refit.RefitSettings? settings) -> System.Net.Http.HttpClient!
+static Refit.RestService.ForGenerated(System.Type! refitInterfaceType, string! hostUrl, Refit.RefitSettings! settings) -> object!
+static Refit.RestService.ForGenerated(System.Type! refitInterfaceType, System.Net.Http.HttpClient! client, Refit.RefitSettings! settings) -> object!
+static Refit.RestService.ForGenerated<T>(string! hostUrl, Refit.RefitSettings! settings) -> T
+static Refit.RestService.ForGenerated<T>(string! hostUrl) -> T
+static Refit.RestService.ForGenerated<T>(System.Net.Http.HttpClient! client, Refit.RefitSettings! settings) -> T
+static Refit.RestService.ForGenerated<T>(System.Net.Http.HttpClient! client) -> T
+static Refit.RestService.For(System.Type! refitInterfaceType, string! hostUrl) -> object!
+static Refit.RestService.For(System.Type! refitInterfaceType, string! hostUrl, Refit.RefitSettings? settings) -> object!
 static Refit.RestService.For(System.Type! refitInterfaceType, System.Net.Http.HttpClient! client) -> object!
 static Refit.RestService.For(System.Type! refitInterfaceType, System.Net.Http.HttpClient! client, Refit.IRequestBuilder! builder) -> object!
 static Refit.RestService.For(System.Type! refitInterfaceType, System.Net.Http.HttpClient! client, Refit.RefitSettings? settings) -> object!
-static Refit.RestService.For(System.Type! refitInterfaceType, string! hostUrl) -> object!
-static Refit.RestService.For(System.Type! refitInterfaceType, string! hostUrl, Refit.RefitSettings? settings) -> object!
-static Refit.RestService.For<T>(System.Net.Http.HttpClient! client) -> T
+static Refit.RestService.For<T>(string! hostUrl, Refit.RefitSettings? settings) -> T
+static Refit.RestService.For<T>(string! hostUrl) -> T
 static Refit.RestService.For<T>(System.Net.Http.HttpClient! client, Refit.IRequestBuilder<T>! builder) -> T
 static Refit.RestService.For<T>(System.Net.Http.HttpClient! client, Refit.RefitSettings? settings) -> T
-static Refit.RestService.For<T>(string! hostUrl) -> T
-static Refit.RestService.For<T>(string! hostUrl, Refit.RefitSettings? settings) -> T
-static Refit.RestService.ForGenerated(System.Type! refitInterfaceType, System.Net.Http.HttpClient! client, Refit.RefitSettings! settings) -> object!
-static Refit.RestService.ForGenerated(System.Type! refitInterfaceType, string! hostUrl, Refit.RefitSettings! settings) -> object!
-static Refit.RestService.ForGenerated<T>(System.Net.Http.HttpClient! client) -> T
-static Refit.RestService.ForGenerated<T>(System.Net.Http.HttpClient! client, Refit.RefitSettings! settings) -> T
-static Refit.RestService.ForGenerated<T>(string! hostUrl) -> T
-static Refit.RestService.ForGenerated<T>(string! hostUrl, Refit.RefitSettings! settings) -> T
+static Refit.RestService.For<T>(System.Net.Http.HttpClient! client) -> T
 static Refit.RestService.RegisterGeneratedFactory(System.Type! refitInterfaceType, System.Func<System.Net.Http.HttpClient!, Refit.IRequestBuilder!, object!>! factory) -> void
 static Refit.RestService.RegisterGeneratedFactory<T>(System.Func<System.Net.Http.HttpClient!, Refit.IRequestBuilder!, T>! factory) -> void
 static Refit.RestService.RegisterGeneratedSettingsFactory<T>(System.Func<System.Net.Http.HttpClient!, Refit.RefitSettings!, T>! factory) -> void
 static Refit.SystemTextJsonContentSerializer.GetDefaultJsonSerializerOptions() -> System.Text.Json.JsonSerializerOptions!
+static Refit.SystemTextJsonContentSerializer.GetFastPathJsonSerializerOptions() -> System.Text.Json.JsonSerializerOptions!
 static Refit.ValidationApiException.Create(Refit.ApiException! exception) -> Refit.ValidationApiException!
 virtual Refit.DefaultFormUrlEncodedParameterFormatter.Format(object? value, string? formatString) -> string?
 virtual Refit.DefaultUrlParameterFormatter.Format(object? value, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string?

--- a/src/Refit/PublicAPI/net8.0/PublicAPI.Shipped.txt
+++ b/src/Refit/PublicAPI/net8.0/PublicAPI.Shipped.txt
@@ -359,6 +359,7 @@ static Refit.GeneratedRequestRunner.CreateUrlEncodedBodyContent<TBody>(Refit.Ref
 static Refit.GeneratedRequestRunner.SendAsync<T, TBody>(System.Net.Http.HttpClient! client, System.Net.Http.HttpRequestMessage! request, Refit.RefitSettings! settings, bool isApiResponse, bool shouldDisposeResponse, bool bufferBody, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<T?>!
 static Refit.GeneratedRequestRunner.SendVoidAsync(System.Net.Http.HttpClient! client, System.Net.Http.HttpRequestMessage! request, Refit.RefitSettings! settings, bool bufferBody, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 static Refit.GeneratedRequestRunner.SetHeader(System.Net.Http.HttpRequestMessage! request, string! name, string? value) -> void
+static Refit.GeneratedRequestRunner.StreamAsync<T>(System.Net.Http.HttpClient! client, System.Net.Http.HttpRequestMessage! request, Refit.RefitSettings! settings, System.Threading.CancellationToken methodCancellationToken, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<T?>!
 static Refit.HttpRequestMessageOptions.InterfaceType.get -> string!
 static Refit.HttpRequestMessageOptions.RestMethodInfo.get -> string!
 static Refit.JsonLinesContent.JsonLinesMediaType.get -> string!

--- a/src/Refit/PublicAPI/net9.0/PublicAPI.Shipped.txt
+++ b/src/Refit/PublicAPI/net9.0/PublicAPI.Shipped.txt
@@ -1,12 +1,37 @@
 #nullable enable
+abstract Refit.HttpMethodAttribute.Method.get -> System.Net.Http.HttpMethod!
+abstract Refit.MultipartItem.CreateContent() -> System.Net.Http.HttpContent!
+override Refit.ByteArrayPart.CreateContent() -> System.Net.Http.HttpContent!
+override Refit.DeleteAttribute.Method.get -> System.Net.Http.HttpMethod!
+override Refit.FileInfoPart.CreateContent() -> System.Net.Http.HttpContent!
+override Refit.GetAttribute.Method.get -> System.Net.Http.HttpMethod!
+override Refit.HeadAttribute.Method.get -> System.Net.Http.HttpMethod!
+override Refit.ObjectToInferredTypesConverter.Read(ref System.Text.Json.Utf8JsonReader reader, System.Type! typeToConvert, System.Text.Json.JsonSerializerOptions! options) -> object?
+override Refit.ObjectToInferredTypesConverter.Write(System.Text.Json.Utf8JsonWriter! writer, object! value, System.Text.Json.JsonSerializerOptions! options) -> void
+override Refit.OptionsAttribute.Method.get -> System.Net.Http.HttpMethod!
+override Refit.PatchAttribute.Method.get -> System.Net.Http.HttpMethod!
+override Refit.PostAttribute.Method.get -> System.Net.Http.HttpMethod!
+override Refit.PutAttribute.Method.get -> System.Net.Http.HttpMethod!
+override Refit.RestMethodInfo.Equals(object? obj) -> bool
+override Refit.RestMethodInfo.GetHashCode() -> int
+override Refit.RestMethodInfo.ToString() -> string!
+override Refit.StreamPart.CreateContent() -> System.Net.Http.HttpContent!
 Refit.AliasAsAttribute
 Refit.AliasAsAttribute.AliasAsAttribute(string! name) -> void
 Refit.AliasAsAttribute.Name.get -> string!
 Refit.ApiException
-Refit.ApiException.ApiException(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, string? content, System.Net.HttpStatusCode statusCode, string? reasonPhrase, System.Net.Http.Headers.HttpResponseHeaders! headers, Refit.RefitSettings! refitSettings) -> void
-Refit.ApiException.ApiException(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, string? content, System.Net.HttpStatusCode statusCode, string? reasonPhrase, System.Net.Http.Headers.HttpResponseHeaders! headers, Refit.RefitSettings! refitSettings, System.Exception? innerException) -> void
-Refit.ApiException.ApiException(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, string? content, System.Net.HttpStatusCode statusCode, string? reasonPhrase, System.Net.Http.Headers.HttpResponseHeaders! headers, Refit.RefitSettings! refitSettings) -> void
 Refit.ApiException.ApiException(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, string? content, System.Net.HttpStatusCode statusCode, string? reasonPhrase, System.Net.Http.Headers.HttpResponseHeaders! headers, Refit.RefitSettings! refitSettings, System.Exception? innerException) -> void
+Refit.ApiException.ApiException(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, string? content, System.Net.HttpStatusCode statusCode, string? reasonPhrase, System.Net.Http.Headers.HttpResponseHeaders! headers, Refit.RefitSettings! refitSettings) -> void
+Refit.ApiException.ApiException(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, string? content, System.Net.HttpStatusCode statusCode, string? reasonPhrase, System.Net.Http.Headers.HttpResponseHeaders! headers, Refit.RefitSettings! refitSettings, System.Exception? innerException) -> void
+Refit.ApiException.ApiException(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, string? content, System.Net.HttpStatusCode statusCode, string? reasonPhrase, System.Net.Http.Headers.HttpResponseHeaders! headers, Refit.RefitSettings! refitSettings) -> void
+Refit.ApiExceptionBase
+Refit.ApiExceptionBase.ApiExceptionBase(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings, System.Exception? innerException) -> void
+Refit.ApiExceptionBase.ApiExceptionBase(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings) -> void
+Refit.ApiExceptionBase.ApiExceptionBase(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings, System.Exception! innerException) -> void
+Refit.ApiExceptionBase.HttpMethod.get -> System.Net.Http.HttpMethod!
+Refit.ApiExceptionBase.RefitSettings.get -> Refit.RefitSettings!
+Refit.ApiExceptionBase.RequestMessage.get -> System.Net.Http.HttpRequestMessage!
+Refit.ApiExceptionBase.Uri.get -> System.Uri?
 Refit.ApiException.Content.get -> string?
 Refit.ApiException.ContentHeaders.get -> System.Net.Http.Headers.HttpContentHeaders?
 Refit.ApiException.ContentHeaders.set -> void
@@ -15,44 +40,36 @@ Refit.ApiException.HasContent.get -> bool
 Refit.ApiException.Headers.get -> System.Net.Http.Headers.HttpResponseHeaders!
 Refit.ApiException.ReasonPhrase.get -> string?
 Refit.ApiException.StatusCode.get -> System.Net.HttpStatusCode
-Refit.ApiExceptionBase
-Refit.ApiExceptionBase.ApiExceptionBase(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings, System.Exception! innerException) -> void
-Refit.ApiExceptionBase.ApiExceptionBase(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings) -> void
-Refit.ApiExceptionBase.ApiExceptionBase(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings, System.Exception? innerException) -> void
-Refit.ApiExceptionBase.HttpMethod.get -> System.Net.Http.HttpMethod!
-Refit.ApiExceptionBase.RefitSettings.get -> Refit.RefitSettings!
-Refit.ApiExceptionBase.RequestMessage.get -> System.Net.Http.HttpRequestMessage!
-Refit.ApiExceptionBase.Uri.get -> System.Uri?
 Refit.ApiRequestException
-Refit.ApiRequestException.ApiRequestException(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings, System.Exception! innerException) -> void
-Refit.ApiRequestException.ApiRequestException(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings) -> void
 Refit.ApiRequestException.ApiRequestException(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings, System.Exception? innerException) -> void
+Refit.ApiRequestException.ApiRequestException(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings) -> void
+Refit.ApiRequestException.ApiRequestException(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, Refit.RefitSettings! refitSettings, System.Exception! innerException) -> void
+Refit.ApiResponseExtensions
+Refit.ApiResponseExtensions.extension<T>(Refit.IApiResponse<T>!)
+Refit.ApiResponseExtensions.extension<T>(Refit.IApiResponse<T>!).EnsureSuccessfulAsync() -> System.Threading.Tasks.Task<Refit.IApiResponse<T>!>!
+Refit.ApiResponseExtensions.extension<T>(Refit.IApiResponse<T>!).EnsureSuccessStatusCodeAsync() -> System.Threading.Tasks.Task<Refit.IApiResponse<T>!>!
 Refit.ApiResponse<T>
 Refit.ApiResponse<T>.ApiResponse(System.Net.Http.HttpRequestMessage! request, System.Net.Http.HttpResponseMessage? response, T? content, Refit.RefitSettings! settings, Refit.ApiExceptionBase? error = null) -> void
-Refit.ApiResponse<T>.ApiResponse(System.Net.Http.HttpResponseMessage! response, T? content, Refit.RefitSettings! settings) -> void
 Refit.ApiResponse<T>.ApiResponse(System.Net.Http.HttpResponseMessage! response, T? content, Refit.RefitSettings! settings, Refit.ApiExceptionBase? error) -> void
+Refit.ApiResponse<T>.ApiResponse(System.Net.Http.HttpResponseMessage! response, T? content, Refit.RefitSettings! settings) -> void
 Refit.ApiResponse<T>.Content.get -> T?
 Refit.ApiResponse<T>.ContentHeaders.get -> System.Net.Http.Headers.HttpContentHeaders?
 Refit.ApiResponse<T>.Dispose() -> void
-Refit.ApiResponse<T>.EnsureSuccessStatusCodeAsync() -> System.Threading.Tasks.Task<Refit.ApiResponse<T>!>!
 Refit.ApiResponse<T>.EnsureSuccessfulAsync() -> System.Threading.Tasks.Task<Refit.ApiResponse<T>!>!
+Refit.ApiResponse<T>.EnsureSuccessStatusCodeAsync() -> System.Threading.Tasks.Task<Refit.ApiResponse<T>!>!
 Refit.ApiResponse<T>.Error.get -> Refit.ApiExceptionBase?
 Refit.ApiResponse<T>.HasContent.get -> bool
 Refit.ApiResponse<T>.HasRequestError(out Refit.ApiRequestException? error) -> bool
 Refit.ApiResponse<T>.HasResponseError(out Refit.ApiException? error) -> bool
 Refit.ApiResponse<T>.Headers.get -> System.Net.Http.Headers.HttpResponseHeaders?
 Refit.ApiResponse<T>.IsReceived.get -> bool
-Refit.ApiResponse<T>.IsSuccessStatusCode.get -> bool
 Refit.ApiResponse<T>.IsSuccessful.get -> bool
+Refit.ApiResponse<T>.IsSuccessStatusCode.get -> bool
 Refit.ApiResponse<T>.ReasonPhrase.get -> string?
 Refit.ApiResponse<T>.RequestMessage.get -> System.Net.Http.HttpRequestMessage!
 Refit.ApiResponse<T>.Settings.get -> Refit.RefitSettings!
 Refit.ApiResponse<T>.StatusCode.get -> System.Net.HttpStatusCode?
 Refit.ApiResponse<T>.Version.get -> System.Version?
-Refit.ApiResponseExtensions
-Refit.ApiResponseExtensions.extension<T>(Refit.IApiResponse<T>!)
-Refit.ApiResponseExtensions.extension<T>(Refit.IApiResponse<T>!).EnsureSuccessStatusCodeAsync() -> System.Threading.Tasks.Task<Refit.IApiResponse<T>!>!
-Refit.ApiResponseExtensions.extension<T>(Refit.IApiResponse<T>!).EnsureSuccessfulAsync() -> System.Threading.Tasks.Task<Refit.IApiResponse<T>!>!
 Refit.AttachmentNameAttribute
 Refit.AttachmentNameAttribute.AttachmentNameAttribute(string! name) -> void
 Refit.AttachmentNameAttribute.Name.get -> string!
@@ -60,10 +77,10 @@ Refit.AuthorizeAttribute
 Refit.AuthorizeAttribute.AuthorizeAttribute(string! scheme = "Bearer") -> void
 Refit.AuthorizeAttribute.Scheme.get -> string!
 Refit.BodyAttribute
-Refit.BodyAttribute.BodyAttribute() -> void
-Refit.BodyAttribute.BodyAttribute(Refit.BodySerializationMethod serializationMethod) -> void
-Refit.BodyAttribute.BodyAttribute(Refit.BodySerializationMethod serializationMethod, bool buffered) -> void
 Refit.BodyAttribute.BodyAttribute(bool buffered) -> void
+Refit.BodyAttribute.BodyAttribute(Refit.BodySerializationMethod serializationMethod, bool buffered) -> void
+Refit.BodyAttribute.BodyAttribute(Refit.BodySerializationMethod serializationMethod) -> void
+Refit.BodyAttribute.BodyAttribute() -> void
 Refit.BodyAttribute.Buffered.get -> bool?
 Refit.BodyAttribute.SerializationMethod.get -> Refit.BodySerializationMethod
 Refit.BodySerializationMethod
@@ -107,13 +124,13 @@ Refit.GetAttribute.GetAttribute(string! path) -> void
 Refit.HeadAttribute
 Refit.HeadAttribute.HeadAttribute(string! path) -> void
 Refit.HeaderAttribute
-Refit.HeaderAttribute.Header.get -> string!
 Refit.HeaderAttribute.HeaderAttribute(string! header) -> void
+Refit.HeaderAttribute.Header.get -> string!
 Refit.HeaderCollectionAttribute
 Refit.HeaderCollectionAttribute.HeaderCollectionAttribute() -> void
 Refit.HeadersAttribute
-Refit.HeadersAttribute.Headers.get -> string![]!
 Refit.HeadersAttribute.HeadersAttribute(params string![]! headers) -> void
+Refit.HeadersAttribute.Headers.get -> string![]!
 Refit.HttpMethodAttribute
 Refit.HttpMethodAttribute.HttpMethodAttribute(string! path) -> void
 Refit.HttpRequestMessageOptions
@@ -124,15 +141,15 @@ Refit.IApiResponse.HasRequestError(out Refit.ApiRequestException? error) -> bool
 Refit.IApiResponse.HasResponseError(out Refit.ApiException? error) -> bool
 Refit.IApiResponse.Headers.get -> System.Net.Http.Headers.HttpResponseHeaders?
 Refit.IApiResponse.IsReceived.get -> bool
-Refit.IApiResponse.IsSuccessStatusCode.get -> bool
 Refit.IApiResponse.IsSuccessful.get -> bool
+Refit.IApiResponse.IsSuccessStatusCode.get -> bool
 Refit.IApiResponse.ReasonPhrase.get -> string?
 Refit.IApiResponse.RequestMessage.get -> System.Net.Http.HttpRequestMessage?
 Refit.IApiResponse.StatusCode.get -> System.Net.HttpStatusCode?
-Refit.IApiResponse.Version.get -> System.Version?
 Refit.IApiResponse<T>
 Refit.IApiResponse<T>.Content.get -> T?
 Refit.IApiResponse<T>.HasContent.get -> bool
+Refit.IApiResponse.Version.get -> System.Version?
 Refit.IFormUrlEncodedParameterFormatter
 Refit.IFormUrlEncodedParameterFormatter.Format(object? value, string? formatString) -> string?
 Refit.IHttpContentSerializer
@@ -143,6 +160,11 @@ Refit.IRequestBuilder
 Refit.IRequestBuilder.BuildRestResultFuncForMethod(string! methodName, System.Type![]? parameterTypes = null, System.Type![]? genericArgumentTypes = null) -> System.Func<System.Net.Http.HttpClient!, object![]!, object?>!
 Refit.IRequestBuilder.Settings.get -> Refit.RefitSettings!
 Refit.IRequestBuilder<T>
+Refit.IStreamingContentSerializer
+Refit.IStreamingContentSerializer.DeserializeStreamAsync<T>(System.IO.Stream! stream, Refit.StreamingContentFormat format, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<T?>!
+Refit.ISynchronousContentSerializer
+Refit.ISynchronousContentSerializer.ToHttpContentSynchronous<T>(T item) -> System.Net.Http.HttpContent!
+Refit.ISynchronousContentSerializer.ToStreamingHttpContent<T>(T item) -> System.Net.Http.HttpContent!
 Refit.IUrlParameterFormatter
 Refit.IUrlParameterFormatter.Format(object? value, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string?
 Refit.IUrlParameterKeyFormatter
@@ -163,8 +185,8 @@ Refit.MultipartAttribute.MultipartAttribute(string! boundaryText = "----MyGreatB
 Refit.MultipartItem
 Refit.MultipartItem.ContentType.get -> string?
 Refit.MultipartItem.FileName.get -> string!
-Refit.MultipartItem.MultipartItem(string! fileName, string? contentType) -> void
 Refit.MultipartItem.MultipartItem(string! fileName, string? contentType, string? name) -> void
+Refit.MultipartItem.MultipartItem(string! fileName, string? contentType) -> void
 Refit.MultipartItem.Name.get -> string?
 Refit.MultipartItem.ToContent() -> System.Net.Http.HttpContent!
 Refit.ObjectToInferredTypesConverter
@@ -196,8 +218,8 @@ Refit.ProblemDetails.Type.get -> string?
 Refit.ProblemDetails.Type.set -> void
 Refit.PropertyAttribute
 Refit.PropertyAttribute.Key.get -> string?
-Refit.PropertyAttribute.PropertyAttribute() -> void
 Refit.PropertyAttribute.PropertyAttribute(string! key) -> void
+Refit.PropertyAttribute.PropertyAttribute() -> void
 Refit.PutAttribute
 Refit.PutAttribute.PutAttribute(string! path) -> void
 Refit.QueryAttribute
@@ -208,17 +230,19 @@ Refit.QueryAttribute.Format.get -> string?
 Refit.QueryAttribute.Format.set -> void
 Refit.QueryAttribute.IsCollectionFormatSpecified.get -> bool
 Refit.QueryAttribute.Prefix.get -> string?
-Refit.QueryAttribute.QueryAttribute() -> void
 Refit.QueryAttribute.QueryAttribute(Refit.CollectionFormat collectionFormat) -> void
-Refit.QueryAttribute.QueryAttribute(string! delimiter) -> void
-Refit.QueryAttribute.QueryAttribute(string! delimiter, string! prefix) -> void
 Refit.QueryAttribute.QueryAttribute(string! delimiter, string! prefix, string! format) -> void
+Refit.QueryAttribute.QueryAttribute(string! delimiter, string! prefix) -> void
+Refit.QueryAttribute.QueryAttribute(string! delimiter) -> void
+Refit.QueryAttribute.QueryAttribute() -> void
 Refit.QueryAttribute.TreatAsString.get -> bool
 Refit.QueryAttribute.TreatAsString.set -> void
 Refit.QueryUriFormatAttribute
 Refit.QueryUriFormatAttribute.QueryUriFormatAttribute(System.UriFormat uriFormat) -> void
 Refit.QueryUriFormatAttribute.UriFormat.get -> System.UriFormat
 Refit.RefitSettings
+Refit.RefitSettings.AllowUnmatchedRouteParameters.get -> bool
+Refit.RefitSettings.AllowUnmatchedRouteParameters.set -> void
 Refit.RefitSettings.AuthorizationHeaderValueGetter.get -> System.Func<System.Net.Http.HttpRequestMessage!, System.Threading.CancellationToken, System.Threading.Tasks.Task<string!>!>?
 Refit.RefitSettings.AuthorizationHeaderValueGetter.set -> void
 Refit.RefitSettings.Buffered.get -> bool
@@ -237,19 +261,27 @@ Refit.RefitSettings.HttpMessageHandlerFactory.get -> System.Func<System.Net.Http
 Refit.RefitSettings.HttpMessageHandlerFactory.set -> void
 Refit.RefitSettings.HttpRequestMessageOptions.get -> System.Collections.Generic.Dictionary<string!, object!>?
 Refit.RefitSettings.HttpRequestMessageOptions.init -> void
-Refit.RefitSettings.RefitSettings() -> void
-Refit.RefitSettings.RefitSettings(Refit.IHttpContentSerializer! contentSerializer) -> void
-Refit.RefitSettings.RefitSettings(Refit.IHttpContentSerializer! contentSerializer, Refit.IUrlParameterFormatter? urlParameterFormatter) -> void
-Refit.RefitSettings.RefitSettings(Refit.IHttpContentSerializer! contentSerializer, Refit.IUrlParameterFormatter? urlParameterFormatter, Refit.IFormUrlEncodedParameterFormatter? formUrlEncodedParameterFormatter) -> void
 Refit.RefitSettings.RefitSettings(Refit.IHttpContentSerializer! contentSerializer, Refit.IUrlParameterFormatter? urlParameterFormatter, Refit.IFormUrlEncodedParameterFormatter? formUrlEncodedParameterFormatter, Refit.IUrlParameterKeyFormatter? urlParameterKeyFormatter) -> void
+Refit.RefitSettings.RefitSettings(Refit.IHttpContentSerializer! contentSerializer, Refit.IUrlParameterFormatter? urlParameterFormatter, Refit.IFormUrlEncodedParameterFormatter? formUrlEncodedParameterFormatter) -> void
+Refit.RefitSettings.RefitSettings(Refit.IHttpContentSerializer! contentSerializer, Refit.IUrlParameterFormatter? urlParameterFormatter) -> void
+Refit.RefitSettings.RefitSettings(Refit.IHttpContentSerializer! contentSerializer) -> void
+Refit.RefitSettings.RefitSettings() -> void
+Refit.RefitSettings.RequestBodySerialization.get -> Refit.RequestBodySerializationMode
+Refit.RefitSettings.RequestBodySerialization.set -> void
 Refit.RefitSettings.UrlParameterFormatter.get -> Refit.IUrlParameterFormatter!
 Refit.RefitSettings.UrlParameterFormatter.set -> void
 Refit.RefitSettings.UrlParameterKeyFormatter.get -> Refit.IUrlParameterKeyFormatter!
 Refit.RefitSettings.UrlParameterKeyFormatter.set -> void
+Refit.RefitSettings.UrlResolution.get -> Refit.UrlResolutionMode
+Refit.RefitSettings.UrlResolution.set -> void
 Refit.RefitSettings.Version.get -> System.Version!
-Refit.RefitSettings.Version.set -> void
 Refit.RefitSettings.VersionPolicy.get -> System.Net.Http.HttpVersionPolicy
 Refit.RefitSettings.VersionPolicy.set -> void
+Refit.RefitSettings.Version.set -> void
+Refit.RequestBodySerializationMode
+Refit.RequestBodySerializationMode.Buffered = 1 -> Refit.RequestBodySerializationMode
+Refit.RequestBodySerializationMode.Default = 0 -> Refit.RequestBodySerializationMode
+Refit.RequestBodySerializationMode.Streamed = 2 -> Refit.RequestBodySerializationMode
 Refit.RequestBuilder
 Refit.RestMethodInfo
 Refit.RestMethodInfo.<Clone>$() -> Refit.RestMethodInfo!
@@ -289,45 +321,38 @@ Refit.RestService
 Refit.SnakeCaseUrlParameterKeyFormatter
 Refit.SnakeCaseUrlParameterKeyFormatter.Format(string! key) -> string!
 Refit.SnakeCaseUrlParameterKeyFormatter.SnakeCaseUrlParameterKeyFormatter() -> void
+Refit.StreamingContentFormat
+Refit.StreamingContentFormat.JsonArray = 0 -> Refit.StreamingContentFormat
+Refit.StreamingContentFormat.JsonLines = 1 -> Refit.StreamingContentFormat
 Refit.StreamPart
 Refit.StreamPart.StreamPart(System.IO.Stream! value, string! fileName, string? contentType = null, string? name = null) -> void
 Refit.StreamPart.Value.get -> System.IO.Stream!
 Refit.SystemTextJsonContentSerializer
+Refit.SystemTextJsonContentSerializer.DeserializeStreamAsync<T>(System.IO.Stream! stream, Refit.StreamingContentFormat format, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<T?>!
 Refit.SystemTextJsonContentSerializer.FromHttpContentAsync<T>(System.Net.Http.HttpContent! content, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<T?>!
 Refit.SystemTextJsonContentSerializer.GetFieldNameForProperty(System.Reflection.PropertyInfo! propertyInfo) -> string?
-Refit.SystemTextJsonContentSerializer.SystemTextJsonContentSerializer() -> void
 Refit.SystemTextJsonContentSerializer.SystemTextJsonContentSerializer(System.Text.Json.JsonSerializerOptions! jsonSerializerOptions) -> void
+Refit.SystemTextJsonContentSerializer.SystemTextJsonContentSerializer() -> void
+Refit.SystemTextJsonContentSerializer.ToHttpContentSynchronous<T>(T item) -> System.Net.Http.HttpContent!
 Refit.SystemTextJsonContentSerializer.ToHttpContent<T>(T item) -> System.Net.Http.HttpContent!
+Refit.SystemTextJsonContentSerializer.ToStreamingHttpContent<T>(T item) -> System.Net.Http.HttpContent!
+Refit.UrlResolutionMode
+Refit.UrlResolutionMode.RefitLegacy = 0 -> Refit.UrlResolutionMode
+Refit.UrlResolutionMode.Rfc3986 = 1 -> Refit.UrlResolutionMode
 Refit.ValidationApiException
 Refit.ValidationApiException.Content.get -> Refit.ProblemDetails?
-Refit.ValidationApiException.ValidationApiException(string! message) -> void
 Refit.ValidationApiException.ValidationApiException(string! message, System.Exception! innerException) -> void
-abstract Refit.HttpMethodAttribute.Method.get -> System.Net.Http.HttpMethod!
-abstract Refit.MultipartItem.CreateContent() -> System.Net.Http.HttpContent!
-override Refit.ByteArrayPart.CreateContent() -> System.Net.Http.HttpContent!
-override Refit.DeleteAttribute.Method.get -> System.Net.Http.HttpMethod!
-override Refit.FileInfoPart.CreateContent() -> System.Net.Http.HttpContent!
-override Refit.GetAttribute.Method.get -> System.Net.Http.HttpMethod!
-override Refit.HeadAttribute.Method.get -> System.Net.Http.HttpMethod!
-override Refit.ObjectToInferredTypesConverter.Read(ref System.Text.Json.Utf8JsonReader reader, System.Type! typeToConvert, System.Text.Json.JsonSerializerOptions! options) -> object?
-override Refit.ObjectToInferredTypesConverter.Write(System.Text.Json.Utf8JsonWriter! writer, object! value, System.Text.Json.JsonSerializerOptions! options) -> void
-override Refit.OptionsAttribute.Method.get -> System.Net.Http.HttpMethod!
-override Refit.PatchAttribute.Method.get -> System.Net.Http.HttpMethod!
-override Refit.PostAttribute.Method.get -> System.Net.Http.HttpMethod!
-override Refit.PutAttribute.Method.get -> System.Net.Http.HttpMethod!
-override Refit.RestMethodInfo.Equals(object? obj) -> bool
-override Refit.RestMethodInfo.GetHashCode() -> int
-override Refit.RestMethodInfo.ToString() -> string!
-override Refit.StreamPart.CreateContent() -> System.Net.Http.HttpContent!
-static Refit.ApiException.Create(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, System.Net.Http.HttpResponseMessage! response, Refit.RefitSettings! refitSettings) -> System.Threading.Tasks.Task<Refit.ApiException!>!
-static Refit.ApiException.Create(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, System.Net.Http.HttpResponseMessage! response, Refit.RefitSettings! refitSettings, System.Exception? innerException) -> System.Threading.Tasks.Task<Refit.ApiException!>!
-static Refit.ApiException.Create(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, System.Net.Http.HttpResponseMessage! response, Refit.RefitSettings! refitSettings) -> System.Threading.Tasks.Task<Refit.ApiException!>!
+Refit.ValidationApiException.ValidationApiException(string! message) -> void
 static Refit.ApiException.Create(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, System.Net.Http.HttpResponseMessage! response, Refit.RefitSettings! refitSettings, System.Exception? innerException) -> System.Threading.Tasks.Task<Refit.ApiException!>!
-static Refit.ApiResponseExtensions.EnsureSuccessStatusCodeAsync<T>(this Refit.IApiResponse<T>! response) -> System.Threading.Tasks.Task<Refit.IApiResponse<T>!>!
+static Refit.ApiException.Create(string! exceptionMessage, System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, System.Net.Http.HttpResponseMessage! response, Refit.RefitSettings! refitSettings) -> System.Threading.Tasks.Task<Refit.ApiException!>!
+static Refit.ApiException.Create(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, System.Net.Http.HttpResponseMessage! response, Refit.RefitSettings! refitSettings, System.Exception? innerException) -> System.Threading.Tasks.Task<Refit.ApiException!>!
+static Refit.ApiException.Create(System.Net.Http.HttpRequestMessage! message, System.Net.Http.HttpMethod! httpMethod, System.Net.Http.HttpResponseMessage! response, Refit.RefitSettings! refitSettings) -> System.Threading.Tasks.Task<Refit.ApiException!>!
 static Refit.ApiResponseExtensions.EnsureSuccessfulAsync<T>(this Refit.IApiResponse<T>! response) -> System.Threading.Tasks.Task<Refit.IApiResponse<T>!>!
+static Refit.ApiResponseExtensions.EnsureSuccessStatusCodeAsync<T>(this Refit.IApiResponse<T>! response) -> System.Threading.Tasks.Task<Refit.IApiResponse<T>!>!
 static Refit.GeneratedRequestRunner.AddConfiguredRequestOptions(System.Net.Http.HttpRequestMessage! request, Refit.RefitSettings! settings, System.Type! interfaceType) -> void
 static Refit.GeneratedRequestRunner.AddHeaderCollection(System.Net.Http.HttpRequestMessage! request, System.Collections.Generic.IDictionary<string!, string!>? headers) -> void
 static Refit.GeneratedRequestRunner.AddRequestProperty<TValue>(System.Net.Http.HttpRequestMessage! request, string! key, TValue value) -> void
+static Refit.GeneratedRequestRunner.BuildRelativeUri(System.Net.Http.HttpClient! client, string! relativePath, Refit.UrlResolutionMode urlResolution) -> System.Uri!
 static Refit.GeneratedRequestRunner.CreateBodyContent<TBody>(Refit.RefitSettings! settings, TBody body, Refit.BodySerializationMethod serializationMethod, bool streamBody) -> System.Net.Http.HttpContent!
 static Refit.GeneratedRequestRunner.CreateJsonLinesBodyContent<TBody>(Refit.RefitSettings! settings, TBody body) -> System.Net.Http.HttpContent!
 static Refit.GeneratedRequestRunner.CreateUrlEncodedBodyContent<TBody>(Refit.RefitSettings! settings, TBody body) -> System.Net.Http.HttpContent!
@@ -347,26 +372,27 @@ static Refit.RequestBuilder.ForType<T>(Refit.RefitSettings? settings) -> Refit.I
 static Refit.RestMethodInfo.operator !=(Refit.RestMethodInfo? left, Refit.RestMethodInfo? right) -> bool
 static Refit.RestMethodInfo.operator ==(Refit.RestMethodInfo? left, Refit.RestMethodInfo? right) -> bool
 static Refit.RestService.CreateHttpClient(string! hostUrl, Refit.RefitSettings? settings) -> System.Net.Http.HttpClient!
+static Refit.RestService.ForGenerated(System.Type! refitInterfaceType, string! hostUrl, Refit.RefitSettings! settings) -> object!
+static Refit.RestService.ForGenerated(System.Type! refitInterfaceType, System.Net.Http.HttpClient! client, Refit.RefitSettings! settings) -> object!
+static Refit.RestService.ForGenerated<T>(string! hostUrl, Refit.RefitSettings! settings) -> T
+static Refit.RestService.ForGenerated<T>(string! hostUrl) -> T
+static Refit.RestService.ForGenerated<T>(System.Net.Http.HttpClient! client, Refit.RefitSettings! settings) -> T
+static Refit.RestService.ForGenerated<T>(System.Net.Http.HttpClient! client) -> T
+static Refit.RestService.For(System.Type! refitInterfaceType, string! hostUrl) -> object!
+static Refit.RestService.For(System.Type! refitInterfaceType, string! hostUrl, Refit.RefitSettings? settings) -> object!
 static Refit.RestService.For(System.Type! refitInterfaceType, System.Net.Http.HttpClient! client) -> object!
 static Refit.RestService.For(System.Type! refitInterfaceType, System.Net.Http.HttpClient! client, Refit.IRequestBuilder! builder) -> object!
 static Refit.RestService.For(System.Type! refitInterfaceType, System.Net.Http.HttpClient! client, Refit.RefitSettings? settings) -> object!
-static Refit.RestService.For(System.Type! refitInterfaceType, string! hostUrl) -> object!
-static Refit.RestService.For(System.Type! refitInterfaceType, string! hostUrl, Refit.RefitSettings? settings) -> object!
-static Refit.RestService.For<T>(System.Net.Http.HttpClient! client) -> T
+static Refit.RestService.For<T>(string! hostUrl, Refit.RefitSettings? settings) -> T
+static Refit.RestService.For<T>(string! hostUrl) -> T
 static Refit.RestService.For<T>(System.Net.Http.HttpClient! client, Refit.IRequestBuilder<T>! builder) -> T
 static Refit.RestService.For<T>(System.Net.Http.HttpClient! client, Refit.RefitSettings? settings) -> T
-static Refit.RestService.For<T>(string! hostUrl) -> T
-static Refit.RestService.For<T>(string! hostUrl, Refit.RefitSettings? settings) -> T
-static Refit.RestService.ForGenerated(System.Type! refitInterfaceType, System.Net.Http.HttpClient! client, Refit.RefitSettings! settings) -> object!
-static Refit.RestService.ForGenerated(System.Type! refitInterfaceType, string! hostUrl, Refit.RefitSettings! settings) -> object!
-static Refit.RestService.ForGenerated<T>(System.Net.Http.HttpClient! client) -> T
-static Refit.RestService.ForGenerated<T>(System.Net.Http.HttpClient! client, Refit.RefitSettings! settings) -> T
-static Refit.RestService.ForGenerated<T>(string! hostUrl) -> T
-static Refit.RestService.ForGenerated<T>(string! hostUrl, Refit.RefitSettings! settings) -> T
+static Refit.RestService.For<T>(System.Net.Http.HttpClient! client) -> T
 static Refit.RestService.RegisterGeneratedFactory(System.Type! refitInterfaceType, System.Func<System.Net.Http.HttpClient!, Refit.IRequestBuilder!, object!>! factory) -> void
 static Refit.RestService.RegisterGeneratedFactory<T>(System.Func<System.Net.Http.HttpClient!, Refit.IRequestBuilder!, T>! factory) -> void
 static Refit.RestService.RegisterGeneratedSettingsFactory<T>(System.Func<System.Net.Http.HttpClient!, Refit.RefitSettings!, T>! factory) -> void
 static Refit.SystemTextJsonContentSerializer.GetDefaultJsonSerializerOptions() -> System.Text.Json.JsonSerializerOptions!
+static Refit.SystemTextJsonContentSerializer.GetFastPathJsonSerializerOptions() -> System.Text.Json.JsonSerializerOptions!
 static Refit.ValidationApiException.Create(Refit.ApiException! exception) -> Refit.ValidationApiException!
 virtual Refit.DefaultFormUrlEncodedParameterFormatter.Format(object? value, string? formatString) -> string?
 virtual Refit.DefaultUrlParameterFormatter.Format(object? value, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string?

--- a/src/Refit/PublicAPI/net9.0/PublicAPI.Shipped.txt
+++ b/src/Refit/PublicAPI/net9.0/PublicAPI.Shipped.txt
@@ -359,6 +359,7 @@ static Refit.GeneratedRequestRunner.CreateUrlEncodedBodyContent<TBody>(Refit.Ref
 static Refit.GeneratedRequestRunner.SendAsync<T, TBody>(System.Net.Http.HttpClient! client, System.Net.Http.HttpRequestMessage! request, Refit.RefitSettings! settings, bool isApiResponse, bool shouldDisposeResponse, bool bufferBody, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<T?>!
 static Refit.GeneratedRequestRunner.SendVoidAsync(System.Net.Http.HttpClient! client, System.Net.Http.HttpRequestMessage! request, Refit.RefitSettings! settings, bool bufferBody, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 static Refit.GeneratedRequestRunner.SetHeader(System.Net.Http.HttpRequestMessage! request, string! name, string? value) -> void
+static Refit.GeneratedRequestRunner.StreamAsync<T>(System.Net.Http.HttpClient! client, System.Net.Http.HttpRequestMessage! request, Refit.RefitSettings! settings, System.Threading.CancellationToken methodCancellationToken, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<T?>!
 static Refit.HttpRequestMessageOptions.InterfaceType.get -> string!
 static Refit.HttpRequestMessageOptions.RestMethodInfo.get -> string!
 static Refit.JsonLinesContent.JsonLinesMediaType.get -> string!

--- a/src/Refit/RefitSettings.cs
+++ b/src/Refit/RefitSettings.cs
@@ -118,6 +118,28 @@ public class RefitSettings
     /// </summary>
     public bool Buffered { get; set; }
 
+    /// <summary>
+    /// Gets or sets a value indicating whether a route placeholder with no matching method argument is allowed.
+    /// When false (the default) Refit throws while building the method; when true the unmatched <c>{token}</c> is
+    /// left in the URL verbatim so it can be rewritten later, for example inside a <see cref="DelegatingHandler"/>.
+    /// </summary>
+    public bool AllowUnmatchedRouteParameters { get; set; }
+
+    /// <summary>
+    /// Gets or sets how the client's base address is combined with a method's relative URL
+    /// (defaults to <see cref="UrlResolutionMode.RefitLegacy"/>). Set to <see cref="UrlResolutionMode.Rfc3986"/>
+    /// to opt in to RFC 3986 / <see cref="System.Net.Http.HttpClient"/> style resolution.
+    /// </summary>
+    public UrlResolutionMode UrlResolution { get; set; } = UrlResolutionMode.RefitLegacy;
+
+    /// <summary>
+    /// Gets or sets how JSON request bodies are serialized (defaults to <see cref="RequestBodySerializationMode.Default"/>).
+    /// <see cref="RequestBodySerializationMode.Buffered"/> and <see cref="RequestBodySerializationMode.Streamed"/> use
+    /// the synchronous serialization path so the System.Text.Json source-generated fast-path can engage; both require
+    /// the configured <see cref="ContentSerializer"/> to implement <see cref="ISynchronousContentSerializer"/>.
+    /// </summary>
+    public RequestBodySerializationMode RequestBodySerialization { get; set; } = RequestBodySerializationMode.Default;
+
     /// <summary>Gets optional Key-Value pairs, which are displayed in the property <see cref="HttpRequestMessage.Properties"/>.</summary>
     public Dictionary<string, object>? HttpRequestMessageOptions { get; init; }
 
@@ -162,7 +184,7 @@ public class RefitSettings
     {
         var options = SystemTextJsonContentSerializer.GetDefaultJsonSerializerOptions();
         options.PropertyNamingPolicy = jsonNamingPolicy;
-        return new RefitSettings(new SystemTextJsonContentSerializer(options))
+        return new(new SystemTextJsonContentSerializer(options))
         {
             UrlParameterKeyFormatter = urlParameterKeyFormatter,
         };

--- a/src/Refit/RequestBodySerializationMode.cs
+++ b/src/Refit/RequestBodySerializationMode.cs
@@ -1,0 +1,30 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Refit;
+
+/// <summary>Controls how Refit serializes JSON request bodies.</summary>
+public enum RequestBodySerializationMode
+{
+    /// <summary>
+    /// The default: the body is serialized asynchronously (via <c>JsonContent</c>). This uses the metadata-based
+    /// System.Text.Json logic, never the source-generated fast-path.
+    /// </summary>
+    Default,
+
+    /// <summary>
+    /// The body is serialized synchronously into a buffer and sent as a <c>ByteArrayContent</c>. This lets the
+    /// source-generated fast-path engage (with fast-path-eligible options) and sets a <c>Content-Length</c> header.
+    /// Best for small-to-medium bodies. Requires an <see cref="ISynchronousContentSerializer"/>.
+    /// </summary>
+    Buffered,
+
+    /// <summary>
+    /// The body is serialized through a <c>Utf8JsonWriter</c> written to the request stream and flushed
+    /// asynchronously. This keeps the source-generated fast-path while bounding peak memory (the writer buffers in
+    /// pooled chunks rather than materializing the whole body), at the cost of a <c>Content-Length</c> header. Best
+    /// for large uploads. Requires an <see cref="ISynchronousContentSerializer"/>.
+    /// </summary>
+    Streamed
+}

--- a/src/Refit/RequestBuilderImplementation.Execution.cs
+++ b/src/Refit/RequestBuilderImplementation.Execution.cs
@@ -86,6 +86,46 @@ namespace Refit
                 .ConfigureAwait(false);
         }
 
+        /// <summary>Builds, sends and streams the response for a method returning <see cref="IAsyncEnumerable{T}"/>.</summary>
+        /// <typeparam name="T">The element type yielded to the caller.</typeparam>
+        /// <param name="client">The HTTP client to send with.</param>
+        /// <param name="restMethod">The rest method being invoked.</param>
+        /// <param name="paramList">The argument values for the call.</param>
+        /// <param name="cancellationToken">A token, supplied by the consumer's enumeration, to cancel streaming.</param>
+        /// <returns>An asynchronous sequence of deserialized elements.</returns>
+        [SuppressMessage(
+            "Major Code Smell",
+            "S4018:Generic methods should provide type parameters",
+            Justification = "Type parameter intentionally specified explicitly by callers.")]
+        [RequiresDynamicCode("Serializing a body by runtime Type requires runtime generic method instantiation.")]
+        private async IAsyncEnumerable<T?> ExecuteAsyncEnumerableRequestAsync<T>(
+            HttpClient client,
+            RestMethodInfoInternal restMethod,
+            object[] paramList,
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            RequestExecutionHelpers.ThrowIfBaseAddressMissing(client);
+
+            var methodCt = restMethod.CancellationToken is not null
+                ? GetCancellationToken(paramList)
+                : CancellationToken.None;
+            using var linked = CancellationTokenSource.CreateLinkedTokenSource(methodCt, cancellationToken);
+
+            var request = await BuildRequestMessageForMethodAsync(
+                    restMethod,
+                    client.BaseAddress!.AbsolutePath,
+                    restMethod.CancellationToken is not null,
+                    paramList)
+                .ConfigureAwait(false);
+
+            await foreach (var item in RequestExecutionHelpers
+                .StreamResponseAsync<T>(client, request!, _settings, false, linked.Token)
+                .ConfigureAwait(false))
+            {
+                yield return item;
+            }
+        }
+
         /// <summary>Builds a cancellable task delegate that sends the request and deserializes the response.</summary>
         /// <typeparam name="T">The result type returned to the caller.</typeparam>
         /// <typeparam name="TBody">The body type used for API responses.</typeparam>
@@ -141,7 +181,7 @@ namespace Refit
                 client,
                 request,
                 _settings,
-                new RequestExecutionOptions(
+                new(
                     restMethod.IsApiResponse,
                     restMethod.ShouldDisposeResponse,
                     IsBodyBuffered(restMethod, request),

--- a/src/Refit/RequestBuilderImplementation.QueryAndHeaders.cs
+++ b/src/Refit/RequestBuilderImplementation.QueryAndHeaders.cs
@@ -78,15 +78,46 @@ namespace Refit
         /// <summary>Extracts any query parameters already present on the URI into the pending list.</summary>
         /// <param name="uri">The URI builder whose query is read.</param>
         /// <param name="queryParamsToAdd">The pending query parameter list, created if needed.</param>
-        private static void ParseExistingQueryString(UriBuilder uri, ref List<KeyValuePair<string, string?>>? queryParamsToAdd)
+        private static void ParseExistingQueryString(UriBuilder uri, ref List<KeyValuePair<string, string?>>? queryParamsToAdd) =>
+            ParseQueryStringInto(uri.Query, ref queryParamsToAdd);
+
+        /// <summary>Assigns the request URI as a bare relative reference so the <see cref="HttpClient"/> merges it
+        /// with the base address using RFC 3986 rules, preserving whether the path has a leading slash.</summary>
+        /// <param name="ret">The request message being populated.</param>
+        /// <param name="urlTarget">The expanded relative path, with dynamic segments already escaped.</param>
+        /// <param name="queryParamsToAdd">The query parameters collected for the request, if any.</param>
+        private static void AssignRequestUriRfc3986(
+            HttpRequestMessage ret,
+            string urlTarget,
+            List<KeyValuePair<string, string?>>? queryParamsToAdd)
         {
-            if (string.IsNullOrEmpty(uri.Query))
+            var path = urlTarget;
+            var queryIndex = urlTarget.IndexOf('?');
+            if (queryIndex >= 0)
+            {
+                ParseQueryStringInto(urlTarget[queryIndex..], ref queryParamsToAdd);
+                path = urlTarget[..queryIndex];
+            }
+
+            var query = queryParamsToAdd is not null && queryParamsToAdd.Count != 0
+                ? CreateQueryString(queryParamsToAdd)
+                : string.Empty;
+
+            ret.RequestUri = new(path + query, UriKind.Relative);
+        }
+
+        /// <summary>Parses a raw query string into the pending query parameter list.</summary>
+        /// <param name="queryString">The raw query string, with or without a leading '?'.</param>
+        /// <param name="queryParamsToAdd">The pending query parameter list, created if needed.</param>
+        private static void ParseQueryStringInto(string? queryString, ref List<KeyValuePair<string, string?>>? queryParamsToAdd)
+        {
+            if (string.IsNullOrEmpty(queryString))
             {
                 return;
             }
 
             queryParamsToAdd ??= [];
-            var query = HttpUtility.ParseQueryString(uri.Query);
+            var query = HttpUtility.ParseQueryString(queryString);
             var index = 0;
             var keys = query.AllKeys;
             for (var i = 0; i < keys.Length; i++)

--- a/src/Refit/RequestBuilderImplementation.RequestBuilding.cs
+++ b/src/Refit/RequestBuilderImplementation.RequestBuilding.cs
@@ -22,6 +22,22 @@ namespace Refit
         private static readonly MethodInfo SerializeBodyMethod =
             FindDeclaredMethod(nameof(SerializeBodyGeneric));
 
+        /// <summary>Cached reflection handle to the generic synchronous body-serialization method.</summary>
+        [UnconditionalSuppressMessage(
+            "Trimming",
+            "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' may break when trimming",
+            Justification = "The cached method handle points to a local generic serialization helper used through runtime generic method closure.")]
+        private static readonly MethodInfo SerializeBodySynchronouslyMethod =
+            FindDeclaredMethod(nameof(SerializeBodySynchronouslyGeneric));
+
+        /// <summary>Cached reflection handle to the generic streaming body-serialization method.</summary>
+        [UnconditionalSuppressMessage(
+            "Trimming",
+            "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' may break when trimming",
+            Justification = "The cached method handle points to a local generic serialization helper used through runtime generic method closure.")]
+        private static readonly MethodInfo SerializeBodyStreamingMethod =
+            FindDeclaredMethod(nameof(SerializeBodyStreamingGeneric));
+
         /// <summary>Maps a single header, header-collection or authorization parameter into the pending headers.</summary>
         /// <param name="restMethod">The rest method being invoked.</param>
         /// <param name="i">The index of the parameter.</param>
@@ -115,6 +131,68 @@ namespace Refit
             Justification = "Type parameter intentionally specified explicitly by callers.")]
         private static HttpContent SerializeBodyGeneric<T>(IHttpContentSerializer serializer, object? body) =>
             serializer.ToHttpContent((T)body!);
+
+        /// <summary>Serializes a request body synchronously as the given type.</summary>
+        /// <param name="serializer">The synchronous content serializer to use.</param>
+        /// <param name="body">The body value to serialize.</param>
+        /// <param name="declaredBodyType">The declared body type to serialize as.</param>
+        /// <returns>The serialized, buffered HTTP content.</returns>
+        [UnconditionalSuppressMessage(
+            "Trimming",
+            "IL2060:MakeGenericMethod",
+            Justification = "The reflection request builder intentionally closes the serializer method over the runtime body type.")]
+        [RequiresDynamicCode("Serializing a body by runtime Type requires runtime generic method instantiation.")]
+        private static HttpContent SerializeBodySynchronously(
+            ISynchronousContentSerializer serializer,
+            object? body,
+            Type declaredBodyType)
+        {
+            var serializeMethod = SerializeBodySynchronouslyMethod.MakeGenericMethod(declaredBodyType);
+            return (HttpContent)serializeMethod.Invoke(null, [serializer, body])!;
+        }
+
+        /// <summary>Serializes a request body synchronously as the given type.</summary>
+        /// <typeparam name="T">The type to serialize the body as.</typeparam>
+        /// <param name="serializer">The synchronous content serializer to use.</param>
+        /// <param name="body">The body value to serialize.</param>
+        /// <returns>The serialized, buffered HTTP content.</returns>
+        [SuppressMessage(
+            "Major Code Smell",
+            "S4018:Generic methods should provide type parameters",
+            Justification = "Type parameter intentionally specified explicitly by callers.")]
+        private static HttpContent SerializeBodySynchronouslyGeneric<T>(ISynchronousContentSerializer serializer, object? body) =>
+            serializer.ToHttpContentSynchronous((T)body!);
+
+        /// <summary>Serializes a request body as a streaming content for the given type.</summary>
+        /// <param name="serializer">The synchronous content serializer to use.</param>
+        /// <param name="body">The body value to serialize.</param>
+        /// <param name="declaredBodyType">The declared body type to serialize as.</param>
+        /// <returns>The streaming HTTP content.</returns>
+        [UnconditionalSuppressMessage(
+            "Trimming",
+            "IL2060:MakeGenericMethod",
+            Justification = "The reflection request builder intentionally closes the serializer method over the runtime body type.")]
+        [RequiresDynamicCode("Serializing a body by runtime Type requires runtime generic method instantiation.")]
+        private static HttpContent SerializeBodyStreaming(
+            ISynchronousContentSerializer serializer,
+            object? body,
+            Type declaredBodyType)
+        {
+            var serializeMethod = SerializeBodyStreamingMethod.MakeGenericMethod(declaredBodyType);
+            return (HttpContent)serializeMethod.Invoke(null, [serializer, body])!;
+        }
+
+        /// <summary>Serializes a request body as a streaming content for the given type.</summary>
+        /// <typeparam name="T">The type to serialize the body as.</typeparam>
+        /// <param name="serializer">The synchronous content serializer to use.</param>
+        /// <param name="body">The body value to serialize.</param>
+        /// <returns>The streaming HTTP content.</returns>
+        [SuppressMessage(
+            "Major Code Smell",
+            "S4018:Generic methods should provide type parameters",
+            Justification = "Type parameter intentionally specified explicitly by callers.")]
+        private static HttpContent SerializeBodyStreamingGeneric<T>(ISynchronousContentSerializer serializer, object? body) =>
+            serializer.ToStreamingHttpContent((T)body!);
 
         /// <summary>Coerces a JSON Lines body argument into the sequence of values to serialize line by line.</summary>
         /// <param name="param">The body argument value.</param>
@@ -326,6 +404,12 @@ namespace Refit
         {
             var urlTarget = BuildRelativePath(basePath, restMethod, paramList);
 
+            if (restMethod.RefitSettings.UrlResolution == UrlResolutionMode.Rfc3986)
+            {
+                AssignRequestUriRfc3986(ret, urlTarget, queryParamsToAdd);
+                return;
+            }
+
             var uri = new UriBuilder(new Uri(BaseUri, urlTarget));
             ParseExistingQueryString(uri, ref queryParamsToAdd);
 
@@ -345,9 +429,13 @@ namespace Refit
         /// <returns>The fully expanded relative path.</returns>
         private string BuildRelativePath(string basePath, RestMethodInfoInternal restMethod, object[] paramList)
         {
-            // Every path fragment is prefixed with '/', so trim a trailing slash from the
-            // base path to avoid emitting a double slash when the base address ends with one.
-            basePath = basePath == "/" ? string.Empty : basePath.TrimEnd('/');
+            // Under RFC 3986 resolution the HttpClient merges the base address with the relative path itself,
+            // so emit only the declared relative path (preserving any leading slash) and prepend nothing.
+            // Otherwise every path fragment is prefixed with '/', so trim a trailing slash from the base path
+            // to avoid emitting a double slash when the base address ends with one.
+            basePath = restMethod.RefitSettings.UrlResolution == UrlResolutionMode.Rfc3986 || basePath == "/"
+                ? string.Empty
+                : basePath.TrimEnd('/');
             var pathFragments = restMethod.FragmentPath;
             if (pathFragments.Count == 0)
             {
@@ -553,6 +641,18 @@ namespace Refit
         {
             var declaredBodyType = restMethod.ParameterInfoArray[
                 restMethod.BodyParameterInfo!.Item3].ParameterType;
+
+            // Synchronous serialization lets the source-gen fast-path engage: Buffered produces a ByteArrayContent up
+            // front, Streamed writes through a Utf8JsonWriter on the request stream without buffering the whole body.
+            if (_settings.RequestBodySerialization != RequestBodySerializationMode.Default
+                && _serializer is ISynchronousContentSerializer syncSerializer)
+            {
+                ret.Content = _settings.RequestBodySerialization == RequestBodySerializationMode.Streamed
+                    ? SerializeBodyStreaming(syncSerializer, param, declaredBodyType)
+                    : SerializeBodySynchronously(syncSerializer, param, declaredBodyType);
+                return;
+            }
+
             var content = SerializeBody(_serializer, param, declaredBodyType);
 
             if (restMethod.BodyParameterInfo.Item2)

--- a/src/Refit/RequestBuilderImplementation.cs
+++ b/src/Refit/RequestBuilderImplementation.cs
@@ -113,6 +113,12 @@ namespace Refit
                 return BuildResultFuncForMethod(restMethod, nameof(BuildValueTaskFuncForMethod));
             }
 
+            // IAsyncEnumerable<T>
+            if (IsGenericReturnType(restMethod, typeof(IAsyncEnumerable<>)))
+            {
+                return BuildResultFuncForMethod(restMethod, nameof(BuildAsyncEnumerableFuncForMethod));
+            }
+
             // IObservable<T>
             return IsGenericReturnType(restMethod, typeof(IObservable<>))
                 ? BuildResultFuncForMethod(restMethod, nameof(BuildRxFuncForMethod))
@@ -481,6 +487,24 @@ namespace Refit
                     return DisposeWhenDoneAsync(task, cts);
                 });
         }
+
+        /// <summary>Builds a delegate that streams the response of a method returning <see cref="IAsyncEnumerable{T}"/>.</summary>
+        /// <typeparam name="T">The element type yielded to the caller.</typeparam>
+        /// <typeparam name="TBody">Unused; present so the delegate factory shares the two-type-parameter shape.</typeparam>
+        /// <param name="restMethod">The rest method to build a delegate for.</param>
+        /// <returns>A delegate that returns an asynchronous sequence of the result.</returns>
+        [SuppressMessage(
+            "Major Code Smell",
+            "S4018:Generic methods should provide type parameters",
+            Justification = "Type parameter intentionally specified explicitly by callers.")]
+        [SuppressMessage(
+            "Major Code Smell",
+            "S2326:Unused type parameters should be removed",
+            Justification = "The second type parameter is required so this factory matches the two-type-argument shape invoked reflectively by BuildResultFuncForMethod.")]
+        [RequiresDynamicCode("Serializing a body by runtime Type requires runtime generic method instantiation.")]
+        private Func<HttpClient, object[], IAsyncEnumerable<T?>> BuildAsyncEnumerableFuncForMethod<T, TBody>(
+            RestMethodInfoInternal restMethod) =>
+            (client, paramList) => ExecuteAsyncEnumerableRequestAsync<T>(client, restMethod, paramList);
 
         /// <summary>Builds a task invocation delegate for a method.</summary>
         /// <typeparam name="T">The result type returned to the caller.</typeparam>

--- a/src/Refit/RequestExecutionHelpers.cs
+++ b/src/Refit/RequestExecutionHelpers.cs
@@ -161,6 +161,41 @@ internal static class RequestExecutionHelpers
         }
     }
 
+    /// <summary>Sends a request and streams the response body into a sequence, throwing on HTTP errors.</summary>
+    /// <typeparam name="T">The element type yielded to the caller.</typeparam>
+    /// <param name="client">The HTTP client to send with.</param>
+    /// <param name="request">The request message; disposed when streaming completes.</param>
+    /// <param name="settings">The Refit settings to use.</param>
+    /// <param name="applyAuthorizationHeader">Whether to apply the configured authorization getter before sending.</param>
+    /// <param name="cancellationToken">A token to cancel streaming.</param>
+    /// <returns>An asynchronous sequence of deserialized elements.</returns>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Major Code Smell",
+        "S4018:Generic methods should provide type parameters",
+        Justification = "Type parameter intentionally specified explicitly by generated and reflection callers.")]
+    public static IAsyncEnumerable<T?> StreamResponseAsync<T>(
+        HttpClient client,
+        HttpRequestMessage request,
+        RefitSettings settings,
+        bool applyAuthorizationHeader,
+        CancellationToken cancellationToken)
+    {
+        if (settings.ContentSerializer is not IStreamingContentSerializer streamingSerializer)
+        {
+            request.Dispose();
+            throw new NotSupportedException(
+                $"The configured {nameof(IHttpContentSerializer)} does not support streaming responses. Implement {nameof(IStreamingContentSerializer)} to return an IAsyncEnumerable<T>.");
+        }
+
+        return StreamResponseIteratorAsync<T>(
+            client,
+            request,
+            settings,
+            streamingSerializer,
+            applyAuthorizationHeader,
+            cancellationToken);
+    }
+
     /// <summary>Populates an empty Authorization header through the configured token getter.</summary>
     /// <param name="request">The request to modify.</param>
     /// <param name="settings">The Refit settings to use.</param>
@@ -185,6 +220,84 @@ internal static class RequestExecutionHelpers
         var token = await settings.AuthorizationHeaderValueGetter(request, cancellationToken)
             .ConfigureAwait(false);
         request.Headers.Authorization = new(auth.Scheme, token);
+    }
+
+    /// <summary>Sends the request and streams its body, throwing on HTTP errors and disposing the request when done.</summary>
+    /// <typeparam name="T">The element type yielded to the caller.</typeparam>
+    /// <param name="client">The HTTP client to send with.</param>
+    /// <param name="request">The request message; disposed when streaming completes.</param>
+    /// <param name="settings">The Refit settings to use.</param>
+    /// <param name="streamingSerializer">The streaming-capable content serializer.</param>
+    /// <param name="applyAuthorizationHeader">Whether to apply the configured authorization getter before sending.</param>
+    /// <param name="cancellationToken">A token to cancel streaming.</param>
+    /// <returns>An asynchronous sequence of deserialized elements.</returns>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Major Code Smell",
+        "S4018:Generic methods should provide type parameters",
+        Justification = "Type parameter intentionally specified explicitly by generated and reflection callers.")]
+    private static async IAsyncEnumerable<T?> StreamResponseIteratorAsync<T>(
+        HttpClient client,
+        HttpRequestMessage request,
+        RefitSettings settings,
+        IStreamingContentSerializer streamingSerializer,
+        bool applyAuthorizationHeader,
+        [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        using (request)
+        {
+            if (applyAuthorizationHeader)
+            {
+                await AddAuthorizationHeaderFromGetterAsync(request, settings, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+
+            using var response = await client
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
+
+            var exception = await settings.ExceptionFactory(response).ConfigureAwait(false);
+            if (exception is not null)
+            {
+                throw exception;
+            }
+
+            var content = response.Content ?? new StringContent(string.Empty);
+            var format = DetectStreamingFormat(content);
+
+#if NET6_0_OR_GREATER
+            var stream = await content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+            await using (stream.ConfigureAwait(false))
+            {
+                await foreach (var item in streamingSerializer
+                    .DeserializeStreamAsync<T>(stream, format, cancellationToken)
+                    .ConfigureAwait(false))
+                {
+                    yield return item;
+                }
+            }
+#else
+            using var stream = await content.ReadAsStreamAsync().ConfigureAwait(false);
+            await foreach (var item in streamingSerializer
+                .DeserializeStreamAsync<T>(stream, format, cancellationToken)
+                .ConfigureAwait(false))
+            {
+                yield return item;
+            }
+#endif
+        }
+    }
+
+    /// <summary>Chooses the streaming frame format from the response content type.</summary>
+    /// <param name="content">The response content whose media type is inspected.</param>
+    /// <returns>The detected streaming format.</returns>
+    private static StreamingContentFormat DetectStreamingFormat(HttpContent content)
+    {
+        var mediaType = content.Headers.ContentType?.MediaType;
+        return string.Equals(mediaType, "application/jsonl", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(mediaType, "application/x-ndjson", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(mediaType, "application/x-jsonlines", StringComparison.OrdinalIgnoreCase)
+            ? StreamingContentFormat.JsonLines
+            : StreamingContentFormat.JsonArray;
     }
 
     /// <summary>Sends the request, capturing a transport failure as an API response when required.</summary>

--- a/src/Refit/RequestExecutionHelpers.cs
+++ b/src/Refit/RequestExecutionHelpers.cs
@@ -118,7 +118,7 @@ internal static class RequestExecutionHelpers
             }
 
             response = sendResult.Response!;
-            content = response.Content ?? new StringContent(string.Empty);
+            content = EnsureResponseContent(response);
             disposeResponse = options.ShouldDisposeResponse;
 
             var exception = typeof(T) != typeof(HttpResponseMessage)
@@ -222,6 +222,12 @@ internal static class RequestExecutionHelpers
         request.Headers.Authorization = new(auth.Scheme, token);
     }
 
+    /// <summary>Returns the response content, substituting empty content when the response has none.</summary>
+    /// <param name="response">The response whose content is read.</param>
+    /// <returns>The response content, or empty content when none is present.</returns>
+    internal static HttpContent EnsureResponseContent(HttpResponseMessage response) =>
+        response.Content ?? new StringContent(string.Empty);
+
     /// <summary>Sends the request and streams its body, throwing on HTTP errors and disposing the request when done.</summary>
     /// <typeparam name="T">The element type yielded to the caller.</typeparam>
     /// <param name="client">The HTTP client to send with.</param>
@@ -261,7 +267,7 @@ internal static class RequestExecutionHelpers
                 throw exception;
             }
 
-            var content = response.Content ?? new StringContent(string.Empty);
+            var content = EnsureResponseContent(response);
             var format = DetectStreamingFormat(content);
 
 #if NET6_0_OR_GREATER

--- a/src/Refit/RestMethodInfoInternal.cs
+++ b/src/Refit/RestMethodInfoInternal.cs
@@ -58,7 +58,7 @@ internal class RestMethodInfoInternal
 
         MultipartBoundary = GetMultipartBoundary(methodInfo, IsMultipart);
 
-        VerifyUrlPathIsSane(RelativePath);
+        VerifyUrlPathIsSane(RelativePath, RefitSettings.UrlResolution);
 
         var (returnType, returnResultType, deserializedResultType) = DetermineReturnTypeInfo(methodInfo);
         ReturnType = returnType;
@@ -68,7 +68,7 @@ internal class RestMethodInfoInternal
 
         // Exclude cancellation token parameters from this list
         ParameterInfoArray = GetNonCancellationTokenParameters(methodInfo.GetParameters());
-        (ParameterMap, FragmentPath) = BuildParameterMap(RelativePath, ParameterInfoArray);
+        (ParameterMap, FragmentPath) = BuildParameterMap(RelativePath, ParameterInfoArray, RefitSettings.AllowUnmatchedRouteParameters);
         BodyParameterInfo = FindBodyParameter(ParameterInfoArray, IsMultipart, hma.Method);
         AuthorizeParameterInfo = FindAuthorizationParameter(ParameterInfoArray);
 
@@ -317,14 +317,16 @@ internal class RestMethodInfoInternal
 
     /// <summary>Verifies that the relative URL path is well formed and free of injection characters.</summary>
     /// <param name="relativePath">The relative URL path to validate.</param>
-    private static void VerifyUrlPathIsSane(string relativePath)
+    /// <param name="urlResolution">The URL resolution mode; the leading-slash requirement is relaxed under <see cref="UrlResolutionMode.Rfc3986"/>.</param>
+    private static void VerifyUrlPathIsSane(string relativePath, UrlResolutionMode urlResolution)
     {
         if (string.IsNullOrEmpty(relativePath))
         {
             return;
         }
 
-        if (!relativePath.StartsWith("/", StringComparison.Ordinal))
+        if (urlResolution == UrlResolutionMode.RefitLegacy
+            && !relativePath.StartsWith("/", StringComparison.Ordinal))
         {
             throw new ArgumentException(
                 $"URL path {relativePath} must start with '/' and be of the form '/foo/bar/baz'");
@@ -343,6 +345,7 @@ internal class RestMethodInfoInternal
     /// <summary>Builds the route parameter map and the ordered URL fragments for the relative path.</summary>
     /// <param name="relativePath">The relative URL path template.</param>
     /// <param name="parameterInfo">The array of method parameters.</param>
+    /// <param name="allowUnmatchedRouteParameters">When true, a placeholder with no matching argument is left in the path verbatim instead of throwing.</param>
     /// <returns>A tuple containing the parameter map and the ordered list of URL fragments.</returns>
     [SuppressMessage(
         "Major Code Smell",
@@ -356,7 +359,8 @@ internal class RestMethodInfoInternal
     private static (Dictionary<int, RestMethodParameterInfo> Map, List<ParameterFragment> Fragments)
         BuildParameterMap(
             string relativePath,
-            ParameterInfo[] parameterInfo)
+            ParameterInfo[] parameterInfo,
+            bool allowUnmatchedRouteParameters)
     {
         var ret = new Dictionary<int, RestMethodParameterInfo>();
 
@@ -428,6 +432,12 @@ internal class RestMethodInfoInternal
             else if (objectParamValidationDict.TryGetValue(name, out var value1) && !isRoundTripping)
             {
                 AddObjectPropertyParameter(parameterInfo, ret, fragmentList, name, value1);
+            }
+            else if (allowUnmatchedRouteParameters)
+            {
+                // Leave the unmatched placeholder in the URL verbatim (including its braces) so the
+                // caller can resolve it later, e.g. inside a DelegatingHandler.
+                fragmentList.Add(ParameterFragment.Constant(match.Value));
             }
             else
             {
@@ -734,6 +744,7 @@ internal class RestMethodInfoInternal
                 returnType.GetGenericTypeDefinition() == typeof(Task<>)
                 || returnType.GetGenericTypeDefinition() == typeof(ValueTask<>)
                 || returnType.GetGenericTypeDefinition() == typeof(IObservable<>)
+                || returnType.GetGenericTypeDefinition() == typeof(IAsyncEnumerable<>)
             )
         )
         {

--- a/src/Refit/RestService.cs
+++ b/src/Refit/RestService.cs
@@ -69,7 +69,7 @@ public static class RestService
         "Major Code Smell",
         "S4018:Generic methods should provide type parameters",
         Justification = "Type parameter intentionally specified explicitly by callers.")]
-    public static T ForGenerated<T>(HttpClient client) => ForGenerated<T>(client, new RefitSettings());
+    public static T ForGenerated<T>(HttpClient client) => ForGenerated<T>(client, new());
 
     /// <summary>Create a source-generated Refit implementation without falling back to reflection.</summary>
     /// <typeparam name="T">Interface to create the implementation for.</typeparam>
@@ -118,7 +118,7 @@ public static class RestService
         "Major Code Smell",
         "S4018:Generic methods should provide type parameters",
         Justification = "Type parameter intentionally specified explicitly by callers.")]
-    public static T ForGenerated<T>(string hostUrl) => ForGenerated<T>(hostUrl, new RefitSettings());
+    public static T ForGenerated<T>(string hostUrl) => ForGenerated<T>(hostUrl, new());
 
     /// <summary>Create a source-generated Refit implementation without falling back to reflection.</summary>
     /// <typeparam name="T">Interface to create the implementation for.</typeparam>
@@ -398,7 +398,11 @@ public static class RestService
             }
         }
 
-        return new(innerHandler ?? new HttpClientHandler()) { BaseAddress = new(hostUrl.TrimEnd('/')) };
+        // Under RFC 3986 resolution the trailing slash is significant (it controls whether a relative path is
+        // appended to or replaces the base path), so preserve the host URL as supplied. The legacy mode trims it
+        // because it prepends the base path itself.
+        var baseAddress = settings?.UrlResolution == UrlResolutionMode.Rfc3986 ? hostUrl : hostUrl.TrimEnd('/');
+        return new(innerHandler ?? new HttpClientHandler()) { BaseAddress = new(baseAddress) };
     }
 
     /// <summary>Resolves the generated implementation type for a Refit interface.</summary>

--- a/src/Refit/StreamingContentFormat.cs
+++ b/src/Refit/StreamingContentFormat.cs
@@ -1,0 +1,15 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Refit;
+
+/// <summary>Describes how a streamed response body is framed when deserializing an <see cref="IAsyncEnumerable{T}"/>.</summary>
+public enum StreamingContentFormat
+{
+    /// <summary>The body is a single JSON array whose elements are yielded as they are read.</summary>
+    JsonArray,
+
+    /// <summary>The body is newline-delimited JSON (JSON Lines): one JSON value per line. See <see href="https://jsonlines.org"/>.</summary>
+    JsonLines
+}

--- a/src/Refit/SystemTextJsonContentSerializer.cs
+++ b/src/Refit/SystemTextJsonContentSerializer.cs
@@ -553,8 +553,9 @@ public sealed class SystemTextJsonContentSerializer(JsonSerializerOptions jsonSe
         Justification = "Type parameter intentionally specified explicitly by callers.")]
     private T? DeserializeLine<T>(byte[] buffer, int start, int length)
     {
+        // DeserializeLine is only called for non-blank lines, so the span is never empty here.
         var span = new ReadOnlySpan<byte>(buffer, start, length);
-        if (span.Length > 0 && span[span.Length - 1] == (byte)'\r')
+        if (span[span.Length - 1] == (byte)'\r')
         {
             span = span.Slice(0, span.Length - 1);
         }

--- a/src/Refit/SystemTextJsonContentSerializer.cs
+++ b/src/Refit/SystemTextJsonContentSerializer.cs
@@ -2,7 +2,12 @@
 // ReactiveUI and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+#if !NET9_0_OR_GREATER
+using System.Buffers;
+using System.Runtime.CompilerServices;
+#endif
 using System.Diagnostics.CodeAnalysis;
+using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Reflection;
 using System.Text.Json;
@@ -20,7 +25,7 @@ namespace Refit;
 /// </remarks>
 /// <param name="jsonSerializerOptions">The serialization options to use for the current instance.</param>
 public sealed class SystemTextJsonContentSerializer(JsonSerializerOptions jsonSerializerOptions)
-    : IHttpContentSerializer
+    : IHttpContentSerializer, IStreamingContentSerializer, ISynchronousContentSerializer
 {
     /// <summary>Justification shared by the reflection-fallback trim/AOT suppressions.</summary>
     private const string ReflectionFallbackJustification =
@@ -41,6 +46,7 @@ public sealed class SystemTextJsonContentSerializer(JsonSerializerOptions jsonSe
         {
             PropertyNameCaseInsensitive = true,
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            NumberHandling = JsonNumberHandling.AllowReadingFromString,
 #if NET10_0_OR_GREATER
             AllowDuplicateProperties = false
 #endif
@@ -50,6 +56,31 @@ public sealed class SystemTextJsonContentSerializer(JsonSerializerOptions jsonSe
 
         return jsonSerializerOptions;
     }
+
+    /// <summary>
+    /// Creates <see cref="JsonSerializerOptions"/> that are eligible for the System.Text.Json source-generated
+    /// fast-path on serialization. Unlike <see cref="GetDefaultJsonSerializerOptions"/>, these options add no
+    /// converters and do not set <see cref="JsonSerializerOptions.NumberHandling"/>, both of which disable the
+    /// fast-path. Assign a source-generated <see cref="JsonSerializerOptions.TypeInfoResolver"/> (a
+    /// <see cref="JsonSerializerContext"/> generated in <see cref="JsonSourceGenerationMode.Serialization"/> or
+    /// <see cref="JsonSourceGenerationMode.Default"/> mode) to enable it. The fast-path runs through the synchronous
+    /// serialization primitives (<c>SerializeToUtf8Bytes</c> / <c>Serialize(Utf8JsonWriter, ...)</c>); only the
+    /// built-in <c>SerializeAsync(Stream)</c> (used by <c>JsonContent</c>) bypasses it for the metadata logic.
+    /// </summary>
+    /// <returns>Fast-path-eligible <see cref="JsonSerializerOptions"/>.</returns>
+    [SuppressMessage(
+        "Design",
+        "CA1024:Use properties where appropriate",
+        Justification = "Returns a new mutable options instance on each call; a property would wrongly imply a cached value.")]
+    public static JsonSerializerOptions GetFastPathJsonSerializerOptions() =>
+        new()
+        {
+            PropertyNameCaseInsensitive = true,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+#if NET10_0_OR_GREATER
+            AllowDuplicateProperties = false
+#endif
+        };
 
     /// <inheritdoc/>
     public HttpContent ToHttpContent<T>(T item)
@@ -77,6 +108,45 @@ public sealed class SystemTextJsonContentSerializer(JsonSerializerOptions jsonSe
         "Major Code Smell",
         "S4018:Generic methods should provide type parameter for inference",
         Justification = "Type parameter intentionally specified explicitly by callers.")]
+    public HttpContent ToHttpContentSynchronous<T>(T item)
+    {
+        var content = new ByteArrayContent(SerializeToUtf8Bytes(item));
+        content.Headers.ContentType = new("application/json") { CharSet = "utf-8" };
+        return content;
+    }
+
+    /// <inheritdoc/>
+    [SuppressMessage(
+        "Major Code Smell",
+        "S4018:Generic methods should provide type parameter for inference",
+        Justification = "Type parameter intentionally specified explicitly by callers.")]
+    [SuppressMessage("Roslynator", "RCS1261:Resource can be disposed asynchronously", Justification = "Newer .NET versions only.")]
+    public HttpContent ToStreamingHttpContent<T>(T item)
+    {
+        var content = new PushStreamContent(
+            async (stream, _, _) =>
+            {
+                // Disposing the stream signals PushStreamContent that serialization is complete.
+                using (stream)
+                {
+#if NET8_0_OR_GREATER
+                    await using var writer = new Utf8JsonWriter(stream);
+#else
+                    using var writer = new Utf8JsonWriter(stream);
+#endif
+                    SerializeToWriter(item, writer);
+                    await writer.FlushAsync().ConfigureAwait(false);
+                }
+            });
+        content.Headers.ContentType = new("application/json") { CharSet = "utf-8" };
+        return content;
+    }
+
+    /// <inheritdoc/>
+    [SuppressMessage(
+        "Major Code Smell",
+        "S4018:Generic methods should provide type parameter for inference",
+        Justification = "Type parameter intentionally specified explicitly by callers.")]
     public async Task<T?> FromHttpContentAsync<T>(
         HttpContent content,
         CancellationToken cancellationToken = default)
@@ -90,6 +160,23 @@ public sealed class SystemTextJsonContentSerializer(JsonSerializerOptions jsonSe
 #else
         return await FromHttpContentReflectionAsync<T>(content, cancellationToken).ConfigureAwait(false);
 #endif
+    }
+
+    /// <inheritdoc/>
+    [SuppressMessage(
+        "Major Code Smell",
+        "S4018:Generic methods should provide type parameter for inference",
+        Justification = "Type parameter intentionally specified explicitly by callers.")]
+    public IAsyncEnumerable<T?> DeserializeStreamAsync<T>(
+        Stream stream,
+        StreamingContentFormat format,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentExceptionHelper.ThrowIfNull(stream);
+
+        return format == StreamingContentFormat.JsonLines
+            ? DeserializeJsonLinesAsync<T>(stream, cancellationToken)
+            : DeserializeJsonArrayAsync<T>(stream, cancellationToken);
     }
 
     /// <summary>
@@ -218,4 +305,280 @@ public sealed class SystemTextJsonContentSerializer(JsonSerializerOptions jsonSe
     [UnconditionalSuppressMessage("AOT", "IL3050", Justification = ReflectionFallbackJustification)]
     private Task<T?> FromHttpContentReflectionAsync<T>(HttpContent content, CancellationToken cancellationToken) =>
         content.ReadFromJsonAsync<T>(jsonSerializerOptions, cancellationToken);
+
+    /// <summary>Serializes an item to UTF-8 JSON bytes, using source-gen metadata when a resolver is configured.</summary>
+    /// <typeparam name="T">The type of the item being serialized.</typeparam>
+    /// <param name="item">The item to serialize.</param>
+    /// <returns>The UTF-8 encoded JSON.</returns>
+    [SuppressMessage(
+        "Major Code Smell",
+        "S4018:Generic methods should provide type parameter for inference",
+        Justification = "Type parameter intentionally specified explicitly by callers.")]
+    private byte[] SerializeToUtf8Bytes<T>(T item)
+    {
+#if NET8_0_OR_GREATER
+        return jsonSerializerOptions.TypeInfoResolver is not null
+            ? JsonSerializer.SerializeToUtf8Bytes(item, GetJsonTypeInfo<T>())
+            : SerializeToUtf8BytesReflection(item);
+#else
+        return SerializeToUtf8BytesReflection(item);
+#endif
+    }
+
+    /// <summary>Serializes an item to UTF-8 JSON bytes using reflection-based metadata.</summary>
+    /// <typeparam name="T">The type of the item being serialized.</typeparam>
+    /// <param name="item">The item to serialize.</param>
+    /// <returns>The UTF-8 encoded JSON.</returns>
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = ReflectionFallbackJustification)]
+    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = ReflectionFallbackJustification)]
+    [SuppressMessage(
+        "Major Code Smell",
+        "S4018:Generic methods should provide type parameter for inference",
+        Justification = "Type parameter intentionally specified explicitly by callers.")]
+    private byte[] SerializeToUtf8BytesReflection<T>(T item) =>
+        JsonSerializer.SerializeToUtf8Bytes(item, jsonSerializerOptions);
+
+    /// <summary>Writes an item to a <see cref="Utf8JsonWriter"/>, using source-gen metadata when a resolver is configured.</summary>
+    /// <typeparam name="T">The type of the item being serialized.</typeparam>
+    /// <param name="item">The item to serialize.</param>
+    /// <param name="writer">The writer to serialize into.</param>
+    [SuppressMessage(
+        "Major Code Smell",
+        "S4018:Generic methods should provide type parameter for inference",
+        Justification = "Type parameter intentionally specified explicitly by callers.")]
+    private void SerializeToWriter<T>(T item, Utf8JsonWriter writer)
+    {
+#if NET8_0_OR_GREATER
+        if (jsonSerializerOptions.TypeInfoResolver is not null)
+        {
+            JsonSerializer.Serialize(writer, item, GetJsonTypeInfo<T>());
+        }
+        else
+        {
+            SerializeToWriterReflection(item, writer);
+        }
+#else
+        SerializeToWriterReflection(item, writer);
+#endif
+    }
+
+    /// <summary>Writes an item to a <see cref="Utf8JsonWriter"/> using reflection-based metadata.</summary>
+    /// <typeparam name="T">The type of the item being serialized.</typeparam>
+    /// <param name="item">The item to serialize.</param>
+    /// <param name="writer">The writer to serialize into.</param>
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = ReflectionFallbackJustification)]
+    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = ReflectionFallbackJustification)]
+    [SuppressMessage(
+        "Major Code Smell",
+        "S4018:Generic methods should provide type parameter for inference",
+        Justification = "Type parameter intentionally specified explicitly by callers.")]
+    private void SerializeToWriterReflection<T>(T item, Utf8JsonWriter writer) =>
+        JsonSerializer.Serialize(writer, item, jsonSerializerOptions);
+
+    /// <summary>Streams the elements of a single top-level JSON array.</summary>
+    /// <typeparam name="T">The element type to deserialize.</typeparam>
+    /// <param name="stream">The response body stream.</param>
+    /// <param name="cancellationToken">A token to cancel enumeration.</param>
+    /// <returns>An asynchronous sequence of deserialized elements.</returns>
+    [SuppressMessage(
+        "Major Code Smell",
+        "S4018:Generic methods should provide type parameter for inference",
+        Justification = "Type parameter intentionally specified explicitly by callers.")]
+    private IAsyncEnumerable<T?> DeserializeJsonArrayAsync<T>(Stream stream, CancellationToken cancellationToken)
+    {
+#if NET8_0_OR_GREATER
+        return jsonSerializerOptions.TypeInfoResolver is not null
+            ? JsonSerializer.DeserializeAsyncEnumerable<T>(stream, GetJsonTypeInfo<T>(), cancellationToken)
+            : DeserializeJsonArrayReflectionAsync<T>(stream, cancellationToken);
+#else
+        return DeserializeJsonArrayReflectionAsync<T>(stream, cancellationToken);
+#endif
+    }
+
+    /// <summary>Streams JSON array elements using reflection-based metadata.</summary>
+    /// <typeparam name="T">The element type to deserialize.</typeparam>
+    /// <param name="stream">The response body stream.</param>
+    /// <param name="cancellationToken">A token to cancel enumeration.</param>
+    /// <returns>An asynchronous sequence of deserialized elements.</returns>
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = ReflectionFallbackJustification)]
+    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = ReflectionFallbackJustification)]
+    [SuppressMessage(
+        "Major Code Smell",
+        "S4018:Generic methods should provide type parameter for inference",
+        Justification = "Type parameter intentionally specified explicitly by callers.")]
+    private IAsyncEnumerable<T?> DeserializeJsonArrayReflectionAsync<T>(Stream stream, CancellationToken cancellationToken) =>
+        JsonSerializer.DeserializeAsyncEnumerable<T>(stream, jsonSerializerOptions, cancellationToken);
+
+    /// <summary>Streams newline-delimited JSON values from the response body.</summary>
+    /// <typeparam name="T">The element type to deserialize.</typeparam>
+    /// <param name="stream">The response body stream.</param>
+    /// <param name="cancellationToken">A token to cancel enumeration.</param>
+    /// <returns>An asynchronous sequence of deserialized values.</returns>
+    [SuppressMessage(
+        "Major Code Smell",
+        "S4018:Generic methods should provide type parameter for inference",
+        Justification = "Type parameter intentionally specified explicitly by callers.")]
+    private IAsyncEnumerable<T?> DeserializeJsonLinesAsync<T>(Stream stream, CancellationToken cancellationToken)
+    {
+#if NET9_0_OR_GREATER
+        // .NET 9 added the topLevelValues overload, which reads a stream of whitespace-separated
+        // top-level JSON values - exactly the JSON Lines framing - without per-line buffering.
+        return jsonSerializerOptions.TypeInfoResolver is not null
+            ? JsonSerializer.DeserializeAsyncEnumerable<T>(stream, GetJsonTypeInfo<T>(), topLevelValues: true, cancellationToken)
+            : DeserializeJsonLinesTopLevelReflectionAsync<T>(stream, cancellationToken);
+#else
+        return DeserializeJsonLinesManualAsync<T>(stream, cancellationToken);
+#endif
+    }
+
+#if NET9_0_OR_GREATER
+    /// <summary>Streams top-level JSON values using reflection-based metadata.</summary>
+    /// <typeparam name="T">The element type to deserialize.</typeparam>
+    /// <param name="stream">The response body stream.</param>
+    /// <param name="cancellationToken">A token to cancel enumeration.</param>
+    /// <returns>An asynchronous sequence of deserialized values.</returns>
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = ReflectionFallbackJustification)]
+    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = ReflectionFallbackJustification)]
+    [SuppressMessage(
+        "Major Code Smell",
+        "S4018:Generic methods should provide type parameter for inference",
+        Justification = "Type parameter intentionally specified explicitly by callers.")]
+    private IAsyncEnumerable<T?> DeserializeJsonLinesTopLevelReflectionAsync<T>(Stream stream, CancellationToken cancellationToken) =>
+        JsonSerializer.DeserializeAsyncEnumerable<T>(stream, topLevelValues: true, jsonSerializerOptions, cancellationToken);
+#else
+    /// <summary>Reads newline-delimited JSON from a stream using a pooled UTF-8 buffer, deserializing each line.</summary>
+    /// <typeparam name="T">The element type to deserialize.</typeparam>
+    /// <param name="stream">The response body stream.</param>
+    /// <param name="cancellationToken">A token to cancel enumeration.</param>
+    /// <returns>An asynchronous sequence of deserialized values.</returns>
+    [SuppressMessage(
+        "Major Code Smell",
+        "S4018:Generic methods should provide type parameter for inference",
+        Justification = "Type parameter intentionally specified explicitly by callers.")]
+    private async IAsyncEnumerable<T?> DeserializeJsonLinesManualAsync<T>(
+        Stream stream,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        static bool IsBlankLine(byte[] lineBuffer, int lineStart, int lineLength)
+        {
+            var line = new ReadOnlySpan<byte>(lineBuffer, lineStart, lineLength);
+            if (line.Length > 0 && line[line.Length - 1] == (byte)'\r')
+            {
+                line = line.Slice(0, line.Length - 1);
+            }
+
+            foreach (var b in line)
+            {
+                if (b != (byte)' ' && b != (byte)'\t')
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        var buffer = ArrayPool<byte>.Shared.Rent(4096);
+        var start = 0;
+        var end = 0;
+        try
+        {
+            while (true)
+            {
+                var newline = Array.IndexOf(buffer, (byte)'\n', start, end - start);
+                if (newline >= 0)
+                {
+                    var length = newline - start;
+                    if (!IsBlankLine(buffer, start, length))
+                    {
+                        yield return DeserializeLine<T>(buffer, start, length);
+                    }
+
+                    start = newline + 1;
+                    continue;
+                }
+
+                if (start > 0)
+                {
+                    Buffer.BlockCopy(buffer, start, buffer, 0, end - start);
+                    end -= start;
+                    start = 0;
+                }
+
+                if (end == buffer.Length)
+                {
+                    var larger = ArrayPool<byte>.Shared.Rent(buffer.Length * 2);
+                    Buffer.BlockCopy(buffer, 0, larger, 0, end);
+                    ArrayPool<byte>.Shared.Return(buffer);
+                    buffer = larger;
+                }
+
+#if NET8_0_OR_GREATER
+                var read = await stream
+                    .ReadAsync(buffer.AsMemory(end, buffer.Length - end), cancellationToken)
+                    .ConfigureAwait(false);
+#else
+                var read = await stream
+                    .ReadAsync(buffer, end, buffer.Length - end, cancellationToken)
+                    .ConfigureAwait(false);
+#endif
+                if (read == 0)
+                {
+                    if (!IsBlankLine(buffer, start, end - start))
+                    {
+                        yield return DeserializeLine<T>(buffer, start, end - start);
+                    }
+
+                    yield break;
+                }
+
+                end += read;
+            }
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+    }
+
+    /// <summary>Deserializes a single buffered JSON line, trimming a trailing carriage return.</summary>
+    /// <typeparam name="T">The element type to deserialize.</typeparam>
+    /// <param name="buffer">The buffer holding the line bytes.</param>
+    /// <param name="start">The offset of the line.</param>
+    /// <param name="length">The length of the line.</param>
+    /// <returns>The deserialized value.</returns>
+    [SuppressMessage(
+        "Major Code Smell",
+        "S4018:Generic methods should provide type parameter for inference",
+        Justification = "Type parameter intentionally specified explicitly by callers.")]
+    private T? DeserializeLine<T>(byte[] buffer, int start, int length)
+    {
+        var span = new ReadOnlySpan<byte>(buffer, start, length);
+        if (span.Length > 0 && span[span.Length - 1] == (byte)'\r')
+        {
+            span = span.Slice(0, span.Length - 1);
+        }
+
+#if NET8_0_OR_GREATER
+        return jsonSerializerOptions.TypeInfoResolver is not null
+            ? JsonSerializer.Deserialize(span, GetJsonTypeInfo<T>())
+            : DeserializeLineReflection<T>(span);
+#else
+        return DeserializeLineReflection<T>(span);
+#endif
+    }
+
+    /// <summary>Deserializes a JSON line using reflection-based metadata.</summary>
+    /// <typeparam name="T">The element type to deserialize.</typeparam>
+    /// <param name="utf8Json">The UTF-8 encoded JSON value.</param>
+    /// <returns>The deserialized value.</returns>
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = ReflectionFallbackJustification)]
+    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = ReflectionFallbackJustification)]
+    [SuppressMessage(
+        "Major Code Smell",
+        "S4018:Generic methods should provide type parameter for inference",
+        Justification = "Type parameter intentionally specified explicitly by callers.")]
+    private T? DeserializeLineReflection<T>(ReadOnlySpan<byte> utf8Json) =>
+        JsonSerializer.Deserialize<T>(utf8Json, jsonSerializerOptions);
+#endif
 }

--- a/src/Refit/UrlResolutionMode.cs
+++ b/src/Refit/UrlResolutionMode.cs
@@ -1,0 +1,22 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Refit;
+
+/// <summary>Defines how Refit combines the client's base address with a method's relative URL.</summary>
+public enum UrlResolutionMode
+{
+    /// <summary>
+    /// The historical Refit behavior: relative paths must start with <c>/</c>, the base address path is prepended,
+    /// and a trailing slash on the base address is trimmed to avoid a double slash. This is the default.
+    /// </summary>
+    RefitLegacy,
+
+    /// <summary>
+    /// RFC 3986 / <see cref="System.Net.Http.HttpClient"/> resolution: the relative URL is merged with the base
+    /// address using <see cref="System.Uri"/> rules. A relative path without a leading slash is appended to the
+    /// base address path, while a leading slash replaces it. The leading-slash requirement is relaxed in this mode.
+    /// </summary>
+    Rfc3986
+}

--- a/src/benchmarks/Refit.Benchmarks/EndToEndBenchmark.cs
+++ b/src/benchmarks/Refit.Benchmarks/EndToEndBenchmark.cs
@@ -126,7 +126,7 @@ public class EndToEndBenchmark
      * Each [Benchmark] tests one return type that Refit allows and is parameterized to test different, serializers, and http methods, and status codes
      */
 
-    /// <summary>Benchmarks a method that returns a plain <see cref="Task"/>.</summary>
+    /// <summary>Benchmarks a method that returns a plain Task.</summary>
     /// <returns>A task that completes when the request has finished.</returns>
     [Benchmark]
     public async Task Task_Async()

--- a/src/benchmarks/Refit.Benchmarks/FastItem.cs
+++ b/src/benchmarks/Refit.Benchmarks/FastItem.cs
@@ -1,0 +1,14 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+namespace Refit.Benchmarks;
+
+/// <summary>A small payload item used by the fast-path serialization benchmark.</summary>
+public sealed class FastItem
+{
+    /// <summary>Gets or sets the item identifier.</summary>
+    public int Id { get; set; }
+
+    /// <summary>Gets or sets the item name.</summary>
+    public string Name { get; set; } = string.Empty;
+}

--- a/src/benchmarks/Refit.Benchmarks/FastPathSerializationBenchmark.cs
+++ b/src/benchmarks/Refit.Benchmarks/FastPathSerializationBenchmark.cs
@@ -1,0 +1,57 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Text.Json;
+using BenchmarkDotNet.Attributes;
+
+namespace Refit.Benchmarks;
+
+/// <summary>Compares sync JSON serialization: source-gen fast-path vs metadata walker vs Refit's default options (not fast-path eligible).</summary>
+[MemoryDiagnoser]
+public class FastPathSerializationBenchmark
+{
+    /// <summary>The small payload item count.</summary>
+    private const int SmallItemCount = 10;
+
+    /// <summary>The large payload item count.</summary>
+    private const int LargeItemCount = 1000;
+
+    /// <summary>The payload serialized by each benchmark.</summary>
+    private List<FastItem> _items = null!;
+
+    /// <summary>Refit's default (not fast-path eligible) options.</summary>
+    private JsonSerializerOptions _defaultOptions = null!;
+
+    /// <summary>Gets or sets the number of items in the payload.</summary>
+    [Params(SmallItemCount, LargeItemCount)]
+    public int Count { get; set; }
+
+    /// <summary>Builds the payload and the reflection options before the benchmarks run.</summary>
+    [GlobalSetup]
+    public void Setup()
+    {
+        _items = new(Count);
+        for (var i = 0; i < Count; i++)
+        {
+            _items.Add(new() { Id = i, Name = "name" });
+        }
+
+        _defaultOptions = SystemTextJsonContentSerializer.GetDefaultJsonSerializerOptions();
+    }
+
+    /// <summary>Serializes using the source-generated fast-path writer.</summary>
+    /// <returns>The serialized length.</returns>
+    [Benchmark(Baseline = true)]
+    public int FastPath() => JsonSerializer.Serialize(_items, FastPathSerializationContext.Default.ListFastItem).Length;
+
+    /// <summary>Serializes using the source-generated metadata walker.</summary>
+    /// <returns>The serialized length.</returns>
+    [Benchmark]
+    public int Metadata() => JsonSerializer.Serialize(_items, MetadataSerializationContext.Default.ListFastItem).Length;
+
+    /// <summary>Serializes using Refit's default reflection-based options (converters + NumberHandling, no fast-path).</summary>
+    /// <returns>The serialized length.</returns>
+    [Benchmark]
+    public int RefitDefault() => JsonSerializer.Serialize(_items, _defaultOptions).Length;
+}

--- a/src/benchmarks/Refit.Benchmarks/FastPathSerializationContext.cs
+++ b/src/benchmarks/Refit.Benchmarks/FastPathSerializationContext.cs
@@ -1,0 +1,14 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Text.Json.Serialization;
+
+namespace Refit.Benchmarks;
+
+/// <summary>Source-gen context for fast-path serialization (converter-free, NumberHandling-free, Serialization mode).</summary>
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    GenerationMode = JsonSourceGenerationMode.Serialization)]
+[JsonSerializable(typeof(List<FastItem>))]
+internal sealed partial class FastPathSerializationContext : JsonSerializerContext;

--- a/src/benchmarks/Refit.Benchmarks/GeneratorBenchmarkHarness.cs
+++ b/src/benchmarks/Refit.Benchmarks/GeneratorBenchmarkHarness.cs
@@ -8,10 +8,7 @@ using Refit.Generator;
 
 namespace Refit.Benchmarks;
 
-/// <summary>
-/// Shared setup for the source-generator benchmarks: builds a compilation that references Refit
-/// plus the current app domain, and creates a driver running <see cref="InterfaceStubGeneratorV2"/>.
-/// </summary>
+/// <summary>Shared setup for the source-generator benchmarks: builds a compilation and a generator driver.</summary>
 internal static class GeneratorBenchmarkHarness
 {
     /// <summary>The metadata reference to the Refit assembly, including its XML documentation.</summary>
@@ -31,9 +28,9 @@ internal static class GeneratorBenchmarkHarness
         typeof(Attribute)
     ];
 
-    /// <summary>Creates a compilation for <paramref name="sourceText"/> and a generator driver for it.</summary>
+    /// <summary>Creates a compilation for the source text and a generator driver for it.</summary>
     /// <param name="sourceText">The source text to compile and feed to the generator.</param>
-    /// <returns>The compilation and generator driver for the supplied source text.</returns>
+    /// <returns>The compilation and generator driver.</returns>
     public static (Compilation Compilation, CSharpGeneratorDriver Driver) Create(string sourceText)
     {
         var references = new List<MetadataReference>();
@@ -58,12 +55,9 @@ internal static class GeneratorBenchmarkHarness
         return (compilation, driver);
     }
 
-    /// <summary>
-    /// Runs the generator once and then adds an unrelated syntax tree, leaving the driver primed
-    /// for an incremental (cached) re-run.
-    /// </summary>
+    /// <summary>Runs the generator once and primes the driver for an incremental (cached) re-run.</summary>
     /// <param name="sourceText">The source text to compile and feed to the generator.</param>
-    /// <returns>The compilation and primed generator driver for the supplied source text.</returns>
+    /// <returns>The compilation and primed generator driver.</returns>
     public static (Compilation Compilation, CSharpGeneratorDriver Driver) CreatePrimedForCachedRun(
         string sourceText)
     {

--- a/src/benchmarks/Refit.Benchmarks/IStreamingService.cs
+++ b/src/benchmarks/Refit.Benchmarks/IStreamingService.cs
@@ -1,0 +1,19 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Refit.Benchmarks;
+
+/// <summary>Service used to benchmark streaming versus buffered response handling.</summary>
+public interface IStreamingService
+{
+    /// <summary>Streams the users of a JSON array response as they are read.</summary>
+    /// <returns>The streamed users.</returns>
+    [Get("/items")]
+    IAsyncEnumerable<User> StreamItemsAsync();
+
+    /// <summary>Buffers the whole JSON array response into a list.</summary>
+    /// <returns>The deserialized users.</returns>
+    [Get("/items")]
+    Task<List<User>> GetItemsAsync();
+}

--- a/src/benchmarks/Refit.Benchmarks/MetadataSerializationContext.cs
+++ b/src/benchmarks/Refit.Benchmarks/MetadataSerializationContext.cs
@@ -1,0 +1,14 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Text.Json.Serialization;
+
+namespace Refit.Benchmarks;
+
+/// <summary>Source-gen context in Metadata mode (no fast-path), used as the contrast baseline.</summary>
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    GenerationMode = JsonSourceGenerationMode.Metadata)]
+[JsonSerializable(typeof(List<FastItem>))]
+internal sealed partial class MetadataSerializationContext : JsonSerializerContext;

--- a/src/benchmarks/Refit.Benchmarks/Refit.Benchmarks.csproj
+++ b/src/benchmarks/Refit.Benchmarks/Refit.Benchmarks.csproj
@@ -13,14 +13,14 @@
     <ProjectReference Include="..\..\Refit.Newtonsoft.Json\Refit.Newtonsoft.Json.csproj" />
     <ProjectReference Include="..\..\Refit\Refit.csproj" />
     <ProjectReference Include="..\..\Refit.Xml\Refit.Xml.csproj" />
-    <ProjectReference Include="..\..\InterfaceStubGenerator.Roslyn48\InterfaceStubGenerator.Roslyn48.csproj" />
+    <ProjectReference Include="..\..\InterfaceStubGenerator.Roslyn48\InterfaceStubGenerator.Roslyn48.csproj" OutputItemType="Analyzer" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="AutoFixture" />
     <PackageReference Include="BenchmarkDotNet" />
-    <!-- Aligned with the Roslyn version BenchmarkDotNet pulls in, so the benchmark's
+    <!-- Kept on the same Roslyn version BenchmarkDotNet pulls in so the benchmark's
          Microsoft.CodeAnalysis.* assemblies stay on a single consistent version. -->
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" VersionOverride="4.14.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />
   </ItemGroup>
   <ItemGroup>
     <None Remove="newtonsoft-json-10-users.json" />

--- a/src/benchmarks/Refit.Benchmarks/RequestBodySerializationBenchmark.cs
+++ b/src/benchmarks/Refit.Benchmarks/RequestBodySerializationBenchmark.cs
@@ -1,0 +1,77 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using BenchmarkDotNet.Attributes;
+
+namespace Refit.Benchmarks;
+
+/// <summary>Benchmarks producing a Refit JSON request body three ways.</summary>
+[MemoryDiagnoser]
+public class RequestBodySerializationBenchmark
+{
+    /// <summary>The small payload item count.</summary>
+    private const int SmallItemCount = 10;
+
+    /// <summary>The large payload item count.</summary>
+    private const int LargeItemCount = 1000;
+
+    /// <summary>The payload serialized by each benchmark.</summary>
+    private List<FastItem> _items = null!;
+
+    /// <summary>A serializer with fast-path-eligible options and a source-gen resolver.</summary>
+    private SystemTextJsonContentSerializer _fastPath = null!;
+
+    /// <summary>A serializer using Refit's default (not fast-path eligible) options.</summary>
+    private SystemTextJsonContentSerializer _default = null!;
+
+    /// <summary>Gets or sets the number of items in the payload.</summary>
+    [Params(SmallItemCount, LargeItemCount)]
+    public int Count { get; set; }
+
+    /// <summary>Builds the payload and serializers before the benchmarks run.</summary>
+    [GlobalSetup]
+    public void Setup()
+    {
+        _items = new(Count);
+        for (var i = 0; i < Count; i++)
+        {
+            _items.Add(new() { Id = i, Name = "name" });
+        }
+
+        var fastPathOptions = SystemTextJsonContentSerializer.GetFastPathJsonSerializerOptions();
+        fastPathOptions.TypeInfoResolver = FastPathSerializationContext.Default;
+        _fastPath = new(fastPathOptions);
+        _default = new();
+    }
+
+    /// <summary>Synchronous serialization with fast-path-eligible options (the fast-path engages).</summary>
+    /// <returns>The number of bytes produced.</returns>
+    [Benchmark(Baseline = true)]
+    public Task<long> SyncFastPathAsync() =>
+        ProduceAsync(((ISynchronousContentSerializer)_fastPath).ToHttpContentSynchronous(_items));
+
+    /// <summary>Synchronous serialization with Refit's default options (no fast-path, due to converters and NumberHandling).</summary>
+    /// <returns>The number of bytes produced.</returns>
+    [Benchmark]
+    public Task<long> SyncDefaultAsync() =>
+        ProduceAsync(((ISynchronousContentSerializer)_default).ToHttpContentSynchronous(_items));
+
+    /// <summary>Asynchronous serialization with Refit's default options (today's default request-body path).</summary>
+    /// <returns>The number of bytes produced.</returns>
+    [Benchmark]
+    public Task<long> AsyncDefaultAsync() => ProduceAsync(_default.ToHttpContent(_items));
+
+    /// <summary>Serializes the content to a buffer and returns the byte count.</summary>
+    /// <param name="content">The HTTP content to materialize.</param>
+    /// <returns>The number of bytes produced.</returns>
+    private static async Task<long> ProduceAsync(HttpContent content)
+    {
+        using (content)
+        {
+            await using var stream = new MemoryStream();
+            await content.CopyToAsync(stream).ConfigureAwait(false);
+            return stream.Length;
+        }
+    }
+}

--- a/src/benchmarks/Refit.Benchmarks/SourceGeneratorProfiledAllocBenchmarks.cs
+++ b/src/benchmarks/Refit.Benchmarks/SourceGeneratorProfiledAllocBenchmarks.cs
@@ -8,12 +8,7 @@ using Microsoft.CodeAnalysis.CSharp;
 
 namespace Refit.Benchmarks;
 
-/// <summary>
-/// Allocation-profile benchmarks for the Refit source generator. Uses an EventPipe GC-verbose
-/// trace, which captures real GC/allocation events and is more accurate than the sampling
-/// MemoryDiagnoser. The exported *.speedscope.json (under BenchmarkDotNet.Artifacts/) can be
-/// opened to inspect per-call-site allocations.
-/// </summary>
+/// <summary>EventPipe GC-verbose allocation profile of the Refit source generator (per-call-site allocations).</summary>
 [ShortRunJob]
 [EventPipeProfiler(EventPipeProfile.GcVerbose)]
 public class SourceGeneratorProfiledAllocBenchmarks

--- a/src/benchmarks/Refit.Benchmarks/SourceGeneratorProfiledCpuBenchmarks.cs
+++ b/src/benchmarks/Refit.Benchmarks/SourceGeneratorProfiledCpuBenchmarks.cs
@@ -8,10 +8,7 @@ using Microsoft.CodeAnalysis.CSharp;
 
 namespace Refit.Benchmarks;
 
-/// <summary>
-/// CPU-profile benchmarks for the Refit source generator using an EventPipe CPU-sampling trace.
-/// The exported *.speedscope.json shows where parse/emit time is spent.
-/// </summary>
+/// <summary>EventPipe CPU-sampling profile of the Refit source generator (where parse/emit time is spent).</summary>
 [ShortRunJob]
 [EventPipeProfiler(EventPipeProfile.CpuSampling)]
 public class SourceGeneratorProfiledCpuBenchmarks

--- a/src/benchmarks/Refit.Benchmarks/StaticFileHttpResponseHandler.cs
+++ b/src/benchmarks/Refit.Benchmarks/StaticFileHttpResponseHandler.cs
@@ -5,7 +5,7 @@ using System.Net;
 
 namespace Refit.Benchmarks;
 
-/// <summary>An <see cref="HttpMessageHandler"/> that always responds with the contents of a file.</summary>
+/// <summary>An HttpMessageHandler that always responds with the contents of a file.</summary>
 public class StaticFileHttpResponseHandler : HttpMessageHandler
 {
     /// <summary>The status code returned for every response.</summary>

--- a/src/benchmarks/Refit.Benchmarks/StreamingBenchmark.cs
+++ b/src/benchmarks/Refit.Benchmarks/StreamingBenchmark.cs
@@ -1,0 +1,78 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Net;
+using System.Text.Json;
+using BenchmarkDotNet.Attributes;
+
+namespace Refit.Benchmarks;
+
+/// <summary>Compares Refit IAsyncEnumerable streaming against buffering the whole response into a list.</summary>
+[MemoryDiagnoser]
+public class StreamingBenchmark
+{
+    /// <summary>The host address used for requests.</summary>
+    private const string Host = "https://github.com";
+
+    /// <summary>The small payload item count.</summary>
+    private const int SmallItemCount = 10;
+
+    /// <summary>The large payload item count.</summary>
+    private const int LargeItemCount = 1000;
+
+    /// <summary>The Refit streaming service under test.</summary>
+    private IStreamingService _service = null!;
+
+    /// <summary>Gets or sets the number of items in the response payload.</summary>
+    [Params(SmallItemCount, LargeItemCount)]
+    public int Count { get; set; }
+
+    /// <summary>Builds the payload and Refit service before the benchmarks run.</summary>
+    [GlobalSetup]
+    public void Setup()
+    {
+        var options = SystemTextJsonContentSerializer.GetDefaultJsonSerializerOptions();
+
+        var users = new List<User>(Count);
+        for (var i = 0; i < Count; i++)
+        {
+            users.Add(new() { Id = i, Name = "name", Bio = "bio", Url = "url", Followers = i, Following = i });
+        }
+
+        var payload = JsonSerializer.Serialize(users, options);
+
+        _service = RestService.For<IStreamingService>(
+            Host,
+            new(new SystemTextJsonContentSerializer(options))
+            {
+                HttpMessageHandlerFactory = () => new StaticValueHttpResponseHandler(payload, HttpStatusCode.OK),
+            });
+    }
+
+    /// <summary>Streams and counts the response through Refit's IAsyncEnumerable support.</summary>
+    /// <returns>The number of items read.</returns>
+    [Benchmark(Baseline = true)]
+    public async Task<int> RefitStreamingAsync()
+    {
+        var count = 0;
+        await foreach (var user in _service.StreamItemsAsync().ConfigureAwait(false))
+        {
+            if (user is not null)
+            {
+                count++;
+            }
+        }
+
+        return count;
+    }
+
+    /// <summary>Buffers the whole response into a list through Refit.</summary>
+    /// <returns>The number of items read.</returns>
+    [Benchmark]
+    public async Task<int> RefitBufferedAsync()
+    {
+        var users = await _service.GetItemsAsync().ConfigureAwait(false);
+        return users.Count;
+    }
+}

--- a/src/benchmarks/Refit.Benchmarks/StreamingProfiledBenchmarks.cs
+++ b/src/benchmarks/Refit.Benchmarks/StreamingProfiledBenchmarks.cs
@@ -1,0 +1,74 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Net;
+using System.Text.Json;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Diagnosers;
+
+namespace Refit.Benchmarks;
+
+/// <summary>EventPipe CPU-sampling profile of Refit streaming, to show whether time is spent in Refit or in System.Text.Json.</summary>
+[ShortRunJob]
+[MemoryDiagnoser]
+[EventPipeProfiler(EventPipeProfile.CpuSampling)]
+public class StreamingProfiledBenchmarks
+{
+    /// <summary>The host address used for requests.</summary>
+    private const string Host = "https://github.com";
+
+    /// <summary>The payload item count used for profiling.</summary>
+    private const int ItemCount = 1000;
+
+    /// <summary>The Refit streaming service under test.</summary>
+    private IStreamingService _service = null!;
+
+    /// <summary>Builds the payload and Refit service before the benchmarks run.</summary>
+    [GlobalSetup]
+    public void Setup()
+    {
+        var options = SystemTextJsonContentSerializer.GetDefaultJsonSerializerOptions();
+
+        var users = new List<User>(ItemCount);
+        for (var i = 0; i < ItemCount; i++)
+        {
+            users.Add(new() { Id = i, Name = "name", Bio = "bio", Url = "url", Followers = i, Following = i });
+        }
+
+        var payload = JsonSerializer.Serialize(users, options);
+
+        _service = RestService.For<IStreamingService>(
+            Host,
+            new(new SystemTextJsonContentSerializer(options))
+            {
+                HttpMessageHandlerFactory = () => new StaticValueHttpResponseHandler(payload, HttpStatusCode.OK),
+            });
+    }
+
+    /// <summary>Streams and counts the response through Refit's IAsyncEnumerable support.</summary>
+    /// <returns>The number of items read.</returns>
+    [Benchmark(Baseline = true)]
+    public async Task<int> RefitStreamingAsync()
+    {
+        var count = 0;
+        await foreach (var user in _service.StreamItemsAsync().ConfigureAwait(false))
+        {
+            if (user is not null)
+            {
+                count++;
+            }
+        }
+
+        return count;
+    }
+
+    /// <summary>Buffers the whole response into a list through Refit.</summary>
+    /// <returns>The number of items read.</returns>
+    [Benchmark]
+    public async Task<int> RefitBufferedAsync()
+    {
+        var users = await _service.GetItemsAsync().ConfigureAwait(false);
+        return users.Count;
+    }
+}

--- a/src/examples/Meow.Common/Services/DemoBackendHandler.cs
+++ b/src/examples/Meow.Common/Services/DemoBackendHandler.cs
@@ -19,7 +19,7 @@ public sealed class DemoBackendHandler : HttpMessageHandler
             {
                 "/echo-customer" => EchoCustomer(request),
                 "/large-payload" => LargePayload(request),
-                _ => new HttpResponseMessage(HttpStatusCode.NotFound),
+                _ => new(HttpStatusCode.NotFound),
             });
 
     /// <summary>Builds the echo response that reflects the CustomerId request header back to the caller.</summary>
@@ -37,7 +37,7 @@ public sealed class DemoBackendHandler : HttpMessageHandler
             }
         }
 
-        return new HttpResponseMessage(HttpStatusCode.OK)
+        return new(HttpStatusCode.OK)
         {
             Content = new StringContent(
                 JsonConvert.SerializeObject(new CustomerEchoResponse { CustomerIdHeader = customerIdHeader }),
@@ -67,6 +67,6 @@ public sealed class DemoBackendHandler : HttpMessageHandler
         response.Items.AddRange(Enumerable.Range(1, size));
         var payload = JsonConvert.SerializeObject(response);
 
-        return new HttpResponseMessage(HttpStatusCode.OK) { Content = new AsyncOnlyJsonHttpContent(payload) };
+        return new(HttpStatusCode.OK) { Content = new AsyncOnlyJsonHttpContent(payload) };
     }
 }

--- a/src/tests/Refit.CodeFixes.Tests/CodeFixFixture.cs
+++ b/src/tests/Refit.CodeFixes.Tests/CodeFixFixture.cs
@@ -159,7 +159,7 @@ internal static class CodeFixFixture
         }
 
         var span = new TextSpan(start, marker.Length);
-        var lineSpan = new LinePositionSpan(new LinePosition(0, 0), new LinePosition(0, marker.Length));
+        var lineSpan = new LinePositionSpan(new(0, 0), new(0, marker.Length));
         var descriptor = new DiagnosticDescriptor(
             diagnosticId,
             "Test diagnostic",

--- a/src/tests/Refit.GeneratorTests/GeneratedCodeComplianceTests.cs
+++ b/src/tests/Refit.GeneratorTests/GeneratedCodeComplianceTests.cs
@@ -237,7 +237,7 @@ public class GeneratedCodeComplianceTests
     private static SyntaxTree ParseComplianceSource(string source, string path) =>
         CSharpSyntaxTree.ParseText(
             source,
-            new CSharpParseOptions(documentationMode: DocumentationMode.Diagnose),
+            new(documentationMode: DocumentationMode.Diagnose),
             path);
 
     /// <summary>Gets compiler errors from a generated-output compilation.</summary>

--- a/src/tests/Refit.GeneratorTests/GeneratedRequestBuildingTests.cs
+++ b/src/tests/Refit.GeneratorTests/GeneratedRequestBuildingTests.cs
@@ -39,6 +39,24 @@ public class GeneratedRequestBuildingTests
         await Assert.That(generated).DoesNotContain(ReflectiveRequestBuilderCall);
     }
 
+    /// <summary>Verifies an IAsyncEnumerable method is generated inline through StreamAsync, not the reflective builder.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task IAsyncEnumerableUsesInlineStreamAsync()
+    {
+        var generated = Fixture.GenerateForBody(
+            """
+            [Get("/items")]
+            IAsyncEnumerable<string> Stream();
+            """,
+            GeneratedClientHintName,
+            generatedRequestBuilding: true);
+
+        await Assert.That(generated).Contains("GeneratedRequestRunner.StreamAsync<");
+        await Assert.That(generated).Contains(NewHttpRequestMessage);
+        await Assert.That(generated).DoesNotContain(ReflectiveRequestBuilderCall);
+    }
+
     /// <summary>Verifies an explicit switch-off keeps using the reflective request builder.</summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Test]

--- a/src/tests/Refit.GeneratorTests/GeneratedRequestBuildingTests.cs
+++ b/src/tests/Refit.GeneratorTests/GeneratedRequestBuildingTests.cs
@@ -57,6 +57,23 @@ public class GeneratedRequestBuildingTests
         await Assert.That(generated).DoesNotContain(ReflectiveRequestBuilderCall);
     }
 
+    /// <summary>Verifies an IAsyncEnumerable method falls back to the reflective builder when inline generation is off.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task IAsyncEnumerableSwitchOffUsesReflectiveRequestBuilder()
+    {
+        var generated = Fixture.GenerateForBody(
+            """
+            [Get("/items")]
+            IAsyncEnumerable<string> Stream();
+            """,
+            GeneratedClientHintName,
+            generatedRequestBuilding: false);
+
+        await Assert.That(generated).Contains(ReflectiveRequestBuilderCall);
+        await Assert.That(generated).DoesNotContain("GeneratedRequestRunner.StreamAsync<");
+    }
+
     /// <summary>Verifies an explicit switch-off keeps using the reflective request builder.</summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Test]

--- a/src/tests/Refit.GeneratorTests/GeneratedRequestBuildingTests.cs
+++ b/src/tests/Refit.GeneratorTests/GeneratedRequestBuildingTests.cs
@@ -186,7 +186,7 @@ public class GeneratedRequestBuildingTests
             GeneratedClientHintName,
             generatedRequestBuilding: true);
 
-        await Assert.That(generated).Contains("refitBasePath + \"/foo?key=value\"");
+        await Assert.That(generated).Contains("BuildRelativeUri(this.Client, \"/foo?key=value\"");
         await Assert.That(generated).DoesNotContain("#name");
         await Assert.That(generated).DoesNotContain(ReflectiveRequestBuilderCall);
     }
@@ -204,7 +204,7 @@ public class GeneratedRequestBuildingTests
             GeneratedClientHintName,
             generatedRequestBuilding: true);
 
-        await Assert.That(generated).Contains("refitBasePath + \"/foo\"");
+        await Assert.That(generated).Contains("BuildRelativeUri(this.Client, \"/foo\"");
         await Assert.That(generated).DoesNotContain("?key=value");
         await Assert.That(generated).DoesNotContain(ReflectiveRequestBuilderCall);
     }
@@ -222,7 +222,7 @@ public class GeneratedRequestBuildingTests
             GeneratedClientHintName,
             generatedRequestBuilding: true);
 
-        await Assert.That(generated).Contains("refitBasePath + \"/foo?key=&two=2\"");
+        await Assert.That(generated).Contains("BuildRelativeUri(this.Client, \"/foo?key=&two=2\"");
         await Assert.That(generated).DoesNotContain("=drop");
         await Assert.That(generated).DoesNotContain(ReflectiveRequestBuilderCall);
     }
@@ -339,9 +339,9 @@ public class GeneratedRequestBuildingTests
             GeneratedClientHintName,
             generatedRequestBuilding: true);
 
-        await Assert.That(generated).Contains("refitBasePath + \"/global\"");
-        await Assert.That(generated).Contains("refitBasePath + \"/alias\"");
-        await Assert.That(generated).Contains("refitBasePath + \"/qualified\"");
+        await Assert.That(generated).Contains("BuildRelativeUri(this.Client, \"/global\"");
+        await Assert.That(generated).Contains("BuildRelativeUri(this.Client, \"/alias\"");
+        await Assert.That(generated).Contains("BuildRelativeUri(this.Client, \"/qualified\"");
         await Assert.That(generated).Contains("HttpMethod.Get");
         await Assert.That(generated).Contains("HttpMethod.Post");
         await Assert.That(generated).Contains("HttpMethod.Put");
@@ -412,9 +412,9 @@ public class GeneratedRequestBuildingTests
             generatedRequestBuilding: true);
 
         await Assert.That(generated).Contains(ReflectiveRequestBuilderCall);
-        await Assert.That(generated).DoesNotContain("refitBasePath + \"relative\"");
-        await Assert.That(generated).DoesNotContain("refitBasePath + \"/users/{id}\"");
-        await Assert.That(generated).DoesNotContain("refitBasePath + \"/bad");
+        await Assert.That(generated).DoesNotContain("BuildRelativeUri(this.Client, \"relative\"");
+        await Assert.That(generated).DoesNotContain("BuildRelativeUri(this.Client, \"/users/{id}\"");
+        await Assert.That(generated).DoesNotContain("BuildRelativeUri(this.Client, \"/bad");
     }
 
     /// <summary>Verifies custom HTTP method attributes are discovered but fall back to the runtime builder.</summary>
@@ -510,7 +510,7 @@ public class GeneratedRequestBuildingTests
             GeneratedClientHintName,
             generatedRequestBuilding: true);
 
-        await Assert.That(generated).Contains("refitBasePath + \"/foo?one=1&two\"");
+        await Assert.That(generated).Contains("BuildRelativeUri(this.Client, \"/foo?one=1&two\"");
         await Assert.That(generated).DoesNotContain("drop");
         await Assert.That(generated).DoesNotContain(ReflectiveRequestBuilderCall);
     }

--- a/src/tests/Refit.GeneratorTests/GeneratorComponentTests.cs
+++ b/src/tests/Refit.GeneratorTests/GeneratorComponentTests.cs
@@ -350,7 +350,7 @@ public static class GeneratorComponentTests
                 ImmutableEquatableArray<MethodModel>.Empty,
                 ImmutableEquatableArray<MethodModel>.Empty);
             var inlineModel = CreateInterfaceModel(
-                new ImmutableEquatableArray<MethodModel>([CreateRefitMethod(canGenerateInline: true)]),
+                new([CreateRefitMethod(canGenerateInline: true)]),
                 ImmutableEquatableArray<MethodModel>.Empty);
 
             await Assert.That(Emitter.CanUseGeneratedSettingsFactoryForTesting(emptyModel)).IsFalse();
@@ -422,21 +422,21 @@ public static class GeneratorComponentTests
             var explicitReflective = CreateRefitMethod(canGenerateInline: false) with { IsExplicitInterface = true };
             var explicitInline = CreateRefitMethod(canGenerateInline: true) with { IsExplicitInterface = true };
             var model = CreateInterfaceModel(
-                new ImmutableEquatableArray<MethodModel>([explicitReflective]),
+                new([explicitReflective]),
                 ImmutableEquatableArray<MethodModel>.Empty);
 
             var reflective = Emitter.BuildRefitMethodForTesting(
                 explicitReflective,
                 isTopLevel: true,
                 model,
-                new UniqueNameBuilder(),
+                new(),
                 "_requestBuilder",
                 "_settings");
             var inline = Emitter.BuildRefitMethodForTesting(
                 explicitInline,
                 isTopLevel: true,
                 model,
-                new UniqueNameBuilder(),
+                new(),
                 "_requestBuilder",
                 "_settings");
 
@@ -472,7 +472,7 @@ public static class GeneratorComponentTests
         {
             var textual = extra.Length == 0
                 ? ImmutableEquatableArray<string>.Empty
-                : new ImmutableEquatableArray<string>(extra);
+                : new(extra);
             return new("T", "T", known, textual);
         }
 
@@ -535,7 +535,7 @@ public static class GeneratorComponentTests
                 "RefitGeneratorTest.IGeneratedClient",
                 "Get",
                 ReturnTypeInfo.AsyncVoid,
-                new RequestModel(
+                new(
                     "GET",
                     "/",
                     TaskTypeName,
@@ -640,11 +640,11 @@ public static class GeneratorComponentTests
             await Assert.That(Parser.GetBodySerializationMethodName(JsonLinesSerializationValue)).IsEqualTo("JsonLines");
             await Assert.That(Parser.GetBodySerializationMethodName(UnsupportedSerializationValue)).IsEqualTo(string.Empty);
             await Assert.That(Parser.IsSupportedInlineBody(ImmutableEquatableArray<RequestParameterModel>.Empty)).IsTrue();
-            await Assert.That(Parser.IsSupportedInlineBody(new ImmutableEquatableArray<RequestParameterModel>([CreateHeaderParameter()]))).IsTrue();
-            await Assert.That(Parser.IsSupportedInlineBody(new ImmutableEquatableArray<RequestParameterModel>([CreateBody(string.Empty)]))).IsFalse();
-            await Assert.That(Parser.IsSupportedInlineBody(new ImmutableEquatableArray<RequestParameterModel>([CreateBody("UrlEncoded")]))).IsTrue();
-            await Assert.That(Parser.IsSupportedInlineBody(new ImmutableEquatableArray<RequestParameterModel>([CreateBody("Serialized")]))).IsTrue();
-            await Assert.That(Parser.IsSupportedInlineBody(new ImmutableEquatableArray<RequestParameterModel>([CreateBody("JsonLines")]))).IsTrue();
+            await Assert.That(Parser.IsSupportedInlineBody(new([CreateHeaderParameter()]))).IsTrue();
+            await Assert.That(Parser.IsSupportedInlineBody(new([CreateBody(string.Empty)]))).IsFalse();
+            await Assert.That(Parser.IsSupportedInlineBody(new([CreateBody("UrlEncoded")]))).IsTrue();
+            await Assert.That(Parser.IsSupportedInlineBody(new([CreateBody("Serialized")]))).IsTrue();
+            await Assert.That(Parser.IsSupportedInlineBody(new([CreateBody("JsonLines")]))).IsTrue();
             await Assert.That(Parser.ShouldDisposeResponse("global::System.Net.Http.HttpResponseMessage")).IsFalse();
             await Assert.That(Parser.ShouldDisposeResponse("global::System.Net.Http.HttpContent")).IsFalse();
             await Assert.That(Parser.ShouldDisposeResponse("global::System.IO.Stream")).IsFalse();

--- a/src/tests/Refit.GeneratorTests/_snapshots/GeneratedTest.ShouldEmitAllFiles#IGeneratedClient.g.verified.cs
+++ b/src/tests/Refit.GeneratorTests/_snapshots/GeneratedTest.ShouldEmitAllFiles#IGeneratedClient.g.verified.cs
@@ -50,9 +50,7 @@ namespace Refit.Implementation
             public global::System.Threading.Tasks.Task<string> Get()
             {
                 var refitSettings = _settings;
-                var refitBasePath = this.Client.BaseAddress?.AbsolutePath ?? throw new global::System.InvalidOperationException("BaseAddress must be set on the HttpClient instance");
-                refitBasePath = refitBasePath == "/" ? string.Empty : refitBasePath.TrimEnd('/');
-                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, new global::System.Uri(refitBasePath + "/users", global::System.UriKind.Relative));
+                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, global::Refit.GeneratedRequestRunner.BuildRelativeUri(this.Client, "/users", refitSettings.UrlResolution));
                 #if NET6_0_OR_GREATER
                 refitRequest.Version = refitSettings.Version;
                 refitRequest.VersionPolicy = refitSettings.VersionPolicy;

--- a/src/tests/Refit.GeneratorTests/_snapshots/InterfaceStubGeneratorTests.FindInterfacesSmokeTest#IGitHubApi.g.verified.cs
+++ b/src/tests/Refit.GeneratorTests/_snapshots/InterfaceStubGeneratorTests.FindInterfacesSmokeTest#IGitHubApi.g.verified.cs
@@ -107,9 +107,7 @@ namespace Refit.Implementation
             public global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage> GetIndex()
             {
                 var refitSettings = _settings;
-                var refitBasePath = this.Client.BaseAddress?.AbsolutePath ?? throw new global::System.InvalidOperationException("BaseAddress must be set on the HttpClient instance");
-                refitBasePath = refitBasePath == "/" ? string.Empty : refitBasePath.TrimEnd('/');
-                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, new global::System.Uri(refitBasePath + "/", global::System.UriKind.Relative));
+                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, global::Refit.GeneratedRequestRunner.BuildRelativeUri(this.Client, "/", refitSettings.UrlResolution));
                 #if NET6_0_OR_GREATER
                 refitRequest.Version = refitSettings.Version;
                 refitRequest.VersionPolicy = refitSettings.VersionPolicy;
@@ -140,9 +138,7 @@ namespace Refit.Implementation
             public global::System.Threading.Tasks.Task<global::Refit.Tests.User> NothingToSeeHere()
             {
                 var refitSettings = _settings;
-                var refitBasePath = this.Client.BaseAddress?.AbsolutePath ?? throw new global::System.InvalidOperationException("BaseAddress must be set on the HttpClient instance");
-                refitBasePath = refitBasePath == "/" ? string.Empty : refitBasePath.TrimEnd('/');
-                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, new global::System.Uri(refitBasePath + "/give-me-some-404-action", global::System.UriKind.Relative));
+                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, global::Refit.GeneratedRequestRunner.BuildRelativeUri(this.Client, "/give-me-some-404-action", refitSettings.UrlResolution));
                 #if NET6_0_OR_GREATER
                 refitRequest.Version = refitSettings.Version;
                 refitRequest.VersionPolicy = refitSettings.VersionPolicy;
@@ -163,9 +159,7 @@ namespace Refit.Implementation
             public global::System.Threading.Tasks.Task<global::Refit.ApiResponse<global::Refit.Tests.User>> NothingToSeeHereWithMetadata()
             {
                 var refitSettings = _settings;
-                var refitBasePath = this.Client.BaseAddress?.AbsolutePath ?? throw new global::System.InvalidOperationException("BaseAddress must be set on the HttpClient instance");
-                refitBasePath = refitBasePath == "/" ? string.Empty : refitBasePath.TrimEnd('/');
-                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, new global::System.Uri(refitBasePath + "/give-me-some-404-action", global::System.UriKind.Relative));
+                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, global::Refit.GeneratedRequestRunner.BuildRelativeUri(this.Client, "/give-me-some-404-action", refitSettings.UrlResolution));
                 #if NET6_0_OR_GREATER
                 refitRequest.Version = refitSettings.Version;
                 refitRequest.VersionPolicy = refitSettings.VersionPolicy;

--- a/src/tests/Refit.GeneratorTests/_snapshots/InterfaceStubGeneratorTests.FindInterfacesSmokeTest#INestedGitHubApi.g.verified.cs
+++ b/src/tests/Refit.GeneratorTests/_snapshots/InterfaceStubGeneratorTests.FindInterfacesSmokeTest#INestedGitHubApi.g.verified.cs
@@ -107,9 +107,7 @@ namespace Refit.Implementation
             public global::System.Threading.Tasks.Task<global::System.Net.Http.HttpResponseMessage> GetIndex()
             {
                 var refitSettings = _settings;
-                var refitBasePath = this.Client.BaseAddress?.AbsolutePath ?? throw new global::System.InvalidOperationException("BaseAddress must be set on the HttpClient instance");
-                refitBasePath = refitBasePath == "/" ? string.Empty : refitBasePath.TrimEnd('/');
-                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, new global::System.Uri(refitBasePath + "/", global::System.UriKind.Relative));
+                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, global::Refit.GeneratedRequestRunner.BuildRelativeUri(this.Client, "/", refitSettings.UrlResolution));
                 #if NET6_0_OR_GREATER
                 refitRequest.Version = refitSettings.Version;
                 refitRequest.VersionPolicy = refitSettings.VersionPolicy;
@@ -140,9 +138,7 @@ namespace Refit.Implementation
             public global::System.Threading.Tasks.Task NothingToSeeHere()
             {
                 var refitSettings = _settings;
-                var refitBasePath = this.Client.BaseAddress?.AbsolutePath ?? throw new global::System.InvalidOperationException("BaseAddress must be set on the HttpClient instance");
-                refitBasePath = refitBasePath == "/" ? string.Empty : refitBasePath.TrimEnd('/');
-                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, new global::System.Uri(refitBasePath + "/give-me-some-404-action", global::System.UriKind.Relative));
+                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, global::Refit.GeneratedRequestRunner.BuildRelativeUri(this.Client, "/give-me-some-404-action", refitSettings.UrlResolution));
                 #if NET6_0_OR_GREATER
                 refitRequest.Version = refitSettings.Version;
                 refitRequest.VersionPolicy = refitSettings.VersionPolicy;

--- a/src/tests/Refit.GeneratorTests/_snapshots/InterfaceStubGeneratorTests.GenerateInterfaceStubsWithoutNamespaceSmokeTest#IServiceWithoutNamespace.g.verified.cs
+++ b/src/tests/Refit.GeneratorTests/_snapshots/InterfaceStubGeneratorTests.GenerateInterfaceStubsWithoutNamespaceSmokeTest#IServiceWithoutNamespace.g.verified.cs
@@ -50,9 +50,7 @@ namespace Refit.Implementation
             public global::System.Threading.Tasks.Task GetRoot()
             {
                 var refitSettings = _settings;
-                var refitBasePath = this.Client.BaseAddress?.AbsolutePath ?? throw new global::System.InvalidOperationException("BaseAddress must be set on the HttpClient instance");
-                refitBasePath = refitBasePath == "/" ? string.Empty : refitBasePath.TrimEnd('/');
-                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, new global::System.Uri(refitBasePath + "/", global::System.UriKind.Relative));
+                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, global::Refit.GeneratedRequestRunner.BuildRelativeUri(this.Client, "/", refitSettings.UrlResolution));
                 #if NET6_0_OR_GREATER
                 refitRequest.Version = refitSettings.Version;
                 refitRequest.VersionPolicy = refitSettings.VersionPolicy;
@@ -70,9 +68,7 @@ namespace Refit.Implementation
             public global::System.Threading.Tasks.Task PostRoot()
             {
                 var refitSettings = _settings;
-                var refitBasePath = this.Client.BaseAddress?.AbsolutePath ?? throw new global::System.InvalidOperationException("BaseAddress must be set on the HttpClient instance");
-                refitBasePath = refitBasePath == "/" ? string.Empty : refitBasePath.TrimEnd('/');
-                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Post, new global::System.Uri(refitBasePath + "/", global::System.UriKind.Relative));
+                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Post, global::Refit.GeneratedRequestRunner.BuildRelativeUri(this.Client, "/", refitSettings.UrlResolution));
                 #if NET6_0_OR_GREATER
                 refitRequest.Version = refitSettings.Version;
                 refitRequest.VersionPolicy = refitSettings.VersionPolicy;

--- a/src/tests/Refit.GeneratorTests/_snapshots/InterfaceTests.ContainedInterfaceTest#IContainedInterface.g.verified.cs
+++ b/src/tests/Refit.GeneratorTests/_snapshots/InterfaceTests.ContainedInterfaceTest#IContainedInterface.g.verified.cs
@@ -50,9 +50,7 @@ namespace Refit.Implementation
             public global::System.Threading.Tasks.Task<string> Get()
             {
                 var refitSettings = _settings;
-                var refitBasePath = this.Client.BaseAddress?.AbsolutePath ?? throw new global::System.InvalidOperationException("BaseAddress must be set on the HttpClient instance");
-                refitBasePath = refitBasePath == "/" ? string.Empty : refitBasePath.TrimEnd('/');
-                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, new global::System.Uri(refitBasePath + "/users", global::System.UriKind.Relative));
+                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, global::Refit.GeneratedRequestRunner.BuildRelativeUri(this.Client, "/users", refitSettings.UrlResolution));
                 #if NET6_0_OR_GREATER
                 refitRequest.Version = refitSettings.Version;
                 refitRequest.VersionPolicy = refitSettings.VersionPolicy;

--- a/src/tests/Refit.GeneratorTests/_snapshots/InterfaceTests.DefaultInterfaceMethod#IGeneratedInterface.g.verified.cs
+++ b/src/tests/Refit.GeneratorTests/_snapshots/InterfaceTests.DefaultInterfaceMethod#IGeneratedInterface.g.verified.cs
@@ -50,9 +50,7 @@ namespace Refit.Implementation
             public global::System.Threading.Tasks.Task<string> Get()
             {
                 var refitSettings = _settings;
-                var refitBasePath = this.Client.BaseAddress?.AbsolutePath ?? throw new global::System.InvalidOperationException("BaseAddress must be set on the HttpClient instance");
-                refitBasePath = refitBasePath == "/" ? string.Empty : refitBasePath.TrimEnd('/');
-                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, new global::System.Uri(refitBasePath + "/users", global::System.UriKind.Relative));
+                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, global::Refit.GeneratedRequestRunner.BuildRelativeUri(this.Client, "/users", refitSettings.UrlResolution));
                 #if NET6_0_OR_GREATER
                 refitRequest.Version = refitSettings.Version;
                 refitRequest.VersionPolicy = refitSettings.VersionPolicy;

--- a/src/tests/Refit.GeneratorTests/_snapshots/InterfaceTests.DerivedDefaultInterfaceMethod#IBaseInterface.g.verified.cs
+++ b/src/tests/Refit.GeneratorTests/_snapshots/InterfaceTests.DerivedDefaultInterfaceMethod#IBaseInterface.g.verified.cs
@@ -50,9 +50,7 @@ namespace Refit.Implementation
             public global::System.Threading.Tasks.Task<string> GetPosts()
             {
                 var refitSettings = _settings;
-                var refitBasePath = this.Client.BaseAddress?.AbsolutePath ?? throw new global::System.InvalidOperationException("BaseAddress must be set on the HttpClient instance");
-                refitBasePath = refitBasePath == "/" ? string.Empty : refitBasePath.TrimEnd('/');
-                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, new global::System.Uri(refitBasePath + "/posts", global::System.UriKind.Relative));
+                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, global::Refit.GeneratedRequestRunner.BuildRelativeUri(this.Client, "/posts", refitSettings.UrlResolution));
                 #if NET6_0_OR_GREATER
                 refitRequest.Version = refitSettings.Version;
                 refitRequest.VersionPolicy = refitSettings.VersionPolicy;

--- a/src/tests/Refit.GeneratorTests/_snapshots/InterfaceTests.DerivedDefaultInterfaceMethod#IGeneratedInterface.g.verified.cs
+++ b/src/tests/Refit.GeneratorTests/_snapshots/InterfaceTests.DerivedDefaultInterfaceMethod#IGeneratedInterface.g.verified.cs
@@ -50,9 +50,7 @@ namespace Refit.Implementation
             public global::System.Threading.Tasks.Task<string> Get()
             {
                 var refitSettings = _settings;
-                var refitBasePath = this.Client.BaseAddress?.AbsolutePath ?? throw new global::System.InvalidOperationException("BaseAddress must be set on the HttpClient instance");
-                refitBasePath = refitBasePath == "/" ? string.Empty : refitBasePath.TrimEnd('/');
-                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, new global::System.Uri(refitBasePath + "/users", global::System.UriKind.Relative));
+                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, global::Refit.GeneratedRequestRunner.BuildRelativeUri(this.Client, "/users", refitSettings.UrlResolution));
                 #if NET6_0_OR_GREATER
                 refitRequest.Version = refitSettings.Version;
                 refitRequest.VersionPolicy = refitSettings.VersionPolicy;
@@ -72,9 +70,7 @@ namespace Refit.Implementation
             global::System.Threading.Tasks.Task<string> global::RefitGeneratorTest.IBaseInterface.GetPosts()
             {
                 var refitSettings = _settings;
-                var refitBasePath = this.Client.BaseAddress?.AbsolutePath ?? throw new global::System.InvalidOperationException("BaseAddress must be set on the HttpClient instance");
-                refitBasePath = refitBasePath == "/" ? string.Empty : refitBasePath.TrimEnd('/');
-                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, new global::System.Uri(refitBasePath + "/posts", global::System.UriKind.Relative));
+                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, global::Refit.GeneratedRequestRunner.BuildRelativeUri(this.Client, "/posts", refitSettings.UrlResolution));
                 #if NET6_0_OR_GREATER
                 refitRequest.Version = refitSettings.Version;
                 refitRequest.VersionPolicy = refitSettings.VersionPolicy;

--- a/src/tests/Refit.GeneratorTests/_snapshots/InterfaceTests.DisposableTest#IGeneratedInterface.g.verified.cs
+++ b/src/tests/Refit.GeneratorTests/_snapshots/InterfaceTests.DisposableTest#IGeneratedInterface.g.verified.cs
@@ -50,9 +50,7 @@ namespace Refit.Implementation
             public global::System.Threading.Tasks.Task<string> Get()
             {
                 var refitSettings = _settings;
-                var refitBasePath = this.Client.BaseAddress?.AbsolutePath ?? throw new global::System.InvalidOperationException("BaseAddress must be set on the HttpClient instance");
-                refitBasePath = refitBasePath == "/" ? string.Empty : refitBasePath.TrimEnd('/');
-                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, new global::System.Uri(refitBasePath + "/users", global::System.UriKind.Relative));
+                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, global::Refit.GeneratedRequestRunner.BuildRelativeUri(this.Client, "/users", refitSettings.UrlResolution));
                 #if NET6_0_OR_GREATER
                 refitRequest.Version = refitSettings.Version;
                 refitRequest.VersionPolicy = refitSettings.VersionPolicy;

--- a/src/tests/Refit.GeneratorTests/_snapshots/InterfaceTests.GlobalNamespaceTest#IGeneratedInterface.g.verified.cs
+++ b/src/tests/Refit.GeneratorTests/_snapshots/InterfaceTests.GlobalNamespaceTest#IGeneratedInterface.g.verified.cs
@@ -50,9 +50,7 @@ namespace Refit.Implementation
             public global::System.Threading.Tasks.Task<string> Get()
             {
                 var refitSettings = _settings;
-                var refitBasePath = this.Client.BaseAddress?.AbsolutePath ?? throw new global::System.InvalidOperationException("BaseAddress must be set on the HttpClient instance");
-                refitBasePath = refitBasePath == "/" ? string.Empty : refitBasePath.TrimEnd('/');
-                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, new global::System.Uri(refitBasePath + "/users", global::System.UriKind.Relative));
+                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, global::Refit.GeneratedRequestRunner.BuildRelativeUri(this.Client, "/users", refitSettings.UrlResolution));
                 #if NET6_0_OR_GREATER
                 refitRequest.Version = refitSettings.Version;
                 refitRequest.VersionPolicy = refitSettings.VersionPolicy;

--- a/src/tests/Refit.GeneratorTests/_snapshots/InterfaceTests.InterfaceDerivedFromRefitBaseTest#IBaseInterface.g.verified.cs
+++ b/src/tests/Refit.GeneratorTests/_snapshots/InterfaceTests.InterfaceDerivedFromRefitBaseTest#IBaseInterface.g.verified.cs
@@ -50,9 +50,7 @@ namespace Refit.Implementation
             public global::System.Threading.Tasks.Task<string> Get()
             {
                 var refitSettings = _settings;
-                var refitBasePath = this.Client.BaseAddress?.AbsolutePath ?? throw new global::System.InvalidOperationException("BaseAddress must be set on the HttpClient instance");
-                refitBasePath = refitBasePath == "/" ? string.Empty : refitBasePath.TrimEnd('/');
-                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, new global::System.Uri(refitBasePath + "/users", global::System.UriKind.Relative));
+                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, global::Refit.GeneratedRequestRunner.BuildRelativeUri(this.Client, "/users", refitSettings.UrlResolution));
                 #if NET6_0_OR_GREATER
                 refitRequest.Version = refitSettings.Version;
                 refitRequest.VersionPolicy = refitSettings.VersionPolicy;

--- a/src/tests/Refit.GeneratorTests/_snapshots/InterfaceTests.InterfaceDerivedFromRefitBaseTest#IDerivedInterface.g.verified.cs
+++ b/src/tests/Refit.GeneratorTests/_snapshots/InterfaceTests.InterfaceDerivedFromRefitBaseTest#IDerivedInterface.g.verified.cs
@@ -50,9 +50,7 @@ namespace Refit.Implementation
             global::System.Threading.Tasks.Task<string> global::RefitGeneratorTest.IBaseInterface.Get()
             {
                 var refitSettings = _settings;
-                var refitBasePath = this.Client.BaseAddress?.AbsolutePath ?? throw new global::System.InvalidOperationException("BaseAddress must be set on the HttpClient instance");
-                refitBasePath = refitBasePath == "/" ? string.Empty : refitBasePath.TrimEnd('/');
-                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, new global::System.Uri(refitBasePath + "/users", global::System.UriKind.Relative));
+                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, global::Refit.GeneratedRequestRunner.BuildRelativeUri(this.Client, "/users", refitSettings.UrlResolution));
                 #if NET6_0_OR_GREATER
                 refitRequest.Version = refitSettings.Version;
                 refitRequest.VersionPolicy = refitSettings.VersionPolicy;

--- a/src/tests/Refit.GeneratorTests/_snapshots/InterfaceTests.InterfaceWithGenericConstraint#IGeneratedInterface.g.verified.cs
+++ b/src/tests/Refit.GeneratorTests/_snapshots/InterfaceTests.InterfaceWithGenericConstraint#IGeneratedInterface.g.verified.cs
@@ -60,9 +60,7 @@ namespace Refit.Implementation
             public global::System.Threading.Tasks.Task<string> Get()
             {
                 var refitSettings = _settings;
-                var refitBasePath = this.Client.BaseAddress?.AbsolutePath ?? throw new global::System.InvalidOperationException("BaseAddress must be set on the HttpClient instance");
-                refitBasePath = refitBasePath == "/" ? string.Empty : refitBasePath.TrimEnd('/');
-                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, new global::System.Uri(refitBasePath + "/users", global::System.UriKind.Relative));
+                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, global::Refit.GeneratedRequestRunner.BuildRelativeUri(this.Client, "/users", refitSettings.UrlResolution));
                 #if NET6_0_OR_GREATER
                 refitRequest.Version = refitSettings.Version;
                 refitRequest.VersionPolicy = refitSettings.VersionPolicy;

--- a/src/tests/Refit.GeneratorTests/_snapshots/InterfaceTests.InterfacesWithDifferentCasing#IApi.g.verified.cs
+++ b/src/tests/Refit.GeneratorTests/_snapshots/InterfaceTests.InterfacesWithDifferentCasing#IApi.g.verified.cs
@@ -50,9 +50,7 @@ namespace Refit.Implementation
             public global::System.Threading.Tasks.Task<string> Get()
             {
                 var refitSettings = _settings;
-                var refitBasePath = this.Client.BaseAddress?.AbsolutePath ?? throw new global::System.InvalidOperationException("BaseAddress must be set on the HttpClient instance");
-                refitBasePath = refitBasePath == "/" ? string.Empty : refitBasePath.TrimEnd('/');
-                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, new global::System.Uri(refitBasePath + "/users", global::System.UriKind.Relative));
+                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, global::Refit.GeneratedRequestRunner.BuildRelativeUri(this.Client, "/users", refitSettings.UrlResolution));
                 #if NET6_0_OR_GREATER
                 refitRequest.Version = refitSettings.Version;
                 refitRequest.VersionPolicy = refitSettings.VersionPolicy;

--- a/src/tests/Refit.GeneratorTests/_snapshots/InterfaceTests.InterfacesWithDifferentCasing#Iapi1.g.verified.cs
+++ b/src/tests/Refit.GeneratorTests/_snapshots/InterfaceTests.InterfacesWithDifferentCasing#Iapi1.g.verified.cs
@@ -50,9 +50,7 @@ namespace Refit.Implementation
             public global::System.Threading.Tasks.Task<string> Get()
             {
                 var refitSettings = _settings;
-                var refitBasePath = this.Client.BaseAddress?.AbsolutePath ?? throw new global::System.InvalidOperationException("BaseAddress must be set on the HttpClient instance");
-                refitBasePath = refitBasePath == "/" ? string.Empty : refitBasePath.TrimEnd('/');
-                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, new global::System.Uri(refitBasePath + "/users", global::System.UriKind.Relative));
+                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, global::Refit.GeneratedRequestRunner.BuildRelativeUri(this.Client, "/users", refitSettings.UrlResolution));
                 #if NET6_0_OR_GREATER
                 refitRequest.Version = refitSettings.Version;
                 refitRequest.VersionPolicy = refitSettings.VersionPolicy;

--- a/src/tests/Refit.GeneratorTests/_snapshots/InterfaceTests.InterfacesWithDifferentSignature#IApi.g.verified.cs
+++ b/src/tests/Refit.GeneratorTests/_snapshots/InterfaceTests.InterfacesWithDifferentSignature#IApi.g.verified.cs
@@ -50,9 +50,7 @@ namespace Refit.Implementation
             public global::System.Threading.Tasks.Task<string> Get()
             {
                 var refitSettings = _settings;
-                var refitBasePath = this.Client.BaseAddress?.AbsolutePath ?? throw new global::System.InvalidOperationException("BaseAddress must be set on the HttpClient instance");
-                refitBasePath = refitBasePath == "/" ? string.Empty : refitBasePath.TrimEnd('/');
-                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, new global::System.Uri(refitBasePath + "/users", global::System.UriKind.Relative));
+                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, global::Refit.GeneratedRequestRunner.BuildRelativeUri(this.Client, "/users", refitSettings.UrlResolution));
                 #if NET6_0_OR_GREATER
                 refitRequest.Version = refitSettings.Version;
                 refitRequest.VersionPolicy = refitSettings.VersionPolicy;

--- a/src/tests/Refit.GeneratorTests/_snapshots/InterfaceTests.InterfacesWithDifferentSignature#IApi1.g.verified.cs
+++ b/src/tests/Refit.GeneratorTests/_snapshots/InterfaceTests.InterfacesWithDifferentSignature#IApi1.g.verified.cs
@@ -51,9 +51,7 @@ namespace Refit.Implementation
             public global::System.Threading.Tasks.Task<string> Get()
             {
                 var refitSettings = _settings;
-                var refitBasePath = this.Client.BaseAddress?.AbsolutePath ?? throw new global::System.InvalidOperationException("BaseAddress must be set on the HttpClient instance");
-                refitBasePath = refitBasePath == "/" ? string.Empty : refitBasePath.TrimEnd('/');
-                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, new global::System.Uri(refitBasePath + "/users", global::System.UriKind.Relative));
+                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, global::Refit.GeneratedRequestRunner.BuildRelativeUri(this.Client, "/users", refitSettings.UrlResolution));
                 #if NET6_0_OR_GREATER
                 refitRequest.Version = refitSettings.Version;
                 refitRequest.VersionPolicy = refitSettings.VersionPolicy;

--- a/src/tests/Refit.GeneratorTests/_snapshots/InterfaceTests.NestedNamespaceTest#IGeneratedInterface.g.verified.cs
+++ b/src/tests/Refit.GeneratorTests/_snapshots/InterfaceTests.NestedNamespaceTest#IGeneratedInterface.g.verified.cs
@@ -50,9 +50,7 @@ namespace Refit.Implementation
             public global::System.Threading.Tasks.Task<string> Get()
             {
                 var refitSettings = _settings;
-                var refitBasePath = this.Client.BaseAddress?.AbsolutePath ?? throw new global::System.InvalidOperationException("BaseAddress must be set on the HttpClient instance");
-                refitBasePath = refitBasePath == "/" ? string.Empty : refitBasePath.TrimEnd('/');
-                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, new global::System.Uri(refitBasePath + "/users", global::System.UriKind.Relative));
+                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, global::Refit.GeneratedRequestRunner.BuildRelativeUri(this.Client, "/users", refitSettings.UrlResolution));
                 #if NET6_0_OR_GREATER
                 refitRequest.Version = refitSettings.Version;
                 refitRequest.VersionPolicy = refitSettings.VersionPolicy;

--- a/src/tests/Refit.GeneratorTests/_snapshots/InterfaceTests.NonRefitMethodShouldRaiseDiagnostic#IGeneratedClient.g.verified.cs
+++ b/src/tests/Refit.GeneratorTests/_snapshots/InterfaceTests.NonRefitMethodShouldRaiseDiagnostic#IGeneratedClient.g.verified.cs
@@ -50,9 +50,7 @@ namespace Refit.Implementation
             public global::System.Threading.Tasks.Task<string> Get()
             {
                 var refitSettings = _settings;
-                var refitBasePath = this.Client.BaseAddress?.AbsolutePath ?? throw new global::System.InvalidOperationException("BaseAddress must be set on the HttpClient instance");
-                refitBasePath = refitBasePath == "/" ? string.Empty : refitBasePath.TrimEnd('/');
-                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, new global::System.Uri(refitBasePath + "/users", global::System.UriKind.Relative));
+                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, global::Refit.GeneratedRequestRunner.BuildRelativeUri(this.Client, "/users", refitSettings.UrlResolution));
                 #if NET6_0_OR_GREATER
                 refitRequest.Version = refitSettings.Version;
                 refitRequest.VersionPolicy = refitSettings.VersionPolicy;

--- a/src/tests/Refit.GeneratorTests/_snapshots/InterfaceTests.RefitInterfaceDerivedFromBaseTest#IGeneratedInterface.g.verified.cs
+++ b/src/tests/Refit.GeneratorTests/_snapshots/InterfaceTests.RefitInterfaceDerivedFromBaseTest#IGeneratedInterface.g.verified.cs
@@ -50,9 +50,7 @@ namespace Refit.Implementation
             public global::System.Threading.Tasks.Task<string> Get()
             {
                 var refitSettings = _settings;
-                var refitBasePath = this.Client.BaseAddress?.AbsolutePath ?? throw new global::System.InvalidOperationException("BaseAddress must be set on the HttpClient instance");
-                refitBasePath = refitBasePath == "/" ? string.Empty : refitBasePath.TrimEnd('/');
-                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, new global::System.Uri(refitBasePath + "/users", global::System.UriKind.Relative));
+                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, global::Refit.GeneratedRequestRunner.BuildRelativeUri(this.Client, "/users", refitSettings.UrlResolution));
                 #if NET6_0_OR_GREATER
                 refitRequest.Version = refitSettings.Version;
                 refitRequest.VersionPolicy = refitSettings.VersionPolicy;

--- a/src/tests/Refit.GeneratorTests/_snapshots/InterfaceTests.RefitInterfaceDerivedFromRefitBaseTest#IBaseInterface.g.verified.cs
+++ b/src/tests/Refit.GeneratorTests/_snapshots/InterfaceTests.RefitInterfaceDerivedFromRefitBaseTest#IBaseInterface.g.verified.cs
@@ -50,9 +50,7 @@ namespace Refit.Implementation
             public global::System.Threading.Tasks.Task<string> GetPosts()
             {
                 var refitSettings = _settings;
-                var refitBasePath = this.Client.BaseAddress?.AbsolutePath ?? throw new global::System.InvalidOperationException("BaseAddress must be set on the HttpClient instance");
-                refitBasePath = refitBasePath == "/" ? string.Empty : refitBasePath.TrimEnd('/');
-                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, new global::System.Uri(refitBasePath + "/posts", global::System.UriKind.Relative));
+                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, global::Refit.GeneratedRequestRunner.BuildRelativeUri(this.Client, "/posts", refitSettings.UrlResolution));
                 #if NET6_0_OR_GREATER
                 refitRequest.Version = refitSettings.Version;
                 refitRequest.VersionPolicy = refitSettings.VersionPolicy;

--- a/src/tests/Refit.GeneratorTests/_snapshots/InterfaceTests.RefitInterfaceDerivedFromRefitBaseTest#IGeneratedInterface.g.verified.cs
+++ b/src/tests/Refit.GeneratorTests/_snapshots/InterfaceTests.RefitInterfaceDerivedFromRefitBaseTest#IGeneratedInterface.g.verified.cs
@@ -50,9 +50,7 @@ namespace Refit.Implementation
             public global::System.Threading.Tasks.Task<string> Get()
             {
                 var refitSettings = _settings;
-                var refitBasePath = this.Client.BaseAddress?.AbsolutePath ?? throw new global::System.InvalidOperationException("BaseAddress must be set on the HttpClient instance");
-                refitBasePath = refitBasePath == "/" ? string.Empty : refitBasePath.TrimEnd('/');
-                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, new global::System.Uri(refitBasePath + "/users", global::System.UriKind.Relative));
+                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, global::Refit.GeneratedRequestRunner.BuildRelativeUri(this.Client, "/users", refitSettings.UrlResolution));
                 #if NET6_0_OR_GREATER
                 refitRequest.Version = refitSettings.Version;
                 refitRequest.VersionPolicy = refitSettings.VersionPolicy;
@@ -72,9 +70,7 @@ namespace Refit.Implementation
             global::System.Threading.Tasks.Task<string> global::RefitGeneratorTest.IBaseInterface.GetPosts()
             {
                 var refitSettings = _settings;
-                var refitBasePath = this.Client.BaseAddress?.AbsolutePath ?? throw new global::System.InvalidOperationException("BaseAddress must be set on the HttpClient instance");
-                refitBasePath = refitBasePath == "/" ? string.Empty : refitBasePath.TrimEnd('/');
-                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, new global::System.Uri(refitBasePath + "/posts", global::System.UriKind.Relative));
+                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, global::Refit.GeneratedRequestRunner.BuildRelativeUri(this.Client, "/posts", refitSettings.UrlResolution));
                 #if NET6_0_OR_GREATER
                 refitRequest.Version = refitSettings.Version;
                 refitRequest.VersionPolicy = refitSettings.VersionPolicy;

--- a/src/tests/Refit.GeneratorTests/_snapshots/ReturnTypeTests.GenericTaskShouldWork#IGeneratedClient.g.verified.cs
+++ b/src/tests/Refit.GeneratorTests/_snapshots/ReturnTypeTests.GenericTaskShouldWork#IGeneratedClient.g.verified.cs
@@ -50,9 +50,7 @@ namespace Refit.Implementation
             public global::System.Threading.Tasks.Task<string> Get()
             {
                 var refitSettings = _settings;
-                var refitBasePath = this.Client.BaseAddress?.AbsolutePath ?? throw new global::System.InvalidOperationException("BaseAddress must be set on the HttpClient instance");
-                refitBasePath = refitBasePath == "/" ? string.Empty : refitBasePath.TrimEnd('/');
-                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, new global::System.Uri(refitBasePath + "/users", global::System.UriKind.Relative));
+                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, global::Refit.GeneratedRequestRunner.BuildRelativeUri(this.Client, "/users", refitSettings.UrlResolution));
                 #if NET6_0_OR_GREATER
                 refitRequest.Version = refitSettings.Version;
                 refitRequest.VersionPolicy = refitSettings.VersionPolicy;

--- a/src/tests/Refit.GeneratorTests/_snapshots/ReturnTypeTests.GenericValueTaskShouldWork#IGeneratedClient.g.verified.cs
+++ b/src/tests/Refit.GeneratorTests/_snapshots/ReturnTypeTests.GenericValueTaskShouldWork#IGeneratedClient.g.verified.cs
@@ -50,9 +50,7 @@ namespace Refit.Implementation
             public global::System.Threading.Tasks.ValueTask<string> Get()
             {
                 var refitSettings = _settings;
-                var refitBasePath = this.Client.BaseAddress?.AbsolutePath ?? throw new global::System.InvalidOperationException("BaseAddress must be set on the HttpClient instance");
-                refitBasePath = refitBasePath == "/" ? string.Empty : refitBasePath.TrimEnd('/');
-                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, new global::System.Uri(refitBasePath + "/users", global::System.UriKind.Relative));
+                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, global::Refit.GeneratedRequestRunner.BuildRelativeUri(this.Client, "/users", refitSettings.UrlResolution));
                 #if NET6_0_OR_GREATER
                 refitRequest.Version = refitSettings.Version;
                 refitRequest.VersionPolicy = refitSettings.VersionPolicy;

--- a/src/tests/Refit.GeneratorTests/_snapshots/ReturnTypeTests.ReturnNullableObject#IGeneratedClient.g.verified.cs
+++ b/src/tests/Refit.GeneratorTests/_snapshots/ReturnTypeTests.ReturnNullableObject#IGeneratedClient.g.verified.cs
@@ -50,9 +50,7 @@ namespace Refit.Implementation
             public global::System.Threading.Tasks.Task<string> Get()
             {
                 var refitSettings = _settings;
-                var refitBasePath = this.Client.BaseAddress?.AbsolutePath ?? throw new global::System.InvalidOperationException("BaseAddress must be set on the HttpClient instance");
-                refitBasePath = refitBasePath == "/" ? string.Empty : refitBasePath.TrimEnd('/');
-                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, new global::System.Uri(refitBasePath + "/users", global::System.UriKind.Relative));
+                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, global::Refit.GeneratedRequestRunner.BuildRelativeUri(this.Client, "/users", refitSettings.UrlResolution));
                 #if NET6_0_OR_GREATER
                 refitRequest.Version = refitSettings.Version;
                 refitRequest.VersionPolicy = refitSettings.VersionPolicy;

--- a/src/tests/Refit.GeneratorTests/_snapshots/ReturnTypeTests.ReturnNullableValueType#IGeneratedClient.g.verified.cs
+++ b/src/tests/Refit.GeneratorTests/_snapshots/ReturnTypeTests.ReturnNullableValueType#IGeneratedClient.g.verified.cs
@@ -50,9 +50,7 @@ namespace Refit.Implementation
             public global::System.Threading.Tasks.Task<int?> Get()
             {
                 var refitSettings = _settings;
-                var refitBasePath = this.Client.BaseAddress?.AbsolutePath ?? throw new global::System.InvalidOperationException("BaseAddress must be set on the HttpClient instance");
-                refitBasePath = refitBasePath == "/" ? string.Empty : refitBasePath.TrimEnd('/');
-                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, new global::System.Uri(refitBasePath + "/users", global::System.UriKind.Relative));
+                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, global::Refit.GeneratedRequestRunner.BuildRelativeUri(this.Client, "/users", refitSettings.UrlResolution));
                 #if NET6_0_OR_GREATER
                 refitRequest.Version = refitSettings.Version;
                 refitRequest.VersionPolicy = refitSettings.VersionPolicy;

--- a/src/tests/Refit.GeneratorTests/_snapshots/ReturnTypeTests.ValueTaskApiResponseShouldWork#IGeneratedClient.g.verified.cs
+++ b/src/tests/Refit.GeneratorTests/_snapshots/ReturnTypeTests.ValueTaskApiResponseShouldWork#IGeneratedClient.g.verified.cs
@@ -50,9 +50,7 @@ namespace Refit.Implementation
             public global::System.Threading.Tasks.ValueTask<global::Refit.ApiResponse<string>> Get()
             {
                 var refitSettings = _settings;
-                var refitBasePath = this.Client.BaseAddress?.AbsolutePath ?? throw new global::System.InvalidOperationException("BaseAddress must be set on the HttpClient instance");
-                refitBasePath = refitBasePath == "/" ? string.Empty : refitBasePath.TrimEnd('/');
-                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, new global::System.Uri(refitBasePath + "/users", global::System.UriKind.Relative));
+                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, global::Refit.GeneratedRequestRunner.BuildRelativeUri(this.Client, "/users", refitSettings.UrlResolution));
                 #if NET6_0_OR_GREATER
                 refitRequest.Version = refitSettings.Version;
                 refitRequest.VersionPolicy = refitSettings.VersionPolicy;

--- a/src/tests/Refit.GeneratorTests/_snapshots/ReturnTypeTests.VoidTaskShouldWork#IGeneratedClient.g.verified.cs
+++ b/src/tests/Refit.GeneratorTests/_snapshots/ReturnTypeTests.VoidTaskShouldWork#IGeneratedClient.g.verified.cs
@@ -50,9 +50,7 @@ namespace Refit.Implementation
             public global::System.Threading.Tasks.Task Post()
             {
                 var refitSettings = _settings;
-                var refitBasePath = this.Client.BaseAddress?.AbsolutePath ?? throw new global::System.InvalidOperationException("BaseAddress must be set on the HttpClient instance");
-                refitBasePath = refitBasePath == "/" ? string.Empty : refitBasePath.TrimEnd('/');
-                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Post, new global::System.Uri(refitBasePath + "/users", global::System.UriKind.Relative));
+                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Post, global::Refit.GeneratedRequestRunner.BuildRelativeUri(this.Client, "/users", refitSettings.UrlResolution));
                 #if NET6_0_OR_GREATER
                 refitRequest.Version = refitSettings.Version;
                 refitRequest.VersionPolicy = refitSettings.VersionPolicy;

--- a/src/tests/Refit.Tests/FormValueMultimapTests.cs
+++ b/src/tests/Refit.Tests/FormValueMultimapTests.cs
@@ -40,7 +40,7 @@ public class FormValueMultimapTests
     /// <returns>A task that represents the asynchronous operation.</returns>
     [Test]
     public async Task RejectsNullSettings() =>
-        await Assert.That(() => new FormValueMultimap(new object(), null!))
+        await Assert.That(() => new FormValueMultimap(new(), null!))
             .ThrowsExactly<ArgumentNullException>();
 
     /// <summary>Verifies the multimap loads entries from a dictionary source.</summary>

--- a/src/tests/Refit.Tests/GeneratedRequestRunnerTests.cs
+++ b/src/tests/Refit.Tests/GeneratedRequestRunnerTests.cs
@@ -924,6 +924,67 @@ public class GeneratedRequestRunnerTests
         await Assert.That(exception!.Message).IsEqualTo("BaseAddress must be set on the HttpClient instance");
     }
 
+    /// <summary>Verifies BuildRelativeUri throws when the legacy mode has no base address.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task BuildRelativeUriThrowsWhenBaseAddressMissing()
+    {
+        using var client = new HttpClient();
+
+        await Assert
+            .That(() => GeneratedRequestRunner.BuildRelativeUri(client, "/x", UrlResolutionMode.RefitLegacy))
+            .ThrowsExactly<InvalidOperationException>();
+    }
+
+    /// <summary>Verifies BuildRelativeUri prepends the base path under legacy resolution.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task BuildRelativeUriPrependsBasePathInLegacyMode()
+    {
+        using var client = new HttpClient { BaseAddress = new("http://foo/api/") };
+
+        var uri = GeneratedRequestRunner.BuildRelativeUri(client, "/x", UrlResolutionMode.RefitLegacy);
+
+        await Assert.That(uri.OriginalString).IsEqualTo("/api/x");
+    }
+
+    /// <summary>Verifies BuildRelativeUri emits the relative path verbatim under RFC 3986 resolution.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task BuildRelativeUriEmitsRelativePathInRfcMode()
+    {
+        using var client = new HttpClient();
+
+        var uri = GeneratedRequestRunner.BuildRelativeUri(client, "x", UrlResolutionMode.Rfc3986);
+
+        await Assert.That(uri.OriginalString).IsEqualTo("x");
+    }
+
+    /// <summary>Verifies EnsureResponseContent substitutes empty content when the response has none.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task EnsureResponseContentSubstitutesEmptyWhenNull()
+    {
+        using var response = new HttpResponseMessage(HttpStatusCode.OK) { Content = null };
+
+        var content = RequestExecutionHelpers.EnsureResponseContent(response);
+
+        await Assert.That(await content.ReadAsStringAsync()).IsEqualTo(string.Empty);
+    }
+
+    /// <summary>Verifies EnsureResponseContent returns the existing content untouched.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task EnsureResponseContentReturnsExistingContent()
+    {
+        var original = new StringContent("hi");
+        using var response = new HttpResponseMessage(HttpStatusCode.OK) { Content = original };
+
+        var content = RequestExecutionHelpers.EnsureResponseContent(response);
+
+        await Assert.That(ReferenceEquals(content, original)).IsTrue();
+    }
+
     /// <summary>Creates settings backed by the test serializer.</summary>
     /// <param name="serializer">The serializer to assign, or null for a recording serializer.</param>
     /// <returns>The configured settings.</returns>

--- a/src/tests/Refit.Tests/HttpClientFactoryExtensionsTests.cs
+++ b/src/tests/Refit.Tests/HttpClientFactoryExtensionsTests.cs
@@ -451,7 +451,7 @@ public class HttpClientFactoryExtensionsTests
 
         var genericSettings = services.AddRefitClient<IFooWithOtherAttribute>(settings, "generic-settings");
         var genericFactory = services.AddRefitClient<IFooWithOtherAttribute>(
-            static _ => new RefitSettings(),
+            static _ => new(),
             "generic-factory");
         var typeSettings = services.AddRefitClient(
             typeof(IFooWithOtherAttribute),
@@ -459,7 +459,7 @@ public class HttpClientFactoryExtensionsTests
             "type-settings");
         var typeFactory = services.AddRefitClient(
             typeof(IFooWithOtherAttribute),
-            static _ => new RefitSettings(),
+            static _ => new(),
             "type-factory");
 
         await Assert.That(genericSettings.Name).IsEqualTo("generic-settings");
@@ -490,7 +490,7 @@ public class HttpClientFactoryExtensionsTests
             "generic-settings-client");
         _ = services.AddKeyedRefitClient<IFooWithOtherAttribute>(
             "generic-factory",
-            static _ => new RefitSettings());
+            static _ => new());
         var genericNamedFactory = services.AddKeyedRefitClient<IFooWithOtherAttribute>(
             "generic-factory-named",
             _ => new() { ContentSerializer = genericFactorySerializer },
@@ -813,7 +813,7 @@ public class HttpClientFactoryExtensionsTests
         var builder = services.AddHttpClient("builder-matrix");
 
         var typeBuilder = builder.AddRefitClient(typeof(IFooWithOtherAttribute));
-        _ = builder.AddRefitClient<IFooWithOtherAttribute>(static _ => new RefitSettings());
+        _ = builder.AddRefitClient<IFooWithOtherAttribute>(static _ => new());
         _ = builder.AddRefitClient(
             typeof(IFooWithOtherAttribute),
             new RefitSettings { ContentSerializer = typeSettingsSerializer });

--- a/src/tests/Refit.Tests/IRfcUrlResolutionApi.cs
+++ b/src/tests/Refit.Tests/IRfcUrlResolutionApi.cs
@@ -1,0 +1,31 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Refit.Tests;
+
+/// <summary>Fixture used to verify <see cref="UrlResolutionMode.Rfc3986"/> base-address resolution.</summary>
+public interface IRfcUrlResolutionApi
+{
+    /// <summary>Relative path without a leading slash: appended to the base address path under RFC 3986.</summary>
+    /// <returns>The response body.</returns>
+    [Get("values")]
+    Task<string> GetValuesRelative();
+
+    /// <summary>Relative path with a dynamic segment and no leading slash.</summary>
+    /// <param name="id">The identifier substituted into the path.</param>
+    /// <returns>The response body.</returns>
+    [Get("users/{id}")]
+    Task<string> GetUser(int id);
+
+    /// <summary>Relative path with a leading slash: replaces the base address path under RFC 3986.</summary>
+    /// <returns>The response body.</returns>
+    [Get("/values")]
+    Task<string> GetValuesAbsolute();
+
+    /// <summary>Relative path without a leading slash that also carries a query string.</summary>
+    /// <param name="page">The page number added as a query parameter.</param>
+    /// <returns>The response body.</returns>
+    [Get("values?active=true")]
+    Task<string> GetValuesWithQuery(int page);
+}

--- a/src/tests/Refit.Tests/IStreamingApi.cs
+++ b/src/tests/Refit.Tests/IStreamingApi.cs
@@ -28,4 +28,10 @@ public interface IStreamingApi
     /// <returns>The streamed items.</returns>
     [Get("/array")]
     IAsyncEnumerable<StreamItem> GetArrayCancellable(CancellationToken cancellationToken);
+
+    /// <summary>Streams a JSON array from a dynamic route, exercising the reflection (non-inline) path.</summary>
+    /// <param name="group">The route segment value.</param>
+    /// <returns>The streamed items.</returns>
+    [Get("/groups/{group}/array")]
+    IAsyncEnumerable<StreamItem> GetGroupArray(string group);
 }

--- a/src/tests/Refit.Tests/IStreamingApi.cs
+++ b/src/tests/Refit.Tests/IStreamingApi.cs
@@ -1,0 +1,31 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+
+namespace Refit.Tests;
+
+/// <summary>Fixture exercising <see cref="IAsyncEnumerable{T}"/> streaming responses.</summary>
+public interface IStreamingApi
+{
+    /// <summary>Streams the elements of a JSON array response.</summary>
+    /// <returns>The streamed items.</returns>
+    [SuppressMessage("Design", "CA1024:Use properties where appropriate", Justification = "Refit endpoint method fixture; must remain a method to exercise the generator.")]
+    [Get("/array")]
+    IAsyncEnumerable<StreamItem> GetArray();
+
+    /// <summary>Streams the elements of a newline-delimited JSON response.</summary>
+    /// <returns>The streamed items.</returns>
+    [SuppressMessage("Design", "CA1024:Use properties where appropriate", Justification = "Refit endpoint method fixture; must remain a method to exercise the generator.")]
+    [Get("/lines")]
+    IAsyncEnumerable<StreamItem> GetLines();
+
+    /// <summary>Streams a JSON array response, observing the supplied cancellation token.</summary>
+    /// <param name="cancellationToken">A token to cancel streaming.</param>
+    /// <returns>The streamed items.</returns>
+    [Get("/array")]
+    IAsyncEnumerable<StreamItem> GetArrayCancellable(CancellationToken cancellationToken);
+}

--- a/src/tests/Refit.Tests/IStreamingApi.cs
+++ b/src/tests/Refit.Tests/IStreamingApi.cs
@@ -34,4 +34,11 @@ public interface IStreamingApi
     /// <returns>The streamed items.</returns>
     [Get("/groups/{group}/array")]
     IAsyncEnumerable<StreamItem> GetGroupArray(string group);
+
+    /// <summary>Streams from a dynamic route with a cancellation token, exercising the reflection path's token linking.</summary>
+    /// <param name="group">The route segment value.</param>
+    /// <param name="cancellationToken">A token to cancel streaming.</param>
+    /// <returns>The streamed items.</returns>
+    [Get("/groups/{group}/array")]
+    IAsyncEnumerable<StreamItem> GetGroupArrayCancellable(string group, CancellationToken cancellationToken);
 }

--- a/src/tests/Refit.Tests/ISyncBodyApi.cs
+++ b/src/tests/Refit.Tests/ISyncBodyApi.cs
@@ -1,0 +1,24 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Threading.Tasks;
+
+namespace Refit.Tests;
+
+/// <summary>Fixture used to verify synchronous request-body serialization.</summary>
+public interface ISyncBodyApi
+{
+    /// <summary>Posts a body through the inline generated request path.</summary>
+    /// <param name="item">The body to post.</param>
+    /// <returns>A task representing the request.</returns>
+    [Post("/items")]
+    Task PostItem([Body] StreamItem item);
+
+    /// <summary>Posts a body through the reflection request path (generic methods are not generated inline).</summary>
+    /// <typeparam name="T">The body type.</typeparam>
+    /// <param name="item">The body to post.</param>
+    /// <returns>A task representing the request.</returns>
+    [Post("/items")]
+    Task PostItemReflected<T>([Body] T item);
+}

--- a/src/tests/Refit.Tests/JsonLinesContentTests.cs
+++ b/src/tests/Refit.Tests/JsonLinesContentTests.cs
@@ -32,7 +32,7 @@ public class JsonLinesContentTests
     public async Task CreateJsonLinesBodyContentPassesThroughHttpContent()
     {
         using var inner = new StringContent("passthrough");
-        var content = GeneratedRequestRunner.CreateJsonLinesBodyContent(new RefitSettings(), inner);
+        var content = GeneratedRequestRunner.CreateJsonLinesBodyContent(new(), inner);
         await Assert.That(content).IsSameReferenceAs(inner);
     }
 
@@ -42,7 +42,7 @@ public class JsonLinesContentTests
     public async Task CreateJsonLinesBodyContentWrapsStream()
     {
         await using var stream = new MemoryStream([1, 2, 3]);
-        var content = GeneratedRequestRunner.CreateJsonLinesBodyContent(new RefitSettings(), stream);
+        var content = GeneratedRequestRunner.CreateJsonLinesBodyContent(new(), stream);
         await Assert.That(content).IsTypeOf<StreamContent>();
     }
 
@@ -52,7 +52,7 @@ public class JsonLinesContentTests
     public async Task CreateJsonLinesBodyContentWrapsSingleValue()
     {
         var content = GeneratedRequestRunner.CreateJsonLinesBodyContent(
-            new RefitSettings(),
+            new(),
             new JsonLineRecord { Id = "1", Name = "single" });
 
         await Assert.That(content).IsTypeOf<JsonLinesContent>();

--- a/src/tests/Refit.Tests/MultipartTests.cs
+++ b/src/tests/Refit.Tests/MultipartTests.cs
@@ -597,7 +597,7 @@ public class MultipartTests
                 ContentSerializer = new ThrowingContentSerializer()
             });
 
-        Task UploadJsonObject() => fixture.UploadJsonObject(new ModelObject());
+        Task UploadJsonObject() => fixture.UploadJsonObject(new());
 
         var exception = await Assert
             .That(UploadJsonObject)

--- a/src/tests/Refit.Tests/NonStreamingContentSerializer.cs
+++ b/src/tests/Refit.Tests/NonStreamingContentSerializer.cs
@@ -1,0 +1,30 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Net.Http;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Refit.Tests;
+
+/// <summary>An <see cref="IHttpContentSerializer"/> that intentionally does not support streaming, used to verify the streaming error path.</summary>
+public sealed class NonStreamingContentSerializer : IHttpContentSerializer
+{
+    /// <summary>The serializer used to satisfy the non-streaming operations.</summary>
+    private readonly SystemTextJsonContentSerializer _inner = new();
+
+    /// <inheritdoc/>
+    public HttpContent ToHttpContent<T>(T item) => _inner.ToHttpContent(item);
+
+    /// <inheritdoc/>
+    [SuppressMessage("Major Code Smell", "S4018:Generic methods should provide type parameters", Justification = "Type parameter intentionally specified explicitly by callers.")]
+    public Task<T?> FromHttpContentAsync<T>(HttpContent content, CancellationToken cancellationToken = default) =>
+        _inner.FromHttpContentAsync<T>(content, cancellationToken);
+
+    /// <inheritdoc/>
+    public string? GetFieldNameForProperty(PropertyInfo propertyInfo) =>
+        _inner.GetFieldNameForProperty(propertyInfo);
+}

--- a/src/tests/Refit.Tests/RestServiceIntegrationTests.RequestBody.cs
+++ b/src/tests/Refit.Tests/RestServiceIntegrationTests.RequestBody.cs
@@ -99,8 +99,8 @@ public partial class RestServiceIntegrationTests
 
         await fixture.PostJsonLines(
             [
-                new JsonLineRecord { Id = "124", Name = "Stark Industries" },
-                new JsonLineRecord { Id = "125", Name = "Acme Corp" }
+                new() { Id = "124", Name = "Stark Industries" },
+                new() { Id = "125", Name = "Acme Corp" }
             ]);
 
         mockHttp.VerifyNoOutstandingExpectation();

--- a/src/tests/Refit.Tests/RestServiceIntegrationTests.cs
+++ b/src/tests/Refit.Tests/RestServiceIntegrationTests.cs
@@ -146,10 +146,10 @@ public partial class RestServiceIntegrationTests
         var explicitGenerated = await Assert.That(explicitSettingsInstance).IsTypeOf<GeneratedSettingsFactoryApiClient>();
         var typedGenerated = await Assert.That(typedInstance).IsTypeOf<GeneratedSettingsFactoryApiClient>();
 
-        await Assert.That(defaultGenerated!.Client.BaseAddress).IsEqualTo(new Uri("http://foo"));
-        await Assert.That(explicitGenerated!.Client.BaseAddress).IsEqualTo(new Uri("http://bar"));
+        await Assert.That(defaultGenerated!.Client.BaseAddress).IsEqualTo(new("http://foo"));
+        await Assert.That(explicitGenerated!.Client.BaseAddress).IsEqualTo(new("http://bar"));
         await Assert.That(explicitGenerated.Settings).IsSameReferenceAs(settings);
-        await Assert.That(typedGenerated!.Client.BaseAddress).IsEqualTo(new Uri("http://baz"));
+        await Assert.That(typedGenerated!.Client.BaseAddress).IsEqualTo(new("http://baz"));
         await Assert.That(typedGenerated.Settings).IsSameReferenceAs(settings);
     }
 
@@ -292,6 +292,42 @@ public partial class RestServiceIntegrationTests
         await Assert.That(result).IsEqualTo("test");
         mockHttp.VerifyNoOutstandingExpectation();
     }
+
+    /// <summary>Verifies an unmatched route placeholder is left in the URL verbatim when <see cref="RefitSettings.AllowUnmatchedRouteParameters"/> is set.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task UnmatchedRouteParameterIsLeftVerbatimWhenAllowed()
+    {
+        var mockHttp = new MockHttpMessageHandler();
+        Uri? captured = null;
+        _ = mockHttp
+            .When("*")
+            .Respond(request =>
+            {
+                captured = request.RequestUri;
+                return new(HttpStatusCode.OK) { Content = new StringContent("test") };
+            });
+
+        var settings = new RefitSettings
+        {
+            AllowUnmatchedRouteParameters = true,
+            HttpMessageHandlerFactory = () => mockHttp,
+        };
+
+        var fixture = RestService.For<IUrlNoMatchingParameters>("http://foo", settings);
+
+        var result = await fixture.GetValue();
+
+        await Assert.That(result).IsEqualTo("test");
+        await Assert.That(captured).IsNotNull();
+        await Assert.That(Uri.UnescapeDataString(captured!.ToString())).Contains("/{value}", StringComparison.Ordinal);
+    }
+
+    /// <summary>Verifies an unmatched route placeholder still throws by default.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task UnmatchedRouteParameterStillThrowsByDefault() =>
+        await Assert.That(() => RestService.For<IUrlNoMatchingParameters>("http://foo")).ThrowsExactly<ArgumentException>();
 
     /// <summary>Verifies methods returning a <see cref="ValueTask{TResult}"/> of an API response work.</summary>
     /// <returns>A task representing the asynchronous test.</returns>

--- a/src/tests/Refit.Tests/SerializedContentTests.cs
+++ b/src/tests/Refit.Tests/SerializedContentTests.cs
@@ -392,6 +392,54 @@ public partial class SerializedContentTests
         await Assert.That(await Assert.That(result!.Value).IsTypeOf<double>()).IsEqualTo(42.5);
     }
 
+    /// <summary>Verifies the default options read numeric properties from JSON strings.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task SystemTextJsonContentSerializer_DefaultOptions_ReadNumbersFromString()
+    {
+        var result = SystemTextJsonSerializer.Deserialize<NumberContainer>(
+            """{"id":"123","amount":"9.99"}""",
+            SystemTextJsonContentSerializer.GetDefaultJsonSerializerOptions());
+
+        await Assert.That(result!.Id).IsEqualTo(123);
+        await Assert.That(result.Amount).IsEqualTo(9.99m);
+    }
+
+    /// <summary>Verifies the default options still write numbers as JSON numbers, not strings.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task SystemTextJsonContentSerializer_DefaultOptions_WriteNumbersAsNumbers()
+    {
+        var json = SystemTextJsonSerializer.Serialize(
+            new NumberContainer { Id = 123, Amount = 9.99m },
+            SystemTextJsonContentSerializer.GetDefaultJsonSerializerOptions());
+
+        await Assert.That(json).Contains("123", StringComparison.Ordinal);
+        await Assert.That(json).DoesNotContain("\"123\"", StringComparison.Ordinal);
+    }
+
+    /// <summary>Verifies the default options expose <see cref="JsonNumberHandling.AllowReadingFromString"/>.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task SystemTextJsonContentSerializer_DefaultOptions_NumberHandlingAllowsReadingFromString() =>
+        await Assert
+            .That(SystemTextJsonContentSerializer.GetDefaultJsonSerializerOptions().NumberHandling)
+            .IsEqualTo(JsonNumberHandling.AllowReadingFromString);
+
+    /// <summary>Verifies the fast-path options omit the settings that disable the System.Text.Json fast-path.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task SystemTextJsonContentSerializer_FastPathOptions_AreFastPathEligible()
+    {
+        var options = SystemTextJsonContentSerializer.GetFastPathJsonSerializerOptions();
+
+        await Assert.That(options.Converters).IsEmpty();
+        await Assert.That(options.NumberHandling).IsEqualTo(JsonNumberHandling.Strict);
+        await Assert.That(options.ReferenceHandler).IsNull();
+        await Assert.That(options.Encoder).IsNull();
+        await Assert.That(options.PropertyNamingPolicy).IsEqualTo(JsonNamingPolicy.CamelCase);
+    }
+
     /// <summary>Verifies that ISO date JSON object values are inferred as <see cref="DateTime"/>.</summary>
     /// <returns>A task that represents the asynchronous test operation.</returns>
     [Test]
@@ -1196,6 +1244,16 @@ public partial class SerializedContentTests
     {
         /// <summary>Gets or sets the boxed value.</summary>
         public object? Value { get; set; }
+    }
+
+    /// <summary>Container with numeric values used to verify <see cref="JsonNumberHandling.AllowReadingFromString"/> behavior.</summary>
+    public sealed class NumberContainer
+    {
+        /// <summary>Gets or sets an integral value.</summary>
+        public int Id { get; set; }
+
+        /// <summary>Gets or sets a decimal value.</summary>
+        public decimal Amount { get; set; }
     }
 
     /// <summary>Source-generated serialization context for the <see cref="User"/> type.</summary>

--- a/src/tests/Refit.Tests/StreamItem.cs
+++ b/src/tests/Refit.Tests/StreamItem.cs
@@ -1,0 +1,12 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Refit.Tests;
+
+/// <summary>A simple streamed item used by streaming response tests.</summary>
+public sealed class StreamItem
+{
+    /// <summary>Gets or sets the item identifier.</summary>
+    public int Id { get; set; }
+}

--- a/src/tests/Refit.Tests/StreamingJsonContext.cs
+++ b/src/tests/Refit.Tests/StreamingJsonContext.cs
@@ -1,0 +1,12 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Text.Json.Serialization;
+
+namespace Refit.Tests;
+
+/// <summary>Source-generated JSON context used to exercise the streaming and synchronous serializer fast paths.</summary>
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
+[JsonSerializable(typeof(StreamItem))]
+internal sealed partial class StreamingJsonContext : JsonSerializerContext;

--- a/src/tests/Refit.Tests/StreamingResponseTests.cs
+++ b/src/tests/Refit.Tests/StreamingResponseTests.cs
@@ -1,0 +1,154 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using RichardSzalay.MockHttp;
+
+namespace Refit.Tests;
+
+/// <summary>Tests for interface methods returning <see cref="IAsyncEnumerable{T}"/>.</summary>
+public class StreamingResponseTests
+{
+    /// <summary>Verifies a JSON array response is streamed element by element.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task StreamsJsonArrayElements()
+    {
+        var fixture = CreateFixture("application/json", "[{\"id\":1},{\"id\":2},{\"id\":3}]");
+
+        var ids = new List<int>();
+        await foreach (var item in fixture.GetArray())
+        {
+            ids.Add(item!.Id);
+        }
+
+        await Assert.That(ids).IsEquivalentTo([1, 2, 3]);
+    }
+
+    /// <summary>Verifies a newline-delimited JSON response is streamed line by line.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task StreamsJsonLinesElements()
+    {
+        var fixture = CreateFixture("application/x-ndjson", "{\"id\":1}\n{\"id\":2}\n\n{\"id\":3}\n");
+
+        var ids = new List<int>();
+        await foreach (var item in fixture.GetLines())
+        {
+            ids.Add(item!.Id);
+        }
+
+        await Assert.That(ids).IsEquivalentTo([1, 2, 3]);
+    }
+
+    /// <summary>Verifies the alternate JSON Lines media type is also streamed line by line.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task StreamsJsonLinesForAlternateMediaType()
+    {
+        var fixture = CreateFixture("application/jsonl", "{\"id\":10}\n{\"id\":20}\n");
+
+        var ids = new List<int>();
+        await foreach (var item in fixture.GetLines())
+        {
+            ids.Add(item!.Id);
+        }
+
+        await Assert.That(ids).IsEquivalentTo([10, 20]);
+    }
+
+    /// <summary>Verifies an HTTP error response throws when the stream is enumerated.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task ErrorResponseThrowsOnEnumeration()
+    {
+        var mockHttp = new MockHttpMessageHandler();
+        _ = mockHttp.When("*").Respond(HttpStatusCode.InternalServerError);
+        var settings = new RefitSettings { HttpMessageHandlerFactory = () => mockHttp };
+        var fixture = RestService.For<IStreamingApi>("http://foo", settings);
+
+        await Assert
+            .That(async () =>
+            {
+                await foreach (var item in fixture.GetArray())
+                {
+                    _ = item;
+                }
+            })
+            .Throws<ApiException>();
+    }
+
+    /// <summary>Verifies a serializer without streaming support throws a clear error.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task NonStreamingSerializerThrowsNotSupported()
+    {
+        var mockHttp = new MockHttpMessageHandler();
+        _ = mockHttp
+            .When("*")
+            .Respond(_ => new(HttpStatusCode.OK)
+            {
+                Content = new StringContent("[{\"id\":1}]", System.Text.Encoding.UTF8, "application/json"),
+            });
+
+        var settings = new RefitSettings(new NonStreamingContentSerializer())
+        {
+            HttpMessageHandlerFactory = () => mockHttp,
+        };
+        var fixture = RestService.For<IStreamingApi>("http://foo", settings);
+
+        await Assert
+            .That(async () =>
+            {
+                await foreach (var item in fixture.GetArray())
+                {
+                    _ = item;
+                }
+            })
+            .Throws<NotSupportedException>();
+    }
+
+    /// <summary>Verifies enumeration stops when the supplied cancellation token is cancelled.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task HonorsCancellationToken()
+    {
+        var fixture = CreateFixture("application/json", "[{\"id\":1},{\"id\":2},{\"id\":3}]");
+
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        await Assert
+            .That(async () =>
+            {
+                await foreach (var item in fixture.GetArrayCancellable(cts.Token))
+                {
+                    _ = item;
+                }
+            })
+            .Throws<OperationCanceledException>();
+    }
+
+    /// <summary>Creates a streaming fixture backed by a mock handler returning the given payload.</summary>
+    /// <param name="mediaType">The response media type.</param>
+    /// <param name="payload">The response body.</param>
+    /// <returns>The streaming API fixture.</returns>
+    private static IStreamingApi CreateFixture(string mediaType, string payload)
+    {
+        var mockHttp = new MockHttpMessageHandler();
+        _ = mockHttp
+            .When("*")
+            .Respond(_ => new(HttpStatusCode.OK)
+            {
+                Content = new StringContent(payload, System.Text.Encoding.UTF8, mediaType),
+            });
+
+        var settings = new RefitSettings { HttpMessageHandlerFactory = () => mockHttp };
+        return RestService.For<IStreamingApi>("http://foo", settings);
+    }
+}

--- a/src/tests/Refit.Tests/StreamingResponseTests.cs
+++ b/src/tests/Refit.Tests/StreamingResponseTests.cs
@@ -30,6 +30,22 @@ public class StreamingResponseTests
         await Assert.That(ids).IsEquivalentTo([1, 2, 3]);
     }
 
+    /// <summary>Verifies streaming works through the reflection (non-inline) path for a dynamic route.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task StreamsViaReflectionPathForDynamicRoute()
+    {
+        var fixture = CreateFixture("application/json", "[{\"id\":4},{\"id\":5}]");
+
+        var ids = new List<int>();
+        await foreach (var item in fixture.GetGroupArray("g1"))
+        {
+            ids.Add(item!.Id);
+        }
+
+        await Assert.That(ids).IsEquivalentTo([4, 5]);
+    }
+
     /// <summary>Verifies a newline-delimited JSON response is streamed line by line.</summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Test]

--- a/src/tests/Refit.Tests/StreamingResponseTests.cs
+++ b/src/tests/Refit.Tests/StreamingResponseTests.cs
@@ -150,11 +150,70 @@ public class StreamingResponseTests
             .Throws<OperationCanceledException>();
     }
 
+    /// <summary>Verifies the source-generated metadata path streams a JSON array.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task StreamsJsonArrayWithSourceGenContext()
+    {
+        var fixture = CreateFixture(
+            "application/json",
+            "[{\"id\":1},{\"id\":2}]",
+            new SystemTextJsonContentSerializer(StreamingJsonContext.Default.Options));
+
+        var ids = new List<int>();
+        await foreach (var item in fixture.GetArray())
+        {
+            ids.Add(item!.Id);
+        }
+
+        await Assert.That(ids).IsEquivalentTo([1, 2]);
+    }
+
+    /// <summary>Verifies the source-gen JSON Lines path handles CRLF endings, a line larger than the read buffer, and a final line with no trailing newline.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task StreamsJsonLinesWithSourceGenContextAndReaderEdges()
+    {
+        var bigGap = new string(' ', 5000);
+
+        // Includes a whitespace-only line (skipped), a line larger than the read buffer, CRLF endings, and no final newline.
+        var payload = "{\"id\":1}\r\n   \r\n{" + bigGap + "\"id\":2}\r\n{\"id\":3}";
+        var fixture = CreateFixture(
+            "application/x-jsonlines",
+            payload,
+            new SystemTextJsonContentSerializer(StreamingJsonContext.Default.Options));
+
+        var ids = new List<int>();
+        await foreach (var item in fixture.GetLines())
+        {
+            ids.Add(item!.Id);
+        }
+
+        await Assert.That(ids).IsEquivalentTo([1, 2, 3]);
+    }
+
+    /// <summary>Verifies the reflection path links the method cancellation token for a dynamic route.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task StreamsViaReflectionPathWithCancellationToken()
+    {
+        var fixture = CreateFixture("application/json", "[{\"id\":8}]");
+
+        var ids = new List<int>();
+        await foreach (var item in fixture.GetGroupArrayCancellable("g1", CancellationToken.None))
+        {
+            ids.Add(item!.Id);
+        }
+
+        await Assert.That(ids).IsEquivalentTo([8]);
+    }
+
     /// <summary>Creates a streaming fixture backed by a mock handler returning the given payload.</summary>
     /// <param name="mediaType">The response media type.</param>
     /// <param name="payload">The response body.</param>
+    /// <param name="serializer">An optional content serializer; the default is used when null.</param>
     /// <returns>The streaming API fixture.</returns>
-    private static IStreamingApi CreateFixture(string mediaType, string payload)
+    private static IStreamingApi CreateFixture(string mediaType, string payload, IHttpContentSerializer? serializer = null)
     {
         var mockHttp = new MockHttpMessageHandler();
         _ = mockHttp
@@ -164,7 +223,8 @@ public class StreamingResponseTests
                 Content = new StringContent(payload, System.Text.Encoding.UTF8, mediaType),
             });
 
-        var settings = new RefitSettings { HttpMessageHandlerFactory = () => mockHttp };
+        var settings = serializer is null ? new RefitSettings() : new RefitSettings(serializer);
+        settings.HttpMessageHandlerFactory = () => mockHttp;
         return RestService.For<IStreamingApi>("http://foo", settings);
     }
 }

--- a/src/tests/Refit.Tests/StreamingResponseTests.cs
+++ b/src/tests/Refit.Tests/StreamingResponseTests.cs
@@ -192,6 +192,60 @@ public class StreamingResponseTests
         await Assert.That(ids).IsEquivalentTo([1, 2, 3]);
     }
 
+    /// <summary>Verifies disposing a JSON array stream after one item cleans up the enumerator.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task JsonArrayStreamDisposesEnumeratorEarly()
+    {
+        var fixture = CreateFixture("application/json", "[{\"id\":1},{\"id\":2},{\"id\":3}]");
+
+        await using var enumerator = fixture.GetArray().GetAsyncEnumerator();
+
+        await Assert.That(await enumerator.MoveNextAsync()).IsTrue();
+        await Assert.That(enumerator.Current!.Id).IsEqualTo(1);
+    }
+
+    /// <summary>Verifies disposing a JSON Lines stream after one item returns the pooled reader buffer.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task JsonLinesStreamDisposesEnumeratorEarly()
+    {
+        var fixture = CreateFixture(
+            "application/x-ndjson",
+            "{\"id\":1}\n{\"id\":2}\n{\"id\":3}\n",
+            new SystemTextJsonContentSerializer(StreamingJsonContext.Default.Options));
+
+        await using var enumerator = fixture.GetLines().GetAsyncEnumerator();
+
+        await Assert.That(await enumerator.MoveNextAsync()).IsTrue();
+        await Assert.That(enumerator.Current!.Id).IsEqualTo(1);
+    }
+
+    /// <summary>Verifies a response with no content type is treated as a JSON array.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task StreamsJsonArrayWhenResponseHasNoContentType()
+    {
+        var mockHttp = new MockHttpMessageHandler();
+        _ = mockHttp
+            .When("*")
+            .Respond(_ => new(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent("[{\"id\":7}]"u8.ToArray()),
+            });
+
+        var settings = new RefitSettings { HttpMessageHandlerFactory = () => mockHttp };
+        var fixture = RestService.For<IStreamingApi>("http://foo", settings);
+
+        var ids = new List<int>();
+        await foreach (var item in fixture.GetArray())
+        {
+            ids.Add(item!.Id);
+        }
+
+        await Assert.That(ids).IsEquivalentTo([7]);
+    }
+
     /// <summary>Verifies the reflection path links the method cancellation token for a dynamic route.</summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Test]

--- a/src/tests/Refit.Tests/SynchronousBodySerializationTests.cs
+++ b/src/tests/Refit.Tests/SynchronousBodySerializationTests.cs
@@ -1,0 +1,95 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using RichardSzalay.MockHttp;
+
+namespace Refit.Tests;
+
+/// <summary>Tests for <see cref="RefitSettings.RequestBodySerialization"/> (synchronous fast-path body serialization).</summary>
+public class SynchronousBodySerializationTests
+{
+    /// <summary>Verifies the buffered mode serializes the body into a buffered JSON content with a Content-Length.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task BufferedInlinePathSerializesBufferedJson()
+    {
+        var capture = await PostAsync(RequestBodySerializationMode.Buffered, api => api.PostItem(new() { Id = 42 }));
+
+        await Assert.That(capture.MediaType).IsEqualTo("application/json");
+        await Assert.That(capture.ContentLength).IsNotNull();
+        await Assert.That(capture.Body).Contains("42", StringComparison.Ordinal);
+    }
+
+    /// <summary>Verifies the buffered mode works through the reflection path.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task BufferedReflectionPathSerializesBufferedJson()
+    {
+        var capture = await PostAsync(RequestBodySerializationMode.Buffered, api => api.PostItemReflected(new StreamItem { Id = 7 }));
+
+        await Assert.That(capture.MediaType).IsEqualTo("application/json");
+        await Assert.That(capture.ContentLength).IsNotNull();
+        await Assert.That(capture.Body).Contains("7", StringComparison.Ordinal);
+    }
+
+    /// <summary>Verifies the streamed mode serializes the body without a Content-Length through the inline path.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task StreamedInlinePathSerializesWithoutContentLength()
+    {
+        var capture = await PostAsync(RequestBodySerializationMode.Streamed, api => api.PostItem(new() { Id = 99 }));
+
+        await Assert.That(capture.MediaType).IsEqualTo("application/json");
+        await Assert.That(capture.ContentLength).IsNull();
+        await Assert.That(capture.Body).Contains("99", StringComparison.Ordinal);
+    }
+
+    /// <summary>Verifies the streamed mode works through the reflection path.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task StreamedReflectionPathSerializesWithoutContentLength()
+    {
+        var capture = await PostAsync(RequestBodySerializationMode.Streamed, api => api.PostItemReflected(new StreamItem { Id = 13 }));
+
+        await Assert.That(capture.MediaType).IsEqualTo("application/json");
+        await Assert.That(capture.ContentLength).IsNull();
+        await Assert.That(capture.Body).Contains("13", StringComparison.Ordinal);
+    }
+
+    /// <summary>Posts through a sync-body fixture and captures the request content details seen by the handler.</summary>
+    /// <param name="mode">The request-body serialization mode to use.</param>
+    /// <param name="call">The interface call to invoke.</param>
+    /// <returns>The captured body, media type, and content length.</returns>
+    private static async Task<(string? Body, string? MediaType, long? ContentLength)> PostAsync(
+        RequestBodySerializationMode mode,
+        Func<ISyncBodyApi, Task> call)
+    {
+        string? body = null;
+        string? mediaType = null;
+        long? contentLength = null;
+        var mockHttp = new MockHttpMessageHandler();
+        _ = mockHttp
+            .When("*")
+            .Respond(async request =>
+            {
+                mediaType = request.Content!.Headers.ContentType?.MediaType;
+                contentLength = request.Content!.Headers.ContentLength;
+                body = await request.Content!.ReadAsStringAsync();
+                return new HttpResponseMessage(HttpStatusCode.OK);
+            });
+
+        var settings = new RefitSettings
+        {
+            RequestBodySerialization = mode,
+            HttpMessageHandlerFactory = () => mockHttp,
+        };
+
+        var fixture = RestService.For<ISyncBodyApi>("http://foo", settings);
+        await call(fixture);
+        return (body, mediaType, contentLength);
+    }
+}

--- a/src/tests/Refit.Tests/SynchronousBodySerializationTests.cs
+++ b/src/tests/Refit.Tests/SynchronousBodySerializationTests.cs
@@ -60,13 +60,43 @@ public class SynchronousBodySerializationTests
         await Assert.That(capture.Body).Contains("13", StringComparison.Ordinal);
     }
 
+    /// <summary>Verifies buffered serialization uses the source-generated metadata fast path.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task SourceGenBufferedSerializesBody()
+    {
+        var capture = await PostAsync(
+            RequestBodySerializationMode.Buffered,
+            api => api.PostItem(new() { Id = 21 }),
+            new SystemTextJsonContentSerializer(StreamingJsonContext.Default.Options));
+
+        await Assert.That(capture.ContentLength).IsNotNull();
+        await Assert.That(capture.Body).Contains("21", StringComparison.Ordinal);
+    }
+
+    /// <summary>Verifies streamed serialization uses the source-generated metadata fast path.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task SourceGenStreamedSerializesBody()
+    {
+        var capture = await PostAsync(
+            RequestBodySerializationMode.Streamed,
+            api => api.PostItem(new() { Id = 34 }),
+            new SystemTextJsonContentSerializer(StreamingJsonContext.Default.Options));
+
+        await Assert.That(capture.ContentLength).IsNull();
+        await Assert.That(capture.Body).Contains("34", StringComparison.Ordinal);
+    }
+
     /// <summary>Posts through a sync-body fixture and captures the request content details seen by the handler.</summary>
     /// <param name="mode">The request-body serialization mode to use.</param>
     /// <param name="call">The interface call to invoke.</param>
+    /// <param name="serializer">An optional content serializer; the default is used when null.</param>
     /// <returns>The captured body, media type, and content length.</returns>
     private static async Task<(string? Body, string? MediaType, long? ContentLength)> PostAsync(
         RequestBodySerializationMode mode,
-        Func<ISyncBodyApi, Task> call)
+        Func<ISyncBodyApi, Task> call,
+        IHttpContentSerializer? serializer = null)
     {
         string? body = null;
         string? mediaType = null;
@@ -82,11 +112,9 @@ public class SynchronousBodySerializationTests
                 return new HttpResponseMessage(HttpStatusCode.OK);
             });
 
-        var settings = new RefitSettings
-        {
-            RequestBodySerialization = mode,
-            HttpMessageHandlerFactory = () => mockHttp,
-        };
+        var settings = serializer is null ? new RefitSettings() : new RefitSettings(serializer);
+        settings.RequestBodySerialization = mode;
+        settings.HttpMessageHandlerFactory = () => mockHttp;
 
         var fixture = RestService.For<ISyncBodyApi>("http://foo", settings);
         await call(fixture);

--- a/src/tests/Refit.Tests/UrlResolutionModeTests.cs
+++ b/src/tests/Refit.Tests/UrlResolutionModeTests.cs
@@ -1,0 +1,84 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using RichardSzalay.MockHttp;
+
+namespace Refit.Tests;
+
+/// <summary>Tests for <see cref="UrlResolutionMode.Rfc3986"/> base-address resolution.</summary>
+public class UrlResolutionModeTests
+{
+    /// <summary>Verifies a leading-slash-less relative path is appended to the base address path under RFC 3986.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task Rfc3986AppendsRelativePathToBasePath()
+    {
+        var captured = await CaptureRfcRequestAsync("http://foo/api/v1/", api => api.GetValuesRelative());
+        await Assert.That(captured!.AbsoluteUri).IsEqualTo("http://foo/api/v1/values");
+    }
+
+    /// <summary>Verifies a dynamic segment is expanded and appended under RFC 3986.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task Rfc3986ExpandsDynamicSegment()
+    {
+        var captured = await CaptureRfcRequestAsync("http://foo/api/v1/", api => api.GetUser(7));
+        await Assert.That(captured!.AbsoluteUri).IsEqualTo("http://foo/api/v1/users/7");
+    }
+
+    /// <summary>Verifies a leading-slash relative path replaces the base address path under RFC 3986.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task Rfc3986LeadingSlashReplacesBasePath()
+    {
+        var captured = await CaptureRfcRequestAsync("http://foo/api/v1/", api => api.GetValuesAbsolute());
+        await Assert.That(captured!.AbsoluteUri).IsEqualTo("http://foo/values");
+    }
+
+    /// <summary>Verifies template and dynamic query parameters are both preserved under RFC 3986.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task Rfc3986PreservesQueryParameters()
+    {
+        var captured = await CaptureRfcRequestAsync("http://foo/api/v1/", api => api.GetValuesWithQuery(3));
+        await Assert.That(captured!.AbsoluteUri).IsEqualTo("http://foo/api/v1/values?active=true&page=3");
+    }
+
+    /// <summary>Verifies a leading-slash-less route still throws under the default legacy mode.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task LegacyModeRejectsLeadingSlashlessRoute() =>
+        await Assert.That(() => RestService.For<IRfcUrlResolutionApi>("http://foo/api/v1/")).ThrowsExactly<ArgumentException>();
+
+    /// <summary>Invokes a call under <see cref="UrlResolutionMode.Rfc3986"/> and returns the captured request URI.</summary>
+    /// <param name="baseAddress">The client base address.</param>
+    /// <param name="call">The interface call to invoke.</param>
+    /// <returns>The absolute request URI seen by the handler.</returns>
+    private static async Task<Uri?> CaptureRfcRequestAsync(string baseAddress, Func<IRfcUrlResolutionApi, Task<string>> call)
+    {
+        var mockHttp = new MockHttpMessageHandler();
+        Uri? captured = null;
+        _ = mockHttp
+            .When("*")
+            .Respond(request =>
+            {
+                captured = request.RequestUri;
+                return new(HttpStatusCode.OK) { Content = new StringContent("test") };
+            });
+
+        var settings = new RefitSettings
+        {
+            UrlResolution = UrlResolutionMode.Rfc3986,
+            HttpMessageHandlerFactory = () => mockHttp,
+        };
+
+        var api = RestService.For<IRfcUrlResolutionApi>(baseAddress, settings);
+        _ = await call(api);
+        return captured;
+    }
+}

--- a/src/tests/Refit.Tests/XmlContentSerializerTests.cs
+++ b/src/tests/Refit.Tests/XmlContentSerializerTests.cs
@@ -161,7 +161,7 @@ public class XmlContentSerializerTests
 
         var readerOnly = new XmlReaderWriterSettings(readerSettings);
         var writerOnly = new XmlReaderWriterSettings(writerSettings);
-        var both = new XmlReaderWriterSettings(new XmlReaderSettings(), new XmlWriterSettings());
+        var both = new XmlReaderWriterSettings(new(), new());
 
         await Assert.That(readerOnly.ReaderSettings).IsSameReferenceAs(readerSettings);
         await Assert.That(readerOnly.ReaderSettings.Async).IsTrue();


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature, several additive, opt-in capabilities, plus one breaking default-behaviour change to the System.Text.Json serializer.

## What is the new behavior?

- **`IAsyncEnumerable<T>` response streaming.** Declare a method returning `IAsyncEnumerable<T>` and Refit reads the response with `ResponseHeadersRead` and yields items as they arrive. The frame format is auto-detected from the content type: `application/jsonl` / `application/x-ndjson` / `application/x-jsonlines` is read as JSON Lines, anything else as a single streamed JSON array. Backed by the new `IStreamingContentSerializer` capability (implemented by `SystemTextJsonContentSerializer`).
- **Opt-in RFC 3986 / `HttpClient`-style URL resolution.** `RefitSettings.UrlResolution = UrlResolutionMode.Rfc3986` combines the base address and relative path with `System.Uri` rules (a leading slash replaces the base path; no leading slash appends) and relaxes the leading-slash requirement. Defaults to `RefitLegacy`, so existing behaviour is unchanged.
- **Opt-in `RefitSettings.AllowUnmatchedRouteParameters`.** When set, a route placeholder with no matching argument is left in the URL verbatim (e.g. `{version:apiVersion}`) for a `DelegatingHandler` to rewrite, instead of throwing.
- **Fast-path JSON serialization for request bodies.** `RefitSettings.RequestBodySerialization` (`Buffered` or `Streamed`) serializes JSON bodies synchronously so the System.Text.Json source-generated fast-path engages, `Buffered` sends a `ByteArrayContent` with `Content-Length`, `Streamed` writes through a `Utf8JsonWriter` for large uploads. `SystemTextJsonContentSerializer.GetFastPathJsonSerializerOptions()` returns a fast-path-eligible options set (no converters, no `NumberHandling`).
- **Numbers can be read from JSON strings by default** (`NumberHandling = AllowReadingFromString`), so responses like `{"id":"123"}` bind to numeric members.
- Tests, BenchmarkDotNet benchmarks (including EventPipe CPU/alloc profiles) and README sections were added for all of the above.

## What is the current behavior?

Previously Refit had no streaming response support, always required leading-slash relative paths with Refit-style base-address joining, always threw on an unmatched route placeholder, always serialized request bodies asynchronously (which can never use the source-gen fast-path), and used strict number handling on the default serializer.

Closes #1299
Closes #1968
Closes #1803 (and consolidates #1358)
Closes #2022

## What might this PR break?

The default `System.Text.Json` serializer now reads numbers from JSON strings (`NumberHandling = AllowReadingFromString`). Writing is unchanged. Opt back out with:

```csharp
var options = SystemTextJsonContentSerializer.GetDefaultJsonSerializerOptions();
options.NumberHandling = JsonNumberHandling.Strict;
var settings = new RefitSettings(new SystemTextJsonContentSerializer(options));
```

Everything else is additive and opt-in (defaults preserve current behaviour).

## Checklist
- [x] I have read the [Contribute guide](https://www.reactiveui.net/contribute/index.html)
- [x] Tests have been added or updated (for bug fixes / features)
- [x] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the `main` branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional information

Why these approaches:

- **`IAsyncEnumerable<T>` is generated inline, with no reflection on the hot path.** The generator emits a direct `GeneratedRequestRunner.StreamAsync<T>` call with the request constructed in source (new `ReturnTypeInfo.AsyncEnumerable`), the same approach used for `Task<T>`. The reflection request-builder remains only as the fallback for shapes that cannot be generated inline (dynamic routes, body/query objects, generic methods). This keeps allocations and dispatch cost minimal for streaming, which is the whole point of the feature.
- **Streaming format is auto-detected** rather than configured, so it "just works" for both standard JSON arrays and JSON Lines APIs. Per-TFM, .NET 9+ uses `DeserializeAsyncEnumerable(topLevelValues: true)` for JSON Lines; older TFMs use a pooled UTF-8 line reader.
- **The fast-path is synchronous-only.** We verified empirically (including on .NET 9) that `SerializeAsync(Stream)` and `SerializeAsync(PipeWriter)` both use the metadata path; only the synchronous primitives (`SerializeToUtf8Bytes`, `Serialize(Utf8JsonWriter)`) hit the generated fast-path. Refit's default `JsonContent` uses `SerializeAsync(Stream)`, so it can never use the fast-path, hence the opt-in `Buffered`/`Streamed` modes and the converter-free `GetFastPathJsonSerializerOptions()` (Refit's default converters and `NumberHandling` also disable the fast-path). A benchmark shows the fast-path is roughly 1.8x to 2x faster than the default path.
- **A single `RequestBodySerializationMode` enum** rather than stacked booleans, because the three states (async default, sync buffered, sync streamed) are mutually exclusive.
- **RFC resolution and unmatched route parameters are opt-in enums/flags** so existing consumers are unaffected; the URL joining was centralized into one helper used by both the reflection and generated request paths.
- New public API is added to `PublicAPI.Shipped.txt` (the project ships continuously).
