### PR TITLE
feat: reflection-free generated form serialization, opt-in null values, and public UniqueName

### DIFF
--- a/README.md
+++ b/README.md
@@ -1014,6 +1014,30 @@ public class SomeObject
 **NOTE:** This use of `AliasAs` applies to querystring parameters and form body posts, but not to response objects; for
 aliasing fields on response objects, you'll still need to use `[JsonProperty("full-property-name")]`.
 
+##### Sending `null` values
+
+By default, a property whose value is `null` is omitted from the form body (and from object querystrings). To send
+an explicit empty value (`key=`) for a `null` property instead of omitting it, set `SerializeNull` on its `[Query]`
+attribute:
+
+```csharp
+public class Measurement
+{
+    [Query(SerializeNull = true)]
+    public string? Note { get; set; }
+}
+
+// With Note = null, serialized as: ...&Note=
+```
+
+##### Reflection-free form serialization
+
+When generated request building is enabled (the default), Refit's source generator emits the form-field flattening
+for strongly-typed bodies at compile time, so no reflection is used at request time. This applies when the body is a
+concrete class or struct serialized with the built-in `SystemTextJsonContentSerializer`. Bodies typed as `object`,
+an `IDictionary`, a collection, or serialized with a custom `IHttpContentSerializer` fall back to the reflection-based
+path, which remains fully supported and produces identical output.
+
 ### Setting request headers
 
 #### Static headers
