### PR TITLE
feat: add IsSuccessfulWithContent and correct IApiResponse nullable annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1562,11 +1562,26 @@ if (response.IsReceived)
 }
 ```
 
-`HasContent` is the covariance-safe way to access `Content` with null-state flow analysis — when it is `true` the
-compiler knows `Content` is non-null:
+A successful response does **not** imply a response body. Per [RFC 9110](https://www.rfc-editor.org/rfc/rfc9110.html) a
+204 (No Content), a 304 (Not Modified), a response to `HEAD`, or any 2xx with a zero-length or literal `null` body
+deserializes to `Content == null` *without* an error — so `IsSuccessful` / `IsSuccessStatusCode` being `true` tells you
+the request succeeded, not that `Content` is present. Use one of the content-presence members below when you need the
+deserialized body:
+
+* `HasContent` — the covariance-safe way to null-check `Content` on its own; when `true` the compiler knows `Content` is
+  non-null.
+* `IsSuccessfulWithContent` — a single check that combines success **and** content presence (`IsSuccessful && Content is
+  not null`); when `true` the compiler knows `Content` is non-null.
 
 ```csharp
 if (response.HasContent)
+{
+    // response.Content is non-null here
+    Process(response.Content);
+}
+
+// Or, when you want "succeeded and has a body" in one narrowing check:
+if (response.IsSuccessfulWithContent)
 {
     // response.Content is non-null here
     Process(response.Content);
@@ -1940,7 +1955,9 @@ else
 > [!NOTE]
 > The `IsSuccessful` property checks whether the response status code is in the range 200-299 and there wasn't any other
 > error (for example, during content deserialization). If you just want to check the HTTP response status code, you can
-> use the `IsSuccessStatusCode` property.
+> use the `IsSuccessStatusCode` property. Neither property implies a non-null `Content` — a successful response can have
+> no body (e.g. 204 No Content or a literal `null` body). Use `HasContent` or `IsSuccessfulWithContent` when you need the
+> deserialized `Content` to be present.
 
 #### When returning `Task<T>`
 

--- a/src/Refit.slnx
+++ b/src/Refit.slnx
@@ -37,6 +37,7 @@
         <Project Path="tests/Refit.CodeFixes.Tests/Refit.CodeFixes.Tests.csproj" />
         <Project Path="tests/Refit.GeneratedCode.TestModels/Refit.GeneratedCode.TestModels.csproj" />
         <Project Path="tests/Refit.GeneratorTests/Refit.GeneratorTests.csproj" />
+        <Project Path="tests/Refit.MockInterop.Tests/Refit.MockInterop.Tests.csproj" />
         <Project Path="tests/Refit.Newtonsoft.Json.Tests/Refit.Newtonsoft.Json.Tests.csproj" />
         <Project Path="tests/Refit.Tests/Refit.Tests.csproj" />
     </Folder>

--- a/src/Refit/ApiResponse{T}.cs
+++ b/src/Refit/ApiResponse{T}.cs
@@ -70,6 +70,10 @@ public sealed class ApiResponse<T>(
     [MemberNotNullWhen(true, nameof(Content))]
     public bool HasContent => Content is not null;
 
+    /// <summary>Gets a value indicating whether the request was successful and deserialized <see cref="Content"/> is available.</summary>
+    [MemberNotNullWhen(true, nameof(Content))]
+    public bool IsSuccessfulWithContent => IsSuccessful && Content is not null;
+
     /// <summary>Gets the Refit settings used to send the request.</summary>
     public RefitSettings Settings { get; } = settings;
 
@@ -79,32 +83,22 @@ public sealed class ApiResponse<T>(
     /// <summary>Gets the HTTP response content headers as defined in RFC 2616.</summary>
     public HttpContentHeaders? ContentHeaders => response?.Content?.Headers;
 
-    /// <summary>Gets a value indicating whether the request was successful.</summary>
+    /// <inheritdoc />
     [MemberNotNullWhen(true, nameof(Headers))]
-    [MemberNotNullWhen(true, nameof(ContentHeaders))]
     [MemberNotNullWhen(true, nameof(StatusCode))]
     [MemberNotNullWhen(true, nameof(Version))]
-    [MemberNotNullWhen(false, nameof(Error))]
     public bool IsSuccessStatusCode => response?.IsSuccessStatusCode ?? false;
 
-    /// <summary>
-    /// Gets a value indicating whether the request was successful and there wasn't any other error (for example, during content deserialization).
-    /// </summary>
+    /// <inheritdoc />
     [MemberNotNullWhen(true, nameof(Headers))]
-    [MemberNotNullWhen(true, nameof(Content))]
-    [MemberNotNullWhen(true, nameof(ContentHeaders))]
     [MemberNotNullWhen(true, nameof(StatusCode))]
     [MemberNotNullWhen(true, nameof(Version))]
-    [MemberNotNullWhen(false, nameof(Error))]
     public bool IsSuccessful => IsSuccessStatusCode && Error is null;
 
     /// <inheritdoc />
     [MemberNotNullWhen(true, nameof(Headers))]
-    [MemberNotNullWhen(true, nameof(Content))]
-    [MemberNotNullWhen(true, nameof(ContentHeaders))]
     [MemberNotNullWhen(true, nameof(StatusCode))]
     [MemberNotNullWhen(true, nameof(Version))]
-    [MemberNotNullWhen(false, nameof(Error))]
     public bool IsReceived => response is not null;
 
     /// <summary>Gets the reason phrase which typically is sent by the server together with the status code.</summary>

--- a/src/Refit/ApiResponse{T}.cs
+++ b/src/Refit/ApiResponse{T}.cs
@@ -72,7 +72,7 @@ public sealed class ApiResponse<T>(
 
     /// <summary>Gets a value indicating whether the request was successful and deserialized <see cref="Content"/> is available.</summary>
     [MemberNotNullWhen(true, nameof(Content))]
-    public bool IsSuccessfulWithContent => IsSuccessful && Content is not null;
+    public bool IsSuccessfulWithContent => IsSuccessful && HasContent;
 
     /// <summary>Gets the Refit settings used to send the request.</summary>
     public RefitSettings Settings { get; } = settings;

--- a/src/Refit/IApiResponse.cs
+++ b/src/Refit/IApiResponse.cs
@@ -17,29 +17,36 @@ public interface IApiResponse : IDisposable
     HttpContentHeaders? ContentHeaders { get; }
 
     /// <summary>Gets a value indicating whether the request was successful.</summary>
+    /// <remarks>
+    /// A successful status code does not imply a response body. Per RFC 9110 a 204 (No Content),
+    /// a 304 (Not Modified), a response to HEAD, or any 2xx with zero-length content carries no
+    /// content, so this intentionally does not narrow <see cref="ContentHeaders"/>. Use
+    /// <see cref="IApiResponse{T}.IsSuccessfulWithContent"/> or <see cref="IApiResponse{T}.HasContent"/>
+    /// when you need deserialized content.
+    /// </remarks>
     [MemberNotNullWhen(true, nameof(Headers))]
-    [MemberNotNullWhen(true, nameof(ContentHeaders))]
     [MemberNotNullWhen(true, nameof(StatusCode))]
     [MemberNotNullWhen(true, nameof(Version))]
-    [MemberNotNullWhen(false, nameof(Error))]
     bool IsSuccessStatusCode { get; }
 
     /// <summary>
     /// Gets a value indicating whether the request was successful and there wasn't any other error (for example, during content deserialization).
     /// </summary>
+    /// <remarks>
+    /// "No error" is not "has content": a 2xx with a <c>null</c> or empty body deserializes to
+    /// <c>null</c> without an error, so this does not narrow content. Use
+    /// <see cref="IApiResponse{T}.IsSuccessfulWithContent"/> or <see cref="IApiResponse{T}.HasContent"/>
+    /// when you need deserialized content.
+    /// </remarks>
     [MemberNotNullWhen(true, nameof(Headers))]
-    [MemberNotNullWhen(true, nameof(ContentHeaders))]
     [MemberNotNullWhen(true, nameof(StatusCode))]
     [MemberNotNullWhen(true, nameof(Version))]
-    [MemberNotNullWhen(false, nameof(Error))]
     bool IsSuccessful { get; }
 
     /// <summary>Gets a value indicating whether a response was received from the server.</summary>
     [MemberNotNullWhen(true, nameof(Headers))]
-    [MemberNotNullWhen(true, nameof(ContentHeaders))]
     [MemberNotNullWhen(true, nameof(StatusCode))]
     [MemberNotNullWhen(true, nameof(Version))]
-    [MemberNotNullWhen(false, nameof(Error))]
     bool IsReceived { get; }
 
     /// <summary>Gets the HTTP response status code.</summary>
@@ -57,6 +64,9 @@ public interface IApiResponse : IDisposable
     /// <summary>Gets the exception object in case of unsuccessful request or response.</summary>
     /// <remarks>
     /// <see cref="HasRequestError"/> and <see cref="HasResponseError"/> methods can be used to check the type of error.
+    /// An unsuccessful response is not guaranteed to carry an error (for example, a non-2xx response
+    /// constructed without one), so a failed state does not narrow this to non-null. Null-check it, or
+    /// use <see cref="HasRequestError"/> / <see cref="HasResponseError"/> for null-safe typed access.
     /// </remarks>
     [SuppressMessage(
         "Naming",

--- a/src/Refit/IApiResponse{T}.cs
+++ b/src/Refit/IApiResponse{T}.cs
@@ -21,4 +21,15 @@ public interface IApiResponse<out T> : IApiResponse
     /// </remarks>
     [MemberNotNullWhen(true, nameof(Content))]
     bool HasContent { get; }
+
+    /// <summary>Gets a value indicating whether the request was successful and deserialized <see cref="Content"/> is available.</summary>
+    /// <remarks>
+    /// This restores single-check content narrowing — <c>if (response.IsSuccessfulWithContent) { /* response.Content is non-null */ }</c>
+    /// — that <see cref="IApiResponse.IsSuccessful"/> can no longer promise (a successful response may
+    /// carry no body). It is a brand-new generic-only member rather than a <c>new</c> shadow of a base
+    /// member, so it references <see cref="Content"/> directly and behaves correctly through mocks and
+    /// explicit interface implementations.
+    /// </remarks>
+    [MemberNotNullWhen(true, nameof(Content))]
+    bool IsSuccessfulWithContent { get; }
 }

--- a/src/Refit/PublicAPI/net10.0/PublicAPI.Shipped.txt
+++ b/src/Refit/PublicAPI/net10.0/PublicAPI.Shipped.txt
@@ -64,6 +64,7 @@ Refit.ApiResponse<T>.HasResponseError(out Refit.ApiException? error) -> bool
 Refit.ApiResponse<T>.Headers.get -> System.Net.Http.Headers.HttpResponseHeaders?
 Refit.ApiResponse<T>.IsReceived.get -> bool
 Refit.ApiResponse<T>.IsSuccessful.get -> bool
+Refit.ApiResponse<T>.IsSuccessfulWithContent.get -> bool
 Refit.ApiResponse<T>.IsSuccessStatusCode.get -> bool
 Refit.ApiResponse<T>.ReasonPhrase.get -> string?
 Refit.ApiResponse<T>.RequestMessage.get -> System.Net.Http.HttpRequestMessage!
@@ -149,6 +150,7 @@ Refit.IApiResponse.StatusCode.get -> System.Net.HttpStatusCode?
 Refit.IApiResponse<T>
 Refit.IApiResponse<T>.Content.get -> T?
 Refit.IApiResponse<T>.HasContent.get -> bool
+Refit.IApiResponse<T>.IsSuccessfulWithContent.get -> bool
 Refit.IApiResponse.Version.get -> System.Version?
 Refit.IFormUrlEncodedParameterFormatter
 Refit.IFormUrlEncodedParameterFormatter.Format(object? value, string? formatString) -> string?

--- a/src/Refit/PublicAPI/net11.0/PublicAPI.Shipped.txt
+++ b/src/Refit/PublicAPI/net11.0/PublicAPI.Shipped.txt
@@ -64,6 +64,7 @@ Refit.ApiResponse<T>.HasResponseError(out Refit.ApiException? error) -> bool
 Refit.ApiResponse<T>.Headers.get -> System.Net.Http.Headers.HttpResponseHeaders?
 Refit.ApiResponse<T>.IsReceived.get -> bool
 Refit.ApiResponse<T>.IsSuccessful.get -> bool
+Refit.ApiResponse<T>.IsSuccessfulWithContent.get -> bool
 Refit.ApiResponse<T>.IsSuccessStatusCode.get -> bool
 Refit.ApiResponse<T>.ReasonPhrase.get -> string?
 Refit.ApiResponse<T>.RequestMessage.get -> System.Net.Http.HttpRequestMessage!
@@ -149,6 +150,7 @@ Refit.IApiResponse.StatusCode.get -> System.Net.HttpStatusCode?
 Refit.IApiResponse<T>
 Refit.IApiResponse<T>.Content.get -> T?
 Refit.IApiResponse<T>.HasContent.get -> bool
+Refit.IApiResponse<T>.IsSuccessfulWithContent.get -> bool
 Refit.IApiResponse.Version.get -> System.Version?
 Refit.IFormUrlEncodedParameterFormatter
 Refit.IFormUrlEncodedParameterFormatter.Format(object? value, string? formatString) -> string?

--- a/src/Refit/PublicAPI/net462/PublicAPI.Shipped.txt
+++ b/src/Refit/PublicAPI/net462/PublicAPI.Shipped.txt
@@ -64,6 +64,7 @@ Refit.ApiResponse<T>.HasResponseError(out Refit.ApiException? error) -> bool
 Refit.ApiResponse<T>.Headers.get -> System.Net.Http.Headers.HttpResponseHeaders?
 Refit.ApiResponse<T>.IsReceived.get -> bool
 Refit.ApiResponse<T>.IsSuccessful.get -> bool
+Refit.ApiResponse<T>.IsSuccessfulWithContent.get -> bool
 Refit.ApiResponse<T>.IsSuccessStatusCode.get -> bool
 Refit.ApiResponse<T>.ReasonPhrase.get -> string?
 Refit.ApiResponse<T>.RequestMessage.get -> System.Net.Http.HttpRequestMessage!
@@ -149,6 +150,7 @@ Refit.IApiResponse.StatusCode.get -> System.Net.HttpStatusCode?
 Refit.IApiResponse<T>
 Refit.IApiResponse<T>.Content.get -> T?
 Refit.IApiResponse<T>.HasContent.get -> bool
+Refit.IApiResponse<T>.IsSuccessfulWithContent.get -> bool
 Refit.IApiResponse.Version.get -> System.Version?
 Refit.IFormUrlEncodedParameterFormatter
 Refit.IFormUrlEncodedParameterFormatter.Format(object? value, string? formatString) -> string?

--- a/src/Refit/PublicAPI/net470/PublicAPI.Shipped.txt
+++ b/src/Refit/PublicAPI/net470/PublicAPI.Shipped.txt
@@ -64,6 +64,7 @@ Refit.ApiResponse<T>.HasResponseError(out Refit.ApiException? error) -> bool
 Refit.ApiResponse<T>.Headers.get -> System.Net.Http.Headers.HttpResponseHeaders?
 Refit.ApiResponse<T>.IsReceived.get -> bool
 Refit.ApiResponse<T>.IsSuccessful.get -> bool
+Refit.ApiResponse<T>.IsSuccessfulWithContent.get -> bool
 Refit.ApiResponse<T>.IsSuccessStatusCode.get -> bool
 Refit.ApiResponse<T>.ReasonPhrase.get -> string?
 Refit.ApiResponse<T>.RequestMessage.get -> System.Net.Http.HttpRequestMessage!
@@ -149,6 +150,7 @@ Refit.IApiResponse.StatusCode.get -> System.Net.HttpStatusCode?
 Refit.IApiResponse<T>
 Refit.IApiResponse<T>.Content.get -> T?
 Refit.IApiResponse<T>.HasContent.get -> bool
+Refit.IApiResponse<T>.IsSuccessfulWithContent.get -> bool
 Refit.IApiResponse.Version.get -> System.Version?
 Refit.IFormUrlEncodedParameterFormatter
 Refit.IFormUrlEncodedParameterFormatter.Format(object? value, string? formatString) -> string?

--- a/src/Refit/PublicAPI/net471/PublicAPI.Shipped.txt
+++ b/src/Refit/PublicAPI/net471/PublicAPI.Shipped.txt
@@ -64,6 +64,7 @@ Refit.ApiResponse<T>.HasResponseError(out Refit.ApiException? error) -> bool
 Refit.ApiResponse<T>.Headers.get -> System.Net.Http.Headers.HttpResponseHeaders?
 Refit.ApiResponse<T>.IsReceived.get -> bool
 Refit.ApiResponse<T>.IsSuccessful.get -> bool
+Refit.ApiResponse<T>.IsSuccessfulWithContent.get -> bool
 Refit.ApiResponse<T>.IsSuccessStatusCode.get -> bool
 Refit.ApiResponse<T>.ReasonPhrase.get -> string?
 Refit.ApiResponse<T>.RequestMessage.get -> System.Net.Http.HttpRequestMessage!
@@ -149,6 +150,7 @@ Refit.IApiResponse.StatusCode.get -> System.Net.HttpStatusCode?
 Refit.IApiResponse<T>
 Refit.IApiResponse<T>.Content.get -> T?
 Refit.IApiResponse<T>.HasContent.get -> bool
+Refit.IApiResponse<T>.IsSuccessfulWithContent.get -> bool
 Refit.IApiResponse.Version.get -> System.Version?
 Refit.IFormUrlEncodedParameterFormatter
 Refit.IFormUrlEncodedParameterFormatter.Format(object? value, string? formatString) -> string?

--- a/src/Refit/PublicAPI/net472/PublicAPI.Shipped.txt
+++ b/src/Refit/PublicAPI/net472/PublicAPI.Shipped.txt
@@ -64,6 +64,7 @@ Refit.ApiResponse<T>.HasResponseError(out Refit.ApiException? error) -> bool
 Refit.ApiResponse<T>.Headers.get -> System.Net.Http.Headers.HttpResponseHeaders?
 Refit.ApiResponse<T>.IsReceived.get -> bool
 Refit.ApiResponse<T>.IsSuccessful.get -> bool
+Refit.ApiResponse<T>.IsSuccessfulWithContent.get -> bool
 Refit.ApiResponse<T>.IsSuccessStatusCode.get -> bool
 Refit.ApiResponse<T>.ReasonPhrase.get -> string?
 Refit.ApiResponse<T>.RequestMessage.get -> System.Net.Http.HttpRequestMessage!
@@ -149,6 +150,7 @@ Refit.IApiResponse.StatusCode.get -> System.Net.HttpStatusCode?
 Refit.IApiResponse<T>
 Refit.IApiResponse<T>.Content.get -> T?
 Refit.IApiResponse<T>.HasContent.get -> bool
+Refit.IApiResponse<T>.IsSuccessfulWithContent.get -> bool
 Refit.IApiResponse.Version.get -> System.Version?
 Refit.IFormUrlEncodedParameterFormatter
 Refit.IFormUrlEncodedParameterFormatter.Format(object? value, string? formatString) -> string?

--- a/src/Refit/PublicAPI/net48/PublicAPI.Shipped.txt
+++ b/src/Refit/PublicAPI/net48/PublicAPI.Shipped.txt
@@ -64,6 +64,7 @@ Refit.ApiResponse<T>.HasResponseError(out Refit.ApiException? error) -> bool
 Refit.ApiResponse<T>.Headers.get -> System.Net.Http.Headers.HttpResponseHeaders?
 Refit.ApiResponse<T>.IsReceived.get -> bool
 Refit.ApiResponse<T>.IsSuccessful.get -> bool
+Refit.ApiResponse<T>.IsSuccessfulWithContent.get -> bool
 Refit.ApiResponse<T>.IsSuccessStatusCode.get -> bool
 Refit.ApiResponse<T>.ReasonPhrase.get -> string?
 Refit.ApiResponse<T>.RequestMessage.get -> System.Net.Http.HttpRequestMessage!
@@ -149,6 +150,7 @@ Refit.IApiResponse.StatusCode.get -> System.Net.HttpStatusCode?
 Refit.IApiResponse<T>
 Refit.IApiResponse<T>.Content.get -> T?
 Refit.IApiResponse<T>.HasContent.get -> bool
+Refit.IApiResponse<T>.IsSuccessfulWithContent.get -> bool
 Refit.IApiResponse.Version.get -> System.Version?
 Refit.IFormUrlEncodedParameterFormatter
 Refit.IFormUrlEncodedParameterFormatter.Format(object? value, string? formatString) -> string?

--- a/src/Refit/PublicAPI/net481/PublicAPI.Shipped.txt
+++ b/src/Refit/PublicAPI/net481/PublicAPI.Shipped.txt
@@ -64,6 +64,7 @@ Refit.ApiResponse<T>.HasResponseError(out Refit.ApiException? error) -> bool
 Refit.ApiResponse<T>.Headers.get -> System.Net.Http.Headers.HttpResponseHeaders?
 Refit.ApiResponse<T>.IsReceived.get -> bool
 Refit.ApiResponse<T>.IsSuccessful.get -> bool
+Refit.ApiResponse<T>.IsSuccessfulWithContent.get -> bool
 Refit.ApiResponse<T>.IsSuccessStatusCode.get -> bool
 Refit.ApiResponse<T>.ReasonPhrase.get -> string?
 Refit.ApiResponse<T>.RequestMessage.get -> System.Net.Http.HttpRequestMessage!
@@ -149,6 +150,7 @@ Refit.IApiResponse.StatusCode.get -> System.Net.HttpStatusCode?
 Refit.IApiResponse<T>
 Refit.IApiResponse<T>.Content.get -> T?
 Refit.IApiResponse<T>.HasContent.get -> bool
+Refit.IApiResponse<T>.IsSuccessfulWithContent.get -> bool
 Refit.IApiResponse.Version.get -> System.Version?
 Refit.IFormUrlEncodedParameterFormatter
 Refit.IFormUrlEncodedParameterFormatter.Format(object? value, string? formatString) -> string?

--- a/src/Refit/PublicAPI/net8.0/PublicAPI.Shipped.txt
+++ b/src/Refit/PublicAPI/net8.0/PublicAPI.Shipped.txt
@@ -64,6 +64,7 @@ Refit.ApiResponse<T>.HasResponseError(out Refit.ApiException? error) -> bool
 Refit.ApiResponse<T>.Headers.get -> System.Net.Http.Headers.HttpResponseHeaders?
 Refit.ApiResponse<T>.IsReceived.get -> bool
 Refit.ApiResponse<T>.IsSuccessful.get -> bool
+Refit.ApiResponse<T>.IsSuccessfulWithContent.get -> bool
 Refit.ApiResponse<T>.IsSuccessStatusCode.get -> bool
 Refit.ApiResponse<T>.ReasonPhrase.get -> string?
 Refit.ApiResponse<T>.RequestMessage.get -> System.Net.Http.HttpRequestMessage!
@@ -149,6 +150,7 @@ Refit.IApiResponse.StatusCode.get -> System.Net.HttpStatusCode?
 Refit.IApiResponse<T>
 Refit.IApiResponse<T>.Content.get -> T?
 Refit.IApiResponse<T>.HasContent.get -> bool
+Refit.IApiResponse<T>.IsSuccessfulWithContent.get -> bool
 Refit.IApiResponse.Version.get -> System.Version?
 Refit.IFormUrlEncodedParameterFormatter
 Refit.IFormUrlEncodedParameterFormatter.Format(object? value, string? formatString) -> string?

--- a/src/Refit/PublicAPI/net9.0/PublicAPI.Shipped.txt
+++ b/src/Refit/PublicAPI/net9.0/PublicAPI.Shipped.txt
@@ -64,6 +64,7 @@ Refit.ApiResponse<T>.HasResponseError(out Refit.ApiException? error) -> bool
 Refit.ApiResponse<T>.Headers.get -> System.Net.Http.Headers.HttpResponseHeaders?
 Refit.ApiResponse<T>.IsReceived.get -> bool
 Refit.ApiResponse<T>.IsSuccessful.get -> bool
+Refit.ApiResponse<T>.IsSuccessfulWithContent.get -> bool
 Refit.ApiResponse<T>.IsSuccessStatusCode.get -> bool
 Refit.ApiResponse<T>.ReasonPhrase.get -> string?
 Refit.ApiResponse<T>.RequestMessage.get -> System.Net.Http.HttpRequestMessage!
@@ -149,6 +150,7 @@ Refit.IApiResponse.StatusCode.get -> System.Net.HttpStatusCode?
 Refit.IApiResponse<T>
 Refit.IApiResponse<T>.Content.get -> T?
 Refit.IApiResponse<T>.HasContent.get -> bool
+Refit.IApiResponse<T>.IsSuccessfulWithContent.get -> bool
 Refit.IApiResponse.Version.get -> System.Version?
 Refit.IFormUrlEncodedParameterFormatter
 Refit.IFormUrlEncodedParameterFormatter.Format(object? value, string? formatString) -> string?

--- a/src/tests/Refit.MockInterop.Tests/ApiResponseMockInteropTests.cs
+++ b/src/tests/Refit.MockInterop.Tests/ApiResponseMockInteropTests.cs
@@ -1,0 +1,205 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Net;
+using System.Net.Http.Headers;
+
+using Moq;
+
+namespace Refit.MockInterop.Tests;
+
+/// <summary>
+/// Moq-based interop tests for <see cref="IApiResponse{T}"/>. These pin the proxy behaviour the
+/// concrete <see cref="ApiResponse{T}"/> cannot exercise: that the generic interface does not
+/// <c>new</c>-shadow base members (regression for #1933), and that the additive
+/// <see cref="IApiResponse{T}.IsSuccessfulWithContent"/> narrows <see cref="IApiResponse{T}.Content"/>
+/// correctly through a mock. Moq lives only in this isolated interop project.
+/// </summary>
+public sealed class ApiResponseMockInteropTests
+{
+    /// <summary>
+    /// Verifies a single setup of <see cref="IApiResponse.IsSuccessful"/> on the generic mock is
+    /// observed through the non-generic <see cref="IApiResponse"/> view. A <c>new</c> shadow would
+    /// split the member into two interface slots and return <c>default</c> through the base (#1933).
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task GenericSetupIsObservedThroughBaseInterfaceForIsSuccessful()
+    {
+        var mock = new Mock<IApiResponse<string>>();
+        _ = mock.SetupGet(x => x.IsSuccessful).Returns(true);
+
+        await Assert.That(mock.Object.IsSuccessful).IsTrue();
+
+        IApiResponse baseView = mock.Object;
+        await Assert.That(baseView.IsSuccessful).IsTrue();
+    }
+
+    /// <summary>
+    /// Verifies the same no-shadow contract for the other base members that used to be redeclared
+    /// with <c>new</c>: a setup through the generic mock is seen through the non-generic interface.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task GenericSetupIsObservedThroughBaseInterfaceForStatusAndReceived()
+    {
+        var mock = new Mock<IApiResponse<string>>();
+        _ = mock.SetupGet(x => x.IsSuccessStatusCode).Returns(true);
+        _ = mock.SetupGet(x => x.IsReceived).Returns(true);
+
+        IApiResponse baseView = mock.Object;
+        await Assert.That(baseView.IsSuccessStatusCode).IsTrue();
+        await Assert.That(baseView.IsReceived).IsTrue();
+    }
+
+    /// <summary>
+    /// Verifies a single setup of <see cref="IApiResponse{T}.Content"/> on the generic mock is
+    /// observed through the generic interface (the covariance-safe declaration carries the value).
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task GenericContentSetupIsObserved()
+    {
+        var mock = new Mock<IApiResponse<string>>();
+        _ = mock.SetupGet(x => x.Content).Returns("payload");
+
+        await Assert.That(mock.Object.Content).IsEqualTo("payload");
+    }
+
+    /// <summary>
+    /// Verifies <see cref="IApiResponse{T}.IsSuccessfulWithContent"/> narrows
+    /// <see cref="IApiResponse{T}.Content"/> through a mock: inside the <c>true</c> branch the
+    /// compiler treats <c>Content</c> as non-null (no null-forgiving operator is used below).
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task IsSuccessfulWithContentNarrowsContentThroughMock()
+    {
+        var mock = new Mock<IApiResponse<string>>();
+        _ = mock.SetupGet(x => x.IsSuccessfulWithContent).Returns(true);
+        _ = mock.SetupGet(x => x.Content).Returns("hello");
+
+        var response = mock.Object;
+
+        await Assert.That(response.IsSuccessfulWithContent).IsTrue();
+        if (response.IsSuccessfulWithContent)
+        {
+            // MemberNotNullWhen(true, nameof(Content)) flows here: Content is non-null without `!`.
+            await Assert.That(response.Content.Length).IsEqualTo(5);
+        }
+        else
+        {
+            Assert.Fail("IsSuccessfulWithContent should have been true.");
+        }
+    }
+
+    /// <summary>
+    /// Verifies a mocked <see cref="IApiResponse{T}.IsSuccessfulWithContent"/> returns its configured
+    /// value through the generic view, with no leakage from an unrelated base-member setup.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task IsSuccessfulWithContentIsIndependentlyMockable()
+    {
+        var mock = new Mock<IApiResponse<string>>();
+        _ = mock.SetupGet(x => x.IsSuccessful).Returns(true);
+        _ = mock.SetupGet(x => x.IsSuccessfulWithContent).Returns(false);
+
+        await Assert.That(mock.Object.IsSuccessful).IsTrue();
+        await Assert.That(mock.Object.IsSuccessfulWithContent).IsFalse();
+    }
+
+    /// <summary>Verifies HasContent narrows Content to non-null through a mock.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task HasContentNarrowsContentThroughMock()
+    {
+        var mock = new Mock<IApiResponse<string>>();
+        _ = mock.SetupGet(x => x.HasContent).Returns(true);
+        _ = mock.SetupGet(x => x.Content).Returns("data");
+
+        var response = mock.Object;
+
+        if (response.HasContent)
+        {
+            // MemberNotNullWhen(true, nameof(Content)) flows here: Content is non-null without `!`.
+            await Assert.That(response.Content.Length).IsEqualTo(4);
+        }
+        else
+        {
+            Assert.Fail("HasContent should have been true.");
+        }
+    }
+
+    /// <summary>
+    /// Verifies a successful response with no content headers is a representable interface state, which
+    /// is why <see cref="IApiResponse.IsSuccessStatusCode"/> no longer narrows
+    /// <see cref="IApiResponse.ContentHeaders"/>. A 204 (No Content), a HEAD response, or a .NET
+    /// Framework response whose <c>Content</c> was never set all produce success with null content headers.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task SuccessStatusCodeDoesNotImplyContentHeaders()
+    {
+        var mock = new Mock<IApiResponse<string>>();
+        _ = mock.SetupGet(x => x.IsSuccessStatusCode).Returns(true);
+        _ = mock.SetupGet(x => x.ContentHeaders).Returns((HttpContentHeaders?)null);
+
+        await Assert.That(mock.Object.IsSuccessStatusCode).IsTrue();
+        await Assert.That(mock.Object.ContentHeaders).IsNull();
+    }
+
+    /// <summary>
+    /// Regression for #1933: a method that takes the non-generic <see cref="IApiResponse"/> must observe
+    /// the <see cref="IApiResponse.StatusCode"/> / <see cref="IApiResponse.ContentHeaders"/> set up on a
+    /// mock of the generic <see cref="IApiResponse{T}"/>. The original <c>new</c>-shadow split those into
+    /// separate slots, so the base view read <c>null</c> and the problem-details check wrongly returned false.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task ProblemDetailsCheckSeesGenericSetupThroughBaseInterface()
+    {
+        var headers = new StringContent(string.Empty).Headers;
+        headers.ContentType = new("application/problem+json");
+
+        var mock = new Mock<IApiResponse<string>>();
+        _ = mock.SetupGet(x => x.IsSuccessStatusCode).Returns(false);
+        _ = mock.SetupGet(x => x.StatusCode).Returns(HttpStatusCode.UnprocessableEntity);
+        _ = mock.SetupGet(x => x.ContentHeaders).Returns(headers);
+
+        await Assert.That(IsProblemDetails(mock.Object)).IsTrue();
+    }
+
+    /// <summary>
+    /// Regression for #1949: reading <see cref="IApiResponse.Error"/> through the non-generic interface must
+    /// return the error set up on the generic mock. The <c>new</c>-shadow made <c>IApiResponse.Error</c> a
+    /// distinct, always-null slot, so a <c>Verify(IApiResponse r)</c> method never saw the captured error.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task ErrorIsObservedThroughBaseInterfaceFromGenericMock()
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, "https://example.test");
+        var error = new ApiRequestException("failed", request, HttpMethod.Get, new RefitSettings());
+
+        var mock = new Mock<IApiResponse<string>>();
+        _ = mock.SetupGet(x => x.Error).Returns(error);
+
+        // A `Verify(IApiResponse r)` method reads the error through the non-generic interface; the
+        // generic setup must be observed there (it was a distinct, always-null slot before the fix).
+        IApiResponse baseView = mock.Object;
+        await Assert.That(baseView.Error).IsSameReferenceAs(error);
+    }
+
+    /// <summary>Returns whether the response is an RFC 7807 problem-details payload, reading only the non-generic interface.</summary>
+    /// <param name="apiResponse">The response, viewed through the non-generic interface.</param>
+    /// <returns><c>true</c> when the response is a 422 with a problem-details content type.</returns>
+    private static bool IsProblemDetails(IApiResponse apiResponse)
+    {
+        var contentType = apiResponse.ContentHeaders?.ContentType?.MediaType;
+
+        return apiResponse.StatusCode == HttpStatusCode.UnprocessableEntity
+            && string.Equals(contentType, "application/problem+json", StringComparison.Ordinal);
+    }
+}

--- a/src/tests/Refit.MockInterop.Tests/Refit.MockInterop.Tests.csproj
+++ b/src/tests/Refit.MockInterop.Tests/Refit.MockInterop.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!-- Interop test project: isolates the Moq-based mock/proxy behaviour tests for IApiResponse<T>.
+       Moq is being removed from the main suites; these tests pin the proxy-interop contract
+       (the #1933 new-shadow regression and mock-safe narrowing) and are the only place Moq lives. -->
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>$(RefitTestTargets)</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Deterministic>false</Deterministic>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Versions are managed centrally in src/Directory.Packages.props. -->
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="TUnit" />
+    <ProjectReference Include="..\..\Refit\Refit.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/tests/Refit.Tests/ApiResponseTests.cs
+++ b/src/tests/Refit.Tests/ApiResponseTests.cs
@@ -228,6 +228,431 @@ public sealed class ApiResponseTests
             .ThrowsExactly<ApiException>();
     }
 
+    /// <summary>Verifies IsSuccessfulWithContent is true only when the request succeeded and content is present.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task IsSuccessfulWithContentReflectsSuccessAndContentPresence()
+    {
+        // Success + content -> true.
+        using var withContent = new ApiResponse<string>(CreateResponse(HttpStatusCode.OK, "x"), "body", new());
+        await Assert.That(withContent.IsSuccessful).IsTrue();
+        await Assert.That(withContent.IsSuccessfulWithContent).IsTrue();
+
+        // Success but no content (a 2xx with a null/empty body deserializes to null with no error)
+        // -> IsSuccessful stays true, but IsSuccessfulWithContent is false. This is the case the old
+        // IsSuccessful -> Content narrowing got wrong.
+        using var okNoContent = new ApiResponse<string>(CreateResponse(HttpStatusCode.OK, "x"), null, new());
+        await Assert.That(okNoContent.IsSuccessful).IsTrue();
+        await Assert.That(okNoContent.HasContent).IsFalse();
+        await Assert.That(okNoContent.IsSuccessfulWithContent).IsFalse();
+
+        // 2xx with a captured error (for example a deserialization failure on an otherwise-successful
+        // response) -> IsSuccessStatusCode stays true but IsSuccessful is false, so it is not
+        // successful-with-content. The error object models the deserialization failure.
+        using var okResponse = CreateResponse(HttpStatusCode.OK, "x");
+        using var failedResponse = CreateResponse(HttpStatusCode.BadRequest, "boom");
+        var deserError = await ApiException.Create(failedResponse.RequestMessage!, HttpMethod.Get, failedResponse, new());
+        using var okWithError = new ApiResponse<string>(okResponse, "body", new(), deserError);
+        await Assert.That(okWithError.IsSuccessStatusCode).IsTrue();
+        await Assert.That(okWithError.IsSuccessful).IsFalse();
+        await Assert.That(okWithError.IsSuccessfulWithContent).IsFalse();
+
+        // Non-success with content present -> not successful-with-content.
+        using var badWithContent = new ApiResponse<string>(CreateResponse(HttpStatusCode.BadRequest, "x"), "body", new());
+        await Assert.That(badWithContent.HasContent).IsTrue();
+        await Assert.That(badWithContent.IsSuccessfulWithContent).IsFalse();
+
+        // No response received -> not successful-with-content.
+        using var request = new HttpRequestMessage(HttpMethod.Get, "https://example.test");
+        using var noResponse = new ApiResponse<string>(request, null, "body", new());
+        await Assert.That(noResponse.IsSuccessfulWithContent).IsFalse();
+    }
+
+    /// <summary>
+    /// Verifies IsSuccessfulWithContent narrows Content through the covariant <see cref="IApiResponse{T}"/>
+    /// (the design relies on <c>out T</c>): an <see cref="IApiResponse{T}"/> of a more-derived type is used
+    /// as a less-derived one, and the narrowing still holds with no null-forgiving operator.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task IsSuccessfulWithContentNarrowsThroughCovariantInterface()
+    {
+        using var concrete = new ApiResponse<string>(CreateResponse(HttpStatusCode.OK, "x"), "hi", new());
+
+        // Passing ApiResponse<string> where IApiResponse<object> is expected exercises out-T covariance.
+        await AssertNarrows(concrete);
+
+        static async Task AssertNarrows(IApiResponse<object> covariant)
+        {
+            if (covariant.IsSuccessfulWithContent)
+            {
+                // Content (viewed as object) is non-null here without `!`.
+                await Assert.That(covariant.Content).IsEqualTo("hi");
+            }
+            else
+            {
+                Assert.Fail("IsSuccessfulWithContent should have been true.");
+            }
+        }
+    }
+
+    /// <summary>Verifies IsSuccessfulWithContent narrows Content to non-null inside its true branch.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task IsSuccessfulWithContentNarrowsContent()
+    {
+        using var response = new ApiResponse<string>(CreateResponse(HttpStatusCode.OK, "x"), "hello", new());
+
+        if (response.IsSuccessfulWithContent)
+        {
+            // MemberNotNullWhen(true, nameof(Content)) flows here: Content is non-null without `!`.
+            await Assert.That(response.Content.Length).IsEqualTo(5);
+        }
+        else
+        {
+            Assert.Fail("IsSuccessfulWithContent should have been true.");
+        }
+    }
+
+    /// <summary>Verifies HasContent narrows Content to non-null inside its true branch.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task HasContentNarrowsContent()
+    {
+        using var response = new ApiResponse<string>(CreateResponse(HttpStatusCode.OK, "x"), "world", new());
+
+        if (response.HasContent)
+        {
+            // MemberNotNullWhen(true, nameof(Content)) flows here: Content is non-null without `!`.
+            await Assert.That(response.Content.Length).IsEqualTo(5);
+        }
+        else
+        {
+            Assert.Fail("HasContent should have been true.");
+        }
+    }
+
+    /// <summary>
+    /// Verifies the surviving success-state annotations narrow at compile time: a successful response
+    /// guarantees the received-response metadata (Headers, StatusCode, Version) is non-null. The
+    /// property bodies below dereference each member with no null-forgiving operator, so this fails to
+    /// compile if any of those annotations are dropped.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task SuccessfulResponseNarrowsReceivedMetadata()
+    {
+        using var response = new ApiResponse<string>(CreateResponse(HttpStatusCode.OK, "x"), "body", new());
+
+        if (response.IsSuccessful)
+        {
+            // No `!` on any of these: the MemberNotNullWhen(true, ...) annotations narrow them.
+            await Assert.That(response.Headers.Contains("nonexistent-header")).IsFalse();
+            await Assert.That(response.StatusCode.Value).IsEqualTo(HttpStatusCode.OK);
+            await Assert.That(response.Version.Major).IsGreaterThanOrEqualTo(1);
+        }
+        else
+        {
+            Assert.Fail("IsSuccessful should have been true.");
+        }
+    }
+
+    /// <summary>
+    /// Verifies an unsuccessful response does not guarantee a non-null Error: a failure can carry a
+    /// captured error, or none at all (the audit removed MemberNotNullWhen(false, nameof(Error)) because
+    /// the two are independent). Refit itself falls back when an unsuccessful response has no error.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task UnsuccessfulResponseErrorIsNotGuaranteed()
+    {
+        // Failure WITH a captured error -> Error present.
+        using var badResponse = CreateResponse(HttpStatusCode.BadRequest, "boom");
+        var error = await ApiException.Create(badResponse.RequestMessage!, HttpMethod.Get, badResponse, new());
+        using var withError = new ApiResponse<string>(badResponse, null, new(), error);
+        await Assert.That(withError.IsSuccessful).IsFalse();
+        await Assert.That(withError.Error).IsNotNull();
+
+        // Failure WITHOUT a captured error -> Error is null even though the response is unsuccessful.
+        using var failureResponse = CreateResponse(HttpStatusCode.BadRequest, "boom");
+        using var withoutError = new ApiResponse<string>(failureResponse, null, new());
+        await Assert.That(withoutError.IsSuccessful).IsFalse();
+        await Assert.That(withoutError.IsSuccessStatusCode).IsFalse();
+        await Assert.That(withoutError.Error).IsNull();
+    }
+
+    /// <summary>Verifies a 204 No Content success carries no deserialized content (the issue headline case).</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task NoContentSuccessHasNoContent()
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, "https://example.test");
+        using var noContent = new HttpResponseMessage(HttpStatusCode.NoContent) { RequestMessage = request };
+        using var response = new ApiResponse<string>(noContent, null, new());
+
+        // 204 is a 2xx, so the call succeeded...
+        await Assert.That(response.IsSuccessStatusCode).IsTrue();
+        await Assert.That(response.IsSuccessful).IsTrue();
+
+        // ...but there is no deserialized content, so the content signals are false.
+        await Assert.That(response.HasContent).IsFalse();
+        await Assert.That(response.IsSuccessfulWithContent).IsFalse();
+    }
+
+    /// <summary>Verifies a successful response that does carry content reports content present (including a 204 with a body).</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task SuccessWithContentReportsContentPresent()
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, "https://example.test");
+        using var noContentWithBody = new HttpResponseMessage(HttpStatusCode.NoContent) { RequestMessage = request };
+        using var response = new ApiResponse<string>(noContentWithBody, "body", new());
+
+        await Assert.That(response.IsSuccessful).IsTrue();
+        await Assert.That(response.HasContent).IsTrue();
+        await Assert.That(response.IsSuccessfulWithContent).IsTrue();
+    }
+
+    /// <summary>Verifies a 304 Not Modified is not treated as a success status (it is outside the 2xx range).</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task NotModifiedIsNotSuccessStatusCode()
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, "https://example.test");
+        using var notModified = new HttpResponseMessage(HttpStatusCode.NotModified) { RequestMessage = request };
+        using var response = new ApiResponse<string>(notModified, null, new());
+
+        await Assert.That(response.IsSuccessStatusCode).IsFalse();
+        await Assert.That(response.IsSuccessful).IsFalse();
+        await Assert.That(response.IsReceived).IsTrue();
+        await Assert.That(response.IsSuccessfulWithContent).IsFalse();
+    }
+
+    /// <summary>Verifies a request error (no response received) is received-false with content-narrowing false.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task RequestErrorWithoutResponseIsNotReceived()
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, "https://example.test");
+        var requestError = new ApiRequestException("failed", request, HttpMethod.Get, new());
+        using var response = new ApiResponse<string>(request, null, "body", new(), requestError);
+
+        await Assert.That(response.IsReceived).IsFalse();
+        await Assert.That(response.IsSuccessStatusCode).IsFalse();
+        await Assert.That(response.IsSuccessful).IsFalse();
+        await Assert.That(response.Error).IsNotNull();
+
+        // Content was supplied but no response was received, so it is not successful-with-content.
+        await Assert.That(response.Content).IsEqualTo("body");
+        await Assert.That(response.HasContent).IsTrue();
+        await Assert.That(response.IsSuccessfulWithContent).IsFalse();
+    }
+
+    /// <summary>Verifies empty-but-non-null content counts as content: HasContent checks null, not emptiness.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task EmptyStringContentCountsAsContent()
+    {
+        using var response = new ApiResponse<string>(CreateResponse(HttpStatusCode.OK, "x"), string.Empty, new());
+
+        await Assert.That(response.HasContent).IsTrue();
+        await Assert.That(response.IsSuccessfulWithContent).IsTrue();
+        await Assert.That(response.Content).IsEqualTo(string.Empty);
+    }
+
+    /// <summary>Verifies a value-type body is always present (a value type is never null), so HasContent tracks success.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task ValueTypeContentIsAlwaysPresent()
+    {
+        using var success = new ApiResponse<int>(CreateResponse(HttpStatusCode.OK, "5"), 5, new());
+        await Assert.That(success.HasContent).IsTrue();
+        await Assert.That(success.IsSuccessfulWithContent).IsTrue();
+
+        // A default value (0) is still non-null for a value type, so content is reported present.
+        using var defaulted = new ApiResponse<int>(CreateResponse(HttpStatusCode.OK, "0"), 0, new());
+        await Assert.That(defaulted.HasContent).IsTrue();
+        await Assert.That(defaulted.IsSuccessfulWithContent).IsTrue();
+    }
+
+    /// <summary>Verifies a nullable value-type body tracks null state through the content signals.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task NullableValueTypeContentTracksNull()
+    {
+        using var present = new ApiResponse<int?>(CreateResponse(HttpStatusCode.OK, "7"), 7, new());
+        await Assert.That(present.HasContent).IsTrue();
+        await Assert.That(present.IsSuccessfulWithContent).IsTrue();
+
+        using var absent = new ApiResponse<int?>(CreateResponse(HttpStatusCode.OK, "x"), null, new());
+        await Assert.That(absent.IsSuccessful).IsTrue();
+        await Assert.That(absent.HasContent).IsFalse();
+        await Assert.That(absent.IsSuccessfulWithContent).IsFalse();
+    }
+
+    /// <summary>Verifies IsSuccessStatusCode narrows the received-response metadata to non-null.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task IsSuccessStatusCodeNarrowsReceivedMetadata()
+    {
+        using var response = new ApiResponse<string>(CreateResponse(HttpStatusCode.OK, "x"), "body", new());
+
+        if (response.IsSuccessStatusCode)
+        {
+            // No `!`: MemberNotNullWhen(true, ...) narrows Headers/StatusCode/Version here.
+            await Assert.That(response.Headers.Contains("nope")).IsFalse();
+            await Assert.That(response.StatusCode.Value).IsEqualTo(HttpStatusCode.OK);
+            await Assert.That(response.Version.Major).IsGreaterThanOrEqualTo(1);
+        }
+        else
+        {
+            Assert.Fail("IsSuccessStatusCode should have been true.");
+        }
+    }
+
+    /// <summary>Verifies IsReceived narrows the received-response metadata to non-null.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task IsReceivedNarrowsReceivedMetadata()
+    {
+        using var response = new ApiResponse<string>(CreateResponse(HttpStatusCode.BadRequest, "x"), null, new());
+
+        if (response.IsReceived)
+        {
+            // A received-but-unsuccessful response still guarantees the metadata is non-null.
+            await Assert.That(response.Headers.Contains("nope")).IsFalse();
+            await Assert.That(response.StatusCode.Value).IsEqualTo(HttpStatusCode.BadRequest);
+            await Assert.That(response.Version.Major).IsGreaterThanOrEqualTo(1);
+        }
+        else
+        {
+            Assert.Fail("IsReceived should have been true.");
+        }
+    }
+
+    /// <summary>Verifies content signals remain correct after the response is disposed.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task ContentSignalsSurviveDisposal()
+    {
+        var response = new ApiResponse<string>(CreateResponse(HttpStatusCode.OK, "x"), "kept", new());
+        response.Dispose();
+        response.Dispose();
+
+        await Assert.That(response.HasContent).IsTrue();
+        await Assert.That(response.IsSuccessfulWithContent).IsTrue();
+        await Assert.That(response.Content).IsEqualTo("kept");
+    }
+
+    /// <summary>
+    /// Verifies the reviewer's existing guard `if (!IsSuccessStatusCode || Content is null)` still compiles
+    /// and narrows Content in the success-with-content branch (#2155 feedback: existing code is unaffected).
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task StatusCodeOrNullContentGuardStillNarrows()
+    {
+        using var ok = new ApiResponse<string>(CreateResponse(HttpStatusCode.OK, "x"), "hello", new());
+        if (!ok.IsSuccessStatusCode || ok.Content is null)
+        {
+            Assert.Fail("Expected a successful response with content.");
+        }
+        else
+        {
+            // The explicit null check narrows Content here without `!`.
+            await Assert.That(ok.Content.Length).IsEqualTo(5);
+        }
+
+        // The same guard correctly rejects a successful response that has no content.
+        using var okNoContent = new ApiResponse<string>(CreateResponse(HttpStatusCode.OK, "x"), null, new());
+        await Assert.That(!okNoContent.IsSuccessStatusCode || okNoContent.Content is null).IsTrue();
+    }
+
+    /// <summary>
+    /// Verifies the reviewer's two-condition guard `if (!IsSuccessful || !HasContent)` works, and that the
+    /// new single-condition `IsSuccessfulWithContent` is exactly its negation (#2155 single-check request).
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task SuccessfulOrHasContentGuardEqualsIsSuccessfulWithContent()
+    {
+        using var ok = new ApiResponse<string>(CreateResponse(HttpStatusCode.OK, "x"), "hello", new());
+        if (!ok.IsSuccessful || !ok.HasContent)
+        {
+            Assert.Fail("Expected a successful response with content.");
+        }
+        else
+        {
+            await Assert.That(ok.Content.Length).IsEqualTo(5);
+        }
+
+        // The single-condition member equals the negation of the two-condition guard for every state.
+        foreach (var response in EnumerateResponseStates())
+        {
+            using (response)
+            {
+                var guardSaysHasIt = response is { IsSuccessful: true, HasContent: true };
+                await Assert.That(response.IsSuccessfulWithContent).IsEqualTo(guardSaysHasIt);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Verifies IsSuccessful and IsSuccessStatusCode are not duplicates (#2155 question): a 2xx with a
+    /// captured deserialization error is IsSuccessStatusCode-true but IsSuccessful-false.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task IsSuccessfulAndIsSuccessStatusCodeDifferOnError()
+    {
+        using var okResponse = CreateResponse(HttpStatusCode.OK, "x");
+        using var failureResponse = CreateResponse(HttpStatusCode.BadRequest, "boom");
+        var deserError = await ApiException.Create(failureResponse.RequestMessage!, HttpMethod.Get, failureResponse, new());
+        using var response = new ApiResponse<string>(okResponse, "body", new(), deserError);
+
+        await Assert.That(response.IsSuccessStatusCode).IsTrue();
+        await Assert.That(response.IsSuccessful).IsFalse();
+    }
+
+    /// <summary>
+    /// Regression for #1949: a captured error on a concrete <see cref="ApiResponse{T}"/> is visible after
+    /// casting to the non-generic <see cref="IApiResponse"/>, so a `Verify(IApiResponse r)` method sees it.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task ErrorIsVisibleThroughBaseInterfaceOnConcreteResponse()
+    {
+        using var badResponse = CreateResponse(HttpStatusCode.BadRequest, "boom");
+        var error = await ApiException.Create(badResponse.RequestMessage!, HttpMethod.Get, badResponse, new());
+        using var response = new ApiResponse<string>(badResponse, null, new(), error);
+
+        await Assert.That(((IApiResponse)response).Error).IsSameReferenceAs(error);
+        await Assert.That(((IApiResponse)response).StatusCode).IsEqualTo(HttpStatusCode.BadRequest);
+    }
+
+    /// <summary>Yields one constructed response per interesting state for exhaustive cross-checks.</summary>
+    /// <returns>The constructed responses; each must be disposed by the caller.</returns>
+    private static IEnumerable<ApiResponse<string>> EnumerateResponseStates()
+    {
+        // success + content
+        yield return new ApiResponse<string>(CreateResponse(HttpStatusCode.OK, "x"), "body", new());
+
+        // success + no content
+        yield return new ApiResponse<string>(CreateResponse(HttpStatusCode.OK, "x"), null, new());
+
+        // 204 + no content
+        yield return new ApiResponse<string>(CreateResponse(HttpStatusCode.NoContent, "x"), null, new());
+
+        // failure + content
+        yield return new ApiResponse<string>(CreateResponse(HttpStatusCode.BadRequest, "x"), "body", new());
+
+        // failure + no content
+        yield return new ApiResponse<string>(CreateResponse(HttpStatusCode.BadRequest, "x"), null, new());
+
+        // no response received + content
+        yield return new ApiResponse<string>(new(HttpMethod.Get, "https://example.test"), null, "body", new());
+    }
+
     /// <summary>Creates an HTTP response message with an attached request.</summary>
     /// <param name="statusCode">The response status code.</param>
     /// <param name="content">The response content.</param>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature + bug fix (nullable annotation correctness) + docs + tests.

## What is the new behavior?

At a high level: checking that a response "succeeded" no longer falsely promises that it has a body, and there is now a single, sound way to check for "succeeded **and** has content".

- Adds `IsSuccessfulWithContent` to `IApiResponse<T>` / `ApiResponse<T>`:
  - One condition (`IsSuccessful && Content is not null`) that narrows `Content` to non-null via `[MemberNotNullWhen]`, so `if (response.IsSuccessfulWithContent) { /* Content is non-null */ }` works in a single check.
  - It is a brand-new generic-only member (not a `new` shadow of a base member), so it behaves correctly through mocks, explicit interface implementations, and the covariant `IApiResponse<out T>`.
- Corrects the `[MemberNotNullWhen]` annotations on `IsSuccessStatusCode`, `IsSuccessful`, and `IsReceived`:
  - Removes the over-promising `Content` (true), `ContentHeaders` (true) and `Error` (false) narrowings, which the success/received state does not actually guarantee.
  - Keeps the sound `Headers`, `StatusCode`, and `Version` (true) narrowings.
  - The non-generic interface and the concrete implementation now carry identical annotation sets.
- `HasContent` remains the pure "is there a deserialized body?" signal; `IsSuccessfulWithContent` combines it with success.
- Documents on `Error` that a failed state does not imply a non-null error (null-check it, or use `HasRequestError` / `HasResponseError`).
- Updates the README to explain that success does not imply content, with `HasContent` / `IsSuccessfulWithContent` examples and an RFC 9110 note.

## What is the current behavior?

- There is no single-condition member that both confirms success and narrows `Content`; callers must write a two-part guard (e.g. `if (!response.IsSuccessful || !response.HasContent)`).
- `IsSuccessStatusCode` / `IsSuccessful` / `IsReceived` assert (via `[MemberNotNullWhen]`) that `Content`, `ContentHeaders`, and a non-null `Error` follow from the success/received state. They do not:
  - Per RFC 9110, a successful response can carry no body (204 No Content, a response to HEAD, a 2xx with zero-length or literal `null` content), so `Content`/`ContentHeaders` can be null while the status is successful.
  - `Error` is supplied independently of the status, so an unsuccessful response can have a null `Error` (Refit's own `EnsureSuccessfulAsync` already falls back when it does).

Closes #2156. Also adds regression coverage for #1933 and #1949 (generic-interface setups must be observed through the non-generic `IApiResponse`).

## What might this PR break?

- Source-level only, and in the direction of correctness: code that relied on the removed narrowings (e.g. dereferencing `response.Content` / `response.ContentHeaders` after `if (response.IsSuccessful)`, or `response.Error` after `if (!response.IsSuccessful)`) may now produce a nullable warning where the value can legitimately be null. The fix is to null-check, use `HasContent` / `IsSuccessfulWithContent` for content, or `HasRequestError` / `HasResponseError` for errors.
- No runtime behavior changes and no signature removals; the only public surface addition is `IsSuccessfulWithContent`.

## Checklist
- [x] I have read the Contribute guide
- [x] Tests have been added or updated (for bug fixes / features)
- [x] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the `main` branch
- [x] PR title follows Conventional Commits

## Additional information

Scenarios covered by the tests:

- Content-state matrix across the wrapper: success with content, success with a null body, success with an empty (non-null) body, a 204 No Content success, a 304 (not a success status), a non-success with content, a non-success without a captured error, a 2xx with a captured deserialization error, and a request error with no response received.
- Value-type bodies (`int`, where content is always present) and nullable value-type bodies (`int?`, which tracks null).
- Compile-time narrowing (no null-forgiving operator) for `IsSuccessful` / `IsSuccessStatusCode` / `IsReceived` (Headers/StatusCode/Version), `HasContent` and `IsSuccessfulWithContent` (Content), including through the covariant `IApiResponse<out T>`.
- That `IsSuccessful` and `IsSuccessStatusCode` are genuinely distinct (a 2xx with a deserialization error).
- That an unsuccessful response is not guaranteed to carry an `Error`.
- Mock/proxy interop (isolated in a new `Refit.MockInterop.Tests` project): a single setup on `IApiResponse<T>` is observed through the non-generic `IApiResponse` (including the problem-details and error-cast scenarios from the original reports), `IsSuccessfulWithContent` / `HasContent` narrowing through a mock, and that a success with null content headers is a representable interface state.