### PR TITLE
fix: disable errors by enabling preview features

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -31,6 +31,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <ReportAnalyzer>true</ReportAnalyzer>
     <Nullable>enable</Nullable>
+    <EnablePreviewFeatures>true</EnablePreviewFeatures>
 
     <WarningsAsErrors>nullable;CS4014</WarningsAsErrors>
 


### PR DESCRIPTION
When trying to build the Refit repository I get the following error, it appears to be caused by the use of `await`

<img width="1875" height="837" alt="image" src="https://github.com/user-attachments/assets/a65a728e-d523-44f4-8825-eb9db7eadcb0" />


CA2252: Opt in to preview features before using them

### Details
On JetBrains Rider 2025.3.1

10.0.109 [C:\Program Files\dotnet\sdk]
11.0.100-preview.1.26104.118 [C:\Program Files\dotnet\sdk]