@@ -1814,6 +1838,14 @@ services.AddRefitClient<IWebApi>(provider => new RefitSettings() { /* configure 
 
 Note that some of the properties of `RefitSettings` will be ignored because the `HttpClient` and `HttpClientHandlers`
 will be managed by the `HttpClientFactory` instead of Refit.
+
+Refit registers each client with `IHttpClientFactory` under a deterministic name. You can compute that same name with
+`UniqueName.ForType<T>()`, for example to configure the underlying named `HttpClient` directly:
+
+```csharp
+services.AddHttpClient(UniqueName.ForType<IWebApi>())
+        .ConfigureHttpClient(c => c.BaseAddress = new Uri("https://api.example.com"));
+```
 
 You can then get the api interface using constructor injection:
 

--- a/src/InterfaceStubGenerator.Shared/Emitter.Helpers.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.Helpers.cs
@@ -18,26 +18,28 @@ internal static partial class Emitter
 
     /// <summary>Builds the request-body buffering expression for an inline generated method.</summary>
     /// <param name="bodyParameter">The parsed body parameter, if any.</param>
+    /// <param name="settingsLocal">The generated settings local name.</param>
     /// <returns>The buffering expression.</returns>
-    internal static string BuildBufferBodyExpression(RequestParameterModel? bodyParameter) =>
+    internal static string BuildBufferBodyExpression(RequestParameterModel? bodyParameter, string settingsLocal) =>
         bodyParameter is null
             ? FalseLiteral
             : bodyParameter.BodyBufferMode switch
             {
-                BodyBufferMode.Settings => "refitSettings.Buffered",
+                BodyBufferMode.Settings => $"{settingsLocal}.Buffered",
                 BodyBufferMode.Buffered => TrueLiteral,
                 _ => FalseLiteral
             };
 
     /// <summary>Builds the serialized-body streaming expression for an inline generated method.</summary>
     /// <param name="bodyParameter">The parsed body parameter.</param>
+    /// <param name="settingsLocal">The generated settings local name.</param>
     /// <returns>The streaming expression.</returns>
-    internal static string BuildStreamBodyExpression(RequestParameterModel bodyParameter) =>
+    internal static string BuildStreamBodyExpression(RequestParameterModel bodyParameter, string settingsLocal) =>
         bodyParameter.BodySerializationMethod == "UrlEncoded"
             ? FalseLiteral
             : bodyParameter.BodyBufferMode switch
             {
-                BodyBufferMode.Settings => "!refitSettings.Buffered",
+                BodyBufferMode.Settings => $"!{settingsLocal}.Buffered",
                 BodyBufferMode.Buffered => FalseLiteral,
                 BodyBufferMode.Streaming => TrueLiteral,
                 _ => FalseLiteral

--- a/src/InterfaceStubGenerator.Shared/Emitter.Inline.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.Inline.cs
@@ -34,6 +34,11 @@ internal static partial class Emitter
             return BuildInlineRefitMethod(methodModel, interfaceModel, isTopLevel, settingsFieldName);
         }
 
+        var locals = CreateMethodLocalNameBuilder(methodModel.Parameters);
+        var argumentsLocal = locals.New("refitArguments");
+        var requestBuilderLocal = locals.New("refitRequestBuilder");
+        var funcLocal = locals.New("refitFunc");
+
         var (typeParameterFieldSource, cachedTypeParameterFieldName) = BuildTypeParameterField(
             methodModel,
             uniqueNames);
@@ -43,16 +48,18 @@ internal static partial class Emitter
         var lookupName = StripExplicitInterfacePrefix(methodModel.Name);
         var typeParameterExpression = BuildTypeParameterExpression(methodModel.Parameters, cachedTypeParameterFieldName);
         var genericTypesArgument = BuildGenericTypesArgument(methodModel);
-        var returnStatement = BuildRefitReturnStatement(methodModel, @return, returnType, configureAwait);
+        var returnStatement = BuildRefitReturnStatement(methodModel, @return, returnType, configureAwait, funcLocal, argumentsLocal);
         var methodIndent = Indent(MethodMemberIndentation);
         var bodyIndent = Indent(MethodBodyIndentation);
+        var requestBuilderInit =
+            $"{requestBuilderFieldName} ?? throw new global::System.InvalidOperationException(\"This generated Refit method requires a request builder.\")";
 
         return typeParameterFieldSource
             + BuildMethodOpening(methodModel, isExplicit, isExplicit, interfaceModel.SupportsNullable, isAsync)
             + $$"""
-                {{bodyIndent}}var refitArguments = {{BuildArgumentsArrayLiteral(methodModel)}};
-                {{bodyIndent}}var refitRequestBuilder = {{requestBuilderFieldName}} ?? throw new global::System.InvalidOperationException("This generated Refit method requires a request builder.");
-                {{bodyIndent}}var refitFunc = refitRequestBuilder.BuildRestResultFuncForMethod("{{lookupName}}", {{typeParameterExpression}}{{genericTypesArgument}} );
+                {{bodyIndent}}var {{argumentsLocal}} = {{BuildArgumentsArrayLiteral(methodModel)}};
+                {{bodyIndent}}var {{requestBuilderLocal}} = {{requestBuilderInit}};
+                {{bodyIndent}}var {{funcLocal}} = {{requestBuilderLocal}}.BuildRestResultFuncForMethod("{{lookupName}}", {{typeParameterExpression}}{{genericTypesArgument}} );
 
                 {{returnStatement}}{{methodIndent}}}
 
@@ -73,24 +80,27 @@ internal static partial class Emitter
     {
         var isExplicit = methodModel.IsExplicitInterface || !isTopLevel;
         var request = methodModel.Request;
+        var locals = CreateMethodLocalNameBuilder(methodModel.Parameters);
+        var settingsLocal = locals.New("refitSettings");
+        var requestLocal = locals.New("refitRequest");
         var bodyParameter = FindRequestParameter(request, RequestParameterKind.Body);
         var cancellationTokenExpression = BuildCancellationTokenExpression(request);
-        var bufferBodyExpression = BuildBufferBodyExpression(bodyParameter);
+        var bufferBodyExpression = BuildBufferBodyExpression(bodyParameter, settingsLocal);
         var requestUriExpression =
-            $"global::Refit.GeneratedRequestRunner.BuildRelativeUri(this.Client, {ToCSharpStringLiteral(request.Path)}, refitSettings.UrlResolution)";
-        var contentSource = bodyParameter is null ? string.Empty : BuildInlineContent(bodyParameter);
-        var headerSource = BuildInlineHeaders(request);
-        var requestPropertySource = BuildInlineRequestProperties(request, interfaceModel);
-        var returnSource = BuildInlineReturn(methodModel, request, bufferBodyExpression, cancellationTokenExpression);
+            $"global::Refit.GeneratedRequestRunner.BuildRelativeUri(this.Client, {ToCSharpStringLiteral(request.Path)}, {settingsLocal}.UrlResolution)";
+        var contentSource = bodyParameter is null ? string.Empty : BuildInlineContent(bodyParameter, requestLocal, settingsLocal);
+        var headerSource = BuildInlineHeaders(request, requestLocal);
+        var requestPropertySource = BuildInlineRequestProperties(request, interfaceModel, requestLocal, settingsLocal);
+        var returnSource = BuildInlineReturn(methodModel, request, bufferBodyExpression, cancellationTokenExpression, requestLocal, settingsLocal);
         var methodIndent = Indent(MethodMemberIndentation);
         var bodyIndent = Indent(MethodBodyIndentation);
 
         return $$"""
-            {{BuildMethodOpening(methodModel, isExplicit, isExplicit, interfaceModel.SupportsNullable)}}{{bodyIndent}}var refitSettings = {{settingsFieldName}};
-            {{bodyIndent}}var refitRequest = new global::System.Net.Http.HttpRequestMessage({{ToHttpMethodExpression(request.HttpMethod)}}, {{requestUriExpression}});
+            {{BuildMethodOpening(methodModel, isExplicit, isExplicit, interfaceModel.SupportsNullable)}}{{bodyIndent}}var {{settingsLocal}} = {{settingsFieldName}};
+            {{bodyIndent}}var {{requestLocal}} = new global::System.Net.Http.HttpRequestMessage({{ToHttpMethodExpression(request.HttpMethod)}}, {{requestUriExpression}});
             {{bodyIndent}}#if NET6_0_OR_GREATER
-            {{bodyIndent}}refitRequest.Version = refitSettings.Version;
-            {{bodyIndent}}refitRequest.VersionPolicy = refitSettings.VersionPolicy;
+            {{bodyIndent}}{{requestLocal}}.Version = {{settingsLocal}}.Version;
+            {{bodyIndent}}{{requestLocal}}.VersionPolicy = {{settingsLocal}}.VersionPolicy;
             {{bodyIndent}}#endif
             {{contentSource}}{{headerSource}}{{requestPropertySource}}{{returnSource}}{{methodIndent}}}
 
@@ -99,15 +109,17 @@ internal static partial class Emitter
 
     /// <summary>Builds request content assignment for an inline generated method.</summary>
     /// <param name="bodyParameter">The body parameter model.</param>
+    /// <param name="requestLocal">The generated request message local name.</param>
+    /// <param name="settingsLocal">The generated settings local name.</param>
     /// <returns>The generated content assignment.</returns>
-    private static string BuildInlineContent(RequestParameterModel bodyParameter)
+    private static string BuildInlineContent(RequestParameterModel bodyParameter, string requestLocal, string settingsLocal)
     {
         var bodyIndent = Indent(MethodBodyIndentation);
         if (bodyParameter.BodySerializationMethod == "UrlEncoded")
         {
             return $$"""
-                {{bodyIndent}}refitRequest.Content = global::Refit.GeneratedRequestRunner.CreateUrlEncodedBodyContent<{{bodyParameter.Type}}>(
-                {{bodyIndent}}    refitSettings,
+                {{bodyIndent}}{{requestLocal}}.Content = global::Refit.GeneratedRequestRunner.CreateUrlEncodedBodyContent<{{bodyParameter.Type}}>(
+                {{bodyIndent}}    {{settingsLocal}},
                 {{bodyIndent}}    @{{bodyParameter.Name}});
 
                 """;
@@ -116,19 +128,19 @@ internal static partial class Emitter
         if (bodyParameter.BodySerializationMethod == "JsonLines")
         {
             return $$"""
-                {{bodyIndent}}refitRequest.Content = global::Refit.GeneratedRequestRunner.CreateJsonLinesBodyContent<{{bodyParameter.Type}}>(
-                {{bodyIndent}}    refitSettings,
+                {{bodyIndent}}{{requestLocal}}.Content = global::Refit.GeneratedRequestRunner.CreateJsonLinesBodyContent<{{bodyParameter.Type}}>(
+                {{bodyIndent}}    {{settingsLocal}},
                 {{bodyIndent}}    @{{bodyParameter.Name}});
 
                 """;
         }
 
-        var streamBodyExpression = BuildStreamBodyExpression(bodyParameter);
+        var streamBodyExpression = BuildStreamBodyExpression(bodyParameter, settingsLocal);
         var serializationMethodExpression = BuildBodySerializationMethodExpression(bodyParameter);
 
         return $$"""
-            {{bodyIndent}}refitRequest.Content = global::Refit.GeneratedRequestRunner.CreateBodyContent<{{bodyParameter.Type}}>(
-            {{bodyIndent}}    refitSettings,
+            {{bodyIndent}}{{requestLocal}}.Content = global::Refit.GeneratedRequestRunner.CreateBodyContent<{{bodyParameter.Type}}>(
+            {{bodyIndent}}    {{settingsLocal}},
             {{bodyIndent}}    @{{bodyParameter.Name}},
             {{bodyIndent}}    {{serializationMethodExpression}},
             {{bodyIndent}}    {{streamBodyExpression}});
@@ -141,12 +153,16 @@ internal static partial class Emitter
     /// <param name="request">The parsed request model.</param>
     /// <param name="bufferBodyExpression">The expression indicating whether request content should be buffered.</param>
     /// <param name="cancellationTokenExpression">The cancellation token expression.</param>
+    /// <param name="requestLocal">The generated request message local name.</param>
+    /// <param name="settingsLocal">The generated settings local name.</param>
     /// <returns>The generated return statement.</returns>
     private static string BuildInlineReturn(
         MethodModel methodModel,
         RequestModel request,
         string bufferBodyExpression,
-        string cancellationTokenExpression)
+        string cancellationTokenExpression,
+        string requestLocal,
+        string settingsLocal)
     {
         var bodyIndent = Indent(MethodBodyIndentation);
         if (methodModel.ReturnTypeMetadata == ReturnTypeInfo.AsyncVoid)
@@ -154,8 +170,8 @@ internal static partial class Emitter
             return $$"""
                 {{bodyIndent}}return global::Refit.GeneratedRequestRunner.SendVoidAsync(
                 {{bodyIndent}}    this.Client,
-                {{bodyIndent}}    refitRequest,
-                {{bodyIndent}}    refitSettings,
+                {{bodyIndent}}    {{requestLocal}},
+                {{bodyIndent}}    {{settingsLocal}},
                 {{bodyIndent}}    {{bufferBodyExpression}},
                 {{bodyIndent}}    {{cancellationTokenExpression}});
 
@@ -167,8 +183,8 @@ internal static partial class Emitter
             return $$"""
                 {{bodyIndent}}return global::Refit.GeneratedRequestRunner.StreamAsync<{{request.ResultType}}>(
                 {{bodyIndent}}    this.Client,
-                {{bodyIndent}}    refitRequest,
-                {{bodyIndent}}    refitSettings,
+                {{bodyIndent}}    {{requestLocal}},
+                {{bodyIndent}}    {{settingsLocal}},
                 {{bodyIndent}}    {{cancellationTokenExpression}});
 
                 """;
@@ -178,8 +194,8 @@ internal static partial class Emitter
             ? $$"""
                 {{bodyIndent}}return new {{methodModel.ReturnType}}(global::Refit.GeneratedRequestRunner.SendAsync<{{request.ResultType}}, {{request.DeserializedResultType}}>(
                 {{bodyIndent}}    this.Client,
-                {{bodyIndent}}    refitRequest,
-                {{bodyIndent}}    refitSettings,
+                {{bodyIndent}}    {{requestLocal}},
+                {{bodyIndent}}    {{settingsLocal}},
                 {{bodyIndent}}    {{ToLowerInvariantString(request.IsApiResponse)}},
                 {{bodyIndent}}    {{ToLowerInvariantString(request.ShouldDisposeResponse)}},
                 {{bodyIndent}}    {{bufferBodyExpression}},
@@ -189,8 +205,8 @@ internal static partial class Emitter
             : $$"""
                 {{bodyIndent}}return global::Refit.GeneratedRequestRunner.SendAsync<{{request.ResultType}}, {{request.DeserializedResultType}}>(
                 {{bodyIndent}}    this.Client,
-                {{bodyIndent}}    refitRequest,
-                {{bodyIndent}}    refitSettings,
+                {{bodyIndent}}    {{requestLocal}},
+                {{bodyIndent}}    {{settingsLocal}},
                 {{bodyIndent}}    {{ToLowerInvariantString(request.IsApiResponse)}},
                 {{bodyIndent}}    {{ToLowerInvariantString(request.ShouldDisposeResponse)}},
                 {{bodyIndent}}    {{bufferBodyExpression}},
@@ -201,8 +217,9 @@ internal static partial class Emitter
 
     /// <summary>Builds static and dynamic header application for an inline generated method.</summary>
     /// <param name="request">The parsed request model.</param>
+    /// <param name="requestLocal">The generated request message local name.</param>
     /// <returns>The generated header statements.</returns>
-    private static string BuildInlineHeaders(RequestModel request)
+    private static string BuildInlineHeaders(RequestModel request, string requestLocal)
     {
         var parts = new string[request.StaticHeaders.Count + request.Parameters.Count];
         var count = 0;
@@ -210,7 +227,7 @@ internal static partial class Emitter
         foreach (var header in request.StaticHeaders)
         {
             parts[count++] =
-                $"{bodyIndent}global::Refit.GeneratedRequestRunner.SetHeader(refitRequest, {ToCSharpStringLiteral(header.Name)}, {ToNullableCSharpStringLiteral(header.Value)});\n";
+                $"{bodyIndent}global::Refit.GeneratedRequestRunner.SetHeader({requestLocal}, {ToCSharpStringLiteral(header.Name)}, {ToNullableCSharpStringLiteral(header.Value)});\n";
         }
 
         foreach (var parameter in request.Parameters)
@@ -220,14 +237,14 @@ internal static partial class Emitter
                 case RequestParameterKind.Header:
                     {
                         parts[count++] =
-                            $"{bodyIndent}global::Refit.GeneratedRequestRunner.SetHeader(refitRequest, {ToCSharpStringLiteral(parameter.HeaderName)}, {BuildHeaderValueExpression(parameter)});\n";
+                            $"{bodyIndent}global::Refit.GeneratedRequestRunner.SetHeader({requestLocal}, {ToCSharpStringLiteral(parameter.HeaderName)}, {BuildHeaderValueExpression(parameter)});\n";
                         continue;
                     }
 
                 case RequestParameterKind.HeaderCollection:
                     {
                         parts[count++] =
-                            $"{bodyIndent}global::Refit.GeneratedRequestRunner.AddHeaderCollection(refitRequest, @{parameter.Name});\n";
+                            $"{bodyIndent}global::Refit.GeneratedRequestRunner.AddHeaderCollection({requestLocal}, @{parameter.Name});\n";
                         break;
                     }
             }
@@ -250,16 +267,20 @@ internal static partial class Emitter
     /// <summary>Builds request-option/property application for an inline generated method.</summary>
     /// <param name="request">The parsed request model.</param>
     /// <param name="interfaceModel">The interface model being emitted.</param>
+    /// <param name="requestLocal">The generated request message local name.</param>
+    /// <param name="settingsLocal">The generated settings local name.</param>
     /// <returns>The generated request option/property statements.</returns>
     private static string BuildInlineRequestProperties(
         RequestModel request,
-        InterfaceModel interfaceModel)
+        InterfaceModel interfaceModel,
+        string requestLocal,
+        string settingsLocal)
     {
         var parts = new string[1 + interfaceModel.Properties.Count + request.Parameters.Count];
         var count = 0;
         var bodyIndent = Indent(MethodBodyIndentation);
         parts[count++] =
-            $"{bodyIndent}global::Refit.GeneratedRequestRunner.AddConfiguredRequestOptions(refitRequest, refitSettings, typeof({interfaceModel.InterfaceDisplayName}));\n";
+            $"{bodyIndent}global::Refit.GeneratedRequestRunner.AddConfiguredRequestOptions({requestLocal}, {settingsLocal}, typeof({interfaceModel.InterfaceDisplayName}));\n";
 
         foreach (var property in interfaceModel.Properties)
         {
@@ -270,7 +291,7 @@ internal static partial class Emitter
 
             parts[count++] =
                 $"{bodyIndent}global::Refit.GeneratedRequestRunner.AddRequestProperty<{property.Type}>"
-                + $"(refitRequest, {ToCSharpStringLiteral(property.RequestPropertyKey)}, "
+                + $"({requestLocal}, {ToCSharpStringLiteral(property.RequestPropertyKey)}, "
                 + $"{BuildPropertyAccessExpression(property)});\n";
         }
 
@@ -279,11 +300,27 @@ internal static partial class Emitter
             if (parameter.Kind == RequestParameterKind.Property)
             {
                 parts[count++] =
-                    $"{bodyIndent}global::Refit.GeneratedRequestRunner.AddRequestProperty<{parameter.Type}>(refitRequest, {ToCSharpStringLiteral(parameter.PropertyKey)}, @{parameter.Name});\n";
+                    $"{bodyIndent}global::Refit.GeneratedRequestRunner.AddRequestProperty<{parameter.Type}>({requestLocal}, {ToCSharpStringLiteral(parameter.PropertyKey)}, @{parameter.Name});\n";
             }
         }
 
         return ConcatParts(parts, count);
+    }
+
+    /// <summary>Creates a name builder reserved with a method's parameter names so generated locals never collide with them.</summary>
+    /// <param name="parameters">The method parameters whose names must be avoided.</param>
+    /// <returns>A <see cref="UniqueNameBuilder"/> seeded with the parameter names.</returns>
+    private static UniqueNameBuilder CreateMethodLocalNameBuilder(ImmutableEquatableArray<ParameterModel> parameters)
+    {
+        var builder = new UniqueNameBuilder();
+        var names = new List<string>(parameters.Count);
+        foreach (var parameter in parameters)
+        {
+            names.Add(parameter.MetadataName);
+        }
+
+        builder.Reserve(names);
+        return builder;
     }
 
     /// <summary>Finds the first request parameter of the given kind.</summary>

--- a/src/InterfaceStubGenerator.Shared/Emitter.Inline.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.Inline.cs
@@ -8,6 +8,30 @@ namespace Refit.Generator;
 /// <summary>Emits inline request-construction source for generated Refit method implementations.</summary>
 internal static partial class Emitter
 {
+    /// <summary>The base member name for a cached form field descriptor array.</summary>
+    private const string FormFieldsVariableName = "______formFields";
+
+    /// <summary>The opening of a generated <c>FormField</c> construction.</summary>
+    private const string FormFieldNew = "new global::Refit.FormField<";
+
+    /// <summary>The getter lambda opening between the body type and the property name.</summary>
+    private const string FormFieldGetterOpen = ">(static body => (object?)body.@";
+
+    /// <summary>The separator before the quoted CLR property name argument.</summary>
+    private const string FormFieldNameOpen = ", \"";
+
+    /// <summary>The separator after the quoted CLR property name argument.</summary>
+    private const string FormFieldNameClose = "\", ";
+
+    /// <summary>The separator between generated arguments.</summary>
+    private const string ArgumentSeparator = ", ";
+
+    /// <summary>The closing of a generated <c>FormField</c> construction including the trailing element separator.</summary>
+    private const string FormFieldClose = "),\n";
+
+    /// <summary>The cast prefix for an explicit collection format value.</summary>
+    private const string CollectionFormatCast = "(global::Refit.CollectionFormat)";
+
     /// <summary>Builds the body of the Refit method.</summary>
     /// <param name="methodModel">The method model being emitted.</param>
     /// <param name="isTopLevel">True if directly from the type we're generating for, false for methods found on base interfaces.</param>
@@ -31,7 +55,7 @@ internal static partial class Emitter
     {
         if (interfaceModel.GeneratedRequestBuilding && methodModel.Request.CanGenerateInline)
         {
-            return BuildInlineRefitMethod(methodModel, interfaceModel, isTopLevel, settingsFieldName);
+            return BuildInlineRefitMethod(methodModel, interfaceModel, isTopLevel, settingsFieldName, uniqueNames);
         }
 
         var locals = CreateMethodLocalNameBuilder(methodModel.Parameters);
@@ -71,12 +95,14 @@ internal static partial class Emitter
     /// <param name="interfaceModel">The interface model being emitted.</param>
     /// <param name="isTopLevel">True if directly from the type we're generating for, false for methods found on base interfaces.</param>
     /// <param name="settingsFieldName">The unique generated field name that stores Refit settings.</param>
+    /// <param name="uniqueNames">Contains the unique member names in the interface scope.</param>
     /// <returns>The generated inline method implementation.</returns>
     private static string BuildInlineRefitMethod(
         MethodModel methodModel,
         InterfaceModel interfaceModel,
         bool isTopLevel,
-        string settingsFieldName)
+        string settingsFieldName,
+        UniqueNameBuilder uniqueNames)
     {
         var isExplicit = methodModel.IsExplicitInterface || !isTopLevel;
         var request = methodModel.Request;
@@ -88,7 +114,8 @@ internal static partial class Emitter
         var bufferBodyExpression = BuildBufferBodyExpression(bodyParameter, settingsLocal);
         var requestUriExpression =
             $"global::Refit.GeneratedRequestRunner.BuildRelativeUri(this.Client, {ToCSharpStringLiteral(request.Path)}, {settingsLocal}.UrlResolution)";
-        var contentSource = bodyParameter is null ? string.Empty : BuildInlineContent(bodyParameter, requestLocal, settingsLocal);
+        var (formFieldsSource, formFieldsFieldName) = BuildFormFieldsField(bodyParameter, uniqueNames);
+        var contentSource = bodyParameter is null ? string.Empty : BuildInlineContent(bodyParameter, requestLocal, settingsLocal, formFieldsFieldName);
         var headerSource = BuildInlineHeaders(request, requestLocal);
         var requestPropertySource = BuildInlineRequestProperties(request, interfaceModel, requestLocal, settingsLocal);
         var returnSource = BuildInlineReturn(methodModel, request, bufferBodyExpression, cancellationTokenExpression, requestLocal, settingsLocal);
@@ -96,7 +123,7 @@ internal static partial class Emitter
         var bodyIndent = Indent(MethodBodyIndentation);
 
         return $$"""
-            {{BuildMethodOpening(methodModel, isExplicit, isExplicit, interfaceModel.SupportsNullable)}}{{bodyIndent}}var {{settingsLocal}} = {{settingsFieldName}};
+            {{formFieldsSource}}{{BuildMethodOpening(methodModel, isExplicit, isExplicit, interfaceModel.SupportsNullable)}}{{bodyIndent}}var {{settingsLocal}} = {{settingsFieldName}};
             {{bodyIndent}}var {{requestLocal}} = new global::System.Net.Http.HttpRequestMessage({{ToHttpMethodExpression(request.HttpMethod)}}, {{requestUriExpression}});
             {{bodyIndent}}#if NET6_0_OR_GREATER
             {{bodyIndent}}{{requestLocal}}.Version = {{settingsLocal}}.Version;
@@ -111,18 +138,27 @@ internal static partial class Emitter
     /// <param name="bodyParameter">The body parameter model.</param>
     /// <param name="requestLocal">The generated request message local name.</param>
     /// <param name="settingsLocal">The generated settings local name.</param>
+    /// <param name="formFieldsFieldName">The cached form field descriptor array name, or null to use the reflection path.</param>
     /// <returns>The generated content assignment.</returns>
-    private static string BuildInlineContent(RequestParameterModel bodyParameter, string requestLocal, string settingsLocal)
+    private static string BuildInlineContent(RequestParameterModel bodyParameter, string requestLocal, string settingsLocal, string? formFieldsFieldName)
     {
         var bodyIndent = Indent(MethodBodyIndentation);
         if (bodyParameter.BodySerializationMethod == "UrlEncoded")
         {
-            return $$"""
-                {{bodyIndent}}{{requestLocal}}.Content = global::Refit.GeneratedRequestRunner.CreateUrlEncodedBodyContent<{{bodyParameter.Type}}>(
-                {{bodyIndent}}    {{settingsLocal}},
-                {{bodyIndent}}    @{{bodyParameter.Name}});
+            return formFieldsFieldName is not null
+                ? $$"""
+                    {{bodyIndent}}{{requestLocal}}.Content = global::Refit.GeneratedRequestRunner.CreateUrlEncodedBodyContent<{{bodyParameter.Type}}>(
+                    {{bodyIndent}}    {{settingsLocal}},
+                    {{bodyIndent}}    @{{bodyParameter.Name}},
+                    {{bodyIndent}}    {{formFieldsFieldName}});
 
-                """;
+                    """
+                : $$"""
+                    {{bodyIndent}}{{requestLocal}}.Content = global::Refit.GeneratedRequestRunner.CreateUrlEncodedBodyContent<{{bodyParameter.Type}}>(
+                    {{bodyIndent}}    {{settingsLocal}},
+                    {{bodyIndent}}    @{{bodyParameter.Name}});
+
+                    """;
         }
 
         if (bodyParameter.BodySerializationMethod == "JsonLines")
@@ -147,6 +183,109 @@ internal static partial class Emitter
 
             """;
     }
+
+    /// <summary>Builds the cached form field descriptor array declaration for a URL-encoded body, if eligible.</summary>
+    /// <param name="bodyParameter">The body parameter model, or null when the method has no body.</param>
+    /// <param name="uniqueNames">Contains the unique member names in the interface scope.</param>
+    /// <returns>The generated field declaration and its name, or empty values when the reflection path is used.</returns>
+    private static (string Source, string? FieldName) BuildFormFieldsField(
+        RequestParameterModel? bodyParameter,
+        UniqueNameBuilder uniqueNames)
+    {
+        if (bodyParameter?.FormFields is not { Count: > 0 } formFields)
+        {
+            return (string.Empty, null);
+        }
+
+        var fields = formFields.AsArray();
+        var bodyType = bodyParameter.Type;
+        var fieldName = uniqueNames.New(FormFieldsVariableName);
+        var elementIndent = Indent(MethodBodyIndentation);
+
+        var elementsLength = 0;
+        for (var i = 0; i < fields.Length; i++)
+        {
+            elementsLength += MeasureFormFieldElement(fields[i], bodyType, elementIndent.Length);
+        }
+
+        var elements = CreateGeneratedString(
+            elementsLength,
+            (fields, bodyType, elementIndent),
+            static (destination, state) =>
+            {
+                var position = 0;
+                var (elementFields, type, indent) = state;
+                for (var i = 0; i < elementFields.Length; i++)
+                {
+                    var field = elementFields[i];
+                    AppendText(destination, indent, ref position);
+                    AppendText(destination, FormFieldNew, ref position);
+                    AppendText(destination, type, ref position);
+                    AppendText(destination, FormFieldGetterOpen, ref position);
+                    AppendText(destination, field.PropertyName, ref position);
+                    AppendText(destination, FormFieldNameOpen, ref position);
+                    AppendText(destination, field.PropertyName, ref position);
+                    AppendText(destination, FormFieldNameClose, ref position);
+                    AppendLiteralOrNull(destination, field.ExplicitName, ref position);
+                    AppendText(destination, ArgumentSeparator, ref position);
+                    AppendLiteralOrNull(destination, field.PrefixSegment, ref position);
+                    AppendText(destination, ArgumentSeparator, ref position);
+                    AppendLiteralOrNull(destination, field.Format, ref position);
+                    AppendText(destination, ArgumentSeparator, ref position);
+                    if (field.CollectionFormatValue is { } collectionFormatValue)
+                    {
+                        AppendText(destination, CollectionFormatCast, ref position);
+                        AppendInt32(destination, collectionFormatValue, ref position);
+                    }
+                    else
+                    {
+                        AppendText(destination, NullLiteral, ref position);
+                    }
+
+                    AppendText(destination, ArgumentSeparator, ref position);
+                    AppendText(destination, field.SerializeNull ? TrueLiteral : FalseLiteral, ref position);
+                    AppendText(destination, FormFieldClose, ref position);
+                }
+            });
+
+        var memberIndent = Indent(MethodMemberIndentation);
+        var source = $$"""
+
+
+            {{memberIndent}}/// <summary>Cached form field descriptors used to serialize the URL-encoded request body without reflection.</summary>
+            {{memberIndent}}private static readonly global::Refit.FormField<{{bodyType}}>[] {{fieldName}} = new global::Refit.FormField<{{bodyType}}>[]
+            {{memberIndent}}{
+            {{elements}}{{memberIndent}}};
+            """;
+        return (source, fieldName);
+    }
+
+    /// <summary>Measures the rendered length of one generated form field element line.</summary>
+    /// <param name="field">The form field descriptor.</param>
+    /// <param name="bodyType">The fully-qualified body type.</param>
+    /// <param name="indentLength">The element indentation length.</param>
+    /// <returns>The number of characters the rendered element occupies.</returns>
+    private static int MeasureFormFieldElement(FormFieldModel field, string bodyType, int indentLength) =>
+        indentLength
+        + FormFieldNew.Length
+        + bodyType.Length
+        + FormFieldGetterOpen.Length
+        + field.PropertyName.Length
+        + FormFieldNameOpen.Length
+        + field.PropertyName.Length
+        + FormFieldNameClose.Length
+        + LiteralOrNullLength(field.ExplicitName)
+        + ArgumentSeparator.Length
+        + LiteralOrNullLength(field.PrefixSegment)
+        + ArgumentSeparator.Length
+        + LiteralOrNullLength(field.Format)
+        + ArgumentSeparator.Length
+        + (field.CollectionFormatValue is { } collectionFormatValue
+            ? CollectionFormatCast.Length + Int32Length(collectionFormatValue)
+            : NullLiteral.Length)
+        + ArgumentSeparator.Length
+        + (field.SerializeNull ? TrueLiteral.Length : FalseLiteral.Length)
+        + FormFieldClose.Length;
 
     /// <summary>Builds the return statement for an inline generated Refit method.</summary>
     /// <param name="methodModel">The method model being emitted.</param>

--- a/src/InterfaceStubGenerator.Shared/Emitter.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.cs
@@ -778,17 +778,21 @@ internal static partial class Emitter
     /// <param name="returnPrefix">The return statement prefix.</param>
     /// <param name="returnType">The generated return type.</param>
     /// <param name="configureAwait">The generated configure-await suffix.</param>
+    /// <param name="funcLocal">The generated request-func local name.</param>
+    /// <param name="argumentsLocal">The generated arguments-array local name.</param>
     /// <returns>The generated return statement.</returns>
     private static string BuildRefitReturnStatement(
         MethodModel methodModel,
         string returnPrefix,
         string returnType,
-        string configureAwait)
+        string configureAwait,
+        string funcLocal,
+        string argumentsLocal)
     {
         var bodyIndent = Indent(MethodBodyIndentation);
         return methodModel.ReturnTypeMetadata == ReturnTypeInfo.SyncVoid
-            ? $"{bodyIndent}refitFunc(this.Client, refitArguments);\n"
-            : $"{bodyIndent}{returnPrefix}({returnType})refitFunc(this.Client, refitArguments){configureAwait};\n";
+            ? $"{bodyIndent}{funcLocal}(this.Client, {argumentsLocal});\n"
+            : $"{bodyIndent}{returnPrefix}({returnType}){funcLocal}(this.Client, {argumentsLocal}){configureAwait};\n";
     }
 
     /// <summary>Concatenates populated source fragments without allocating a trimmed array.</summary>

--- a/src/InterfaceStubGenerator.Shared/Emitter.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.cs
@@ -12,6 +12,15 @@ internal static partial class Emitter
     /// <summary>The generated literal for <see langword="false"/>.</summary>
     private const string FalseLiteral = "false";
 
+    /// <summary>The C# null keyword literal.</summary>
+    private const string NullLiteral = "null";
+
+    /// <summary>The number of quote characters wrapping a C# string literal.</summary>
+    private const int StringLiteralQuoteLength = 2;
+
+    /// <summary>The radix used when rendering decimal integers.</summary>
+    private const int DecimalRadix = 10;
+
     /// <summary>The generated literal for <see langword="true"/>.</summary>
     private const string TrueLiteral = "true";
 
@@ -860,6 +869,169 @@ internal static partial class Emitter
     /// <param name="level">The indentation level.</param>
     /// <returns>The generated indentation.</returns>
     private static string Indent(int level) => new(' ', level * CharsPerIndentation);
+
+    /// <summary>Gets the two-character escape sequence for a C# string-literal character, or null when none is needed.</summary>
+    /// <param name="character">The character to escape.</param>
+    /// <returns>The interned escape sequence, or <see langword="null"/> when the character is emitted verbatim.</returns>
+    private static string? EscapeSequence(char character) =>
+        character switch
+        {
+            '\\' => "\\\\",
+            '"' => "\\\"",
+            '\0' => "\\0",
+            '\a' => "\\a",
+            '\b' => "\\b",
+            '\f' => "\\f",
+            '\n' => "\\n",
+            '\r' => "\\r",
+            '\t' => "\\t",
+            '\v' => "\\v",
+            _ => null
+        };
+
+    /// <summary>Computes the rendered length of a C# string literal or the <c>null</c> keyword.</summary>
+    /// <param name="value">The value to quote, or <see langword="null"/>.</param>
+    /// <returns>The number of characters the rendered expression occupies.</returns>
+    private static int LiteralOrNullLength(string? value)
+    {
+        if (value is null)
+        {
+            return NullLiteral.Length;
+        }
+
+        var length = StringLiteralQuoteLength;
+        foreach (var character in value)
+        {
+            length += EscapeSequence(character) is null ? 1 : StringLiteralQuoteLength;
+        }
+
+        return length;
+    }
+
+    /// <summary>Computes the rendered decimal length of a 32-bit integer.</summary>
+    /// <param name="value">The value to render.</param>
+    /// <returns>The number of characters the decimal rendering occupies.</returns>
+    private static int Int32Length(int value)
+    {
+        var length = value < 0 ? 1 : 0;
+        var magnitude = value < 0 ? -(long)value : value;
+        do
+        {
+            length++;
+            magnitude /= DecimalRadix;
+        }
+        while (magnitude > 0);
+
+        return length;
+    }
+
+#if NETSTANDARD2_0
+    /// <summary>Writes a C# string literal or the <c>null</c> keyword into a generated string buffer.</summary>
+    /// <param name="destination">The target character buffer.</param>
+    /// <param name="value">The value to quote, or <see langword="null"/>.</param>
+    /// <param name="position">The current write position.</param>
+    private static void AppendLiteralOrNull(char[] destination, string? value, ref int position)
+    {
+        if (value is null)
+        {
+            AppendText(destination, NullLiteral, ref position);
+            return;
+        }
+
+        destination[position++] = '"';
+        foreach (var character in value)
+        {
+            var escape = EscapeSequence(character);
+            if (escape is null)
+            {
+                destination[position++] = character;
+            }
+            else
+            {
+                AppendText(destination, escape, ref position);
+            }
+        }
+
+        destination[position++] = '"';
+    }
+
+    /// <summary>Writes the decimal rendering of a 32-bit integer into a generated string buffer.</summary>
+    /// <param name="destination">The target character buffer.</param>
+    /// <param name="value">The value to render.</param>
+    /// <param name="position">The current write position.</param>
+    private static void AppendInt32(char[] destination, int value, ref int position)
+    {
+        var end = position + Int32Length(value);
+        var write = end;
+        var magnitude = value < 0 ? -(long)value : value;
+        do
+        {
+            destination[--write] = (char)('0' + (int)(magnitude % DecimalRadix));
+            magnitude /= DecimalRadix;
+        }
+        while (magnitude > 0);
+
+        if (value < 0)
+        {
+            destination[position] = '-';
+        }
+
+        position = end;
+    }
+#else
+    /// <summary>Writes a C# string literal or the <c>null</c> keyword into a generated string buffer.</summary>
+    /// <param name="destination">The target character span.</param>
+    /// <param name="value">The value to quote, or <see langword="null"/>.</param>
+    /// <param name="position">The current write position.</param>
+    private static void AppendLiteralOrNull(Span<char> destination, string? value, ref int position)
+    {
+        if (value is null)
+        {
+            AppendText(destination, NullLiteral, ref position);
+            return;
+        }
+
+        destination[position++] = '"';
+        foreach (var character in value)
+        {
+            var escape = EscapeSequence(character);
+            if (escape is null)
+            {
+                destination[position++] = character;
+            }
+            else
+            {
+                AppendText(destination, escape, ref position);
+            }
+        }
+
+        destination[position++] = '"';
+    }
+
+    /// <summary>Writes the decimal rendering of a 32-bit integer into a generated string buffer.</summary>
+    /// <param name="destination">The target character span.</param>
+    /// <param name="value">The value to render.</param>
+    /// <param name="position">The current write position.</param>
+    private static void AppendInt32(Span<char> destination, int value, ref int position)
+    {
+        var end = position + Int32Length(value);
+        var write = end;
+        var magnitude = value < 0 ? -(long)value : value;
+        do
+        {
+            destination[--write] = (char)('0' + (int)(magnitude % DecimalRadix));
+            magnitude /= DecimalRadix;
+        }
+        while (magnitude > 0);
+
+        if (value < 0)
+        {
+            destination[position] = '-';
+        }
+
+        position = end;
+    }
+#endif
 
 #if NETSTANDARD2_0
     /// <summary>Creates a generated string using a pre-sized buffer.</summary>

--- a/src/InterfaceStubGenerator.Shared/Models/FormFieldModel.cs
+++ b/src/InterfaceStubGenerator.Shared/Models/FormFieldModel.cs
@@ -1,0 +1,19 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+namespace Refit.Generator;
+
+/// <summary>Compile-time metadata for one form-url-encoded field of a strongly-typed body.</summary>
+/// <param name="PropertyName">The declared CLR property name read by the generated getter.</param>
+/// <param name="ExplicitName">The explicit field name from <c>[AliasAs]</c> or <c>[JsonPropertyName]</c>, or <see langword="null"/>.</param>
+/// <param name="PrefixSegment">The precomputed <c>prefix + delimiter</c> prepended to the field name, or <see langword="null"/>.</param>
+/// <param name="Format">The <c>[Query]</c> value format, or <see langword="null"/>.</param>
+/// <param name="CollectionFormatValue">The explicit collection format underlying value, or <see langword="null"/> to use the settings default.</param>
+/// <param name="SerializeNull">Whether a <see langword="null"/> value should be serialized as an empty field.</param>
+internal sealed record FormFieldModel(
+    string PropertyName,
+    string? ExplicitName,
+    string? PrefixSegment,
+    string? Format,
+    int? CollectionFormatValue,
+    bool SerializeNull);

--- a/src/InterfaceStubGenerator.Shared/Models/RequestParameterModel.cs
+++ b/src/InterfaceStubGenerator.Shared/Models/RequestParameterModel.cs
@@ -20,4 +20,11 @@ internal sealed record RequestParameterModel(
     string HeaderName,
     string PropertyKey,
     string BodySerializationMethod,
-    BodyBufferMode BodyBufferMode);
+    BodyBufferMode BodyBufferMode)
+{
+    /// <summary>
+    /// Gets the reflection-free form field descriptors for a URL-encoded body, or <see langword="null"/> when the
+    /// body type is not eligible and the reflection-based form path must be used.
+    /// </summary>
+    public ImmutableEquatableArray<FormFieldModel>? FormFields { get; init; }
+}

--- a/src/InterfaceStubGenerator.Shared/Parser.Request.cs
+++ b/src/InterfaceStubGenerator.Shared/Parser.Request.cs
@@ -1,6 +1,8 @@
 // Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
 // ReactiveUI and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
+using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis;
@@ -328,6 +330,9 @@ internal static partial class Parser
             }
 
             var bodyInfo = ParseBodyAttribute(attribute);
+            var formFields = bodyInfo.SerializationMethod == "UrlEncoded"
+                ? TryBuildFormFields(parameter.Type)
+                : null;
             bodyParameter = new(
                     parameter.MetadataName,
                     parameterType,
@@ -336,7 +341,10 @@ internal static partial class Parser
                     string.Empty,
                     string.Empty,
                     bodyInfo.SerializationMethod,
-                bodyInfo.BufferMode);
+                bodyInfo.BufferMode)
+            {
+                FormFields = formFields,
+            };
             return true;
         }
 
@@ -350,6 +358,198 @@ internal static partial class Parser
             string.Empty,
             BodyBufferMode.None);
         return false;
+    }
+
+    /// <summary>Builds reflection-free form field descriptors for a URL-encoded body type.</summary>
+    /// <param name="bodyType">The declared body type.</param>
+    /// <returns>The field descriptors, or <see langword="null"/> when the type is not eligible for the descriptor path.</returns>
+    private static ImmutableEquatableArray<FormFieldModel>? TryBuildFormFields(ITypeSymbol bodyType)
+    {
+        if (!IsFormFieldEligibleType(bodyType))
+        {
+            return null;
+        }
+
+        var fields = new List<FormFieldModel>();
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        for (var current = bodyType;
+            current is not null && current.SpecialType != SpecialType.System_Object;
+            current = current.BaseType)
+        {
+            foreach (var member in current.GetMembers())
+            {
+                if (member is IPropertySymbol property && IsReadableFormProperty(property) && seen.Add(property.Name))
+                {
+                    fields.Add(BuildFormFieldModel(property));
+                }
+            }
+        }
+
+        return ImmutableEquatableArrayFactory.FromList(fields);
+    }
+
+    /// <summary>Determines whether a property contributes a readable public instance form field.</summary>
+    /// <param name="property">The property to inspect.</param>
+    /// <returns><see langword="true"/> when the property is read through a public instance getter.</returns>
+    private static bool IsReadableFormProperty(IPropertySymbol property) =>
+        !property.IsStatic
+        && !property.IsIndexer
+        && property.DeclaredAccessibility == Accessibility.Public
+        && property.GetMethod is { DeclaredAccessibility: Accessibility.Public };
+
+    /// <summary>Determines whether a body type can be flattened to form fields without reflection.</summary>
+    /// <param name="type">The declared body type.</param>
+    /// <returns><see langword="true"/> when descriptor-based flattening matches the reflection path.</returns>
+    private static bool IsFormFieldEligibleType(ITypeSymbol type) =>
+        type.TypeKind is not (TypeKind.Interface or TypeKind.TypeParameter or TypeKind.Dynamic
+            or TypeKind.Array or TypeKind.Pointer or TypeKind.Error)
+        && type.SpecialType is not (SpecialType.System_String or SpecialType.System_Object)
+        && type is not INamedTypeSymbol { OriginalDefinition.SpecialType: SpecialType.System_Nullable_T }
+
+        // Dictionaries and other enumerables flow through the reflection path, which special-cases them.
+        && !ImplementsEnumerable(type);
+
+    /// <summary>Determines whether a type implements the non-generic <see cref="System.Collections.IEnumerable"/>.</summary>
+    /// <param name="type">The type to inspect.</param>
+    /// <returns><see langword="true"/> when the type is enumerable.</returns>
+    private static bool ImplementsEnumerable(ITypeSymbol type)
+    {
+        if (type.SpecialType == SpecialType.System_Collections_IEnumerable)
+        {
+            return true;
+        }
+
+        foreach (var contract in type.AllInterfaces)
+        {
+            if (contract.SpecialType == SpecialType.System_Collections_IEnumerable)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>Builds the form field descriptor for one body property.</summary>
+    /// <param name="property">The property to describe.</param>
+    /// <returns>The field descriptor.</returns>
+    private static FormFieldModel BuildFormFieldModel(IPropertySymbol property)
+    {
+        string? aliasName = null;
+        string? jsonName = null;
+        var query = default(QueryFormData);
+
+        foreach (var attribute in property.GetAttributes())
+        {
+            var attributeName = attribute.AttributeClass?.ToDisplayString();
+            if (attributeName == "Refit.AliasAsAttribute")
+            {
+                aliasName = GetFirstStringArgument(attribute);
+            }
+            else if (attributeName == "System.Text.Json.Serialization.JsonPropertyNameAttribute")
+            {
+                jsonName = GetFirstStringArgument(attribute);
+            }
+            else if (attributeName == "Refit.QueryAttribute")
+            {
+                query = ParseFormQueryAttribute(attribute);
+            }
+        }
+
+        var prefixSegment = string.IsNullOrWhiteSpace(query.Prefix) ? null : query.Prefix + query.Delimiter;
+        return new(
+            property.Name,
+            aliasName ?? jsonName,
+            prefixSegment,
+            query.Format,
+            query.CollectionFormatValue,
+            query.SerializeNull);
+    }
+
+    /// <summary>Reads the first string constructor argument from an attribute.</summary>
+    /// <param name="attribute">The attribute to inspect.</param>
+    /// <returns>The first string argument, or <see langword="null"/>.</returns>
+    private static string? GetFirstStringArgument(AttributeData attribute)
+    {
+        foreach (var argument in attribute.ConstructorArguments)
+        {
+            if (argument.Value is string value)
+            {
+                return value;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>Parses the form-relevant members of a <c>[Query]</c> attribute applied to a property.</summary>
+    /// <param name="attribute">The query attribute data.</param>
+    /// <returns>The parsed form query data.</returns>
+    private static QueryFormData ParseFormQueryAttribute(AttributeData attribute) =>
+        ApplyQueryNamedArguments(attribute, ParseQueryConstructorArguments(attribute));
+
+    /// <summary>Parses the constructor arguments of a <c>[Query]</c> attribute.</summary>
+    /// <param name="attribute">The query attribute data.</param>
+    /// <returns>The form query data carried by the constructor arguments.</returns>
+    private static QueryFormData ParseQueryConstructorArguments(AttributeData attribute)
+    {
+        var delimiter = ".";
+        string? prefix = null;
+        string? format = null;
+        int? collectionFormatValue = null;
+        var stringArguments = 0;
+
+        foreach (var argument in attribute.ConstructorArguments)
+        {
+            if (argument.Type?.ToDisplayString() == "Refit.CollectionFormat" && argument.Value is int constructorCollectionFormat)
+            {
+                collectionFormatValue = constructorCollectionFormat;
+            }
+            else if (argument.Value is string stringValue)
+            {
+                if (stringArguments == 0)
+                {
+                    delimiter = stringValue;
+                }
+                else if (stringArguments == 1)
+                {
+                    prefix = stringValue;
+                }
+                else
+                {
+                    format = stringValue;
+                }
+
+                stringArguments++;
+            }
+        }
+
+        return new(delimiter, prefix, format, collectionFormatValue, false);
+    }
+
+    /// <summary>Applies the named arguments of a <c>[Query]</c> attribute over constructor-supplied data.</summary>
+    /// <param name="attribute">The query attribute data.</param>
+    /// <param name="data">The data parsed from constructor arguments.</param>
+    /// <returns>The form query data with named arguments applied.</returns>
+    private static QueryFormData ApplyQueryNamedArguments(AttributeData attribute, QueryFormData data)
+    {
+        foreach (var named in attribute.NamedArguments)
+        {
+            if (named.Key == "Format" && named.Value.Value is string formatValue)
+            {
+                data = data with { Format = formatValue };
+            }
+            else if (named.Key == "CollectionFormat" && named.Value.Value is int namedCollectionFormat)
+            {
+                data = data with { CollectionFormatValue = namedCollectionFormat };
+            }
+            else if (named.Key == "SerializeNull" && named.Value.Value is bool serializeNullValue)
+            {
+                data = data with { SerializeNull = serializeNullValue };
+            }
+        }
+
+        return data;
     }
 
     /// <summary>Tries to parse a dynamic header parameter.</summary>
@@ -622,6 +822,19 @@ internal static partial class Parser
     private readonly record struct BodyAttributeInfo(
         string SerializationMethod,
         BodyBufferMode BufferMode);
+
+    /// <summary>Form-relevant data parsed from a <c>[Query]</c> attribute on a body property.</summary>
+    /// <param name="Delimiter">The delimiter combined with the prefix.</param>
+    /// <param name="Prefix">The field name prefix, if any.</param>
+    /// <param name="Format">The value format, if any.</param>
+    /// <param name="CollectionFormatValue">The explicit collection format value, if any.</param>
+    /// <param name="SerializeNull">Whether null values are serialized as empty fields.</param>
+    private readonly record struct QueryFormData(
+        string Delimiter,
+        string? Prefix,
+        string? Format,
+        int? CollectionFormatValue,
+        bool SerializeNull);
 
     /// <summary>Parsed return-type data for generated requests.</summary>
     /// <param name="ResultType">The method result type.</param>

--- a/src/Refit.HttpClientFactory/Refit.HttpClientFactory.csproj
+++ b/src/Refit.HttpClientFactory/Refit.HttpClientFactory.csproj
@@ -8,8 +8,8 @@
     <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>
   <ItemGroup>
-    <!-- Linked internal helpers shared with Refit (one internal copy per assembly, no InternalsVisibleTo). -->
-    <Compile Include="..\Shared\UniqueName.cs" Link="Shared\UniqueName.cs" />
+    <!-- Linked internal helpers shared with Refit (one internal copy per assembly, no InternalsVisibleTo).
+         UniqueName is public on Refit, so it is consumed from the Refit reference rather than compiled here. -->
     <Compile Include="..\Shared\AuthenticatedHttpClientHandler.cs" Link="Shared\AuthenticatedHttpClientHandler.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Refit/FormField.cs
+++ b/src/Refit/FormField.cs
@@ -1,0 +1,73 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+using System.ComponentModel;
+
+namespace Refit;
+
+/// <summary>
+/// Describes a single form-url-encoded field for a strongly-typed body, allowing source-generated code to
+/// flatten a form body without reflection. The getter and all naming metadata are resolved at compile time
+/// by the Refit source generator; the runtime only formats the value using the configured
+/// <see cref="RefitSettings"/>.
+/// </summary>
+/// <typeparam name="TBody">The declared body type the field belongs to.</typeparam>
+[EditorBrowsable(EditorBrowsableState.Never)]
+public sealed class FormField<TBody>
+{
+    /// <summary>Initializes a new instance of the <see cref="FormField{TBody}"/> class.</summary>
+    /// <param name="getter">Reads the property value from a body instance without reflection.</param>
+    /// <param name="clrName">The declared CLR property name, used when no explicit name is configured.</param>
+    /// <param name="explicitName">The explicit field name from <c>[AliasAs]</c> or <c>[JsonPropertyName]</c>, or <see langword="null"/>.</param>
+    /// <param name="prefixSegment">The precomputed <c>prefix + delimiter</c> prepended to the field name, or <see langword="null"/> when no prefix applies.</param>
+    /// <param name="format">The <see cref="QueryAttribute.Format"/> applied to the value, or <see langword="null"/>.</param>
+    /// <param name="collectionFormat">The explicit <see cref="CollectionFormat"/>, or <see langword="null"/> to use the settings default.</param>
+    /// <param name="serializeNull">Whether a <see langword="null"/> value should be serialized as an empty field instead of omitted.</param>
+    public FormField(
+        Func<TBody, object?> getter,
+        string clrName,
+        string? explicitName,
+        string? prefixSegment,
+        string? format,
+        CollectionFormat? collectionFormat,
+        bool serializeNull)
+    {
+        Getter = getter;
+        ClrName = clrName;
+        ExplicitName = explicitName;
+        PrefixSegment = prefixSegment;
+        Format = format;
+        CollectionFormat = collectionFormat;
+        SerializeNull = serializeNull;
+    }
+
+    /// <summary>Gets the delegate that reads the property value from a body instance.</summary>
+    public Func<TBody, object?> Getter { get; }
+
+    /// <summary>Gets the declared CLR property name.</summary>
+    public string ClrName { get; }
+
+    /// <summary>Gets the explicit field name from <c>[AliasAs]</c> or <c>[JsonPropertyName]</c>, if any.</summary>
+    public string? ExplicitName { get; }
+
+    /// <summary>Gets the precomputed <c>prefix + delimiter</c> prepended to the field name, if any.</summary>
+    public string? PrefixSegment { get; }
+
+    /// <summary>Gets the value format string, if any.</summary>
+    public string? Format { get; }
+
+    /// <summary>Gets the explicit collection format, or <see langword="null"/> to use the settings default.</summary>
+    public CollectionFormat? CollectionFormat { get; }
+
+    /// <summary>Gets a value indicating whether a <see langword="null"/> value should be serialized as an empty field.</summary>
+    public bool SerializeNull { get; }
+
+    /// <summary>Resolves the form field name, applying the key formatter and any prefix.</summary>
+    /// <param name="urlParameterKeyFormatter">The formatter applied to the CLR name when no explicit name is set.</param>
+    /// <returns>The resolved field name.</returns>
+    public string? ResolveFieldName(IUrlParameterKeyFormatter urlParameterKeyFormatter)
+    {
+        var name = ExplicitName ?? urlParameterKeyFormatter.Format(ClrName);
+        return PrefixSegment is null ? name : PrefixSegment + name;
+    }
+}

--- a/src/Refit/FormValueMultimap.cs
+++ b/src/Refit/FormValueMultimap.cs
@@ -89,6 +89,40 @@ internal sealed class FormValueMultimap : IEnumerable<KeyValuePair<string?, stri
                 settings,
                 GetCachedProperties(source));
 
+    /// <summary>Creates a form value map from source-generated field descriptors, avoiding reflection.</summary>
+    /// <typeparam name="TBody">The declared body type.</typeparam>
+    /// <param name="body">The body instance to flatten into form entries.</param>
+    /// <param name="fields">The compile-time field descriptors for the body type.</param>
+    /// <param name="settings">The Refit settings controlling formatting.</param>
+    /// <returns>The created form value map.</returns>
+    internal static FormValueMultimap CreateFromFields<TBody>(
+        TBody body,
+        FormField<TBody>[] fields,
+        RefitSettings settings)
+    {
+        var map = new FormValueMultimap(null, settings, null);
+        for (var i = 0; i < fields.Length; i++)
+        {
+            var field = fields[i];
+            var value = field.Getter(body);
+            var fieldName = field.ResolveFieldName(map._urlParameterKeyFormatter);
+
+            if (value is null)
+            {
+                if (field.SerializeNull)
+                {
+                    map.Add(fieldName, string.Empty);
+                }
+
+                continue;
+            }
+
+            map.AppendValue(fieldName, value, field.Format, field.CollectionFormat, settings);
+        }
+
+        return map;
+    }
+
     /// <summary>Resolves the cached readable public properties for the given source type.</summary>
     /// <param name="type">The type to inspect.</param>
     /// <returns>The cached readable public properties.</returns>
@@ -129,7 +163,7 @@ internal sealed class FormValueMultimap : IEnumerable<KeyValuePair<string?, stri
     /// <summary>Formats and joins a collection-valued form field without LINQ adapters.</summary>
     /// <param name="enumerable">The collection to format.</param>
     /// <param name="delimiter">The delimiter between formatted values.</param>
-    /// <param name="attrib">The query attribute, if any.</param>
+    /// <param name="format">The value format string, if any.</param>
     /// <param name="settings">The Refit settings controlling formatting.</param>
     /// <returns>The joined formatted value.</returns>
     [SuppressMessage(
@@ -139,7 +173,7 @@ internal sealed class FormValueMultimap : IEnumerable<KeyValuePair<string?, stri
     private static string JoinFormattedValues(
         IEnumerable enumerable,
         string delimiter,
-        QueryAttribute? attrib,
+        string? format,
         RefitSettings settings)
     {
         var enumerator = enumerable.GetEnumerator();
@@ -151,11 +185,11 @@ internal sealed class FormValueMultimap : IEnumerable<KeyValuePair<string?, stri
             }
 
             var builder = new ValueStringBuilder(stackalloc char[256]);
-            builder.Append(settings.FormUrlEncodedParameterFormatter.Format(enumerator.Current, attrib?.Format));
+            builder.Append(settings.FormUrlEncodedParameterFormatter.Format(enumerator.Current, format));
             while (enumerator.MoveNext())
             {
                 builder.Append(delimiter);
-                builder.Append(settings.FormUrlEncodedParameterFormatter.Format(enumerator.Current, attrib?.Format));
+                builder.Append(settings.FormUrlEncodedParameterFormatter.Format(enumerator.Current, format));
             }
 
             return builder.ToString();
@@ -196,46 +230,67 @@ internal sealed class FormValueMultimap : IEnumerable<KeyValuePair<string?, stri
         {
             var property = properties[i];
             var value = property.GetValue(source, null);
-            if (value is null)
-            {
-                continue;
-            }
-
-            var fieldName = GetFieldNameForProperty(property);
 
             // see if there's a query attribute
             var attrib = property.GetCustomAttribute<QueryAttribute>(true);
 
-            // add strings/non enumerable properties
-            if (value is not IEnumerable enumerable || value is string)
+            if (value is null)
             {
-                Add(
-                    fieldName,
-                    settings.FormUrlEncodedParameterFormatter.Format(value, attrib?.Format));
+                if (attrib?.SerializeNull == true)
+                {
+                    Add(GetFieldNameForProperty(property), string.Empty);
+                }
+
                 continue;
             }
 
-            var collectionFormat =
-                attrib?.IsCollectionFormatSpecified == true
-                    ? attrib.CollectionFormat
-                    : settings.CollectionFormat;
+            var fieldName = GetFieldNameForProperty(property);
+            var collectionFormat = attrib?.IsCollectionFormatSpecified == true
+                ? attrib.CollectionFormat
+                : (CollectionFormat?)null;
 
-            AddCollection(fieldName, enumerable, value, attrib, collectionFormat, settings);
+            AppendValue(fieldName, value, attrib?.Format, collectionFormat, settings);
         }
+    }
+
+    /// <summary>Adds a non-null property or descriptor value, choosing scalar or collection handling.</summary>
+    /// <param name="fieldName">The resolved form field name.</param>
+    /// <param name="value">The non-null value to add.</param>
+    /// <param name="format">The value format string, if any.</param>
+    /// <param name="explicitCollectionFormat">The explicit collection format, or <see langword="null"/> to use the settings default.</param>
+    /// <param name="settings">The Refit settings controlling formatting.</param>
+    private void AppendValue(
+        string? fieldName,
+        object value,
+        string? format,
+        CollectionFormat? explicitCollectionFormat,
+        RefitSettings settings)
+    {
+        // add strings/non enumerable properties
+        if (value is not IEnumerable enumerable || value is string)
+        {
+            Add(
+                fieldName,
+                settings.FormUrlEncodedParameterFormatter.Format(value, format));
+            return;
+        }
+
+        var collectionFormat = explicitCollectionFormat ?? settings.CollectionFormat;
+        AddCollection(fieldName, enumerable, value, format, collectionFormat, settings);
     }
 
     /// <summary>Adds a collection-valued property using the resolved collection format.</summary>
     /// <param name="fieldName">The resolved form field name.</param>
     /// <param name="enumerable">The enumerable value.</param>
     /// <param name="value">The original property value.</param>
-    /// <param name="attrib">The query attribute, if any.</param>
+    /// <param name="format">The value format string, if any.</param>
     /// <param name="collectionFormat">The resolved collection format.</param>
     /// <param name="settings">The Refit settings controlling formatting.</param>
     private void AddCollection(
-        string fieldName,
+        string? fieldName,
         IEnumerable enumerable,
         object value,
-        QueryAttribute? attrib,
+        string? format,
         CollectionFormat collectionFormat,
         RefitSettings settings)
     {
@@ -249,7 +304,7 @@ internal sealed class FormValueMultimap : IEnumerable<KeyValuePair<string?, stri
                         fieldName,
                         settings.FormUrlEncodedParameterFormatter.Format(
                             item,
-                            attrib?.Format));
+                            format));
                 }
 
                 break;
@@ -262,7 +317,7 @@ internal sealed class FormValueMultimap : IEnumerable<KeyValuePair<string?, stri
             {
                 var delimiter = GetDelimiter(collectionFormat);
 
-                Add(fieldName, JoinFormattedValues(enumerable, delimiter, attrib, settings));
+                Add(fieldName, JoinFormattedValues(enumerable, delimiter, format, settings));
                 break;
             }
 
@@ -272,7 +327,7 @@ internal sealed class FormValueMultimap : IEnumerable<KeyValuePair<string?, stri
                     fieldName,
                     settings.FormUrlEncodedParameterFormatter.Format(
                         value,
-                        attrib?.Format));
+                        format));
                 break;
             }
         }

--- a/src/Refit/GeneratedRequestRunner.cs
+++ b/src/Refit/GeneratedRequestRunner.cs
@@ -249,6 +249,58 @@ public static class GeneratedRequestRunner
             : new FormUrlEncodedContent(FormValueMultimap.Create(body, settings));
     }
 
+    /// <summary>Serializes a generated URL-encoded request body using source-generated field descriptors.</summary>
+    /// <typeparam name="TBody">The declared body type.</typeparam>
+    /// <param name="settings">The Refit settings to use.</param>
+    /// <param name="body">The body value.</param>
+    /// <param name="fields">The compile-time field descriptors for the body type.</param>
+    /// <returns>The HTTP content for the URL-encoded body.</returns>
+    /// <remarks>
+    /// The reflection-free path runs only when the configured content serializer resolves field names purely
+    /// from attributes the generator already inlined (the built-in <see cref="SystemTextJsonContentSerializer"/>).
+    /// For any other serializer the field-name hook may need the runtime <see cref="System.Reflection.PropertyInfo"/>,
+    /// so this falls back to the reflection-based <see cref="FormValueMultimap"/>.
+    /// </remarks>
+    [SuppressMessage(
+        "Major Code Smell",
+        "S4018:Generic methods should provide type parameters",
+        Justification = "Generated callers specify the declared body type for AOT-safe form property discovery.")]
+    public static HttpContent CreateUrlEncodedBodyContent<
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)]
+        TBody>(
+        RefitSettings settings,
+        TBody body,
+        FormField<TBody>[] fields)
+    {
+        if (body is HttpContent httpContent)
+        {
+            return httpContent;
+        }
+
+        if (body is Stream stream)
+        {
+            return new StreamContent(stream);
+        }
+
+        if (body is string stringBody)
+        {
+            return new StringContent(
+                StringHelpers.EscapeDataString(stringBody),
+                Encoding.UTF8,
+                "application/x-www-form-urlencoded");
+        }
+
+        // The descriptor path only matches the reflection path when the serializer resolves field names from
+        // attributes the generator already inlined (the built-in System.Text.Json serializer); otherwise fall back.
+        var useDescriptors = body is not null and not System.Collections.IDictionary
+            && settings.ContentSerializer is SystemTextJsonContentSerializer;
+
+        return new FormUrlEncodedContent(
+            useDescriptors
+                ? FormValueMultimap.CreateFromFields(body, fields, settings)
+                : FormValueMultimap.Create(body, settings));
+    }
+
     /// <summary>Sets, replaces, or removes a generated request header.</summary>
     /// <param name="request">The request to modify.</param>
     /// <param name="name">The header name.</param>

--- a/src/Refit/PublicAPI/net10.0/PublicAPI.Unshipped.txt
+++ b/src/Refit/PublicAPI/net10.0/PublicAPI.Unshipped.txt
@@ -1,1 +1,19 @@
 #nullable enable
+Refit.UniqueName
+static Refit.UniqueName.ForType<T>() -> string!
+static Refit.UniqueName.ForType<T>(object? serviceKey) -> string!
+static Refit.UniqueName.ForType(System.Type! refitInterfaceType) -> string!
+static Refit.UniqueName.ForType(System.Type! refitInterfaceType, object? serviceKey) -> string!
+Refit.QueryAttribute.SerializeNull.get -> bool
+Refit.QueryAttribute.SerializeNull.set -> void
+Refit.FormField<TBody>
+Refit.FormField<TBody>.ClrName.get -> string!
+Refit.FormField<TBody>.CollectionFormat.get -> Refit.CollectionFormat?
+Refit.FormField<TBody>.ExplicitName.get -> string?
+Refit.FormField<TBody>.Format.get -> string?
+Refit.FormField<TBody>.FormField(System.Func<TBody, object?>! getter, string! clrName, string? explicitName, string? prefixSegment, string? format, Refit.CollectionFormat? collectionFormat, bool serializeNull) -> void
+Refit.FormField<TBody>.Getter.get -> System.Func<TBody, object?>!
+Refit.FormField<TBody>.PrefixSegment.get -> string?
+Refit.FormField<TBody>.ResolveFieldName(Refit.IUrlParameterKeyFormatter! urlParameterKeyFormatter) -> string?
+Refit.FormField<TBody>.SerializeNull.get -> bool
+static Refit.GeneratedRequestRunner.CreateUrlEncodedBodyContent<TBody>(Refit.RefitSettings! settings, TBody body, Refit.FormField<TBody>![]! fields) -> System.Net.Http.HttpContent!

--- a/src/Refit/PublicAPI/net11.0/PublicAPI.Unshipped.txt
+++ b/src/Refit/PublicAPI/net11.0/PublicAPI.Unshipped.txt
@@ -1,1 +1,19 @@
 #nullable enable
+Refit.UniqueName
+static Refit.UniqueName.ForType<T>() -> string!
+static Refit.UniqueName.ForType<T>(object? serviceKey) -> string!
+static Refit.UniqueName.ForType(System.Type! refitInterfaceType) -> string!
+static Refit.UniqueName.ForType(System.Type! refitInterfaceType, object? serviceKey) -> string!
+Refit.QueryAttribute.SerializeNull.get -> bool
+Refit.QueryAttribute.SerializeNull.set -> void
+Refit.FormField<TBody>
+Refit.FormField<TBody>.ClrName.get -> string!
+Refit.FormField<TBody>.CollectionFormat.get -> Refit.CollectionFormat?
+Refit.FormField<TBody>.ExplicitName.get -> string?
+Refit.FormField<TBody>.Format.get -> string?
+Refit.FormField<TBody>.FormField(System.Func<TBody, object?>! getter, string! clrName, string? explicitName, string? prefixSegment, string? format, Refit.CollectionFormat? collectionFormat, bool serializeNull) -> void
+Refit.FormField<TBody>.Getter.get -> System.Func<TBody, object?>!
+Refit.FormField<TBody>.PrefixSegment.get -> string?
+Refit.FormField<TBody>.ResolveFieldName(Refit.IUrlParameterKeyFormatter! urlParameterKeyFormatter) -> string?
+Refit.FormField<TBody>.SerializeNull.get -> bool
+static Refit.GeneratedRequestRunner.CreateUrlEncodedBodyContent<TBody>(Refit.RefitSettings! settings, TBody body, Refit.FormField<TBody>![]! fields) -> System.Net.Http.HttpContent!

--- a/src/Refit/PublicAPI/net462/PublicAPI.Unshipped.txt
+++ b/src/Refit/PublicAPI/net462/PublicAPI.Unshipped.txt
@@ -1,1 +1,19 @@
 #nullable enable
+Refit.UniqueName
+static Refit.UniqueName.ForType<T>() -> string!
+static Refit.UniqueName.ForType<T>(object? serviceKey) -> string!
+static Refit.UniqueName.ForType(System.Type! refitInterfaceType) -> string!
+static Refit.UniqueName.ForType(System.Type! refitInterfaceType, object? serviceKey) -> string!
+Refit.QueryAttribute.SerializeNull.get -> bool
+Refit.QueryAttribute.SerializeNull.set -> void
+Refit.FormField<TBody>
+Refit.FormField<TBody>.ClrName.get -> string!
+Refit.FormField<TBody>.CollectionFormat.get -> Refit.CollectionFormat?
+Refit.FormField<TBody>.ExplicitName.get -> string?
+Refit.FormField<TBody>.Format.get -> string?
+Refit.FormField<TBody>.FormField(System.Func<TBody, object?>! getter, string! clrName, string? explicitName, string? prefixSegment, string? format, Refit.CollectionFormat? collectionFormat, bool serializeNull) -> void
+Refit.FormField<TBody>.Getter.get -> System.Func<TBody, object?>!
+Refit.FormField<TBody>.PrefixSegment.get -> string?
+Refit.FormField<TBody>.ResolveFieldName(Refit.IUrlParameterKeyFormatter! urlParameterKeyFormatter) -> string?
+Refit.FormField<TBody>.SerializeNull.get -> bool
+static Refit.GeneratedRequestRunner.CreateUrlEncodedBodyContent<TBody>(Refit.RefitSettings! settings, TBody body, Refit.FormField<TBody>![]! fields) -> System.Net.Http.HttpContent!

--- a/src/Refit/PublicAPI/net470/PublicAPI.Unshipped.txt
+++ b/src/Refit/PublicAPI/net470/PublicAPI.Unshipped.txt
@@ -1,1 +1,19 @@
 #nullable enable
+Refit.UniqueName
+static Refit.UniqueName.ForType<T>() -> string!
+static Refit.UniqueName.ForType<T>(object? serviceKey) -> string!
+static Refit.UniqueName.ForType(System.Type! refitInterfaceType) -> string!
+static Refit.UniqueName.ForType(System.Type! refitInterfaceType, object? serviceKey) -> string!
+Refit.QueryAttribute.SerializeNull.get -> bool
+Refit.QueryAttribute.SerializeNull.set -> void
+Refit.FormField<TBody>
+Refit.FormField<TBody>.ClrName.get -> string!
+Refit.FormField<TBody>.CollectionFormat.get -> Refit.CollectionFormat?
+Refit.FormField<TBody>.ExplicitName.get -> string?
+Refit.FormField<TBody>.Format.get -> string?
+Refit.FormField<TBody>.FormField(System.Func<TBody, object?>! getter, string! clrName, string? explicitName, string? prefixSegment, string? format, Refit.CollectionFormat? collectionFormat, bool serializeNull) -> void
+Refit.FormField<TBody>.Getter.get -> System.Func<TBody, object?>!
+Refit.FormField<TBody>.PrefixSegment.get -> string?
+Refit.FormField<TBody>.ResolveFieldName(Refit.IUrlParameterKeyFormatter! urlParameterKeyFormatter) -> string?
+Refit.FormField<TBody>.SerializeNull.get -> bool
+static Refit.GeneratedRequestRunner.CreateUrlEncodedBodyContent<TBody>(Refit.RefitSettings! settings, TBody body, Refit.FormField<TBody>![]! fields) -> System.Net.Http.HttpContent!

--- a/src/Refit/PublicAPI/net471/PublicAPI.Unshipped.txt
+++ b/src/Refit/PublicAPI/net471/PublicAPI.Unshipped.txt
@@ -1,1 +1,19 @@
 #nullable enable
+Refit.UniqueName
+static Refit.UniqueName.ForType<T>() -> string!
+static Refit.UniqueName.ForType<T>(object? serviceKey) -> string!
+static Refit.UniqueName.ForType(System.Type! refitInterfaceType) -> string!
+static Refit.UniqueName.ForType(System.Type! refitInterfaceType, object? serviceKey) -> string!
+Refit.QueryAttribute.SerializeNull.get -> bool
+Refit.QueryAttribute.SerializeNull.set -> void
+Refit.FormField<TBody>
+Refit.FormField<TBody>.ClrName.get -> string!
+Refit.FormField<TBody>.CollectionFormat.get -> Refit.CollectionFormat?
+Refit.FormField<TBody>.ExplicitName.get -> string?
+Refit.FormField<TBody>.Format.get -> string?
+Refit.FormField<TBody>.FormField(System.Func<TBody, object?>! getter, string! clrName, string? explicitName, string? prefixSegment, string? format, Refit.CollectionFormat? collectionFormat, bool serializeNull) -> void
+Refit.FormField<TBody>.Getter.get -> System.Func<TBody, object?>!
+Refit.FormField<TBody>.PrefixSegment.get -> string?
+Refit.FormField<TBody>.ResolveFieldName(Refit.IUrlParameterKeyFormatter! urlParameterKeyFormatter) -> string?
+Refit.FormField<TBody>.SerializeNull.get -> bool
+static Refit.GeneratedRequestRunner.CreateUrlEncodedBodyContent<TBody>(Refit.RefitSettings! settings, TBody body, Refit.FormField<TBody>![]! fields) -> System.Net.Http.HttpContent!

--- a/src/Refit/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/Refit/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -1,1 +1,19 @@
 #nullable enable
+Refit.UniqueName
+static Refit.UniqueName.ForType<T>() -> string!
+static Refit.UniqueName.ForType<T>(object? serviceKey) -> string!
+static Refit.UniqueName.ForType(System.Type! refitInterfaceType) -> string!
+static Refit.UniqueName.ForType(System.Type! refitInterfaceType, object? serviceKey) -> string!
+Refit.QueryAttribute.SerializeNull.get -> bool
+Refit.QueryAttribute.SerializeNull.set -> void
+Refit.FormField<TBody>
+Refit.FormField<TBody>.ClrName.get -> string!
+Refit.FormField<TBody>.CollectionFormat.get -> Refit.CollectionFormat?
+Refit.FormField<TBody>.ExplicitName.get -> string?
+Refit.FormField<TBody>.Format.get -> string?
+Refit.FormField<TBody>.FormField(System.Func<TBody, object?>! getter, string! clrName, string? explicitName, string? prefixSegment, string? format, Refit.CollectionFormat? collectionFormat, bool serializeNull) -> void
+Refit.FormField<TBody>.Getter.get -> System.Func<TBody, object?>!
+Refit.FormField<TBody>.PrefixSegment.get -> string?
+Refit.FormField<TBody>.ResolveFieldName(Refit.IUrlParameterKeyFormatter! urlParameterKeyFormatter) -> string?
+Refit.FormField<TBody>.SerializeNull.get -> bool
+static Refit.GeneratedRequestRunner.CreateUrlEncodedBodyContent<TBody>(Refit.RefitSettings! settings, TBody body, Refit.FormField<TBody>![]! fields) -> System.Net.Http.HttpContent!

--- a/src/Refit/PublicAPI/net48/PublicAPI.Unshipped.txt
+++ b/src/Refit/PublicAPI/net48/PublicAPI.Unshipped.txt
@@ -1,1 +1,19 @@
 #nullable enable
+Refit.UniqueName
+static Refit.UniqueName.ForType<T>() -> string!
+static Refit.UniqueName.ForType<T>(object? serviceKey) -> string!
+static Refit.UniqueName.ForType(System.Type! refitInterfaceType) -> string!
+static Refit.UniqueName.ForType(System.Type! refitInterfaceType, object? serviceKey) -> string!
+Refit.QueryAttribute.SerializeNull.get -> bool
+Refit.QueryAttribute.SerializeNull.set -> void
+Refit.FormField<TBody>
+Refit.FormField<TBody>.ClrName.get -> string!
+Refit.FormField<TBody>.CollectionFormat.get -> Refit.CollectionFormat?
+Refit.FormField<TBody>.ExplicitName.get -> string?
+Refit.FormField<TBody>.Format.get -> string?
+Refit.FormField<TBody>.FormField(System.Func<TBody, object?>! getter, string! clrName, string? explicitName, string? prefixSegment, string? format, Refit.CollectionFormat? collectionFormat, bool serializeNull) -> void
+Refit.FormField<TBody>.Getter.get -> System.Func<TBody, object?>!
+Refit.FormField<TBody>.PrefixSegment.get -> string?
+Refit.FormField<TBody>.ResolveFieldName(Refit.IUrlParameterKeyFormatter! urlParameterKeyFormatter) -> string?
+Refit.FormField<TBody>.SerializeNull.get -> bool
+static Refit.GeneratedRequestRunner.CreateUrlEncodedBodyContent<TBody>(Refit.RefitSettings! settings, TBody body, Refit.FormField<TBody>![]! fields) -> System.Net.Http.HttpContent!

--- a/src/Refit/PublicAPI/net481/PublicAPI.Unshipped.txt
+++ b/src/Refit/PublicAPI/net481/PublicAPI.Unshipped.txt
@@ -1,1 +1,19 @@
 #nullable enable
+Refit.UniqueName
+static Refit.UniqueName.ForType<T>() -> string!
+static Refit.UniqueName.ForType<T>(object? serviceKey) -> string!
+static Refit.UniqueName.ForType(System.Type! refitInterfaceType) -> string!
+static Refit.UniqueName.ForType(System.Type! refitInterfaceType, object? serviceKey) -> string!
+Refit.QueryAttribute.SerializeNull.get -> bool
+Refit.QueryAttribute.SerializeNull.set -> void
+Refit.FormField<TBody>
+Refit.FormField<TBody>.ClrName.get -> string!
+Refit.FormField<TBody>.CollectionFormat.get -> Refit.CollectionFormat?
+Refit.FormField<TBody>.ExplicitName.get -> string?
+Refit.FormField<TBody>.Format.get -> string?
+Refit.FormField<TBody>.FormField(System.Func<TBody, object?>! getter, string! clrName, string? explicitName, string? prefixSegment, string? format, Refit.CollectionFormat? collectionFormat, bool serializeNull) -> void
+Refit.FormField<TBody>.Getter.get -> System.Func<TBody, object?>!
+Refit.FormField<TBody>.PrefixSegment.get -> string?
+Refit.FormField<TBody>.ResolveFieldName(Refit.IUrlParameterKeyFormatter! urlParameterKeyFormatter) -> string?
+Refit.FormField<TBody>.SerializeNull.get -> bool
+static Refit.GeneratedRequestRunner.CreateUrlEncodedBodyContent<TBody>(Refit.RefitSettings! settings, TBody body, Refit.FormField<TBody>![]! fields) -> System.Net.Http.HttpContent!

--- a/src/Refit/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/Refit/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -1,1 +1,19 @@
 #nullable enable
+Refit.UniqueName
+static Refit.UniqueName.ForType<T>() -> string!
+static Refit.UniqueName.ForType<T>(object? serviceKey) -> string!
+static Refit.UniqueName.ForType(System.Type! refitInterfaceType) -> string!
+static Refit.UniqueName.ForType(System.Type! refitInterfaceType, object? serviceKey) -> string!
+Refit.QueryAttribute.SerializeNull.get -> bool
+Refit.QueryAttribute.SerializeNull.set -> void
+Refit.FormField<TBody>
+Refit.FormField<TBody>.ClrName.get -> string!
+Refit.FormField<TBody>.CollectionFormat.get -> Refit.CollectionFormat?
+Refit.FormField<TBody>.ExplicitName.get -> string?
+Refit.FormField<TBody>.Format.get -> string?
+Refit.FormField<TBody>.FormField(System.Func<TBody, object?>! getter, string! clrName, string? explicitName, string? prefixSegment, string? format, Refit.CollectionFormat? collectionFormat, bool serializeNull) -> void
+Refit.FormField<TBody>.Getter.get -> System.Func<TBody, object?>!
+Refit.FormField<TBody>.PrefixSegment.get -> string?
+Refit.FormField<TBody>.ResolveFieldName(Refit.IUrlParameterKeyFormatter! urlParameterKeyFormatter) -> string?
+Refit.FormField<TBody>.SerializeNull.get -> bool
+static Refit.GeneratedRequestRunner.CreateUrlEncodedBodyContent<TBody>(Refit.RefitSettings! settings, TBody body, Refit.FormField<TBody>![]! fields) -> System.Net.Http.HttpContent!

--- a/src/Refit/PublicAPI/net9.0/PublicAPI.Unshipped.txt
+++ b/src/Refit/PublicAPI/net9.0/PublicAPI.Unshipped.txt
@@ -1,1 +1,19 @@
 #nullable enable
+Refit.UniqueName
+static Refit.UniqueName.ForType<T>() -> string!
+static Refit.UniqueName.ForType<T>(object? serviceKey) -> string!
+static Refit.UniqueName.ForType(System.Type! refitInterfaceType) -> string!
+static Refit.UniqueName.ForType(System.Type! refitInterfaceType, object? serviceKey) -> string!
+Refit.QueryAttribute.SerializeNull.get -> bool
+Refit.QueryAttribute.SerializeNull.set -> void
+Refit.FormField<TBody>
+Refit.FormField<TBody>.ClrName.get -> string!
+Refit.FormField<TBody>.CollectionFormat.get -> Refit.CollectionFormat?
+Refit.FormField<TBody>.ExplicitName.get -> string?
+Refit.FormField<TBody>.Format.get -> string?
+Refit.FormField<TBody>.FormField(System.Func<TBody, object?>! getter, string! clrName, string? explicitName, string? prefixSegment, string? format, Refit.CollectionFormat? collectionFormat, bool serializeNull) -> void
+Refit.FormField<TBody>.Getter.get -> System.Func<TBody, object?>!
+Refit.FormField<TBody>.PrefixSegment.get -> string?
+Refit.FormField<TBody>.ResolveFieldName(Refit.IUrlParameterKeyFormatter! urlParameterKeyFormatter) -> string?
+Refit.FormField<TBody>.SerializeNull.get -> bool
+static Refit.GeneratedRequestRunner.CreateUrlEncodedBodyContent<TBody>(Refit.RefitSettings! settings, TBody body, Refit.FormField<TBody>![]! fields) -> System.Net.Http.HttpContent!

--- a/src/Refit/QueryAttribute.cs
+++ b/src/Refit/QueryAttribute.cs
@@ -53,6 +53,13 @@ public sealed class QueryAttribute : Attribute
     /// </summary>
     public bool TreatAsString { get; set; }
 
+    /// <summary>
+    /// Gets or sets a value indicating whether a <see langword="null"/> property value should still be
+    /// serialized (as an empty value, e.g. <c>key=</c>) instead of being omitted. By default null
+    /// properties are skipped; set this to <see langword="true"/> on a property whose null must be sent.
+    /// </summary>
+    public bool SerializeNull { get; set; }
+
     /// <summary>Gets the value used to customize the name of either the query parameter pair or of the form field when form encoding.</summary>
     /// <seealso cref="Prefix"/>
     public string Delimiter { get; } = ".";

--- a/src/Refit/RequestBuilderImplementation.QueryAndHeaders.cs
+++ b/src/Refit/RequestBuilderImplementation.QueryAndHeaders.cs
@@ -375,13 +375,24 @@ namespace Refit
             CollectionFormat? collectionFormat)
         {
             var obj = propertyInfo.GetValue(@object);
-            if (obj is null || ShouldSkipQueryProperty(propertyInfo, parameterInfo))
+            if (ShouldSkipQueryProperty(propertyInfo, parameterInfo))
             {
                 return;
             }
 
             var queryAttribute = propertyInfo.GetCustomAttribute<QueryAttribute>();
             var key = BuildPropertyQueryKey(propertyInfo, queryAttribute);
+
+            if (obj is null)
+            {
+                // Null properties are skipped unless the property opts in via [Query(SerializeNull = true)].
+                if (queryAttribute?.SerializeNull == true)
+                {
+                    kvps.Add(new(key, string.Empty));
+                }
+
+                return;
+            }
 
             if (!TryFormatQueryPropertyValue(queryAttribute, obj, out var formattedObj))
             {

--- a/src/Shared/UniqueName.cs
+++ b/src/Shared/UniqueName.cs
@@ -5,8 +5,12 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace Refit;
 
-/// <summary>Builds the unique generated type name for a Refit interface.</summary>
-internal static class UniqueName
+/// <summary>
+/// Builds the unique generated type name for a Refit interface. This matches the name Refit uses when
+/// registering a client with <c>IHttpClientFactory</c>, so it can be used to resolve or configure that
+/// same named client (for example <c>services.AddHttpClient(UniqueName.ForType&lt;T&gt;())</c>).
+/// </summary>
+public static class UniqueName
 {
     /// <summary>Builds the unique name for the generated implementation of the given interface type.</summary>
     /// <typeparam name="T">The Refit interface type.</typeparam>

--- a/src/benchmarks/Refit.Benchmarks/FormBenchmarkModel.cs
+++ b/src/benchmarks/Refit.Benchmarks/FormBenchmarkModel.cs
@@ -1,0 +1,31 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Refit.Benchmarks;
+
+/// <summary>A representative URL-encoded form payload used by the form serialization benchmark.</summary>
+public sealed class FormBenchmarkModel
+{
+    /// <summary>Gets or sets the aliased first name.</summary>
+    [AliasAs("first_name")]
+    public string? FirstName { get; set; }
+
+    /// <summary>Gets or sets the aliased last name.</summary>
+    [AliasAs("last_name")]
+    public string? LastName { get; set; }
+
+    /// <summary>Gets or sets the email.</summary>
+    public string? Email { get; set; }
+
+    /// <summary>Gets or sets the age.</summary>
+    public int Age { get; set; }
+
+    /// <summary>Gets or sets a note serialized even when null.</summary>
+    [Query(SerializeNull = true)]
+    public string? Note { get; set; }
+
+    /// <summary>Gets the multi-value roles collection.</summary>
+    [Query(CollectionFormat.Multi)]
+    public List<string> Roles { get; } = [];
+}

--- a/src/benchmarks/Refit.Benchmarks/FormBodySerializationBenchmark.cs
+++ b/src/benchmarks/Refit.Benchmarks/FormBodySerializationBenchmark.cs
@@ -1,0 +1,75 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using BenchmarkDotNet.Attributes;
+
+namespace Refit.Benchmarks;
+
+/// <summary>Benchmarks producing a URL-encoded form body via the reflection and generated descriptor paths.</summary>
+[MemoryDiagnoser]
+public class FormBodySerializationBenchmark
+{
+    /// <summary>A representative age value for the sample payload.</summary>
+    private const int SampleAge = 36;
+
+    /// <summary>Settings using the built-in serializer that enables the reflection-free descriptor path.</summary>
+    private static readonly RefitSettings _settings = new(new SystemTextJsonContentSerializer());
+
+    /// <summary>The payload serialized by each benchmark.</summary>
+    private FormBenchmarkModel _body = null!;
+
+    /// <summary>The generated field descriptors mirroring <see cref="FormBenchmarkModel"/>.</summary>
+    private FormField<FormBenchmarkModel>[] _fields = null!;
+
+    /// <summary>Builds the payload and descriptors before the benchmarks run.</summary>
+    [GlobalSetup]
+    public void Setup()
+    {
+        _body = new FormBenchmarkModel
+        {
+            FirstName = "Ada",
+            LastName = "Lovelace",
+            Email = "ada@example.com",
+            Age = SampleAge,
+            Note = null
+        };
+        _body.Roles.Add("admin");
+        _body.Roles.Add("author");
+
+        _fields =
+        [
+            new(static b => b.FirstName, "FirstName", "first_name", null, null, null, false),
+            new(static b => b.LastName, "LastName", "last_name", null, null, null, false),
+            new(static b => b.Email, "Email", null, null, null, null, false),
+            new(static b => b.Age, "Age", null, null, null, null, false),
+            new(static b => b.Note, "Note", null, null, null, null, true),
+            new(static b => b.Roles, "Roles", null, null, null, CollectionFormat.Multi, false)
+        ];
+    }
+
+    /// <summary>Serializes the form body through the reflection-based <c>FormValueMultimap</c> path.</summary>
+    /// <returns>The number of bytes produced.</returns>
+    [Benchmark(Baseline = true)]
+    public Task<long> ReflectionAsync() =>
+        ProduceAsync(GeneratedRequestRunner.CreateUrlEncodedBodyContent(_settings, _body));
+
+    /// <summary>Serializes the form body through the generated reflection-free descriptor path.</summary>
+    /// <returns>The number of bytes produced.</returns>
+    [Benchmark]
+    public Task<long> DescriptorAsync() =>
+        ProduceAsync(GeneratedRequestRunner.CreateUrlEncodedBodyContent(_settings, _body, _fields));
+
+    /// <summary>Serializes the content to a buffer and returns the byte count.</summary>
+    /// <param name="content">The HTTP content to materialize.</param>
+    /// <returns>The number of bytes produced.</returns>
+    private static async Task<long> ProduceAsync(HttpContent content)
+    {
+        using (content)
+        {
+            await using var stream = new MemoryStream();
+            await content.CopyToAsync(stream).ConfigureAwait(false);
+            return stream.Length;
+        }
+    }
+}

--- a/src/tests/Refit.GeneratorTests/GeneratedRequestBuildingTests.cs
+++ b/src/tests/Refit.GeneratorTests/GeneratedRequestBuildingTests.cs
@@ -190,6 +190,30 @@ public class GeneratedRequestBuildingTests
         await Assert.That(errorMessages).IsEqualTo(string.Empty);
     }
 
+    /// <summary>Verifies a parameter named like a generated local does not collide (issue #2161).</summary>
+    /// <param name="parameterName">A parameter name matching a generated local variable.</param>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    [Arguments("refitSettings")]
+    [Arguments("refitRequest")]
+    [Arguments("refitArguments")]
+    [Arguments("refitRequestBuilder")]
+    [Arguments("refitFunc")]
+    public async Task ParameterNamedLikeGeneratedLocalCompiles(string parameterName)
+    {
+        var body = $$"""
+            [Post("/todos")]
+            Task<string> CreateAsync([Body] string {{parameterName}});
+            """;
+
+        foreach (var generatedRequestBuilding in new bool?[] { true, false })
+        {
+            var errors = Fixture.GenerateErrorsForBody(body, generatedRequestBuilding);
+            var errorMessages = string.Join(Environment.NewLine, errors.Select(diagnostic => diagnostic.ToString()));
+            await Assert.That(errorMessages).IsEqualTo(string.Empty);
+        }
+    }
+
     /// <summary>Verifies static headers are emitted into inline request construction.</summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Test]

--- a/src/tests/Refit.GeneratorTests/GeneratedRequestBuildingTests.cs
+++ b/src/tests/Refit.GeneratorTests/GeneratedRequestBuildingTests.cs
@@ -884,4 +884,137 @@ public class GeneratedRequestBuildingTests
         await Assert.That(generated).Contains("void global::System.IDisposable.Dispose()");
         await Assert.That(generated).DoesNotContain("global::IBaseApi.Helper");
     }
+
+    /// <summary>Verifies a URL-encoded form body emits reflection-free generated field descriptors.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task UrlEncodedFormBodyEmitsGeneratedFieldDescriptors()
+    {
+        const string source =
+            """
+            using System;
+            using System.Collections.Generic;
+            using System.Threading.Tasks;
+            using System.Text.Json.Serialization;
+            using Refit;
+
+            namespace RefitGeneratorTest;
+
+            public class LoginForm
+            {
+                [AliasAs("user_name")]
+                public string UserName { get; set; }
+
+                [JsonPropertyName("pwd")]
+                public string Password { get; set; }
+
+                [Query(SerializeNull = true)]
+                public string Note { get; set; }
+
+                [Query(CollectionFormat.Multi)]
+                public List<string> Roles { get; set; }
+            }
+
+            public interface IGeneratedClient
+            {
+                [Post("/login")]
+                Task Login([Body(BodySerializationMethod.UrlEncoded)] LoginForm form);
+            }
+            """;
+
+        var result = Fixture.RunGenerator(source, generatedRequestBuilding: true);
+        var generated = result.GeneratedSources[GeneratedClientHintName];
+
+        await Assert.That(result.CompilesWithoutErrors).IsTrue();
+        await Assert.That(generated).Contains(
+            "global::Refit.FormField<global::RefitGeneratorTest.LoginForm>[]");
+        await Assert.That(generated).Contains(
+            "static body => (object?)body.@UserName");
+        await Assert.That(generated).Contains("\"user_name\"");
+        await Assert.That(generated).Contains("\"pwd\"");
+        await Assert.That(generated).Contains("(global::Refit.CollectionFormat)");
+        await Assert.That(generated).Contains(
+            "global::Refit.GeneratedRequestRunner.CreateUrlEncodedBodyContent<global::RefitGeneratorTest.LoginForm>(");
+    }
+
+    /// <summary>Verifies a string-typed form body keeps the reflection-based content path.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task UrlEncodedStringBodyKeepsReflectionContentPath()
+    {
+        var generated = Fixture.GenerateForBody(
+            """
+            [Post("/login")]
+            Task Login([Body(BodySerializationMethod.UrlEncoded)] string form);
+            """,
+            GeneratedClientHintName,
+            generatedRequestBuilding: true);
+
+        await Assert.That(generated).Contains(
+            "global::Refit.GeneratedRequestRunner.CreateUrlEncodedBodyContent<string>(");
+        await Assert.That(generated).DoesNotContain("global::Refit.FormField<");
+    }
+
+    /// <summary>Verifies non-flattenable form body types keep the reflection-based content path.</summary>
+    /// <param name="bodyType">The ineligible body type expression.</param>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    [Arguments("object")]
+    [Arguments("System.Collections.Generic.Dictionary<string, string>")]
+    [Arguments("System.Collections.Generic.List<string>")]
+    [Arguments("int[]")]
+    [Arguments("System.IDisposable")]
+    public async Task UrlEncodedIneligibleBodyKeepsReflectionContentPath(string bodyType)
+    {
+        var generated = Fixture.GenerateForBody(
+            $$"""
+            [Post("/x")]
+            Task Post([Body(BodySerializationMethod.UrlEncoded)] {{bodyType}} body);
+            """,
+            GeneratedClientHintName,
+            generatedRequestBuilding: true);
+
+        await Assert.That(generated).Contains(
+            "global::Refit.GeneratedRequestRunner.CreateUrlEncodedBodyContent<");
+        await Assert.That(generated).DoesNotContain("global::Refit.FormField<");
+    }
+
+    /// <summary>Verifies form field descriptors include inherited properties and apply the query prefix.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task UrlEncodedFormBodyEmitsInheritedAndPrefixedFieldDescriptors()
+    {
+        const string source =
+            """
+            using System.Threading.Tasks;
+            using Refit;
+
+            namespace RefitGeneratorTest;
+
+            public class BaseForm
+            {
+                public string BaseValue { get; set; }
+            }
+
+            public class DerivedForm : BaseForm
+            {
+                [Query("-", "secret")]
+                public string Token { get; set; }
+            }
+
+            public interface IGeneratedClient
+            {
+                [Post("/login")]
+                Task Login([Body(BodySerializationMethod.UrlEncoded)] DerivedForm form);
+            }
+            """;
+
+        var result = Fixture.RunGenerator(source, generatedRequestBuilding: true);
+        var generated = result.GeneratedSources[GeneratedClientHintName];
+
+        await Assert.That(result.CompilesWithoutErrors).IsTrue();
+        await Assert.That(generated).Contains("static body => (object?)body.@Token");
+        await Assert.That(generated).Contains("static body => (object?)body.@BaseValue");
+        await Assert.That(generated).Contains("\"secret-\"");
+    }
 }

--- a/src/tests/Refit.GeneratorTests/GeneratorComponentTests.cs
+++ b/src/tests/Refit.GeneratorTests/GeneratorComponentTests.cs
@@ -222,22 +222,27 @@ public static class GeneratorComponentTests
         [Test]
         public async Task BodyExpressionHelpers_HandleBufferModes()
         {
+            const string settings = "refitSettings";
             var settingsBody = CreateBody(DefaultSerializationMethod, BodyBufferMode.Settings);
             var bufferedBody = CreateBody(DefaultSerializationMethod, BodyBufferMode.Buffered);
             var streamingBody = CreateBody(DefaultSerializationMethod, BodyBufferMode.Streaming);
             var noneBody = CreateBody(DefaultSerializationMethod, BodyBufferMode.None);
             var urlEncodedBody = CreateBody("UrlEncoded", BodyBufferMode.Streaming);
 
-            await Assert.That(Emitter.BuildBufferBodyExpression(null)).IsEqualTo(FalseLiteral);
-            await Assert.That(Emitter.BuildBufferBodyExpression(settingsBody)).IsEqualTo("refitSettings.Buffered");
-            await Assert.That(Emitter.BuildBufferBodyExpression(bufferedBody)).IsEqualTo(TrueLiteral);
-            await Assert.That(Emitter.BuildBufferBodyExpression(streamingBody)).IsEqualTo(FalseLiteral);
-            await Assert.That(Emitter.BuildBufferBodyExpression(noneBody)).IsEqualTo(FalseLiteral);
-            await Assert.That(Emitter.BuildStreamBodyExpression(settingsBody)).IsEqualTo("!refitSettings.Buffered");
-            await Assert.That(Emitter.BuildStreamBodyExpression(bufferedBody)).IsEqualTo(FalseLiteral);
-            await Assert.That(Emitter.BuildStreamBodyExpression(streamingBody)).IsEqualTo(TrueLiteral);
-            await Assert.That(Emitter.BuildStreamBodyExpression(noneBody)).IsEqualTo(FalseLiteral);
-            await Assert.That(Emitter.BuildStreamBodyExpression(urlEncodedBody)).IsEqualTo(FalseLiteral);
+            await Assert.That(Emitter.BuildBufferBodyExpression(null, settings)).IsEqualTo(FalseLiteral);
+            await Assert.That(Emitter.BuildBufferBodyExpression(settingsBody, settings)).IsEqualTo($"{settings}.Buffered");
+            await Assert.That(Emitter.BuildBufferBodyExpression(bufferedBody, settings)).IsEqualTo(TrueLiteral);
+            await Assert.That(Emitter.BuildBufferBodyExpression(streamingBody, settings)).IsEqualTo(FalseLiteral);
+            await Assert.That(Emitter.BuildBufferBodyExpression(noneBody, settings)).IsEqualTo(FalseLiteral);
+            await Assert.That(Emitter.BuildStreamBodyExpression(settingsBody, settings)).IsEqualTo($"!{settings}.Buffered");
+            await Assert.That(Emitter.BuildStreamBodyExpression(bufferedBody, settings)).IsEqualTo(FalseLiteral);
+            await Assert.That(Emitter.BuildStreamBodyExpression(streamingBody, settings)).IsEqualTo(TrueLiteral);
+            await Assert.That(Emitter.BuildStreamBodyExpression(noneBody, settings)).IsEqualTo(FalseLiteral);
+            await Assert.That(Emitter.BuildStreamBodyExpression(urlEncodedBody, settings)).IsEqualTo(FalseLiteral);
+
+            // With a different settings local name, the expression follows it (collision-avoidance threading).
+            await Assert.That(Emitter.BuildBufferBodyExpression(settingsBody, "renamed")).IsEqualTo("renamed.Buffered");
+            await Assert.That(Emitter.BuildStreamBodyExpression(settingsBody, "renamed")).IsEqualTo("!renamed.Buffered");
         }
 
         /// <summary>Verifies property access and global-prefix helpers.</summary>

--- a/src/tests/Refit.Tests/GeneratedFormData.cs
+++ b/src/tests/Refit.Tests/GeneratedFormData.cs
@@ -1,0 +1,26 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Text.Json.Serialization;
+
+namespace Refit.Tests;
+
+/// <summary>A strongly-typed URL-encoded form payload.</summary>
+public class GeneratedFormData
+{
+    /// <summary>Gets or sets the aliased user name.</summary>
+    [AliasAs("user_name")]
+    public string? UserName { get; set; }
+
+    /// <summary>Gets or sets the password named via the JSON serializer attribute.</summary>
+    [JsonPropertyName("pwd")]
+    public string? Password { get; set; }
+
+    /// <summary>Gets or sets a plain property.</summary>
+    public string? Plain { get; set; }
+
+    /// <summary>Gets or sets a nullable property serialized even when null.</summary>
+    [Query(SerializeNull = true)]
+    public string? Nullable { get; set; }
+}

--- a/src/tests/Refit.Tests/GeneratedRequestRunnerTests.cs
+++ b/src/tests/Refit.Tests/GeneratedRequestRunnerTests.cs
@@ -178,6 +178,132 @@ public class GeneratedRequestRunnerTests
         await Assert.That(await result.ReadAsStringAsync()).IsEqualTo("Name=Ada");
     }
 
+    /// <summary>Verifies the descriptor overload uses generated field metadata for the built-in JSON serializer.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task CreateUrlEncodedBodyContentWithFieldsUsesDescriptorsForSystemTextJson()
+    {
+        var settings = new RefitSettings(new SystemTextJsonContentSerializer());
+        var body = new DeclaredFormBody { Name = "Ada" };
+        var fields = new[]
+        {
+            new FormField<DeclaredFormBody>(static _ => "from-getter", "Name", "renamed", null, null, null, false)
+        };
+
+        var result = GeneratedRequestRunner.CreateUrlEncodedBodyContent(settings, body, fields);
+
+        await Assert.That(await result.ReadAsStringAsync()).IsEqualTo("renamed=from-getter");
+    }
+
+    /// <summary>Verifies the descriptor overload falls back to reflection for a custom content serializer.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task CreateUrlEncodedBodyContentWithFieldsFallsBackForCustomSerializer()
+    {
+        var settings = CreateSettings();
+        var body = new DeclaredFormBody { Name = "Ada" };
+        var fields = new[]
+        {
+            new FormField<DeclaredFormBody>(static _ => "from-getter", "Name", "renamed", null, null, null, false)
+        };
+
+        var result = GeneratedRequestRunner.CreateUrlEncodedBodyContent(settings, body, fields);
+
+        await Assert.That(await result.ReadAsStringAsync()).IsEqualTo("Name=Ada");
+    }
+
+    /// <summary>Verifies the descriptor overload routes dictionaries through the reflection path.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task CreateUrlEncodedBodyContentWithFieldsHandlesDictionary()
+    {
+        var settings = new RefitSettings(new SystemTextJsonContentSerializer());
+        var body = new Dictionary<string, object> { ["a"] = "1" };
+
+        var result = GeneratedRequestRunner.CreateUrlEncodedBodyContent(settings, body, []);
+
+        await Assert.That(await result.ReadAsStringAsync()).IsEqualTo("a=1");
+    }
+
+    /// <summary>Verifies the descriptor overload escapes string bodies and skips descriptors.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task CreateUrlEncodedBodyContentWithFieldsEscapesStringBodies()
+    {
+        var settings = new RefitSettings(new SystemTextJsonContentSerializer());
+
+        var result = GeneratedRequestRunner.CreateUrlEncodedBodyContent(settings, "url&string", []);
+
+        await Assert.That(await result.ReadAsStringAsync()).IsEqualTo("url%26string");
+    }
+
+    /// <summary>Verifies the descriptor overload serializes null fields and collections per metadata.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task CreateUrlEncodedBodyContentWithFieldsSerializesNullsAndCollections()
+    {
+        var settings = new RefitSettings(new SystemTextJsonContentSerializer());
+        var body = new DeclaredFormBody();
+        var fields = new[]
+        {
+            new FormField<DeclaredFormBody>(static _ => null, "Note", "note", null, null, null, serializeNull: true),
+            new FormField<DeclaredFormBody>(static _ => new List<string> { "a", "b" }, "Roles", "roles", null, null, CollectionFormat.Multi, false),
+            new FormField<DeclaredFormBody>(static _ => null, "Skip", "skip", null, null, null, serializeNull: false)
+        };
+
+        var result = GeneratedRequestRunner.CreateUrlEncodedBodyContent(settings, body, fields);
+
+        await Assert.That(await result.ReadAsStringAsync()).IsEqualTo("note=&roles=a&roles=b");
+    }
+
+    /// <summary>Verifies the descriptor overload applies a precomputed prefix segment to the field name.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task CreateUrlEncodedBodyContentWithFieldsAppliesPrefixSegment()
+    {
+        var settings = new RefitSettings(new SystemTextJsonContentSerializer());
+        var body = new DeclaredFormBody { Name = "v" };
+        var fields = new[]
+        {
+            new FormField<DeclaredFormBody>(static b => b.Name, "Name", null, "pre-", null, null, false)
+        };
+
+        var result = GeneratedRequestRunner.CreateUrlEncodedBodyContent(settings, body, fields);
+
+        await Assert.That(await result.ReadAsStringAsync()).IsEqualTo("pre-Name=v");
+    }
+
+    /// <summary>Verifies the descriptor path and the reflection path produce identical form output.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task DescriptorAndReflectionFormPathsProduceIdenticalOutput()
+    {
+        var body = new ParityFormBody
+        {
+            WebPropertyId = "UA-1",
+            Plain = "p",
+            Note = null,
+            Roles = ["x", "y"]
+        };
+        var fields = new[]
+        {
+            new FormField<ParityFormBody>(static b => b.WebPropertyId, "WebPropertyId", "tid", null, null, null, false),
+            new FormField<ParityFormBody>(static b => b.Plain, "Plain", null, null, null, null, false),
+            new FormField<ParityFormBody>(static b => b.Note, "Note", null, null, null, null, serializeNull: true),
+            new FormField<ParityFormBody>(static b => b.Roles, "Roles", null, null, null, CollectionFormat.Multi, false)
+        };
+
+        // SystemTextJson takes the generated descriptor path; the recording serializer forces the reflection path.
+        var descriptor = await GeneratedRequestRunner
+            .CreateUrlEncodedBodyContent(new RefitSettings(new SystemTextJsonContentSerializer()), body, fields)
+            .ReadAsStringAsync();
+        var reflection = await GeneratedRequestRunner
+            .CreateUrlEncodedBodyContent(CreateSettings(), body, fields)
+            .ReadAsStringAsync();
+
+        await Assert.That(descriptor).IsEqualTo(reflection);
+    }
+
     /// <summary>Verifies that unsupported body serialization modes are rejected.</summary>
     /// <returns>A task that represents the asynchronous operation.</returns>
     [Test]
@@ -1123,6 +1249,25 @@ public class GeneratedRequestRunnerTests
     {
         /// <summary>Gets or sets a derived-only value.</summary>
         public string? Hidden { get; set; }
+    }
+
+    /// <summary>Form model used to compare the descriptor and reflection serialization paths.</summary>
+    private sealed class ParityFormBody
+    {
+        /// <summary>Gets or sets the aliased property.</summary>
+        [AliasAs("tid")]
+        public string? WebPropertyId { get; set; }
+
+        /// <summary>Gets or sets a plain property.</summary>
+        public string? Plain { get; set; }
+
+        /// <summary>Gets or sets a property serialized even when null.</summary>
+        [Query(SerializeNull = true)]
+        public string? Note { get; set; }
+
+        /// <summary>Gets or sets a multi-value collection property.</summary>
+        [Query(CollectionFormat.Multi)]
+        public List<string>? Roles { get; set; }
     }
 
     /// <summary>Simple deserialized response model for generated runtime tests.</summary>

--- a/src/tests/Refit.Tests/IGeneratedFormApi.cs
+++ b/src/tests/Refit.Tests/IGeneratedFormApi.cs
@@ -1,0 +1,17 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Threading.Tasks;
+
+namespace Refit.Tests;
+
+/// <summary>A Refit API posting a strongly-typed URL-encoded form body.</summary>
+public interface IGeneratedFormApi
+{
+    /// <summary>Posts a URL-encoded form body.</summary>
+    /// <param name="form">The form payload.</param>
+    /// <returns>The response string.</returns>
+    [Post("/form")]
+    Task<string> PostForm([Body(BodySerializationMethod.UrlEncoded)] GeneratedFormData form);
+}

--- a/src/tests/Refit.Tests/IRequestBin.cs
+++ b/src/tests/Refit.Tests/IRequestBin.cs
@@ -60,6 +60,12 @@ public interface IRequestBin
     [Post("/big")]
     Task PostBig(BigObject big);
 
+    /// <summary>Posts a body whose parameter name collides with a generated local variable (issue #2161).</summary>
+    /// <param name="refitSettings">A body parameter deliberately named like a generated local.</param>
+    /// <returns>A task that completes when the request finishes.</returns>
+    [Post("/foo")]
+    Task PostBodyNamedLikeGeneratedLocal([Body] string refitSettings);
+
     /// <summary>Posts a collection serialized as JSON Lines (newline-delimited JSON).</summary>
     /// <param name="records">The records to post, one JSON document per line.</param>
     /// <returns>A task that completes when the request finishes.</returns>

--- a/src/tests/Refit.Tests/RestServiceIntegrationTests.RequestBody.cs
+++ b/src/tests/Refit.Tests/RestServiceIntegrationTests.RequestBody.cs
@@ -78,6 +78,27 @@ public partial class RestServiceIntegrationTests
         mockHttp.VerifyNoOutstandingExpectation();
     }
 
+    /// <summary>Verifies a body parameter named like a generated local variable still works (issue #2161).</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task PostBodyNamedLikeGeneratedLocalToRequestBin()
+    {
+        var mockHttp = new MockHttpMessageHandler();
+
+        var settings = new RefitSettings { HttpMessageHandlerFactory = () => mockHttp };
+
+        _ = mockHttp
+            .Expect(HttpMethod.Post, "http://httpbin.org/foo")
+            .WithContent("payload")
+            .Respond(HttpStatusCode.OK);
+
+        var fixture = RestService.For<IRequestBin>("http://httpbin.org/", settings);
+
+        await fixture.PostBodyNamedLikeGeneratedLocal("payload");
+
+        mockHttp.VerifyNoOutstandingExpectation();
+    }
+
     /// <summary>Verifies a collection body is sent as JSON Lines (newline-delimited JSON).</summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Test]

--- a/src/tests/Refit.Tests/RestServiceIntegrationTests.RequestBody.cs
+++ b/src/tests/Refit.Tests/RestServiceIntegrationTests.RequestBody.cs
@@ -525,4 +525,34 @@ public partial class RestServiceIntegrationTests
         await Assert.That(resp.Args["LastName"]).IsEqualTo("Rambo");
         await Assert.That(resp.Args["Addr_Zip"]).IsEqualTo("9999");
     }
+
+    /// <summary>Verifies an object URL-encoded body flows through generated reflection-free form fields.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task PostGeneratedUrlEncodedFormUsesFieldDescriptors()
+    {
+        var mockHttp = new MockHttpMessageHandler();
+        var settings = new RefitSettings { HttpMessageHandlerFactory = () => mockHttp };
+
+        _ = mockHttp
+            .Expect(HttpMethod.Post, "http://foo/form")
+            .WithFormData("user_name", "bob")
+            .WithFormData("pwd", "secret")
+            .WithFormData("Plain", "x")
+            .WithFormData("Nullable", string.Empty)
+            .Respond("application/json", "\"ok\"");
+
+        var fixture = RestService.For<IGeneratedFormApi>("http://foo", settings);
+
+        _ = await fixture.PostForm(
+            new GeneratedFormData
+            {
+                UserName = "bob",
+                Password = "secret",
+                Plain = "x",
+                Nullable = null,
+            });
+
+        mockHttp.VerifyNoOutstandingExpectation();
+    }
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature (additive) plus a generator bug fix. No breaking changes.

## What is the new behavior?

- Reflection-free generated URL-encoded form serialization: the source generator emits compile-time `FormField<T>` descriptors with compiled getters, so form bodies flatten without reflection at request time when the built-in `SystemTextJsonContentSerializer` is used. About 5x faster and ~45% fewer allocations than the reflection path for a typical form (#1098).
- `QueryAttribute.SerializeNull`: opt in to send a null form/query property as an empty value (`key=`) instead of omitting it. Honored on both the reflection and generated paths (#1098).
- `UniqueName.ForType<T>()` is now public, so the generated `IHttpClientFactory` client name can be resolved, e.g. `services.AddHttpClient(UniqueName.ForType<T>())` (#1330).
- Generated local variable names no longer collide with method parameters named like the generated locals (#2161).
- Added tests, README docs, and a form serialization benchmark.

## What is the current behavior?

- Generated form bodies always flatten via reflection (`FormValueMultimap`).
- Null form/query properties are always omitted, with no way to send `key=`.
- `UniqueName` is internal, so consumers cannot resolve the generated named client.
- Generated locals could collide with parameters of the same name (#2161).

Closes #2161
Closes #1330
Closes #1098

## What might this PR break?

None. All changes are additive. The reflection-based form path remains and is used as the fallback (custom serializers, dictionaries, collections, object bodies) and the correctness oracle; a parity test asserts the descriptor and reflection paths produce identical output.

## Checklist
- [x] I have read the Contribute guide
- [x] Tests have been added or updated (for bug fixes / features)
- [x] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the `main` branch
- [x] PR title follows Conventional Commits

## Additional information

Form serialization benchmark (ShortRun, 6-field model):

| Method          | Mean    | Allocated |
|-----------------|---------|-----------|
| ReflectionAsync | 9.02 us | 4.04 KB   |
| DescriptorAsync | 1.77 us | 2.23 KB   |