### PR TITLE
test: cover TransportExceptionFactory cancellation and timeout behavior

### DIFF
--- a/src/Refit/RequestExecutionHelpers.cs
+++ b/src/Refit/RequestExecutionHelpers.cs
@@ -386,6 +386,13 @@ internal static class RequestExecutionHelpers
                 .ConfigureAwait(false);
             return SendResult<T>.FromResponse(response);
         }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // Caller-requested cancellation is control flow, not a transport error.
+            // Propagate it unwrapped so callers, ASP.NET Core request-abort handling and
+            // Polly cancellation policies still see an OperationCanceledException.
+            throw;
+        }
         catch (Exception ex)
         {
             if (!isApiResponse)

--- a/src/Refit/RequestExecutionHelpers.cs
+++ b/src/Refit/RequestExecutionHelpers.cs
@@ -386,13 +386,6 @@ internal static class RequestExecutionHelpers
                 .ConfigureAwait(false);
             return SendResult<T>.FromResponse(response);
         }
-        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-        {
-            // Caller-requested cancellation is control flow, not a transport error.
-            // Propagate it unwrapped so callers, ASP.NET Core request-abort handling and
-            // Polly cancellation policies still see an OperationCanceledException.
-            throw;
-        }
         catch (Exception ex)
         {
             var transportException = settings.TransportExceptionFactory(request, ex, cancellationToken);

--- a/src/tests/Refit.Tests/GeneratedRequestRunnerTests.TransportExceptionFactory.cs
+++ b/src/tests/Refit.Tests/GeneratedRequestRunnerTests.TransportExceptionFactory.cs
@@ -1,0 +1,61 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Refit.Tests;
+
+/// <summary>Send-path tests covering <see cref="RefitSettings.TransportExceptionFactory"/> behavior.</summary>
+public partial class GeneratedRequestRunnerTests
+{
+    /// <summary>Verifies a cancellation the caller did not request (for example an <see cref="HttpClient"/> timeout) is still wrapped in <see cref="ApiRequestException"/>.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task SendAsyncWrapsCancellationWhenCallerTokenNotSignalled()
+    {
+        var handler = new CapturingHandler(
+            (_, _) => throw new TaskCanceledException("timeout"));
+        using var client = CreateClient(handler);
+        using var request = new HttpRequestMessage(HttpMethod.Get, RelativeResourcePath);
+
+        var thrown = await Assert
+            .That(
+                () => GeneratedRequestRunner.SendAsync<string, string>(
+                    client,
+                    request,
+                    CreateSettings(),
+                    isApiResponse: false,
+                    shouldDisposeResponse: true,
+                    bufferBody: false,
+                    CancellationToken.None))
+            .ThrowsExactly<ApiRequestException>();
+
+        await Assert.That(thrown!.InnerException is OperationCanceledException).IsTrue();
+    }
+
+    /// <summary>Verifies a custom <see cref="RefitSettings.TransportExceptionFactory"/> controls the exception surfaced from the send path.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task SendAsyncHonorsCustomTransportExceptionFactory()
+    {
+        var settings = CreateSettings();
+        settings.TransportExceptionFactory = (_, _, _) => new InvalidOperationException("mapped by factory");
+        var handler = new CapturingHandler(
+            (_, _) => throw new HttpRequestException("boom"));
+        using var client = CreateClient(handler);
+        using var request = new HttpRequestMessage(HttpMethod.Get, RelativeResourcePath);
+
+        var thrown = await Assert
+            .That(
+                () => GeneratedRequestRunner.SendAsync<string, string>(
+                    client,
+                    request,
+                    settings,
+                    isApiResponse: false,
+                    shouldDisposeResponse: true,
+                    bufferBody: false,
+                    CancellationToken.None))
+            .ThrowsExactly<InvalidOperationException>();
+
+        await Assert.That(thrown!.Message).IsEqualTo("mapped by factory");
+    }
+}

--- a/src/tests/Refit.Tests/GeneratedRequestRunnerTests.cs
+++ b/src/tests/Refit.Tests/GeneratedRequestRunnerTests.cs
@@ -1033,9 +1033,9 @@ public partial class GeneratedRequestRunnerTests
     {
         using var tokenSource = new CancellationTokenSource();
         var handler = new CapturingHandler(
-            (_, _) =>
+            async (_, _) =>
             {
-                tokenSource.Cancel();
+                await tokenSource.CancelAsync();
                 throw new OperationCanceledException(tokenSource.Token);
             });
         using var client = CreateClient(handler);

--- a/src/tests/Refit.Tests/GeneratedRequestRunnerTests.cs
+++ b/src/tests/Refit.Tests/GeneratedRequestRunnerTests.cs
@@ -1026,6 +1026,34 @@ public partial class GeneratedRequestRunnerTests
             .ThrowsExactly<OperationCanceledException>();
     }
 
+    /// <summary>Verifies caller-requested cancellation during send is rethrown instead of being wrapped in <see cref="ApiRequestException"/>.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task SendAsyncRethrowsCancellationRequestedDuringSend()
+    {
+        using var tokenSource = new CancellationTokenSource();
+        var handler = new CapturingHandler(
+            (_, _) =>
+            {
+                tokenSource.Cancel();
+                throw new OperationCanceledException(tokenSource.Token);
+            });
+        using var client = CreateClient(handler);
+        using var request = new HttpRequestMessage(HttpMethod.Get, RelativeResourcePath);
+
+        await Assert
+            .That(
+                () => GeneratedRequestRunner.SendAsync<string, string>(
+                    client,
+                    request,
+                    CreateSettings(),
+                    isApiResponse: false,
+                    shouldDisposeResponse: true,
+                    bufferBody: false,
+                    tokenSource.Token))
+            .Throws<OperationCanceledException>();
+    }
+
     /// <summary>Verifies that best-effort response buffering failures do not prevent serializer deserialization.</summary>
     /// <returns>A task that represents the asynchronous operation.</returns>
     [Test]


### PR DESCRIPTION
## What kind of change does this PR introduce?

- Tests only. No product code changes.

## What is the new behavior?

- Adds tests for the TransportExceptionFactory send path added in #2205:
  - Caller-requested cancellation is rethrown unwrapped as OperationCanceledException.
  - A cancellation the caller did not request (for example a timeout) is still wrapped in ApiRequestException.
  - A custom TransportExceptionFactory controls the exception that is surfaced.

## What is the current behavior?

- These branches were not covered by tests after #2205 merged.

## What might this PR break?

- None. Tests only.

## Checklist
- [x] I have read the Contribute guide
- [x] Tests have been added or updated (for bug fixes / features)
- [ ] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the main branch
- [x] PR title follows Conventional Commits

## Additional information

- The original fix was superseded by #2205, which added TransportExceptionFactory. Its default already propagates caller cancellation unwrapped, so the production guard was reverted and this PR now only adds the missing test coverage.
