### PR TITLE
feat: add null handling for round trip parameter and add verifying test

### DIFF
--- a/src/Refit/RequestBuilderImplementation.RequestBuilding.cs
+++ b/src/Refit/RequestBuilderImplementation.RequestBuilding.cs
@@ -549,6 +549,18 @@ namespace Refit
             // If round tripping, format each path segment independently.
             Debug.Assert(parameterMapValue.Type == ParameterType.RoundTripping, "Dynamic route fragments must be Normal or RoundTripping.");
             var paramValue = (string)param;
+
+            if (paramValue is null)
+            {
+                vsb.Append(
+                    StringHelpers.EscapeDataString(
+                        _settings.UrlParameterFormatter.Format(
+                            paramValue,
+                            parameterInfo,
+                            parameterInfo.ParameterType) ?? string.Empty));
+                return;
+            }
+
             var sectionStart = 0;
             for (var i = 0; i <= paramValue.Length; i++)
             {

--- a/src/tests/Refit.Tests/IRoundTrippingNullString.cs
+++ b/src/tests/Refit.Tests/IRoundTrippingNullString.cs
@@ -1,0 +1,15 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Refit.Tests;
+
+/// <summary>Fixture whose round-tripping parameter is nullable, used to verify ignores it.</summary>
+public interface IRoundTrippingNullString
+{
+    /// <summary>Endpoint with a round-tripping parameter name followed by whitespace.</summary>
+    /// <param name="path">The nullable path value.</param>
+    /// <returns>The response body.</returns>
+    [Get("/{**path}")]
+    Task<string> GetValue(string? path);
+}

--- a/src/tests/Refit.Tests/RestServiceIntegrationTests.cs
+++ b/src/tests/Refit.Tests/RestServiceIntegrationTests.cs
@@ -2,15 +2,9 @@
 // ReactiveUI and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.IO;
-using System.Linq;
 using System.Net;
-using System.Net.Http;
 using System.Text.Json;
-using System.Threading.Tasks;
 using Refit.Testing;
 
 namespace Refit.Tests;
@@ -1153,6 +1147,22 @@ public partial class RestServiceIntegrationTests
         var fixture = handler.CreateGeneratedClient<IGeneratedParametersApi>(BaseUrl);
 
         _ = await fixture.GetNullableParam(null);
+
+        await handler.VerifyAllCalledAsync();
+    }
+
+    /// <summary>Verifies a round trip URL with a nullable parameter.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task GetWithNullRoundTripParameterGenerated()
+    {
+        var handler = new StubHttp
+        {
+            { Route.Get(BaseUrlWithSlash), Reply.Json("Ok") },
+        };
+        var fixture = handler.CreateClient<IRoundTrippingNullString>(BaseUrl);
+
+        _ = await fixture.GetValue(null);
 
         await handler.VerifyAllCalledAsync();
     }


### PR DESCRIPTION
Passing a null value into as a round tripping parameter would previously result in:
```C#
[Null Reference] Object reference not set to an instance of an object.
   at Refit.RequestBuilderImplementation.AppendDynamicRouteFragment(ValueStringBuilder& vsb, RestMethodInfoInternal restMethod, Object[] paramList, ParameterFragment fragment, RestMethodParameterInfo parameterMapValue)
```

- I've added a null check, when the parameter is null it will instead call `StringHelpers.EscapeDataString(_settings.UrlParameterFormatter.Format())`, similar to how `AppendObjectPropertyFragment` and `AppendDynamicRouteFragment` handle it. This way the user can choose how this is handled.
  - Not sure if this would be considered to be a breaking change
- Added a test verifying the behaviour