### PR TITLE
chore: Update version numbers for Primitives and TUnit

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <PropertyGroup Label="Shared Version Variables">
-    <PrimitivesVersion>5.6.0</PrimitivesVersion>
-    <TUnitVersion>1.56.0</TUnitVersion>
+    <PrimitivesVersion>5.8.0</PrimitivesVersion>
+    <TUnitVersion>1.57.0</TUnitVersion>
   </PropertyGroup>
 
   <PropertyGroup Label="Framework-Aligned Versions">


### PR DESCRIPTION
This pull request updates dependency versions in the `src/Directory.Packages.props` file to keep the project up to date with the latest releases.

Dependency version updates:

* Bumped `PrimitivesVersion` from `5.6.0` to `5.8.0`.
* Bumped `TUnitVersion` from `1.56.0` to `1.57.0`.