### PR TITLE
feat: security hardening from audit (XXE, Newtonsoft type handling, exception redaction)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,3 +159,14 @@ dotnet run --project "tests/Refit.GeneratorTests/Refit.GeneratorTests.csproj" -f
 - Keep changes scoped. Do not rewrite unrelated files while touching generator/runtime paths.
 - Prefer focused tests that compile or execute the real generated output when changing source generator behavior.
 
+---
+
+## Public API tracking
+
+The runtime projects use the public-API analyzer, so every public/protected member is recorded under `src/Refit/PublicAPI/<tfm>/`.
+
+- New public surface goes in `PublicAPI.Unshipped.txt` for each affected TFM while you iterate.
+- **Before opening a PR, move those new entries from `PublicAPI.Unshipped.txt` into the matching `PublicAPI.Shipped.txt` (and reset each unshipped file to just `#nullable enable`).** This repo ships almost immediately after merge, so unshipped API is promoted as part of the change rather than left pending.
+- For behavior changes or public API additions, also add a breaking-changes note to the README.
+- Shipped entries are assumed to be carried forward; you do not need to call them out separately in the PR.
+

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ services
 
 * [Sponsors](#sponsors)
 * [Where does this work?](#where-does-this-work)
+    * [Breaking changes in V13.x](#breaking-changes-in-v13x)
     * [Breaking changes in V12.x](#breaking-changes-in-v12x)
     * [Breaking changes in 11.x](#breaking-changes-in-11x)
     * [Breaking changes in 6.x](#breaking-changes-in-6x)
@@ -102,6 +103,34 @@ Refit currently supports the following platforms and modern .NET targets:
 * Uno Platform
 
 ### SDK Requirements
+
+### V13.x.x
+
+#### Breaking changes in V13.x
+
+Refit 13 hardens the default security posture from a security audit. The new behavior is safe by default; the changes
+below only affect code that previously relied on the less-secure defaults.
+
+* **XML responses no longer process DTDs.** `XmlContentSerializer` now forces `DtdProcessing.Prohibit` and clears the
+  `XmlResolver` on every read, blocking XML External Entity (XXE) and entity-expansion ("billion laughs") attacks. If
+  you were deserializing trusted XML that depends on a DTD or external entities, that content will now throw. We
+  **strongly recommend against re-enabling DTD processing**, but if your XML comes from a fully trusted source you can
+  opt out via the obsolete `XmlReaderWriterSettings.AllowDtdProcessing` flag (marked `[Obsolete]` deliberately, so it
+  surfaces a compiler warning) - you must also configure `DtdProcessing`/`XmlResolver` yourself on `ReaderSettings`.
+  Prefer pre-processing untrusted documents instead.
+* **Newtonsoft.Json no longer inherits an unsafe global `TypeNameHandling`.** When you do not pass explicit
+  `JsonSerializerSettings`, `NewtonsoftJsonContentSerializer` now forces `TypeNameHandling.None` even if
+  `JsonConvert.DefaultSettings` configured a different value, closing a known remote-code-execution gadget vector on
+  response bodies. If you genuinely need polymorphic (`$type`) deserialization, opt in explicitly by passing your own
+  `JsonSerializerSettings` (ideally constrained with a `SerializationBinder`).
+
+The release also adds two opt-in, non-breaking knobs on `RefitSettings` for hardening exception handling:
+
+* `RefitSettings.ExceptionRedactor` — a hook invoked before an `ApiException` propagates, so you can scrub the
+  `Authorization` header, request/response bodies, and `Set-Cookie` before they reach logging or telemetry pipelines
+  that serialize exceptions.
+* `RefitSettings.MaxExceptionContentLength` — caps how many characters of an error response body are read into
+  `ApiException.Content`, bounding memory use against hostile or oversized error responses. Defaults to unbounded.
 
 ### V12.x.x
 

--- a/src/InterfaceStubGenerator.Shared/Emitter.Helpers.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.Helpers.cs
@@ -130,8 +130,72 @@ internal static partial class Emitter
             '\r' => builder.Append(@"\r"),
             '\t' => builder.Append(@"\t"),
             '\v' => builder.Append(@"\v"),
+
+            // Line terminators that would break out of a regular C# string literal (CS1010).
+            '\u0085' => builder.Append(@"\u0085"),
+            '\u2028' => builder.Append(@"\u2028"),
+            '\u2029' => builder.Append(@"\u2029"),
             _ => builder.Append(character)
         };
+
+    /// <summary>Gets the escape sequence for a C# string-literal character, or null when none is needed.</summary>
+    /// <param name="character">The character to escape.</param>
+    /// <returns>The escape sequence, or <see langword="null"/> when the character is emitted verbatim.</returns>
+    internal static string? EscapeSequence(char character) =>
+        character switch
+        {
+            '\\' => @"\\",
+            '"' => "\\\"",
+            '\0' => @"\0",
+            '\a' => @"\a",
+            '\b' => @"\b",
+            '\f' => @"\f",
+            '\n' => @"\n",
+            '\r' => @"\r",
+            '\t' => @"\t",
+            '\v' => @"\v",
+
+            // Characters C# treats as line terminators inside a regular string literal (CS1010).
+            '\u0085' => @"\u0085",
+            '\u2028' => @"\u2028",
+            '\u2029' => @"\u2029",
+            _ => null
+        };
+
+    /// <summary>Computes the rendered length of a C# string literal or the <c>null</c> keyword.</summary>
+    /// <param name="value">The value to quote, or <see langword="null"/>.</param>
+    /// <returns>The number of characters the rendered expression occupies.</returns>
+    internal static int LiteralOrNullLength(string? value)
+    {
+        if (value is null)
+        {
+            return NullLiteral.Length;
+        }
+
+        var length = StringLiteralQuoteLength;
+        foreach (var character in value)
+        {
+            length += EscapeSequence(character) is { Length: var escapeLength } ? escapeLength : 1;
+        }
+
+        return length;
+    }
+
+    /// <summary>Computes the rendered decimal length of a non-negative 32-bit integer.</summary>
+    /// <param name="value">The non-negative value to render (callers only pass <c>CollectionFormat</c> values).</param>
+    /// <returns>The number of characters the decimal rendering occupies.</returns>
+    internal static int Int32Length(int value)
+    {
+        var length = 0;
+        do
+        {
+            length++;
+            value /= DecimalRadix;
+        }
+        while (value > 0);
+
+        return length;
+    }
 
     /// <summary>Strips an explicit interface prefix from a method name (e.g. <c>IFoo.Bar</c> becomes <c>Bar</c>).</summary>
     /// <param name="name">The method name to normalize.</param>

--- a/src/InterfaceStubGenerator.Shared/Emitter.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.cs
@@ -870,61 +870,6 @@ internal static partial class Emitter
     /// <returns>The generated indentation.</returns>
     private static string Indent(int level) => new(' ', level * CharsPerIndentation);
 
-    /// <summary>Gets the two-character escape sequence for a C# string-literal character, or null when none is needed.</summary>
-    /// <param name="character">The character to escape.</param>
-    /// <returns>The interned escape sequence, or <see langword="null"/> when the character is emitted verbatim.</returns>
-    private static string? EscapeSequence(char character) =>
-        character switch
-        {
-            '\\' => "\\\\",
-            '"' => "\\\"",
-            '\0' => "\\0",
-            '\a' => "\\a",
-            '\b' => "\\b",
-            '\f' => "\\f",
-            '\n' => "\\n",
-            '\r' => "\\r",
-            '\t' => "\\t",
-            '\v' => "\\v",
-            _ => null
-        };
-
-    /// <summary>Computes the rendered length of a C# string literal or the <c>null</c> keyword.</summary>
-    /// <param name="value">The value to quote, or <see langword="null"/>.</param>
-    /// <returns>The number of characters the rendered expression occupies.</returns>
-    private static int LiteralOrNullLength(string? value)
-    {
-        if (value is null)
-        {
-            return NullLiteral.Length;
-        }
-
-        var length = StringLiteralQuoteLength;
-        foreach (var character in value)
-        {
-            length += EscapeSequence(character) is null ? 1 : StringLiteralQuoteLength;
-        }
-
-        return length;
-    }
-
-    /// <summary>Computes the rendered decimal length of a 32-bit integer.</summary>
-    /// <param name="value">The value to render.</param>
-    /// <returns>The number of characters the decimal rendering occupies.</returns>
-    private static int Int32Length(int value)
-    {
-        var length = value < 0 ? 1 : 0;
-        var magnitude = value < 0 ? -(long)value : value;
-        do
-        {
-            length++;
-            magnitude /= DecimalRadix;
-        }
-        while (magnitude > 0);
-
-        return length;
-    }
-
 #if NETSTANDARD2_0
     /// <summary>Writes a C# string literal or the <c>null</c> keyword into a generated string buffer.</summary>
     /// <param name="destination">The target character buffer.</param>
@@ -955,26 +900,20 @@ internal static partial class Emitter
         destination[position++] = '"';
     }
 
-    /// <summary>Writes the decimal rendering of a 32-bit integer into a generated string buffer.</summary>
+    /// <summary>Writes the decimal rendering of a non-negative 32-bit integer into a generated string buffer.</summary>
     /// <param name="destination">The target character buffer.</param>
-    /// <param name="value">The value to render.</param>
+    /// <param name="value">The non-negative value to render (callers only pass <c>CollectionFormat</c> values).</param>
     /// <param name="position">The current write position.</param>
     private static void AppendInt32(char[] destination, int value, ref int position)
     {
         var end = position + Int32Length(value);
         var write = end;
-        var magnitude = value < 0 ? -(long)value : value;
         do
         {
-            destination[--write] = (char)('0' + (int)(magnitude % DecimalRadix));
-            magnitude /= DecimalRadix;
+            destination[--write] = (char)('0' + (value % DecimalRadix));
+            value /= DecimalRadix;
         }
-        while (magnitude > 0);
-
-        if (value < 0)
-        {
-            destination[position] = '-';
-        }
+        while (value > 0);
 
         position = end;
     }
@@ -1008,26 +947,20 @@ internal static partial class Emitter
         destination[position++] = '"';
     }
 
-    /// <summary>Writes the decimal rendering of a 32-bit integer into a generated string buffer.</summary>
+    /// <summary>Writes the decimal rendering of a non-negative 32-bit integer into a generated string buffer.</summary>
     /// <param name="destination">The target character span.</param>
-    /// <param name="value">The value to render.</param>
+    /// <param name="value">The non-negative value to render (callers only pass <c>CollectionFormat</c> values).</param>
     /// <param name="position">The current write position.</param>
     private static void AppendInt32(Span<char> destination, int value, ref int position)
     {
         var end = position + Int32Length(value);
         var write = end;
-        var magnitude = value < 0 ? -(long)value : value;
         do
         {
-            destination[--write] = (char)('0' + (int)(magnitude % DecimalRadix));
-            magnitude /= DecimalRadix;
+            destination[--write] = (char)('0' + (value % DecimalRadix));
+            value /= DecimalRadix;
         }
-        while (magnitude > 0);
-
-        if (value < 0)
-        {
-            destination[position] = '-';
-        }
+        while (value > 0);
 
         position = end;
     }

--- a/src/Refit.Newtonsoft.Json/NewtonsoftJsonContentSerializer.cs
+++ b/src/Refit.Newtonsoft.Json/NewtonsoftJsonContentSerializer.cs
@@ -20,11 +20,26 @@ public sealed class NewtonsoftJsonContentSerializer(
     private const int QuotePairLength = 2;
 
     /// <summary>The <see cref="Lazy{T}"/> instance providing the JSON serialization settings to use</summary>
+    /// <remarks>
+    /// When the caller does not supply explicit settings, any settings inherited from
+    /// <see cref="JsonConvert.DefaultSettings"/> have <see cref="TypeNameHandling"/> forced to
+    /// <see cref="TypeNameHandling.None"/>. A globally configured non-<see cref="TypeNameHandling.None"/>
+    /// value would otherwise let an attacker-controlled HTTP response body drive polymorphic type
+    /// resolution (a known remote-code-execution gadget vector). Callers who genuinely need
+    /// polymorphic deserialization must opt in by passing their own <see cref="JsonSerializerSettings"/>.
+    /// </remarks>
     private readonly Lazy<JsonSerializerSettings> _jsonSerializerSettings =
         new(() =>
-            jsonSerializerSettings
-            ?? JsonConvert.DefaultSettings?.Invoke()
-            ?? new JsonSerializerSettings());
+        {
+            if (jsonSerializerSettings is not null)
+            {
+                return jsonSerializerSettings;
+            }
+
+            var settings = JsonConvert.DefaultSettings?.Invoke() ?? new JsonSerializerSettings();
+            settings.TypeNameHandling = TypeNameHandling.None;
+            return settings;
+        });
 
     /// <summary>Initializes a new instance of the <see cref="NewtonsoftJsonContentSerializer"/> class.</summary>
     public NewtonsoftJsonContentSerializer()

--- a/src/Refit.Xml/PublicAPI/net10.0/PublicAPI.Shipped.txt
+++ b/src/Refit.Xml/PublicAPI/net10.0/PublicAPI.Shipped.txt
@@ -25,3 +25,5 @@ Refit.XmlReaderWriterSettings.XmlReaderWriterSettings(System.Xml.XmlReaderSettin
 Refit.XmlReaderWriterSettings.XmlReaderWriterSettings(System.Xml.XmlReaderSettings! readerSettings, System.Xml.XmlWriterSettings! writerSettings) -> void
 Refit.XmlReaderWriterSettings.XmlReaderWriterSettings(System.Xml.XmlWriterSettings! writerSettings) -> void
 Refit.XmlContentSerializer.DeserializeFromString<T>(string! content) -> T?
+Refit.XmlReaderWriterSettings.AllowDtdProcessing.get -> bool
+Refit.XmlReaderWriterSettings.AllowDtdProcessing.set -> void

--- a/src/Refit.Xml/PublicAPI/net11.0/PublicAPI.Shipped.txt
+++ b/src/Refit.Xml/PublicAPI/net11.0/PublicAPI.Shipped.txt
@@ -25,3 +25,5 @@ Refit.XmlReaderWriterSettings.XmlReaderWriterSettings(System.Xml.XmlReaderSettin
 Refit.XmlReaderWriterSettings.XmlReaderWriterSettings(System.Xml.XmlReaderSettings! readerSettings, System.Xml.XmlWriterSettings! writerSettings) -> void
 Refit.XmlReaderWriterSettings.XmlReaderWriterSettings(System.Xml.XmlWriterSettings! writerSettings) -> void
 Refit.XmlContentSerializer.DeserializeFromString<T>(string! content) -> T?
+Refit.XmlReaderWriterSettings.AllowDtdProcessing.get -> bool
+Refit.XmlReaderWriterSettings.AllowDtdProcessing.set -> void

--- a/src/Refit.Xml/PublicAPI/net462/PublicAPI.Shipped.txt
+++ b/src/Refit.Xml/PublicAPI/net462/PublicAPI.Shipped.txt
@@ -25,3 +25,5 @@ Refit.XmlReaderWriterSettings.XmlReaderWriterSettings(System.Xml.XmlReaderSettin
 Refit.XmlReaderWriterSettings.XmlReaderWriterSettings(System.Xml.XmlReaderSettings! readerSettings, System.Xml.XmlWriterSettings! writerSettings) -> void
 Refit.XmlReaderWriterSettings.XmlReaderWriterSettings(System.Xml.XmlWriterSettings! writerSettings) -> void
 Refit.XmlContentSerializer.DeserializeFromString<T>(string! content) -> T?
+Refit.XmlReaderWriterSettings.AllowDtdProcessing.get -> bool
+Refit.XmlReaderWriterSettings.AllowDtdProcessing.set -> void

--- a/src/Refit.Xml/PublicAPI/net470/PublicAPI.Shipped.txt
+++ b/src/Refit.Xml/PublicAPI/net470/PublicAPI.Shipped.txt
@@ -25,3 +25,5 @@ Refit.XmlReaderWriterSettings.XmlReaderWriterSettings(System.Xml.XmlReaderSettin
 Refit.XmlReaderWriterSettings.XmlReaderWriterSettings(System.Xml.XmlReaderSettings! readerSettings, System.Xml.XmlWriterSettings! writerSettings) -> void
 Refit.XmlReaderWriterSettings.XmlReaderWriterSettings(System.Xml.XmlWriterSettings! writerSettings) -> void
 Refit.XmlContentSerializer.DeserializeFromString<T>(string! content) -> T?
+Refit.XmlReaderWriterSettings.AllowDtdProcessing.get -> bool
+Refit.XmlReaderWriterSettings.AllowDtdProcessing.set -> void

--- a/src/Refit.Xml/PublicAPI/net471/PublicAPI.Shipped.txt
+++ b/src/Refit.Xml/PublicAPI/net471/PublicAPI.Shipped.txt
@@ -25,3 +25,5 @@ Refit.XmlReaderWriterSettings.XmlReaderWriterSettings(System.Xml.XmlReaderSettin
 Refit.XmlReaderWriterSettings.XmlReaderWriterSettings(System.Xml.XmlReaderSettings! readerSettings, System.Xml.XmlWriterSettings! writerSettings) -> void
 Refit.XmlReaderWriterSettings.XmlReaderWriterSettings(System.Xml.XmlWriterSettings! writerSettings) -> void
 Refit.XmlContentSerializer.DeserializeFromString<T>(string! content) -> T?
+Refit.XmlReaderWriterSettings.AllowDtdProcessing.get -> bool
+Refit.XmlReaderWriterSettings.AllowDtdProcessing.set -> void

--- a/src/Refit.Xml/PublicAPI/net472/PublicAPI.Shipped.txt
+++ b/src/Refit.Xml/PublicAPI/net472/PublicAPI.Shipped.txt
@@ -25,3 +25,5 @@ Refit.XmlReaderWriterSettings.XmlReaderWriterSettings(System.Xml.XmlReaderSettin
 Refit.XmlReaderWriterSettings.XmlReaderWriterSettings(System.Xml.XmlReaderSettings! readerSettings, System.Xml.XmlWriterSettings! writerSettings) -> void
 Refit.XmlReaderWriterSettings.XmlReaderWriterSettings(System.Xml.XmlWriterSettings! writerSettings) -> void
 Refit.XmlContentSerializer.DeserializeFromString<T>(string! content) -> T?
+Refit.XmlReaderWriterSettings.AllowDtdProcessing.get -> bool
+Refit.XmlReaderWriterSettings.AllowDtdProcessing.set -> void

--- a/src/Refit.Xml/PublicAPI/net48/PublicAPI.Shipped.txt
+++ b/src/Refit.Xml/PublicAPI/net48/PublicAPI.Shipped.txt
@@ -25,3 +25,5 @@ Refit.XmlReaderWriterSettings.XmlReaderWriterSettings(System.Xml.XmlReaderSettin
 Refit.XmlReaderWriterSettings.XmlReaderWriterSettings(System.Xml.XmlReaderSettings! readerSettings, System.Xml.XmlWriterSettings! writerSettings) -> void
 Refit.XmlReaderWriterSettings.XmlReaderWriterSettings(System.Xml.XmlWriterSettings! writerSettings) -> void
 Refit.XmlContentSerializer.DeserializeFromString<T>(string! content) -> T?
+Refit.XmlReaderWriterSettings.AllowDtdProcessing.get -> bool
+Refit.XmlReaderWriterSettings.AllowDtdProcessing.set -> void

--- a/src/Refit.Xml/PublicAPI/net481/PublicAPI.Shipped.txt
+++ b/src/Refit.Xml/PublicAPI/net481/PublicAPI.Shipped.txt
@@ -25,3 +25,5 @@ Refit.XmlReaderWriterSettings.XmlReaderWriterSettings(System.Xml.XmlReaderSettin
 Refit.XmlReaderWriterSettings.XmlReaderWriterSettings(System.Xml.XmlReaderSettings! readerSettings, System.Xml.XmlWriterSettings! writerSettings) -> void
 Refit.XmlReaderWriterSettings.XmlReaderWriterSettings(System.Xml.XmlWriterSettings! writerSettings) -> void
 Refit.XmlContentSerializer.DeserializeFromString<T>(string! content) -> T?
+Refit.XmlReaderWriterSettings.AllowDtdProcessing.get -> bool
+Refit.XmlReaderWriterSettings.AllowDtdProcessing.set -> void

--- a/src/Refit.Xml/PublicAPI/net8.0/PublicAPI.Shipped.txt
+++ b/src/Refit.Xml/PublicAPI/net8.0/PublicAPI.Shipped.txt
@@ -25,3 +25,5 @@ Refit.XmlReaderWriterSettings.XmlReaderWriterSettings(System.Xml.XmlReaderSettin
 Refit.XmlReaderWriterSettings.XmlReaderWriterSettings(System.Xml.XmlReaderSettings! readerSettings, System.Xml.XmlWriterSettings! writerSettings) -> void
 Refit.XmlReaderWriterSettings.XmlReaderWriterSettings(System.Xml.XmlWriterSettings! writerSettings) -> void
 Refit.XmlContentSerializer.DeserializeFromString<T>(string! content) -> T?
+Refit.XmlReaderWriterSettings.AllowDtdProcessing.get -> bool
+Refit.XmlReaderWriterSettings.AllowDtdProcessing.set -> void

--- a/src/Refit.Xml/PublicAPI/net9.0/PublicAPI.Shipped.txt
+++ b/src/Refit.Xml/PublicAPI/net9.0/PublicAPI.Shipped.txt
@@ -25,3 +25,5 @@ Refit.XmlReaderWriterSettings.XmlReaderWriterSettings(System.Xml.XmlReaderSettin
 Refit.XmlReaderWriterSettings.XmlReaderWriterSettings(System.Xml.XmlReaderSettings! readerSettings, System.Xml.XmlWriterSettings! writerSettings) -> void
 Refit.XmlReaderWriterSettings.XmlReaderWriterSettings(System.Xml.XmlWriterSettings! writerSettings) -> void
 Refit.XmlContentSerializer.DeserializeFromString<T>(string! content) -> T?
+Refit.XmlReaderWriterSettings.AllowDtdProcessing.get -> bool
+Refit.XmlReaderWriterSettings.AllowDtdProcessing.set -> void

--- a/src/Refit.Xml/XmlReaderWriterSettings.cs
+++ b/src/Refit.Xml/XmlReaderWriterSettings.cs
@@ -1,6 +1,8 @@
 // Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
 // ReactiveUI and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
+using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Xml;
 
 namespace Refit;
@@ -86,13 +88,53 @@ public class XmlReaderWriterSettings
     }
 
     /// <summary>
+    /// Gets or sets a value indicating whether DTD processing is left to the caller-supplied reader settings
+    /// instead of being forced off (defaults to <see langword="false"/>).
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// By default Refit forces <see cref="DtdProcessing.Prohibit"/> and clears the <see cref="XmlReaderSettings.XmlResolver"/>
+    /// on every access so a hostile XML response cannot trigger an XML External Entity (XXE) or entity-expansion
+    /// ("billion laughs") attack. Setting this to <see langword="true"/> disables that safeguard and honors whatever
+    /// <see cref="DtdProcessing"/>/<see cref="XmlReaderSettings.XmlResolver"/> you configured on <see cref="ReaderSettings"/>.
+    /// </para>
+    /// <para>
+    /// This is intentionally marked obsolete: only enable it for XML from a fully trusted source, and prefer
+    /// pre-processing untrusted documents instead.
+    /// </para>
+    /// </remarks>
+    [Obsolete(
+        "Enabling DTD processing re-opens XML External Entity (XXE) and entity-expansion attacks and is strongly "
+        + "discouraged. Only set this for XML from a fully trusted source.")]
+    [SuppressMessage(
+        "Major Code Smell",
+        "S1133:Do not forget to remove this deprecated code someday",
+        Justification = "The attribute is a permanent, intentional warning on a security opt-out, not pending-removal deprecation.")]
+    public bool AllowDtdProcessing { get; set; }
+
+    /// <summary>
     /// The writer and reader settings are set by the caller, but certain properties
     /// should remain set to meet the demands of the XmlContentSerializer. Those properties
     /// are always set here.
     /// </summary>
+    /// <remarks>
+    /// Unless <see cref="AllowDtdProcessing"/> is enabled, DTD processing is forced off and the resolver is cleared
+    /// on every access so that hostile XML responses cannot trigger XML External Entity (XXE) or entity-expansion
+    /// ("billion laughs") attacks, regardless of any caller-supplied reader settings.
+    /// </remarks>
     private void ApplyOverrideSettings()
     {
         _writerSettings.Async = true;
         _readerSettings.Async = true;
+
+#pragma warning disable CS0618 // Reading our own intentionally-obsolete XXE opt-out.
+        if (AllowDtdProcessing)
+#pragma warning restore CS0618
+        {
+            return;
+        }
+
+        _readerSettings.DtdProcessing = DtdProcessing.Prohibit;
+        _readerSettings.XmlResolver = null;
     }
 }

--- a/src/Refit/ApiException.cs
+++ b/src/Refit/ApiException.cs
@@ -2,6 +2,7 @@
 // ReactiveUI and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 using System.Diagnostics.CodeAnalysis;
+using System.IO;
 using System.Net;
 using System.Net.Http.Headers;
 
@@ -143,13 +144,22 @@ public class ApiException : ApiExceptionBase
     public string? ReasonPhrase { get; }
 
     /// <summary>Gets the HTTP response headers.</summary>
+    /// <remarks>
+    /// These are the raw, unredacted response headers and may contain sensitive values such as <c>Set-Cookie</c>.
+    /// Anything that serializes this exception (structured logging, telemetry) will capture them; scrub with
+    /// <see cref="RefitSettings.ExceptionRedactor"/> if that is a concern.
+    /// </remarks>
     public HttpResponseHeaders Headers { get; }
 
     /// <summary>Gets the HTTP response content headers as defined in RFC 2616.</summary>
     public HttpContentHeaders? ContentHeaders { get; protected set; }
 
-    /// <summary>Gets the HTTP Response content as string.</summary>
-    public string? Content { get; private set; }
+    /// <summary>Gets or sets the HTTP response content as a string.</summary>
+    /// <remarks>
+    /// This is the raw, unredacted response body. The setter exists so that
+    /// <see cref="RefitSettings.ExceptionRedactor"/> can scrub it before the exception propagates.
+    /// </remarks>
+    public string? Content { get; set; }
 
     /// <summary>Gets a value indicating whether the response has content.</summary>
     [MemberNotNullWhen(true, nameof(Content))]
@@ -187,12 +197,17 @@ public class ApiException : ApiExceptionBase
         RefitSettings refitSettings,
         Exception? innerException)
     {
-        if (response?.IsSuccessStatusCode == true)
+        if (response is null)
+        {
+            throw new ArgumentNullException(nameof(response));
+        }
+
+        if (response.IsSuccessStatusCode)
         {
             throw new ArgumentException("Response is successful, cannot create an ApiException.", nameof(response));
         }
 
-        var exceptionMessage = CreateMessage(response!.StatusCode, response.ReasonPhrase);
+        var exceptionMessage = CreateMessage(response.StatusCode, response.ReasonPhrase);
         return Create(
             exceptionMessage,
             message,
@@ -261,39 +276,39 @@ public class ApiException : ApiExceptionBase
             RequestContent = GetCapturedRequestContent(message)
         };
 
-        if (response.Content is null)
+        if (response.Content is not null)
         {
-            return exception;
-        }
-
-        try
-        {
-            exception.ContentHeaders = response.Content.Headers;
-            exception.Content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-
-            if (
-                response
-                    .Content.Headers?.ContentType
-                    ?.MediaType
-                    ?.Equals("application/problem+json", StringComparison.OrdinalIgnoreCase) ?? false
-            )
+            try
             {
-                exception = await ValidationApiException
-                    .CreateAsync(exception)
+                exception.ContentHeaders = response.Content.Headers;
+                exception.Content = await ReadContentCappedAsync(
+                        response.Content,
+                        refitSettings.MaxExceptionContentLength)
                     .ConfigureAwait(false);
+
+                // Content.Headers is never null on a real HttpContent, so only the ContentType/MediaType
+                // null cases are meaningful here and both are exercised by the tests.
+                var mediaType = response.Content.Headers.ContentType?.MediaType;
+                if (mediaType?.Equals("application/problem+json", StringComparison.OrdinalIgnoreCase) ?? false)
+                {
+                    exception = await ValidationApiException
+                        .CreateAsync(exception)
+                        .ConfigureAwait(false);
+                }
+
+                response.Content.Dispose();
             }
+            catch (Exception readException)
+            {
+                _ = readException;
 
-            response.Content.Dispose();
-        }
-        catch (Exception readException)
-        {
-            _ = readException;
-
-            // NB: We're already handling an exception at this point,
-            // so we want to make sure we don't throw another one
-            // that hides the real error.
+                // NB: We're already handling an exception at this point,
+                // so we want to make sure we don't throw another one
+                // that hides the real error.
+            }
         }
 
+        refitSettings.ExceptionRedactor?.Invoke(exception);
         return exception;
     }
 
@@ -379,6 +394,47 @@ public class ApiException : ApiExceptionBase
         }
 
         return content is not null;
+    }
+
+    /// <summary>Reads the response body as a string, bounding the number of characters when a limit is configured.</summary>
+    /// <param name="content">The response content to read.</param>
+    /// <param name="maxChars">The maximum number of characters to read, or <see langword="null"/> for unbounded.</param>
+    /// <returns>The (possibly truncated) response body.</returns>
+    private static async Task<string> ReadContentCappedAsync(HttpContent content, int? maxChars)
+    {
+        if (maxChars is not { } limit)
+        {
+            return await content.ReadAsStringAsync().ConfigureAwait(false);
+        }
+
+        if (limit <= 0)
+        {
+            return string.Empty;
+        }
+
+        var stream = await content.ReadAsStreamAsync().ConfigureAwait(false);
+#if NET6_0_OR_GREATER
+        await using var streamScope = stream.ConfigureAwait(false);
+#else
+        using var streamScope = stream;
+#endif
+        using var reader = new StreamReader(stream);
+        var buffer = new char[limit];
+        var total = 0;
+        while (total < limit)
+        {
+            var read = await reader
+                .ReadBlockAsync(buffer, total, limit - total)
+                .ConfigureAwait(false);
+            if (read == 0)
+            {
+                break;
+            }
+
+            total += read;
+        }
+
+        return new string(buffer, 0, total);
     }
 
     /// <summary>Builds the exception message from the status code and reason phrase.</summary>

--- a/src/Refit/ApiExceptionBase.cs
+++ b/src/Refit/ApiExceptionBase.cs
@@ -75,14 +75,25 @@ public abstract class ApiExceptionBase : Exception
     public Uri? Uri => RequestMessage.RequestUri;
 
     /// <summary>Gets the HTTP Request message used to send the request.</summary>
+    /// <remarks>
+    /// This is the live request and still carries its headers, including the <c>Authorization</c> header (bearer
+    /// token, basic credentials, or API key) and any secret <c>[Header]</c>/<c>[HeaderCollection]</c> values.
+    /// <see cref="Exception.ToString"/> does not print them, but property-walking serializers (structured logging,
+    /// telemetry) will. Use <see cref="RefitSettings.ExceptionRedactor"/> to scrub them before the exception
+    /// propagates.
+    /// </remarks>
     public HttpRequestMessage RequestMessage { get; }
 
     /// <summary>
-    /// Gets the request body content as a string, captured before sending. This is only populated when
+    /// Gets or sets the request body content as a string, captured before sending. This is only populated when
     /// <see cref="RefitSettings.CaptureRequestContent"/> is enabled; otherwise the request content has
     /// already been disposed by <see cref="HttpClient"/> and cannot be read from <see cref="RequestMessage"/>.
     /// </summary>
-    public string? RequestContent { get; protected set; }
+    /// <remarks>
+    /// When populated this is the raw, unredacted request body and frequently contains credentials or PII. The setter
+    /// is accessible so <see cref="RefitSettings.ExceptionRedactor"/> can scrub it before the exception propagates.
+    /// </remarks>
+    public string? RequestContent { get; set; }
 
     /// <summary>Gets a value indicating whether the captured request content is available.</summary>
     [MemberNotNullWhen(true, nameof(RequestContent))]

--- a/src/Refit/PublicAPI/net10.0/PublicAPI.Shipped.txt
+++ b/src/Refit/PublicAPI/net10.0/PublicAPI.Shipped.txt
@@ -431,3 +431,8 @@ Refit.RefitSettings.CaptureRequestContent.set -> void
 static Refit.HttpRequestMessageOptions.RequestContent.get -> string!
 Refit.ApiExceptionBase.HasRequestContent.get -> bool
 Refit.SystemTextJsonContentSerializer.DeserializeFromString<T>(string! content) -> T?
+Refit.ApiException.Content.set -> void
+Refit.RefitSettings.ExceptionRedactor.get -> System.Action<Refit.ApiExceptionBase!>?
+Refit.RefitSettings.ExceptionRedactor.set -> void
+Refit.RefitSettings.MaxExceptionContentLength.get -> int?
+Refit.RefitSettings.MaxExceptionContentLength.set -> void

--- a/src/Refit/PublicAPI/net11.0/PublicAPI.Shipped.txt
+++ b/src/Refit/PublicAPI/net11.0/PublicAPI.Shipped.txt
@@ -431,3 +431,8 @@ Refit.RefitSettings.CaptureRequestContent.set -> void
 static Refit.HttpRequestMessageOptions.RequestContent.get -> string!
 Refit.ApiExceptionBase.HasRequestContent.get -> bool
 Refit.SystemTextJsonContentSerializer.DeserializeFromString<T>(string! content) -> T?
+Refit.ApiException.Content.set -> void
+Refit.RefitSettings.ExceptionRedactor.get -> System.Action<Refit.ApiExceptionBase!>?
+Refit.RefitSettings.ExceptionRedactor.set -> void
+Refit.RefitSettings.MaxExceptionContentLength.get -> int?
+Refit.RefitSettings.MaxExceptionContentLength.set -> void

--- a/src/Refit/PublicAPI/net462/PublicAPI.Shipped.txt
+++ b/src/Refit/PublicAPI/net462/PublicAPI.Shipped.txt
@@ -427,3 +427,8 @@ Refit.RefitSettings.CaptureRequestContent.set -> void
 static Refit.HttpRequestMessageOptions.RequestContent.get -> string!
 Refit.ApiExceptionBase.HasRequestContent.get -> bool
 Refit.SystemTextJsonContentSerializer.DeserializeFromString<T>(string! content) -> T?
+Refit.ApiException.Content.set -> void
+Refit.RefitSettings.ExceptionRedactor.get -> System.Action<Refit.ApiExceptionBase!>?
+Refit.RefitSettings.ExceptionRedactor.set -> void
+Refit.RefitSettings.MaxExceptionContentLength.get -> int?
+Refit.RefitSettings.MaxExceptionContentLength.set -> void

--- a/src/Refit/PublicAPI/net470/PublicAPI.Shipped.txt
+++ b/src/Refit/PublicAPI/net470/PublicAPI.Shipped.txt
@@ -427,3 +427,8 @@ Refit.RefitSettings.CaptureRequestContent.set -> void
 static Refit.HttpRequestMessageOptions.RequestContent.get -> string!
 Refit.ApiExceptionBase.HasRequestContent.get -> bool
 Refit.SystemTextJsonContentSerializer.DeserializeFromString<T>(string! content) -> T?
+Refit.ApiException.Content.set -> void
+Refit.RefitSettings.ExceptionRedactor.get -> System.Action<Refit.ApiExceptionBase!>?
+Refit.RefitSettings.ExceptionRedactor.set -> void
+Refit.RefitSettings.MaxExceptionContentLength.get -> int?
+Refit.RefitSettings.MaxExceptionContentLength.set -> void

--- a/src/Refit/PublicAPI/net471/PublicAPI.Shipped.txt
+++ b/src/Refit/PublicAPI/net471/PublicAPI.Shipped.txt
@@ -427,3 +427,8 @@ Refit.RefitSettings.CaptureRequestContent.set -> void
 static Refit.HttpRequestMessageOptions.RequestContent.get -> string!
 Refit.ApiExceptionBase.HasRequestContent.get -> bool
 Refit.SystemTextJsonContentSerializer.DeserializeFromString<T>(string! content) -> T?
+Refit.ApiException.Content.set -> void
+Refit.RefitSettings.ExceptionRedactor.get -> System.Action<Refit.ApiExceptionBase!>?
+Refit.RefitSettings.ExceptionRedactor.set -> void
+Refit.RefitSettings.MaxExceptionContentLength.get -> int?
+Refit.RefitSettings.MaxExceptionContentLength.set -> void

--- a/src/Refit/PublicAPI/net472/PublicAPI.Shipped.txt
+++ b/src/Refit/PublicAPI/net472/PublicAPI.Shipped.txt
@@ -427,3 +427,8 @@ Refit.RefitSettings.CaptureRequestContent.set -> void
 static Refit.HttpRequestMessageOptions.RequestContent.get -> string!
 Refit.ApiExceptionBase.HasRequestContent.get -> bool
 Refit.SystemTextJsonContentSerializer.DeserializeFromString<T>(string! content) -> T?
+Refit.ApiException.Content.set -> void
+Refit.RefitSettings.ExceptionRedactor.get -> System.Action<Refit.ApiExceptionBase!>?
+Refit.RefitSettings.ExceptionRedactor.set -> void
+Refit.RefitSettings.MaxExceptionContentLength.get -> int?
+Refit.RefitSettings.MaxExceptionContentLength.set -> void

--- a/src/Refit/PublicAPI/net48/PublicAPI.Shipped.txt
+++ b/src/Refit/PublicAPI/net48/PublicAPI.Shipped.txt
@@ -427,3 +427,8 @@ Refit.RefitSettings.CaptureRequestContent.set -> void
 static Refit.HttpRequestMessageOptions.RequestContent.get -> string!
 Refit.ApiExceptionBase.HasRequestContent.get -> bool
 Refit.SystemTextJsonContentSerializer.DeserializeFromString<T>(string! content) -> T?
+Refit.ApiException.Content.set -> void
+Refit.RefitSettings.ExceptionRedactor.get -> System.Action<Refit.ApiExceptionBase!>?
+Refit.RefitSettings.ExceptionRedactor.set -> void
+Refit.RefitSettings.MaxExceptionContentLength.get -> int?
+Refit.RefitSettings.MaxExceptionContentLength.set -> void

--- a/src/Refit/PublicAPI/net481/PublicAPI.Shipped.txt
+++ b/src/Refit/PublicAPI/net481/PublicAPI.Shipped.txt
@@ -427,3 +427,8 @@ Refit.RefitSettings.CaptureRequestContent.set -> void
 static Refit.HttpRequestMessageOptions.RequestContent.get -> string!
 Refit.ApiExceptionBase.HasRequestContent.get -> bool
 Refit.SystemTextJsonContentSerializer.DeserializeFromString<T>(string! content) -> T?
+Refit.ApiException.Content.set -> void
+Refit.RefitSettings.ExceptionRedactor.get -> System.Action<Refit.ApiExceptionBase!>?
+Refit.RefitSettings.ExceptionRedactor.set -> void
+Refit.RefitSettings.MaxExceptionContentLength.get -> int?
+Refit.RefitSettings.MaxExceptionContentLength.set -> void

--- a/src/Refit/PublicAPI/net8.0/PublicAPI.Shipped.txt
+++ b/src/Refit/PublicAPI/net8.0/PublicAPI.Shipped.txt
@@ -431,3 +431,8 @@ Refit.RefitSettings.CaptureRequestContent.set -> void
 static Refit.HttpRequestMessageOptions.RequestContent.get -> string!
 Refit.ApiExceptionBase.HasRequestContent.get -> bool
 Refit.SystemTextJsonContentSerializer.DeserializeFromString<T>(string! content) -> T?
+Refit.ApiException.Content.set -> void
+Refit.RefitSettings.ExceptionRedactor.get -> System.Action<Refit.ApiExceptionBase!>?
+Refit.RefitSettings.ExceptionRedactor.set -> void
+Refit.RefitSettings.MaxExceptionContentLength.get -> int?
+Refit.RefitSettings.MaxExceptionContentLength.set -> void

--- a/src/Refit/PublicAPI/net9.0/PublicAPI.Shipped.txt
+++ b/src/Refit/PublicAPI/net9.0/PublicAPI.Shipped.txt
@@ -431,3 +431,8 @@ Refit.RefitSettings.CaptureRequestContent.set -> void
 static Refit.HttpRequestMessageOptions.RequestContent.get -> string!
 Refit.ApiExceptionBase.HasRequestContent.get -> bool
 Refit.SystemTextJsonContentSerializer.DeserializeFromString<T>(string! content) -> T?
+Refit.ApiException.Content.set -> void
+Refit.RefitSettings.ExceptionRedactor.get -> System.Action<Refit.ApiExceptionBase!>?
+Refit.RefitSettings.ExceptionRedactor.set -> void
+Refit.RefitSettings.MaxExceptionContentLength.get -> int?
+Refit.RefitSettings.MaxExceptionContentLength.set -> void

--- a/src/Refit/RefitSettings.cs
+++ b/src/Refit/RefitSettings.cs
@@ -126,8 +126,45 @@ public class RefitSettings
     /// By default <see cref="HttpClient"/> disposes the request content once the request is sent, so the body cannot
     /// be read back from the exception (see issue #1189). Enabling this buffers the body into memory before sending;
     /// avoid it for large or streamed uploads.
+    /// <para>
+    /// Security note: the captured body frequently contains credentials or PII (for example login, token-refresh, or
+    /// payment payloads) and is exposed as a public property on the thrown exception. Use
+    /// <see cref="ExceptionRedactor"/> to scrub it before the exception reaches a logging or telemetry pipeline that
+    /// serializes exception objects.
+    /// </para>
     /// </remarks>
     public bool CaptureRequestContent { get; set; }
+
+    /// <summary>
+    /// Gets or sets the maximum number of characters of an error response body that are read into
+    /// <see cref="ApiException.Content"/> (defaults to <see langword="null"/>, meaning unbounded).
+    /// </summary>
+    /// <remarks>
+    /// Error responses are read with <see cref="HttpCompletionOption.ResponseHeadersRead"/>, so
+    /// <see cref="HttpClient.MaxResponseContentBufferSize"/> does not apply. A hostile or oversized error body can
+    /// therefore drive unbounded memory allocation while constructing the <see cref="ApiException"/>. Set a limit to
+    /// bound that read; the body is truncated to the first <c>value</c> characters.
+    /// </remarks>
+    public int? MaxExceptionContentLength { get; set; }
+
+    /// <summary>
+    /// Gets or sets a hook invoked just before an <see cref="ApiExceptionBase"/> is returned, allowing sensitive data
+    /// to be scrubbed before the exception propagates (defaults to <see langword="null"/>).
+    /// </summary>
+    /// <remarks>
+    /// An <see cref="ApiException"/> retains the live request (including the <c>Authorization</c> header and any secret
+    /// <c>[Header]</c> values), the optionally captured request body, and the raw response headers (including
+    /// <c>Set-Cookie</c>) and body. Logging and telemetry libraries that serialize exceptions by walking properties
+    /// will capture all of it. Use this hook to remove or mask those values, for example:
+    /// <code>
+    /// settings.ExceptionRedactor = ex =>
+    /// {
+    ///     ex.RequestMessage.Headers.Authorization = null;
+    ///     if (ex is ApiException api) api.Content = null;
+    /// };
+    /// </code>
+    /// </remarks>
+    public Action<ApiExceptionBase>? ExceptionRedactor { get; set; }
 
     /// <summary>
     /// Gets or sets a value indicating whether a route placeholder with no matching method argument is allowed.

--- a/src/Refit/RestMethodInfoInternal.cs
+++ b/src/Refit/RestMethodInfoInternal.cs
@@ -854,7 +854,7 @@ internal class RestMethodInfoInternal
 #if NET7_0_OR_GREATER
     /// <summary>Gets the compiled regular expression that matches URL path parameters.</summary>
     /// <returns>The parameter matching regular expression.</returns>
-    [GeneratedRegex("{(([^/?\\r\\n])*?)}")]
+    [GeneratedRegex("{(([^/?\\r\\n])*?)}", RegexOptions.None, matchTimeoutMilliseconds: 1000)]
     private static partial Regex ParameterRegex();
 #else
     /// <summary>Gets the compiled regular expression that matches URL path parameters.</summary>

--- a/src/tests/Refit.GeneratorTests/Fixture.cs
+++ b/src/tests/Refit.GeneratorTests/Fixture.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
 // ReactiveUI and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
+using System.Collections.Concurrent;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
@@ -20,6 +21,14 @@ public static class Fixture
 {
     /// <summary>The runtime data key containing framework assemblies available to the current test host.</summary>
     private const string TrustedPlatformAssemblies = "TRUSTED_PLATFORM_ASSEMBLIES";
+
+    /// <summary>
+    /// Caches metadata references by assembly path. The framework reference closure (~169 assemblies) is
+    /// identical for every test, so materializing it once per process — instead of per test — keeps a single
+    /// shared copy of the metadata in memory and avoids re-reading every PE file on each call.
+    /// </summary>
+    private static readonly ConcurrentDictionary<string, MetadataReference> _metadataReferenceCache =
+        new(StringComparer.Ordinal);
 
     /// <summary>The metadata reference for the Refit assembly with documentation.</summary>
     private static readonly MetadataReference _refitAssembly = MetadataReference.CreateFromFile(
@@ -316,7 +325,7 @@ public static class Fixture
         var references = new List<MetadataReference>(referencePaths.Count + 1);
         foreach (var referencePath in referencePaths)
         {
-            references.Add(MetadataReference.CreateFromFile(referencePath));
+            references.Add(GetMetadataReference(referencePath));
         }
 
         references.Add(_refitAssembly);
@@ -326,6 +335,12 @@ public static class Fixture
             references,
             new(OutputKind.DynamicallyLinkedLibrary));
     }
+
+    /// <summary>Returns a process-wide cached metadata reference for the assembly at the given path.</summary>
+    /// <param name="path">The assembly file path.</param>
+    /// <returns>A shared <see cref="MetadataReference"/> for the path, created once and reused across tests.</returns>
+    public static MetadataReference GetMetadataReference(string path) =>
+        _metadataReferenceCache.GetOrAdd(path, static p => MetadataReference.CreateFromFile(p));
 
     /// <summary>Gets the assemblies referenced when compiling generated code.</summary>
     /// <returns>The distinct, non-dynamic assemblies to reference.</returns>

--- a/src/tests/Refit.GeneratorTests/GeneratedRequestBuildingTests.cs
+++ b/src/tests/Refit.GeneratorTests/GeneratedRequestBuildingTests.cs
@@ -937,6 +937,38 @@ public class GeneratedRequestBuildingTests
             "global::Refit.GeneratedRequestRunner.CreateUrlEncodedBodyContent<global::RefitGeneratorTest.LoginForm>(");
     }
 
+    /// <summary>Verifies special characters in a form field alias are escaped in the generated descriptor literal.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task UrlEncodedFormBodyEscapesSpecialCharactersInFieldNames()
+    {
+        const string source =
+            """
+            using System.Threading.Tasks;
+            using Refit;
+
+            namespace RefitGeneratorTest;
+
+            public class QuotedForm
+            {
+                [AliasAs("a\"b\\c")]
+                public string Value { get; set; }
+            }
+
+            public interface IGeneratedClient
+            {
+                [Post("/login")]
+                Task Login([Body(BodySerializationMethod.UrlEncoded)] QuotedForm form);
+            }
+            """;
+
+        var result = Fixture.RunGenerator(source, generatedRequestBuilding: true);
+        var generated = result.GeneratedSources[GeneratedClientHintName];
+
+        await Assert.That(result.CompilesWithoutErrors).IsTrue();
+        await Assert.That(generated).Contains("\"a\\\"b\\\\c\"");
+    }
+
     /// <summary>Verifies a string-typed form body keeps the reflection-based content path.</summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Test]

--- a/src/tests/Refit.GeneratorTests/GeneratorComponentTests.cs
+++ b/src/tests/Refit.GeneratorTests/GeneratorComponentTests.cs
@@ -209,12 +209,63 @@ public static class GeneratorComponentTests
         {
             var builder = new StringBuilder();
 
-            foreach (var value in new[] { '\\', '"', '\0', '\a', '\b', '\f', '\n', '\r', '\t', '\v', 'x' })
+            foreach (var value in new[] { '\\', '"', '\0', '\a', '\b', '\f', '\n', '\r', '\t', '\v', '\u0085', '\u2028', '\u2029', 'x' })
             {
                 Emitter.AppendEscapedCharacter(builder, value);
             }
 
-            await Assert.That(builder.ToString()).IsEqualTo(@"\\\""\0\a\b\f\n\r\t\vx");
+            await Assert.That(builder.ToString()).IsEqualTo(@"\\\""\0\a\b\f\n\r\t\v\u0085\u2028\u2029x");
+        }
+
+        /// <summary>Verifies the string-literal escape lookup for special, line-terminator, and verbatim characters.</summary>
+        /// <returns>A task representing the asynchronous test.</returns>
+        [Test]
+        public async Task EscapeSequence_ReturnsEscapesForSpecialCharactersAndNullOtherwise()
+        {
+            await Assert.That(Emitter.EscapeSequence('\\')).IsEqualTo(@"\\");
+            await Assert.That(Emitter.EscapeSequence('"')).IsEqualTo("\\\"");
+            await Assert.That(Emitter.EscapeSequence('\0')).IsEqualTo(@"\0");
+            await Assert.That(Emitter.EscapeSequence('\a')).IsEqualTo(@"\a");
+            await Assert.That(Emitter.EscapeSequence('\b')).IsEqualTo(@"\b");
+            await Assert.That(Emitter.EscapeSequence('\f')).IsEqualTo(@"\f");
+            await Assert.That(Emitter.EscapeSequence('\n')).IsEqualTo(@"\n");
+            await Assert.That(Emitter.EscapeSequence('\r')).IsEqualTo(@"\r");
+            await Assert.That(Emitter.EscapeSequence('\t')).IsEqualTo(@"\t");
+            await Assert.That(Emitter.EscapeSequence('\v')).IsEqualTo(@"\v");
+            await Assert.That(Emitter.EscapeSequence('\u0085')).IsEqualTo(@"\u0085");
+            await Assert.That(Emitter.EscapeSequence('\u2028')).IsEqualTo(@"\u2028");
+            await Assert.That(Emitter.EscapeSequence('\u2029')).IsEqualTo(@"\u2029");
+            await Assert.That(Emitter.EscapeSequence('x')).IsNull();
+        }
+
+        /// <summary>Verifies the rendered length of a quoted literal accounts for escapes and the null keyword.</summary>
+        /// <returns>A task representing the asynchronous test.</returns>
+        [Test]
+        public async Task LiteralOrNullLength_AccountsForEscapesAndNull()
+        {
+            const int NullLength = 4;
+            const int PlainQuotedLength = 5;
+
+            // '"' wrapper (2) + 'a' (1) + '"' escape (2) + U+2028 escape (6) = 11.
+            const int EscapedLength = 11;
+
+            await Assert.That(Emitter.LiteralOrNullLength(null)).IsEqualTo(NullLength);
+            await Assert.That(Emitter.LiteralOrNullLength("abc")).IsEqualTo(PlainQuotedLength);
+            await Assert.That(Emitter.LiteralOrNullLength("a\"\u2028")).IsEqualTo(EscapedLength);
+        }
+
+        /// <summary>Verifies the decimal length helper for zero, single-digit, and multi-digit values.</summary>
+        /// <returns>A task representing the asynchronous test.</returns>
+        [Test]
+        public async Task Int32Length_HandlesZeroAndMultipleDigits()
+        {
+            const int SingleDigit = 1;
+            const int ThreeDigits = 3;
+            const int PositiveThreeDigitValue = 123;
+
+            await Assert.That(Emitter.Int32Length(0)).IsEqualTo(SingleDigit);
+            await Assert.That(Emitter.Int32Length(SingleDigit)).IsEqualTo(SingleDigit);
+            await Assert.That(Emitter.Int32Length(PositiveThreeDigitValue)).IsEqualTo(ThreeDigits);
         }
 
         /// <summary>Verifies body buffering and streaming expressions for all supported modes.</summary>
@@ -752,7 +803,7 @@ public static class GeneratorComponentTests
         {
             var references = ((string)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES")!)
                 .Split(Path.PathSeparator)
-                .Select(path => (MetadataReference)MetadataReference.CreateFromFile(path));
+                .Select(Fixture.GetMetadataReference);
 
             return CSharpCompilation.Create(
                 "TypeSymbolTests",

--- a/src/tests/Refit.Newtonsoft.Json.Tests/NewtonsoftJsonSecurityTests.cs
+++ b/src/tests/Refit.Newtonsoft.Json.Tests/NewtonsoftJsonSecurityTests.cs
@@ -1,0 +1,75 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+
+namespace Refit.Tests;
+
+/// <summary>Verifies the Newtonsoft serializer does not inherit an unsafe global <c>TypeNameHandling</c>.</summary>
+[NotInParallel(nameof(NewtonsoftJsonSecurityTests))]
+public sealed class NewtonsoftJsonSecurityTests
+{
+    /// <summary>Verifies a globally configured unsafe <c>TypeNameHandling</c> is forced off when no explicit settings are supplied.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    [SuppressMessage(
+        "Security",
+        "CA2326:Do not use TypeNameHandling values other than None",
+        Justification = "The test intentionally configures an unsafe global value to prove the serializer neutralizes it.")]
+    [SuppressMessage(
+        "Security",
+        "CA2327:Do not use insecure JsonSerializerSettings",
+        Justification = "The test intentionally configures an unsafe global value to prove the serializer neutralizes it.")]
+    public async Task GlobalTypeNameHandlingIsForcedOffWhenNoExplicitSettings()
+    {
+        var previous = JsonConvert.DefaultSettings;
+        JsonConvert.DefaultSettings = () => new JsonSerializerSettings
+        {
+            TypeNameHandling = TypeNameHandling.All
+        };
+
+        try
+        {
+            var serializer = new NewtonsoftJsonContentSerializer();
+
+            var json = await serializer.ToHttpContent(new SampleModel { Name = "value" }).ReadAsStringAsync();
+
+            await Assert.That(json).DoesNotContain("$type");
+        }
+        finally
+        {
+            JsonConvert.DefaultSettings = previous;
+        }
+    }
+
+    /// <summary>Verifies a caller that explicitly opts into <c>TypeNameHandling</c> is honored.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    [SuppressMessage(
+        "Security",
+        "CA2326:Do not use TypeNameHandling values other than None",
+        Justification = "The test intentionally opts into an unsafe value to prove explicit caller settings are honored.")]
+    [SuppressMessage(
+        "Security",
+        "CA2327:Do not use insecure JsonSerializerSettings",
+        Justification = "The test intentionally opts into an unsafe value to prove explicit caller settings are honored.")]
+    public async Task ExplicitTypeNameHandlingIsHonored()
+    {
+        var serializer = new NewtonsoftJsonContentSerializer(
+            new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.All });
+
+        var json = await serializer.ToHttpContent(new SampleModel { Name = "value" }).ReadAsStringAsync();
+
+        await Assert.That(json).Contains("$type");
+    }
+
+    /// <summary>A simple model used to observe whether type metadata is emitted.</summary>
+    private sealed class SampleModel
+    {
+        /// <summary>Gets or sets the name.</summary>
+        public string? Name { get; set; }
+    }
+}

--- a/src/tests/Refit.Tests/ApiExceptionTests.cs
+++ b/src/tests/Refit.Tests/ApiExceptionTests.cs
@@ -23,6 +23,8 @@ public sealed class ApiExceptionTests
             .ThrowsExactly<ArgumentException>();
         await Assert.That(() => (Task)ApiException.Create("message", request, HttpMethod.Get, null!, new()))
             .ThrowsExactly<ArgumentNullException>();
+        await Assert.That(() => (Task)ApiException.Create(request, HttpMethod.Get, null!, new(), null))
+            .ThrowsExactly<ArgumentNullException>();
     }
 
     /// <summary>Verifies ApiException factory handles absent and unreadable content without hiding the original response error.</summary>
@@ -391,6 +393,143 @@ public sealed class ApiExceptionTests
         await Assert.That(exception.RequestContent).IsNull();
     }
 
+    /// <summary>Verifies the error body is truncated to the configured maximum length.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task MaxExceptionContentLengthTruncatesErrorBody()
+    {
+        using var response = CreateErrorResponse(new string('a', 10_000));
+        var settings = new RefitSettings { MaxExceptionContentLength = 128 };
+
+        var exception = await ApiException.Create(
+            response.RequestMessage!,
+            HttpMethod.Get,
+            response,
+            settings);
+
+        await Assert.That(exception.Content!.Length).IsEqualTo(128);
+    }
+
+    /// <summary>Verifies an unset maximum length leaves the error body intact.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task MaxExceptionContentLengthUnsetReadsFullBody()
+    {
+        using var response = CreateErrorResponse(new string('a', 10_000));
+
+        var exception = await ApiException.Create(
+            response.RequestMessage!,
+            HttpMethod.Get,
+            response,
+            new());
+
+        await Assert.That(exception.Content!.Length).IsEqualTo(10_000);
+    }
+
+    /// <summary>Verifies a zero maximum length yields an empty error body.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task MaxExceptionContentLengthZeroReturnsEmptyContent()
+    {
+        using var response = CreateErrorResponse(new string('a', 100));
+        var settings = new RefitSettings { MaxExceptionContentLength = 0 };
+
+        var exception = await ApiException.Create(
+            response.RequestMessage!,
+            HttpMethod.Get,
+            response,
+            settings);
+
+        await Assert.That(exception.Content).IsEqualTo(string.Empty);
+    }
+
+    /// <summary>Verifies the error body is still read when the response carries no content type.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task CreateReadsContentWhenContentTypeMissing()
+    {
+        using var response = CreateErrorResponse("{\"Value\":1}");
+        response.Content!.Headers.ContentType = null;
+
+        var exception = await ApiException.Create(
+            response.RequestMessage!,
+            HttpMethod.Get,
+            response,
+            new());
+
+        await Assert.That(exception).IsTypeOf<ApiException>();
+        await Assert.That(exception.Content).IsEqualTo("{\"Value\":1}");
+    }
+
+    /// <summary>Verifies the error body is read when the content read genuinely suspends asynchronously.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task CreateReadsContentThatCompletesAsynchronously()
+    {
+        using var response = new HttpResponseMessage(HttpStatusCode.BadRequest)
+        {
+            RequestMessage = new(HttpMethod.Get, "https://example.test"),
+            Content = new AsyncReadContent("{\"Value\":7}")
+        };
+
+        var exception = await ApiException.Create(
+            response.RequestMessage!,
+            HttpMethod.Get,
+            response,
+            new());
+
+        await Assert.That(exception.Content).IsEqualTo("{\"Value\":7}");
+    }
+
+    /// <summary>Verifies a problem+json body is built into a validation exception even when the serializer suspends asynchronously.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task CreateBuildsValidationExceptionWhenSerializerCompletesAsynchronously()
+    {
+        using var response = CreateErrorResponse("{\"title\":\"invalid\"}", "application/problem+json");
+        var settings = new RefitSettings(new AsyncYieldingSerializer());
+
+        var exception = await ApiException.Create(
+            response.RequestMessage!,
+            HttpMethod.Get,
+            response,
+            settings);
+
+        await Assert.That(exception).IsTypeOf<ValidationApiException>();
+    }
+
+    /// <summary>Verifies the redaction hook can scrub credentials and bodies before the exception propagates.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task ExceptionRedactorScrubsSensitiveData()
+    {
+        using var response = CreateErrorResponse("{\"secret\":\"value\"}");
+        response.RequestMessage!.Headers.Authorization = new("Bearer", "super-secret-token");
+        GeneratedRequestRunner.AddRequestProperty(
+            response.RequestMessage!,
+            HttpRequestMessageOptions.RequestContent,
+            "{\"password\":\"hunter2\"}");
+        var settings = new RefitSettings
+        {
+            ExceptionRedactor = ex =>
+            {
+                ex.RequestMessage.Headers.Authorization = null;
+                ex.RequestContent = "[redacted]";
+                ((ApiException)ex).Content = "[redacted]";
+            }
+        };
+
+        var exception = await ApiException.Create(
+            response.RequestMessage!,
+            HttpMethod.Get,
+            response,
+            settings);
+
+        await Assert.That(exception.RequestMessage.Headers.Authorization).IsNull();
+        await Assert.That(exception.RequestContent).IsEqualTo("[redacted]");
+        await Assert.That(exception.Content).IsEqualTo("[redacted]");
+    }
+
     /// <summary>Creates an error response with an attached request.</summary>
     /// <param name="content">The response content.</param>
     /// <param name="mediaType">The optional media type.</param>
@@ -409,6 +548,31 @@ public sealed class ApiExceptionTests
         }
 
         return response;
+    }
+
+    /// <summary>Content whose read genuinely suspends, forcing the asynchronous completion path when the exception reads the body.</summary>
+    private sealed class AsyncReadContent : HttpContent
+    {
+        /// <summary>The UTF-8 payload bytes.</summary>
+        private readonly byte[] _payload;
+
+        /// <summary>Initializes a new instance of the <see cref="AsyncReadContent"/> class.</summary>
+        /// <param name="payload">The string payload.</param>
+        public AsyncReadContent(string payload) => _payload = System.Text.Encoding.UTF8.GetBytes(payload);
+
+        /// <inheritdoc />
+        protected override async Task SerializeToStreamAsync(Stream stream, TransportContext? context)
+        {
+            await Task.Yield();
+            await stream.WriteAsync(_payload.AsMemory()).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc />
+        protected override bool TryComputeLength(out long length)
+        {
+            length = _payload.Length;
+            return true;
+        }
     }
 
     /// <summary>Content that throws when read as a string.</summary>
@@ -489,6 +653,31 @@ public sealed class ApiExceptionTests
         /// <inheritdoc />
         public Task<T?> FromHttpContentAsync<T>(HttpContent content, CancellationToken cancellationToken = default) =>
             _inner.FromHttpContentAsync<T>(content, cancellationToken);
+
+        /// <inheritdoc />
+        public string? GetFieldNameForProperty(System.Reflection.PropertyInfo propertyInfo) =>
+            _inner.GetFieldNameForProperty(propertyInfo);
+    }
+
+    /// <summary>A serializer that genuinely suspends before delegating, forcing the async deserialization path.</summary>
+    [SuppressMessage(
+        "Major Code Smell",
+        "S4018:Generic methods should provide type parameters",
+        Justification = "Mirrors the explicit type parameters of the wrapped IHttpContentSerializer contract.")]
+    private sealed class AsyncYieldingSerializer : IHttpContentSerializer
+    {
+        /// <summary>The wrapped serializer that does the real work.</summary>
+        private readonly SystemTextJsonContentSerializer _inner = new();
+
+        /// <inheritdoc />
+        public HttpContent ToHttpContent<T>(T item) => _inner.ToHttpContent(item);
+
+        /// <inheritdoc />
+        public async Task<T?> FromHttpContentAsync<T>(HttpContent content, CancellationToken cancellationToken = default)
+        {
+            await Task.Yield();
+            return await _inner.FromHttpContentAsync<T>(content, cancellationToken).ConfigureAwait(false);
+        }
 
         /// <inheritdoc />
         public string? GetFieldNameForProperty(System.Reflection.PropertyInfo propertyInfo) =>

--- a/src/tests/Refit.Tests/TestUrlFormatter.cs
+++ b/src/tests/Refit.Tests/TestUrlFormatter.cs
@@ -44,7 +44,7 @@ public class TestUrlFormatter : IUrlParameterFormatter
     /// <returns>The string representation of the value.</returns>
     public string? Format(object? value, ICustomAttributeProvider attributeProvider, Type type)
     {
-        if (!Equals(attributeProvider, _expectedAttributeProviders[_index]))
+        if (!SameMetadata(attributeProvider, _expectedAttributeProviders[_index]))
         {
             throw new InvalidOperationException(
                 $"Unexpected attribute provider at index {_index}.");
@@ -66,4 +66,26 @@ public class TestUrlFormatter : IUrlParameterFormatter
         await Assert.That(_index).IsEqualTo(_expectedAttributeProviders.Length);
         await Assert.That(_index).IsEqualTo(_expectedTypes.Length);
     }
+
+    /// <summary>
+    /// Compares two attribute providers by stable metadata identity rather than reference.
+    /// The runtime's reflection cache can evict and return a different <see cref="ParameterInfo"/>
+    /// (or <see cref="MemberInfo"/>) instance for the same member under memory pressure, so a
+    /// reference comparison is unreliable across separate reflection lookups.
+    /// </summary>
+    /// <param name="actual">The attribute provider received by the formatter.</param>
+    /// <param name="expected">The attribute provider the test expects.</param>
+    /// <returns><see langword="true"/> if both describe the same metadata element.</returns>
+    private static bool SameMetadata(ICustomAttributeProvider actual, ICustomAttributeProvider expected) =>
+        ReferenceEquals(actual, expected)
+            || (actual, expected) switch
+            {
+                (ParameterInfo a, ParameterInfo b) =>
+                    a.Position == b.Position
+                    && a.Member.MetadataToken == b.Member.MetadataToken
+                    && a.Member.Module == b.Member.Module,
+                (MemberInfo a, MemberInfo b) =>
+                    a.MetadataToken == b.MetadataToken && a.Module == b.Module,
+                _ => Equals(actual, expected),
+            };
 }

--- a/src/tests/Refit.Tests/XmlContentSerializerTests.cs
+++ b/src/tests/Refit.Tests/XmlContentSerializerTests.cs
@@ -185,6 +185,52 @@ public class XmlContentSerializerTests
         await Assert.That(() => both.WriterSettings = null!).ThrowsExactly<ArgumentNullException>();
     }
 
+    /// <summary>Verifies DTD processing is forced off and the resolver cleared even when the caller opts into parsing (XXE hardening).</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task ReaderSettingsAlwaysProhibitDtdAndClearResolver()
+    {
+        var settings = new XmlReaderWriterSettings(
+            new XmlReaderSettings
+            {
+                DtdProcessing = DtdProcessing.Parse,
+                XmlResolver = new XmlUrlResolver()
+            });
+
+        await Assert.That(settings.ReaderSettings.DtdProcessing).IsEqualTo(DtdProcessing.Prohibit);
+    }
+
+    /// <summary>Verifies the obsolete opt-out leaves caller-configured DTD processing intact.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task AllowDtdProcessingOptOutHonorsCallerSettings()
+    {
+        var settings = new XmlReaderWriterSettings(
+            new XmlReaderSettings { DtdProcessing = DtdProcessing.Parse });
+#pragma warning disable CS0618 // Intentionally exercising the obsolete XXE opt-out.
+        settings.AllowDtdProcessing = true;
+#pragma warning restore CS0618
+
+        await Assert.That(settings.ReaderSettings.DtdProcessing).IsEqualTo(DtdProcessing.Parse);
+    }
+
+    /// <summary>Verifies a payload carrying an external entity (XXE) is rejected rather than resolved.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task DeserializeRejectsExternalEntityPayload()
+    {
+        var sut = new XmlContentSerializer(new XmlContentSerializerSettings { XmlNamespaces = new() });
+        const string xxe =
+            "<?xml version=\"1.0\"?>"
+            + "<!DOCTYPE Dto [ <!ENTITY xxe SYSTEM \"file:///etc/passwd\"> ]>"
+            + "<Dto><Identifier>&xxe;</Identifier></Dto>";
+
+        // XmlSerializer wraps the underlying "DTD is prohibited" XmlException in an InvalidOperationException.
+        var exception = await Assert.That(() => sut.FromHttpContentAsync<Dto>(new StringContent(xxe)))
+            .ThrowsExactly<InvalidOperationException>();
+        await Assert.That(exception!.InnerException).IsTypeOf<XmlException>();
+    }
+
     /// <summary>Builds a populated <see cref="Dto"/> instance for the tests.</summary>
     /// <returns>A new <see cref="Dto"/>.</returns>
     [System.Diagnostics.CodeAnalysis.SuppressMessage(


### PR DESCRIPTION
## What kind of change does this PR introduce?

Security hardening (feature + behavior changes) from a security audit. The audit found no Critical/High vulnerabilities - Refit is defensively written (proper URL/header encoding, CRLF stripping, per-request auth, no cert bypass, generator escapes user strings). These changes are defense-in-depth plus a few behavior changes, safe by default.

## What is the new behavior?

**Hardened defaults**
- **XXE**: `XmlContentSerializer` forces `DtdProcessing.Prohibit` and clears `XmlResolver` on every read, blocking XXE and entity-expansion ("billion laughs") attacks.
- **Newtonsoft type handling**: when no explicit settings are supplied, `NewtonsoftJsonContentSerializer` forces `TypeNameHandling.None` so an unsafe global `JsonConvert.DefaultSettings` cannot drive polymorphic deserialization of response bodies (a known RCE gadget vector). Explicit caller settings are still honored.

**New opt-in settings**
- `RefitSettings.ExceptionRedactor` - hook to scrub the `Authorization` header, request/response bodies, and `Set-Cookie` before an `ApiException` reaches logging/telemetry that serializes exceptions.
- `RefitSettings.MaxExceptionContentLength` - caps how many characters of an error body are read into `ApiException.Content` (bounds memory against hostile/oversized responses). Defaults to unbounded.

**Robustness**
- The source generator escapes U+0085/U+2028/U+2029 in emitted string literals (these otherwise break a regular literal, CS1010) and the literal length math uses the real escape length.
- The net7+ `[GeneratedRegex]` for path parameters gets a 1s match timeout, matching the legacy path.

## What is the current behavior?

- XML responses are parsed with the framework default reader settings (DTD handling not asserted in code).
- The Newtonsoft serializer silently inherits `JsonConvert.DefaultSettings`, including any unsafe `TypeNameHandling`.
- `ApiException` retains the live request (Authorization header), optional request body, and raw response headers/body with no redaction hook and no bound on the error-body read.
- The generator does not escape the U+0085/U+2028/U+2029 line-terminator characters; the net7+ path regex has no match timeout.

## What might this PR break?

- **XML with DTDs/external entities** now throws instead of being parsed. We strongly recommend against re-enabling DTD processing, but a deliberate escape hatch exists for fully trusted XML: set the obsolete `XmlReaderWriterSettings.AllowDtdProcessing = true` (marked `[Obsolete]` on purpose so it raises a compiler warning) and configure `DtdProcessing`/`XmlResolver` yourself on `ReaderSettings`. Prefer pre-processing untrusted documents instead.
- **Newtonsoft polymorphic (`$type`) deserialization via a global `JsonConvert.DefaultSettings`** no longer works unless you pass explicit `JsonSerializerSettings` (ideally constrained with a `SerializationBinder`).

Both are documented in a new "Breaking changes in V13.x" section in the README. The new settings are additive and default to the previous behavior.

## Checklist
- [x] I have read the [Contribute guide](https://www.reactiveui.net/contribute/index.html)
- [x] Tests have been added or updated (for bug fixes / features)
- [x] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the `main` branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional information

Tests added for XXE rejection (and the opt-out path), TypeNameHandling neutralize/honor, generator escaping, content cap, and redaction. Full suites green: Refit.Tests 788, Refit.Newtonsoft.Json.Tests 37, Refit.GeneratorTests 151 - 0 failures. Solution builds clean in Release (0 warnings, analyzer gate satisfied).