### PR TITLE
[codex] Fix R3 bridge analyzer removal target

### DIFF
--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -11,9 +11,14 @@
     <Error Condition="$(PackageDescription) == '' or $(PackageDescription) == $(DefaultPackageDescription)" Text="The Nuget PackageDescription property needs to be set for the project. Currently : '$(PackageDescription)'"/>
   </Target>
 
-  <Target Name="RemoveReactiveUIPrimitivesR3BridgeAnalyzer" AfterTargets="ResolveLockFileAnalyzers">
+  <Target Name="RemoveReactiveUIPrimitivesR3BridgeAnalyzers"
+          AfterTargets="ResolvePackageAssets"
+          BeforeTargets="CoreCompile;Csc">
     <ItemGroup>
-      <Analyzer Remove="@(Analyzer)" Condition="'%(Analyzer.NuGetPackageId)' == 'ReactiveUI.Primitives' and '%(Analyzer.Filename)%(Analyzer.Extension)' == 'ReactiveUI.Primitives.R3Bridge.Generator.dll'"/>
+      <ResolvedAnalyzers Remove="@(ResolvedAnalyzers)"
+                         Condition="'%(ResolvedAnalyzers.Filename)' == 'ReactiveUI.Primitives.R3Bridge.Generator'" />
+      <Analyzer Remove="@(Analyzer)"
+                Condition="'%(Analyzer.Filename)' == 'ReactiveUI.Primitives.R3Bridge.Generator'" />
     </ItemGroup>
   </Target>
 </Project>

--- a/src/Refit.slnx
+++ b/src/Refit.slnx
@@ -19,6 +19,7 @@
         <File Path="../LICENSE" />
         <File Path="../README.md" />
         <File Path="Directory.Build.props" />
+        <File Path="Directory.Build.targets" />
         <File Path="Directory.Packages.props" />
         <File Path="testconfig.json" />
     </Folder>


### PR DESCRIPTION
## Summary
- Update the shared MSBuild target that removes the ReactiveUI.Primitives R3 bridge generator so it runs after package assets are resolved and before compilation.
- Remove the generator from both `ResolvedAnalyzers` and `Analyzer` item groups by filename.
- Add `Directory.Build.targets` to `Refit.slnx` so the shared build target is visible in the solution.

## Why
The existing target ran after `ResolveLockFileAnalyzers` and only removed from `Analyzer`, which can miss analyzer items that are populated later through resolved package assets. Running before `CoreCompile`/`Csc` ensures the unwanted generator is filtered before compilation.

## Impact
This keeps the R3 bridge generator from being passed to compilation while preserving the rest of the analyzer pipeline.

## Validation
- `dotnet build src\Refit.slnx -c Release -v minimal`