### PR TITLE
fix: annotate HasRequestError/HasResponseError out-params for nullable flow

### DIFF
--- a/src/Refit/ApiResponse{T}.cs
+++ b/src/Refit/ApiResponse{T}.cs
@@ -147,7 +147,7 @@ public sealed class ApiResponse<T>(
         "CA1716:Identifiers should not match keywords",
         Justification = "By Design")]
     public bool HasRequestError(
-        [MaybeNullWhen(false)] out ApiRequestException? error)
+        [NotNullWhen(true)] out ApiRequestException? error)
     {
         error = Error as ApiRequestException;
         return error is not null;
@@ -159,7 +159,7 @@ public sealed class ApiResponse<T>(
         "CA1716:Identifiers should not match keywords",
         Justification = "By Design")]
     public bool HasResponseError(
-        [MaybeNullWhen(false)]
+        [NotNullWhen(true)]
         out ApiException? error)
     {
         error = Error as ApiException;

--- a/src/Refit/IApiResponse.cs
+++ b/src/Refit/IApiResponse.cs
@@ -82,7 +82,7 @@ public interface IApiResponse : IDisposable
         "CA1716:Identifiers should not match keywords",
         Justification = "By Design")]
     bool HasRequestError(
-        [MaybeNullWhen(false)] out ApiRequestException? error);
+        [NotNullWhen(true)] out ApiRequestException? error);
 
     /// <summary>Checks if the call failed due to an unsuccessful response from the server.</summary>
     /// <param name="error">The <see cref="ApiException"/> object in case of unsuccessful response.</param>
@@ -92,6 +92,6 @@ public interface IApiResponse : IDisposable
         "CA1716:Identifiers should not match keywords",
         Justification = "By Design")]
     bool HasResponseError(
-        [MaybeNullWhen(false)]
+        [NotNullWhen(true)]
         out ApiException? error);
 }


### PR DESCRIPTION
### Problem

`IApiResponse.HasRequestError` / `HasResponseError` (and the `ApiResponse<T>` implementations) declare their `out` parameter as nullable (`out ApiRequestException?` / `out ApiException?`) but annotate it with only `[MaybeNullWhen(false)]`. On an already-nullable `out`, `[MaybeNullWhen(false)]` says nothing about the `true` branch, so the compiler keeps treating the value as *maybe-null* even when the method returns `true`:

```csharp
if (response.HasResponseError(out var error))
{
    var status = error.StatusCode; // CS8602: dereference of a possibly null reference
}
```

This is a nullable-annotation regression: in v11 the parameter was non-nullable `out ApiException` + `[MaybeNullWhen(false)]`, which *did* flow non-null on the `true` branch. When the out-params were made nullable (#2159), `[NotNullWhen(true)]` was not added, so the positive narrowing was lost.

### Fix

Replace `[MaybeNullWhen(false)]` with `[NotNullWhen(true)]` on all four declarations (interface + implementation, both methods). This matches the actual runtime contract — each method returns `true` exactly when `error` is non-null:

```csharp
error = Error as ApiException;
return error is not null;
```

so callers now get correct non-null narrowing in the `true` branch.

### Notes

- Annotation-only; **no runtime behavior change**.
- **No `PublicAPI.Shipped.txt` change required** — those baselines record `out Refit.ApiException? error`, and nullability *flow* attributes are not part of that signature.
- Verified `Refit.csproj` builds clean on `net8.0` (0 warnings).

Follows up #2159.
