### PR TITLE
docs: document v12 breaking changes and update package versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Refit currently supports the following platforms and modern .NET targets:
 
 #### Breaking changes in V12.x
 
-Refit 12.0 is a large release centred on a near-complete rewrite of request building. The source generator now builds
+Refit 12.0 is a large release centered on a near-complete rewrite of request building. The source generator now builds
 eligible HTTP requests inline at compile time instead of going through the reflection request-builder pipeline, with the
 reflection path kept as a fallback for shapes that cannot be generated inline.
 
@@ -834,7 +834,7 @@ var otherApi = RestService.For<IOtherApi>("https://api.example.com",
     )});
 ```
 
-Property serialization/deserialization can be customised using Json.NET's
+Property serialization/deserialization can be customized using Json.NET's
 JsonProperty attribute:
 
 ```csharp
@@ -922,7 +922,7 @@ var gitHubApi = RestService.For<IXmlApi>("https://www.w3.org/XML",
     });
 ```
 
-Property serialization/deserialization can be customised using attributes found in the _System.Xml.Serialization_
+Property serialization/deserialization can be customized using attributes found in the _System.Xml.Serialization_
 namespace:
 
 ```csharp

--- a/README.md
+++ b/README.md
@@ -40,8 +40,9 @@ services
 
 * [Sponsors](#sponsors)
 * [Where does this work?](#where-does-this-work)
-    * [Breaking changes in 6.x](#breaking-changes-in-6x)
+    * [Breaking changes in V12.x](#breaking-changes-in-v12x)
     * [Breaking changes in 11.x](#breaking-changes-in-11x)
+    * [Breaking changes in 6.x](#breaking-changes-in-6x)
 * [Source generation](#source-generation)
     * [Generated-only client creation](#generated-only-client-creation)
     * [Generated request building](#generated-request-building)
@@ -102,9 +103,58 @@ Refit currently supports the following platforms and modern .NET targets:
 
 ### SDK Requirements
 
+### V12.x.x
+
+#### Breaking changes in V12.x
+
+Refit 12.0 is a large release centred on a near-complete rewrite of request building. The source generator now builds
+eligible HTTP requests inline at compile time instead of going through the reflection request-builder pipeline, with the
+reflection path kept as a fallback for shapes that cannot be generated inline.
+
+Two breaking changes are called out for migration:
+
+* `IApiResponse<T>` no longer shadows base interface members. The `new`-shadowed `Error`, `ContentHeaders`,
+  `IsSuccessStatusCode`, and `IsSuccessful` members were removed from the generic interface. Source that reads these
+  members still binds to the inherited base members, but assemblies compiled against v8-v11 should be recompiled.
+  If you used `IsSuccessful` to narrow `Content` to non-null on an `IApiResponse<T>` value, use `HasContent` or
+  `IsSuccessfulWithContent` instead.
+* The default `System.Text.Json` serializer now reads numbers from JSON strings by setting
+  `JsonNumberHandling.AllowReadingFromString`. To opt back out, set `NumberHandling = JsonNumberHandling.Strict` on
+  your `JsonSerializerOptions`.
+
+See the [Refit 12.0.0 release notes](https://github.com/reactiveui/refit/releases/tag/v12.0.0) for the full release
+details.
+
+### V11.x.x
+
+#### Breaking changes in 11.x
+
+Refit 11 introduces `ApiRequestException` to represent requests that fail before receiving a response from the server.
+This exception will now wrap previous exceptions such as `HttpRequestException` and `TaskCanceledException` when they
+occur during request execution.
+
+* If you were not wrapping responses with `IApiResponse` and were catching these exceptions directly, you will need to
+  update your code to catch `ApiRequestException` instead.
+* If you were wrapping responses with `IApiResponse`, these exceptions will no longer be thrown and will instead be
+  captured in the `IApiResponse.Error` property.
+  You can use the new `IApiResponse.HasRequestError(out var apiRequestException)` method to safely check and retrieve
+  the `ApiRequestException` instance.
+
+The `IApiResponse.Error` property's type has also changed to `ApiExceptionBase`, which is the new base class for
+`ApiException` and `ApiRequestException`.
+If your code accessed members specific to `ApiException` (i.e. anything related to the response from the server), you
+can use the new `IApiResponse.HasResponseError(out var apiException)` method to safely check and retrieve the
+`ApiException` instance.
+
+All response-related properties of `IApiResponse` are now nullable.
+The new `IApiResponse.IsReceived` property can be used to check if a response was received from the server, and will
+mark those properties as non-null.
+The original `IApiResponse.IsSuccessful` and `IApiResponse.IsSuccessStatusCode` properties can still be used to check if
+the response was received and is successful.
+
 ### Updates in 8.0.x
 
-Fixes for some issues experienced, this lead to some breaking changes.
+Fixes for some issues experienced, this led to some breaking changes.
 See [Releases](https://github.com/reactiveui/refit/releases) for full details.
 
 ### V6.x.x
@@ -137,33 +187,6 @@ Refit 6.3 splits out the XML serialization via `XmlContentSerializer` into a sep
 is to reduce the dependency size when using Refit with Web Assembly (WASM) applications. If you require XML, add a
 reference
 to `Refit.Xml`.
-
-### V11.x.x
-
-#### Breaking changes in 11.x
-
-Refit 11 introduces `ApiRequestException` to represent requests that fail before receiving a response from the server.
-This exception will now wrap previous exceptions such as `HttpRequestException` and `TaskCanceledException` when they
-occur during request execution.
-
-* If you were not wrapping responses with `IApiResponse` and were catching these exceptions directly, you will need to
-  update your code to catch `ApiRequestException` instead.
-* If you were wrapping responses with `IApiResponse`, these exceptions will no longer be thrown and will instead be
-  captured in the `IApiResponse.Error` property.
-  You can use the new `IApiResponse.HasRequestError(out var apiRequestException)` method to safely check and retrieve
-  the `ApiRequestException` instance.
-
-The `IApiResponse.Error` property's type has also changed to `ApiExceptionBase`, which is the new base class for
-`ApiException` and `ApiRequestException`.
-If your code accessed members specific to `ApiException` (i.e. anything related to the response from the server), you
-can use the new `IApiResponse.HasResponseError(out var apiException)` method to safely check and retrieve the
-`ApiException` instance.
-
-All response-related properties of `IApiResponse` are now nullable.
-The new `IApiResponse.IsReceived` property can be used to check if a response was received from the server, and will
-mark those properties as non-null.
-The original `IApiResponse.IsSuccessful` and `IApiResponse.IsSuccessStatusCode` properties can still be used to check if
-the response was received and is successful.
 
 ### Source generation
 

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <PropertyGroup Label="Shared Version Variables">
-    <PrimitivesVersion>5.6.0</PrimitivesVersion>
-    <TUnitVersion>1.56.0</TUnitVersion>
+    <PrimitivesVersion>5.8.0</PrimitivesVersion>
+    <TUnitVersion>1.57.0</TUnitVersion>
   </PropertyGroup>
 
   <PropertyGroup Label="Framework-Aligned Versions">
@@ -56,7 +56,7 @@
        the 4.x line. Renovate is configured to hold these back (see .github/renovate.json). -->
   <ItemGroup Label="Roslyn Toolchain">
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(MicrosoftCodeAnalysisWorkspacesVersion)"/>
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing" Version="1.1.3"/>
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing" Version="1.1.4"/>
   </ItemGroup>
 
   <ItemGroup Label="Microsoft Runtime And Extensions">


### PR DESCRIPTION
## What kind of change does this PR introduce?
- Documentation update and dependency version refresh

## What is the new behavior?
- Adds a new V12.x breaking-changes section to the README
- Reorders the breaking-changes index so V12.x appears before 11.x and 6.x
- Updates shared package versions for `ReactiveUI.Primitives`, `TUnit`, and Roslyn source generator testing

## What is the current behavior?
- The README did not surface V12.x breaking changes in the version summary
- Package versions were still pinned to older patch releases

## Checklist
- [x] I have read the [Contribute guide](https://www.reactiveui.net/contribute/index.html)
- [ ] Tests have been added or updated (for bug fixes / features) 
- [x] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the main branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) 

## Additional information
- The README now documents the V12 migration notes alongside the existing 11.x and 6.x sections
- Testing: Not run (not requested)