### PR TITLE
feature: Create a TransportExceptionFactory to let the user decide the exception to be thrown

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ lets you stub responses and verify requests with a declarative route table — s
     * [Inspecting the error body synchronously](#inspecting-the-error-body-synchronously)
     * [Reading the request body that was sent](#reading-the-request-body-that-was-sent)
     * [Providing a custom ExceptionFactory](#providing-a-custom-exceptionfactory)
+    * [Providing a custom TransportExceptionFactory](#providing-a-custom-transportexceptionfactory)
     * [ApiException deconstruction with Serilog](#apiexception-deconstruction-with-serilog)
 * [Testing your Refit clients](#testing-your-refit-clients)
 
@@ -265,6 +266,7 @@ clients continue to honor settings such as:
 * `AuthorizationHeaderValueGetter`
 * `ExceptionFactory`
 * `DeserializationExceptionFactory`
+* `TransportExceptionFactory`
 * `HttpRequestMessageOptions`
 * `Version` and `VersionPolicy`
 
@@ -2222,6 +2224,47 @@ var gitHubApi = RestService.For<IGitHubApi>("https://api.github.com",
     new RefitSettings {
         DeserializationExceptionFactory = (httpResponse, exception) => nullTask;
     });
+```
+
+#### Providing a custom `TransportExceptionFactory`
+
+You can control the exception that is surfaced when `HttpClient.SendAsync` throws a transport-level error (for example,
+`HttpRequestException`, `SocketException`, or `TaskCanceledException`) by setting `TransportExceptionFactory` on
+`RefitSettings`. The factory receives the `HttpRequestMessage` that was being sent, the raw exception, and the
+`CancellationToken` that was passed to the call, and returns the exception that Refit will ultimately throw
+(non-`ApiResponse` path) or store in `IApiResponse.Error` (`ApiResponse` path).
+
+By default, Refit wraps the transport exception in an `ApiRequestException` that carries the full request context,
+except when the exception is an `OperationCanceledException` and the `CancellationToken` is already cancelled — in
+that case the original exception is returned unchanged. You can replace that behavior entirely, for example to
+re-throw the original exception unchanged in all cases:
+
+```csharp
+var gitHubApi = RestService.For<IGitHubApi>("https://api.github.com",
+    new RefitSettings
+    {
+        TransportExceptionFactory = (request, ex, ct) => ex
+    });
+```
+
+Because `RefitSettings` is captured in the closure, you can also reconstruct the default behavior with your own
+adjustments:
+
+```csharp
+var settings = new RefitSettings();
+
+settings.TransportExceptionFactory = (request, ex, ct) =>
+{
+    // Pass cancellation through so ApiResponse callers still throw rather
+    // than capturing a cancelled request as a soft error.
+    if (ex is OperationCanceledException && ct.IsCancellationRequested)
+        return ex;
+
+    // Wrap everything else in ApiRequestException, just like the default.
+    return new ApiRequestException(request, request.Method, settings, ex);
+};
+
+var gitHubApi = RestService.For<IGitHubApi>("https://api.github.com", settings);
 ```
 
 #### `ApiException` deconstruction with Serilog

--- a/src/Refit/PublicAPI/net10.0/PublicAPI.Unshipped.txt
+++ b/src/Refit/PublicAPI/net10.0/PublicAPI.Unshipped.txt
@@ -4,6 +4,6 @@ Refit.GeneratedParameterAttributeProvider.GeneratedParameterAttributeProvider(Sy
 Refit.GeneratedParameterAttributeProvider.GetCustomAttributes(bool inherit) -> object![]!
 Refit.GeneratedParameterAttributeProvider.GetCustomAttributes(System.Type! attributeType, bool inherit) -> object![]!
 Refit.GeneratedParameterAttributeProvider.IsDefined(System.Type! attributeType, bool inherit) -> bool
-Refit.RefitSettings.TransportExceptionFactory.get -> System.Func<System.Net.Http.HttpRequestMessage!, System.Exception!, System.Exception!>!
+Refit.RefitSettings.TransportExceptionFactory.get -> System.Func<System.Net.Http.HttpRequestMessage!, System.Exception!, System.Threading.CancellationToken, System.Exception!>!
 Refit.RefitSettings.TransportExceptionFactory.set -> void
 static Refit.GeneratedRequestRunner.BuildRequestPath(string! relativePathTemplate, bool allowUnmatchedParameter, params ((int startIdx, int endIdx) range, string? value)[]! uriParams) -> string!

--- a/src/Refit/PublicAPI/net10.0/PublicAPI.Unshipped.txt
+++ b/src/Refit/PublicAPI/net10.0/PublicAPI.Unshipped.txt
@@ -4,4 +4,6 @@ Refit.GeneratedParameterAttributeProvider.GeneratedParameterAttributeProvider(Sy
 Refit.GeneratedParameterAttributeProvider.GetCustomAttributes(bool inherit) -> object![]!
 Refit.GeneratedParameterAttributeProvider.GetCustomAttributes(System.Type! attributeType, bool inherit) -> object![]!
 Refit.GeneratedParameterAttributeProvider.IsDefined(System.Type! attributeType, bool inherit) -> bool
+Refit.RefitSettings.TransportExceptionFactory.get -> System.Func<System.Net.Http.HttpRequestMessage!, System.Exception!, System.Exception!>!
+Refit.RefitSettings.TransportExceptionFactory.set -> void
 static Refit.GeneratedRequestRunner.BuildRequestPath(string! relativePathTemplate, bool allowUnmatchedParameter, params ((int startIdx, int endIdx) range, string? value)[]! uriParams) -> string!

--- a/src/Refit/PublicAPI/net11.0/PublicAPI.Unshipped.txt
+++ b/src/Refit/PublicAPI/net11.0/PublicAPI.Unshipped.txt
@@ -4,6 +4,6 @@ Refit.GeneratedParameterAttributeProvider.GeneratedParameterAttributeProvider(Sy
 Refit.GeneratedParameterAttributeProvider.GetCustomAttributes(bool inherit) -> object![]!
 Refit.GeneratedParameterAttributeProvider.GetCustomAttributes(System.Type! attributeType, bool inherit) -> object![]!
 Refit.GeneratedParameterAttributeProvider.IsDefined(System.Type! attributeType, bool inherit) -> bool
-Refit.RefitSettings.TransportExceptionFactory.get -> System.Func<System.Net.Http.HttpRequestMessage!, System.Exception!, System.Exception!>!
+Refit.RefitSettings.TransportExceptionFactory.get -> System.Func<System.Net.Http.HttpRequestMessage!, System.Exception!, System.Threading.CancellationToken, System.Exception!>!
 Refit.RefitSettings.TransportExceptionFactory.set -> void
 static Refit.GeneratedRequestRunner.BuildRequestPath(string! relativePathTemplate, bool allowUnmatchedParameter, params ((int startIdx, int endIdx) range, string? value)[]! uriParams) -> string!

--- a/src/Refit/PublicAPI/net11.0/PublicAPI.Unshipped.txt
+++ b/src/Refit/PublicAPI/net11.0/PublicAPI.Unshipped.txt
@@ -4,4 +4,6 @@ Refit.GeneratedParameterAttributeProvider.GeneratedParameterAttributeProvider(Sy
 Refit.GeneratedParameterAttributeProvider.GetCustomAttributes(bool inherit) -> object![]!
 Refit.GeneratedParameterAttributeProvider.GetCustomAttributes(System.Type! attributeType, bool inherit) -> object![]!
 Refit.GeneratedParameterAttributeProvider.IsDefined(System.Type! attributeType, bool inherit) -> bool
+Refit.RefitSettings.TransportExceptionFactory.get -> System.Func<System.Net.Http.HttpRequestMessage!, System.Exception!, System.Exception!>!
+Refit.RefitSettings.TransportExceptionFactory.set -> void
 static Refit.GeneratedRequestRunner.BuildRequestPath(string! relativePathTemplate, bool allowUnmatchedParameter, params ((int startIdx, int endIdx) range, string? value)[]! uriParams) -> string!

--- a/src/Refit/PublicAPI/net462/PublicAPI.Unshipped.txt
+++ b/src/Refit/PublicAPI/net462/PublicAPI.Unshipped.txt
@@ -4,6 +4,6 @@ Refit.GeneratedParameterAttributeProvider.GeneratedParameterAttributeProvider(Sy
 Refit.GeneratedParameterAttributeProvider.GetCustomAttributes(bool inherit) -> object![]!
 Refit.GeneratedParameterAttributeProvider.GetCustomAttributes(System.Type! attributeType, bool inherit) -> object![]!
 Refit.GeneratedParameterAttributeProvider.IsDefined(System.Type! attributeType, bool inherit) -> bool
-Refit.RefitSettings.TransportExceptionFactory.get -> System.Func<System.Net.Http.HttpRequestMessage!, System.Exception!, System.Exception!>!
+Refit.RefitSettings.TransportExceptionFactory.get -> System.Func<System.Net.Http.HttpRequestMessage!, System.Exception!, System.Threading.CancellationToken, System.Exception!>!
 Refit.RefitSettings.TransportExceptionFactory.set -> void
 static Refit.GeneratedRequestRunner.BuildRequestPath(string! relativePathTemplate, bool allowUnmatchedParameter, params ((int startIdx, int endIdx) range, string? value)[]! uriParams) -> string!

--- a/src/Refit/PublicAPI/net462/PublicAPI.Unshipped.txt
+++ b/src/Refit/PublicAPI/net462/PublicAPI.Unshipped.txt
@@ -4,4 +4,6 @@ Refit.GeneratedParameterAttributeProvider.GeneratedParameterAttributeProvider(Sy
 Refit.GeneratedParameterAttributeProvider.GetCustomAttributes(bool inherit) -> object![]!
 Refit.GeneratedParameterAttributeProvider.GetCustomAttributes(System.Type! attributeType, bool inherit) -> object![]!
 Refit.GeneratedParameterAttributeProvider.IsDefined(System.Type! attributeType, bool inherit) -> bool
+Refit.RefitSettings.TransportExceptionFactory.get -> System.Func<System.Net.Http.HttpRequestMessage!, System.Exception!, System.Exception!>!
+Refit.RefitSettings.TransportExceptionFactory.set -> void
 static Refit.GeneratedRequestRunner.BuildRequestPath(string! relativePathTemplate, bool allowUnmatchedParameter, params ((int startIdx, int endIdx) range, string? value)[]! uriParams) -> string!

--- a/src/Refit/PublicAPI/net470/PublicAPI.Unshipped.txt
+++ b/src/Refit/PublicAPI/net470/PublicAPI.Unshipped.txt
@@ -4,6 +4,6 @@ Refit.GeneratedParameterAttributeProvider.GeneratedParameterAttributeProvider(Sy
 Refit.GeneratedParameterAttributeProvider.GetCustomAttributes(bool inherit) -> object![]!
 Refit.GeneratedParameterAttributeProvider.GetCustomAttributes(System.Type! attributeType, bool inherit) -> object![]!
 Refit.GeneratedParameterAttributeProvider.IsDefined(System.Type! attributeType, bool inherit) -> bool
-Refit.RefitSettings.TransportExceptionFactory.get -> System.Func<System.Net.Http.HttpRequestMessage!, System.Exception!, System.Exception!>!
+Refit.RefitSettings.TransportExceptionFactory.get -> System.Func<System.Net.Http.HttpRequestMessage!, System.Exception!, System.Threading.CancellationToken, System.Exception!>!
 Refit.RefitSettings.TransportExceptionFactory.set -> void
 static Refit.GeneratedRequestRunner.BuildRequestPath(string! relativePathTemplate, bool allowUnmatchedParameter, params ((int startIdx, int endIdx) range, string? value)[]! uriParams) -> string!

--- a/src/Refit/PublicAPI/net470/PublicAPI.Unshipped.txt
+++ b/src/Refit/PublicAPI/net470/PublicAPI.Unshipped.txt
@@ -4,4 +4,6 @@ Refit.GeneratedParameterAttributeProvider.GeneratedParameterAttributeProvider(Sy
 Refit.GeneratedParameterAttributeProvider.GetCustomAttributes(bool inherit) -> object![]!
 Refit.GeneratedParameterAttributeProvider.GetCustomAttributes(System.Type! attributeType, bool inherit) -> object![]!
 Refit.GeneratedParameterAttributeProvider.IsDefined(System.Type! attributeType, bool inherit) -> bool
+Refit.RefitSettings.TransportExceptionFactory.get -> System.Func<System.Net.Http.HttpRequestMessage!, System.Exception!, System.Exception!>!
+Refit.RefitSettings.TransportExceptionFactory.set -> void
 static Refit.GeneratedRequestRunner.BuildRequestPath(string! relativePathTemplate, bool allowUnmatchedParameter, params ((int startIdx, int endIdx) range, string? value)[]! uriParams) -> string!

--- a/src/Refit/PublicAPI/net471/PublicAPI.Unshipped.txt
+++ b/src/Refit/PublicAPI/net471/PublicAPI.Unshipped.txt
@@ -4,6 +4,6 @@ Refit.GeneratedParameterAttributeProvider.GeneratedParameterAttributeProvider(Sy
 Refit.GeneratedParameterAttributeProvider.GetCustomAttributes(bool inherit) -> object![]!
 Refit.GeneratedParameterAttributeProvider.GetCustomAttributes(System.Type! attributeType, bool inherit) -> object![]!
 Refit.GeneratedParameterAttributeProvider.IsDefined(System.Type! attributeType, bool inherit) -> bool
-Refit.RefitSettings.TransportExceptionFactory.get -> System.Func<System.Net.Http.HttpRequestMessage!, System.Exception!, System.Exception!>!
+Refit.RefitSettings.TransportExceptionFactory.get -> System.Func<System.Net.Http.HttpRequestMessage!, System.Exception!, System.Threading.CancellationToken, System.Exception!>!
 Refit.RefitSettings.TransportExceptionFactory.set -> void
 static Refit.GeneratedRequestRunner.BuildRequestPath(string! relativePathTemplate, bool allowUnmatchedParameter, params ((int startIdx, int endIdx) range, string? value)[]! uriParams) -> string!

--- a/src/Refit/PublicAPI/net471/PublicAPI.Unshipped.txt
+++ b/src/Refit/PublicAPI/net471/PublicAPI.Unshipped.txt
@@ -4,4 +4,6 @@ Refit.GeneratedParameterAttributeProvider.GeneratedParameterAttributeProvider(Sy
 Refit.GeneratedParameterAttributeProvider.GetCustomAttributes(bool inherit) -> object![]!
 Refit.GeneratedParameterAttributeProvider.GetCustomAttributes(System.Type! attributeType, bool inherit) -> object![]!
 Refit.GeneratedParameterAttributeProvider.IsDefined(System.Type! attributeType, bool inherit) -> bool
+Refit.RefitSettings.TransportExceptionFactory.get -> System.Func<System.Net.Http.HttpRequestMessage!, System.Exception!, System.Exception!>!
+Refit.RefitSettings.TransportExceptionFactory.set -> void
 static Refit.GeneratedRequestRunner.BuildRequestPath(string! relativePathTemplate, bool allowUnmatchedParameter, params ((int startIdx, int endIdx) range, string? value)[]! uriParams) -> string!

--- a/src/Refit/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/Refit/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -4,6 +4,6 @@ Refit.GeneratedParameterAttributeProvider.GeneratedParameterAttributeProvider(Sy
 Refit.GeneratedParameterAttributeProvider.GetCustomAttributes(bool inherit) -> object![]!
 Refit.GeneratedParameterAttributeProvider.GetCustomAttributes(System.Type! attributeType, bool inherit) -> object![]!
 Refit.GeneratedParameterAttributeProvider.IsDefined(System.Type! attributeType, bool inherit) -> bool
-Refit.RefitSettings.TransportExceptionFactory.get -> System.Func<System.Net.Http.HttpRequestMessage!, System.Exception!, System.Exception!>!
+Refit.RefitSettings.TransportExceptionFactory.get -> System.Func<System.Net.Http.HttpRequestMessage!, System.Exception!, System.Threading.CancellationToken, System.Exception!>!
 Refit.RefitSettings.TransportExceptionFactory.set -> void
 static Refit.GeneratedRequestRunner.BuildRequestPath(string! relativePathTemplate, bool allowUnmatchedParameter, params ((int startIdx, int endIdx) range, string? value)[]! uriParams) -> string!

--- a/src/Refit/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/Refit/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -4,4 +4,6 @@ Refit.GeneratedParameterAttributeProvider.GeneratedParameterAttributeProvider(Sy
 Refit.GeneratedParameterAttributeProvider.GetCustomAttributes(bool inherit) -> object![]!
 Refit.GeneratedParameterAttributeProvider.GetCustomAttributes(System.Type! attributeType, bool inherit) -> object![]!
 Refit.GeneratedParameterAttributeProvider.IsDefined(System.Type! attributeType, bool inherit) -> bool
+Refit.RefitSettings.TransportExceptionFactory.get -> System.Func<System.Net.Http.HttpRequestMessage!, System.Exception!, System.Exception!>!
+Refit.RefitSettings.TransportExceptionFactory.set -> void
 static Refit.GeneratedRequestRunner.BuildRequestPath(string! relativePathTemplate, bool allowUnmatchedParameter, params ((int startIdx, int endIdx) range, string? value)[]! uriParams) -> string!

--- a/src/Refit/PublicAPI/net48/PublicAPI.Unshipped.txt
+++ b/src/Refit/PublicAPI/net48/PublicAPI.Unshipped.txt
@@ -4,6 +4,6 @@ Refit.GeneratedParameterAttributeProvider.GeneratedParameterAttributeProvider(Sy
 Refit.GeneratedParameterAttributeProvider.GetCustomAttributes(bool inherit) -> object![]!
 Refit.GeneratedParameterAttributeProvider.GetCustomAttributes(System.Type! attributeType, bool inherit) -> object![]!
 Refit.GeneratedParameterAttributeProvider.IsDefined(System.Type! attributeType, bool inherit) -> bool
-Refit.RefitSettings.TransportExceptionFactory.get -> System.Func<System.Net.Http.HttpRequestMessage!, System.Exception!, System.Exception!>!
+Refit.RefitSettings.TransportExceptionFactory.get -> System.Func<System.Net.Http.HttpRequestMessage!, System.Exception!, System.Threading.CancellationToken, System.Exception!>!
 Refit.RefitSettings.TransportExceptionFactory.set -> void
 static Refit.GeneratedRequestRunner.BuildRequestPath(string! relativePathTemplate, bool allowUnmatchedParameter, params ((int startIdx, int endIdx) range, string? value)[]! uriParams) -> string!

--- a/src/Refit/PublicAPI/net48/PublicAPI.Unshipped.txt
+++ b/src/Refit/PublicAPI/net48/PublicAPI.Unshipped.txt
@@ -4,4 +4,6 @@ Refit.GeneratedParameterAttributeProvider.GeneratedParameterAttributeProvider(Sy
 Refit.GeneratedParameterAttributeProvider.GetCustomAttributes(bool inherit) -> object![]!
 Refit.GeneratedParameterAttributeProvider.GetCustomAttributes(System.Type! attributeType, bool inherit) -> object![]!
 Refit.GeneratedParameterAttributeProvider.IsDefined(System.Type! attributeType, bool inherit) -> bool
+Refit.RefitSettings.TransportExceptionFactory.get -> System.Func<System.Net.Http.HttpRequestMessage!, System.Exception!, System.Exception!>!
+Refit.RefitSettings.TransportExceptionFactory.set -> void
 static Refit.GeneratedRequestRunner.BuildRequestPath(string! relativePathTemplate, bool allowUnmatchedParameter, params ((int startIdx, int endIdx) range, string? value)[]! uriParams) -> string!

--- a/src/Refit/PublicAPI/net481/PublicAPI.Unshipped.txt
+++ b/src/Refit/PublicAPI/net481/PublicAPI.Unshipped.txt
@@ -4,6 +4,6 @@ Refit.GeneratedParameterAttributeProvider.GeneratedParameterAttributeProvider(Sy
 Refit.GeneratedParameterAttributeProvider.GetCustomAttributes(bool inherit) -> object![]!
 Refit.GeneratedParameterAttributeProvider.GetCustomAttributes(System.Type! attributeType, bool inherit) -> object![]!
 Refit.GeneratedParameterAttributeProvider.IsDefined(System.Type! attributeType, bool inherit) -> bool
-Refit.RefitSettings.TransportExceptionFactory.get -> System.Func<System.Net.Http.HttpRequestMessage!, System.Exception!, System.Exception!>!
+Refit.RefitSettings.TransportExceptionFactory.get -> System.Func<System.Net.Http.HttpRequestMessage!, System.Exception!, System.Threading.CancellationToken, System.Exception!>!
 Refit.RefitSettings.TransportExceptionFactory.set -> void
 static Refit.GeneratedRequestRunner.BuildRequestPath(string! relativePathTemplate, bool allowUnmatchedParameter, params ((int startIdx, int endIdx) range, string? value)[]! uriParams) -> string!

--- a/src/Refit/PublicAPI/net481/PublicAPI.Unshipped.txt
+++ b/src/Refit/PublicAPI/net481/PublicAPI.Unshipped.txt
@@ -4,4 +4,6 @@ Refit.GeneratedParameterAttributeProvider.GeneratedParameterAttributeProvider(Sy
 Refit.GeneratedParameterAttributeProvider.GetCustomAttributes(bool inherit) -> object![]!
 Refit.GeneratedParameterAttributeProvider.GetCustomAttributes(System.Type! attributeType, bool inherit) -> object![]!
 Refit.GeneratedParameterAttributeProvider.IsDefined(System.Type! attributeType, bool inherit) -> bool
+Refit.RefitSettings.TransportExceptionFactory.get -> System.Func<System.Net.Http.HttpRequestMessage!, System.Exception!, System.Exception!>!
+Refit.RefitSettings.TransportExceptionFactory.set -> void
 static Refit.GeneratedRequestRunner.BuildRequestPath(string! relativePathTemplate, bool allowUnmatchedParameter, params ((int startIdx, int endIdx) range, string? value)[]! uriParams) -> string!

--- a/src/Refit/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/Refit/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -4,6 +4,6 @@ Refit.GeneratedParameterAttributeProvider.GeneratedParameterAttributeProvider(Sy
 Refit.GeneratedParameterAttributeProvider.GetCustomAttributes(bool inherit) -> object![]!
 Refit.GeneratedParameterAttributeProvider.GetCustomAttributes(System.Type! attributeType, bool inherit) -> object![]!
 Refit.GeneratedParameterAttributeProvider.IsDefined(System.Type! attributeType, bool inherit) -> bool
-Refit.RefitSettings.TransportExceptionFactory.get -> System.Func<System.Net.Http.HttpRequestMessage!, System.Exception!, System.Exception!>!
+Refit.RefitSettings.TransportExceptionFactory.get -> System.Func<System.Net.Http.HttpRequestMessage!, System.Exception!, System.Threading.CancellationToken, System.Exception!>!
 Refit.RefitSettings.TransportExceptionFactory.set -> void
 static Refit.GeneratedRequestRunner.BuildRequestPath(string! relativePathTemplate, bool allowUnmatchedParameter, params ((int startIdx, int endIdx) range, string? value)[]! uriParams) -> string!

--- a/src/Refit/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/Refit/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -4,4 +4,6 @@ Refit.GeneratedParameterAttributeProvider.GeneratedParameterAttributeProvider(Sy
 Refit.GeneratedParameterAttributeProvider.GetCustomAttributes(bool inherit) -> object![]!
 Refit.GeneratedParameterAttributeProvider.GetCustomAttributes(System.Type! attributeType, bool inherit) -> object![]!
 Refit.GeneratedParameterAttributeProvider.IsDefined(System.Type! attributeType, bool inherit) -> bool
+Refit.RefitSettings.TransportExceptionFactory.get -> System.Func<System.Net.Http.HttpRequestMessage!, System.Exception!, System.Exception!>!
+Refit.RefitSettings.TransportExceptionFactory.set -> void
 static Refit.GeneratedRequestRunner.BuildRequestPath(string! relativePathTemplate, bool allowUnmatchedParameter, params ((int startIdx, int endIdx) range, string? value)[]! uriParams) -> string!

--- a/src/Refit/PublicAPI/net9.0/PublicAPI.Unshipped.txt
+++ b/src/Refit/PublicAPI/net9.0/PublicAPI.Unshipped.txt
@@ -4,6 +4,6 @@ Refit.GeneratedParameterAttributeProvider.GeneratedParameterAttributeProvider(Sy
 Refit.GeneratedParameterAttributeProvider.GetCustomAttributes(bool inherit) -> object![]!
 Refit.GeneratedParameterAttributeProvider.GetCustomAttributes(System.Type! attributeType, bool inherit) -> object![]!
 Refit.GeneratedParameterAttributeProvider.IsDefined(System.Type! attributeType, bool inherit) -> bool
-Refit.RefitSettings.TransportExceptionFactory.get -> System.Func<System.Net.Http.HttpRequestMessage!, System.Exception!, System.Exception!>!
+Refit.RefitSettings.TransportExceptionFactory.get -> System.Func<System.Net.Http.HttpRequestMessage!, System.Exception!, System.Threading.CancellationToken, System.Exception!>!
 Refit.RefitSettings.TransportExceptionFactory.set -> void
 static Refit.GeneratedRequestRunner.BuildRequestPath(string! relativePathTemplate, bool allowUnmatchedParameter, params ((int startIdx, int endIdx) range, string? value)[]! uriParams) -> string!

--- a/src/Refit/PublicAPI/net9.0/PublicAPI.Unshipped.txt
+++ b/src/Refit/PublicAPI/net9.0/PublicAPI.Unshipped.txt
@@ -4,4 +4,6 @@ Refit.GeneratedParameterAttributeProvider.GeneratedParameterAttributeProvider(Sy
 Refit.GeneratedParameterAttributeProvider.GetCustomAttributes(bool inherit) -> object![]!
 Refit.GeneratedParameterAttributeProvider.GetCustomAttributes(System.Type! attributeType, bool inherit) -> object![]!
 Refit.GeneratedParameterAttributeProvider.IsDefined(System.Type! attributeType, bool inherit) -> bool
+Refit.RefitSettings.TransportExceptionFactory.get -> System.Func<System.Net.Http.HttpRequestMessage!, System.Exception!, System.Exception!>!
+Refit.RefitSettings.TransportExceptionFactory.set -> void
 static Refit.GeneratedRequestRunner.BuildRequestPath(string! relativePathTemplate, bool allowUnmatchedParameter, params ((int startIdx, int endIdx) range, string? value)[]! uriParams) -> string!

--- a/src/Refit/RefitSettings.cs
+++ b/src/Refit/RefitSettings.cs
@@ -195,18 +195,20 @@ public class RefitSettings
     public Dictionary<string, object>? HttpRequestMessageOptions { get; init; }
 
     /// <summary>
-    /// Gets or sets a factory invoked when <see cref="HttpClient.SendAsync(HttpRequestMessage)"/> throws a transport-level
-    /// exception, giving callers full control over the exception that is ultimately thrown or captured.
+    /// Gets or sets a factory invoked when <see cref="HttpClient.SendAsync(HttpRequestMessage)"/> throws a
+    /// transport-level exception, giving callers full control over the exception that is ultimately surfaced.
     /// </summary>
     /// <remarks>
+    /// The factory receives the <see cref="HttpRequestMessage"/>, the raw transport exception, and the
+    /// <see cref="CancellationToken"/> that was passed to the call, and returns the exception to surface.
     /// <para>
-    /// The factory receives the <see cref="HttpRequestMessage"/> and the raw transport exception.
-    /// The returned exception is thrown directly (non-ApiResponse path) or stored as the error inside the
-    /// <see cref="ApiResponse{T}"/> (ApiResponse path); if it is not already an <see cref="ApiRequestException"/>,
-    /// it is automatically wrapped in one that carries the full request context.
+    /// By default, an <see cref="OperationCanceledException"/> is returned unchanged when
+    /// <see cref="CancellationToken.IsCancellationRequested"/> is <see langword="true"/> (so a cancelled
+    /// <see cref="ApiResponse{T}"/> call throws instead of populating <c>Error</c>); every other exception
+    /// is wrapped in an <see cref="ApiRequestException"/> that carries the full request context.
     /// </para>
     /// </remarks>
-    public Func<HttpRequestMessage, Exception, Exception> TransportExceptionFactory { get; set; }
+    public Func<HttpRequestMessage, Exception, CancellationToken, Exception> TransportExceptionFactory { get; set; }
 
 #if NET6_0_OR_GREATER
 
@@ -255,12 +257,13 @@ public class RefitSettings
         };
     }
 
-    /// <summary>The default <see cref="TransportExceptionFactory"/>.</summary>
+    /// <summary>Returns the default <see cref="TransportExceptionFactory"/> delegate for this instance.</summary>
     /// <returns>
-    /// A factory delegate that, given an <see cref="HttpRequestMessage"/> and an <see cref="Exception"/>,
-    /// returns a new <see cref="ApiRequestException"/> with the original exception as its inner exception.
+    /// A factory that passes an <see cref="OperationCanceledException"/> through unchanged when
+    /// <see cref="CancellationToken.IsCancellationRequested"/> is <see langword="true"/>, and wraps every
+    /// other exception in an <see cref="ApiRequestException"/> that captures the request and these settings.
     /// </returns>
-    private Func<HttpRequestMessage, Exception, Exception> DefaultTransportExceptionFactory()
-        => (req, ex) =>
-             ex is OperationCanceledException ? ex : new ApiRequestException(req, req.Method, this, ex);
+    private Func<HttpRequestMessage, Exception, CancellationToken, Exception> DefaultTransportExceptionFactory()
+        => (req, ex, ct) =>
+             ex is OperationCanceledException && ct.IsCancellationRequested ? ex : new ApiRequestException(req, req.Method, this, ex);
 }

--- a/src/Refit/RefitSettings.cs
+++ b/src/Refit/RefitSettings.cs
@@ -19,6 +19,7 @@ public class RefitSettings
         UrlParameterFormatter = new DefaultUrlParameterFormatter();
         FormUrlEncodedParameterFormatter = new DefaultFormUrlEncodedParameterFormatter();
         ExceptionFactory = new DefaultApiExceptionFactory(this).CreateAsync;
+        TransportExceptionFactory = DefaultTransportExceptionFactory();
     }
 
     /// <summary>Initializes a new instance of the <see cref="RefitSettings"/> class.</summary>
@@ -72,6 +73,7 @@ public class RefitSettings
         UrlParameterKeyFormatter =
             urlParameterKeyFormatter ?? new DefaultUrlParameterKeyFormatter();
         ExceptionFactory = new DefaultApiExceptionFactory(this).CreateAsync;
+        TransportExceptionFactory = DefaultTransportExceptionFactory();
     }
 
     /// <summary>Gets or sets a function to provide the Authorization header. Does not work if you supply an HttpClient instance.</summary>
@@ -192,6 +194,20 @@ public class RefitSettings
     /// <summary>Gets optional Key-Value pairs, which are displayed in the property <see cref="HttpRequestMessage.Properties"/>.</summary>
     public Dictionary<string, object>? HttpRequestMessageOptions { get; init; }
 
+    /// <summary>
+    /// Gets or sets a factory invoked when <see cref="HttpClient.SendAsync(HttpRequestMessage)"/> throws a transport-level
+    /// exception, giving callers full control over the exception that is ultimately thrown or captured.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The factory receives the <see cref="HttpRequestMessage"/> and the raw transport exception.
+    /// The returned exception is thrown directly (non-ApiResponse path) or stored as the error inside the
+    /// <see cref="ApiResponse{T}"/> (ApiResponse path); if it is not already an <see cref="ApiRequestException"/>,
+    /// it is automatically wrapped in one that carries the full request context.
+    /// </para>
+    /// </remarks>
+    public Func<HttpRequestMessage, Exception, Exception> TransportExceptionFactory { get; set; }
+
 #if NET6_0_OR_GREATER
 
     /// <summary>Gets or sets the version.</summary>
@@ -238,4 +254,13 @@ public class RefitSettings
             UrlParameterKeyFormatter = urlParameterKeyFormatter,
         };
     }
+
+    /// <summary>The default <see cref="TransportExceptionFactory"/>.</summary>
+    /// <returns>
+    /// A factory delegate that, given an <see cref="HttpRequestMessage"/> and an <see cref="Exception"/>,
+    /// returns a new <see cref="ApiRequestException"/> with the original exception as its inner exception.
+    /// </returns>
+    private Func<HttpRequestMessage, Exception, Exception> DefaultTransportExceptionFactory()
+        => (req, ex) =>
+             ex is OperationCanceledException ? ex : new ApiRequestException(req, req.Method, this, ex);
 }

--- a/src/Refit/RequestExecutionHelpers.cs
+++ b/src/Refit/RequestExecutionHelpers.cs
@@ -1,6 +1,8 @@
 // Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
 // ReactiveUI and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
+using System.Runtime.ExceptionServices;
+
 namespace Refit;
 
 /// <summary>Shared send and response-processing helpers for generated and reflection-built requests.</summary>
@@ -388,7 +390,7 @@ internal static class RequestExecutionHelpers
         }
         catch (Exception ex)
         {
-            var transportException = settings.TransportExceptionFactory(request, ex);
+            var transportException = settings.TransportExceptionFactory(request, ex, cancellationToken);
             if (transportException is ApiExceptionBase apiExceptionBase)
             {
                 if (!isApiResponse)
@@ -405,6 +407,7 @@ internal static class RequestExecutionHelpers
                 return SendResult<T>.FromFailure(failure);
             }
 
+            ExceptionDispatchInfo.Capture(transportException).Throw();
             throw transportException;
         }
     }

--- a/src/Refit/RequestExecutionHelpers.cs
+++ b/src/Refit/RequestExecutionHelpers.cs
@@ -388,18 +388,24 @@ internal static class RequestExecutionHelpers
         }
         catch (Exception ex)
         {
-            if (!isApiResponse)
+            var transportException = settings.TransportExceptionFactory(request, ex);
+            if (transportException is ApiExceptionBase apiExceptionBase)
             {
-                throw new ApiRequestException(request, request.Method, settings, ex);
+                if (!isApiResponse)
+                {
+                    throw apiExceptionBase;
+                }
+
+                var failure = ApiResponse.Create<T, TBody>(
+                    request,
+                    null,
+                    default,
+                    settings,
+                    apiExceptionBase);
+                return SendResult<T>.FromFailure(failure);
             }
 
-            var failure = ApiResponse.Create<T, TBody>(
-                request,
-                null,
-                default,
-                settings,
-                new ApiRequestException(request, request.Method, settings, ex));
-            return SendResult<T>.FromFailure(failure);
+            throw transportException;
         }
     }
 

--- a/src/Refit/RequestExecutionHelpers.cs
+++ b/src/Refit/RequestExecutionHelpers.cs
@@ -1,8 +1,6 @@
 // Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
 // ReactiveUI and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
-using System.Runtime.ExceptionServices;
-
 namespace Refit;
 
 /// <summary>Shared send and response-processing helpers for generated and reflection-built requests.</summary>
@@ -407,7 +405,7 @@ internal static class RequestExecutionHelpers
                 return SendResult<T>.FromFailure(failure);
             }
 
-            ExceptionDispatchInfo.Capture(transportException).Throw();
+            System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(transportException).Throw();
             throw transportException;
         }
     }

--- a/src/tests/Refit.Newtonsoft.Json.Tests/RestServiceIntegrationTests.GitHub.cs
+++ b/src/tests/Refit.Newtonsoft.Json.Tests/RestServiceIntegrationTests.GitHub.cs
@@ -2,14 +2,8 @@
 // ReactiveUI and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Linq;
 using System.Net;
-using System.Net.Http;
 using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
-using Newtonsoft.Json;
 using Refit.Testing;
 
 namespace Refit.Tests;
@@ -384,7 +378,7 @@ public partial class RestServiceIntegrationTests
     /// <summary>Verifies a request canceled before the response is read surfaces the cancellation.</summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Test]
-    public async Task RequestCanceledBeforeResponseRead()
+    public async Task RequestCanceledBeforeResponseRead_WhenNoTransportExceptionFactory()
     {
         using var cts = new CancellationTokenSource();
 
@@ -419,6 +413,51 @@ public partial class RestServiceIntegrationTests
         });
 
         var result = await Assert.That(
+            () => (Task)fixture.GetOrgMembers(OrgName, cts.Token)).ThrowsExactly<TaskCanceledException>();
+
+        // Source generated requests directly return the SendAsync task so won't contain the caller stack frame.
+        await AssertStackTraceContains(nameof(GeneratedRequestRunner.SendAsync), result!.StackTrace);
+    }
+
+    /// <summary>Verifies a request canceled before the response is read surfaces the cancellation. Providing a custom <see cref="RefitSettings.TransportExceptionFactory"/>.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task RequestCanceledBeforeResponseRead_WhenTransportExceptionFactory()
+    {
+        using var cts = new CancellationTokenSource();
+
+        var handler = new StubHttp
+        {
+            {
+                new RouteMatcher
+                {
+                    Method = HttpMethod.Get,
+                    Template = OrgMembersUrl,
+                    Reusable = true
+                },
+                Reply.From(req =>
+                {
+                    // Cancel the request
+                    cts.Cancel();
+                    return new(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent(OrgMembersJson, Encoding.UTF8, JsonMediaType)
+                    };
+                })
+            },
+        };
+        var refitSettings = new RefitSettings
+        {
+            ContentSerializer = new NewtonsoftJsonContentSerializer(
+                new()
+                {
+                    ContractResolver = new SnakeCasePropertyNamesContractResolver()
+                })
+        };
+        refitSettings.TransportExceptionFactory = (req, ex) => new ApiRequestException(req, req.Method, refitSettings, ex);
+        var fixture = handler.CreateClient<IGitHubApi>(GitHubBaseUrl, refitSettings);
+
+        var result = await Assert.That(
             () => (Task)fixture.GetOrgMembers(OrgName, cts.Token)).ThrowsExactly<ApiRequestException>();
 
         await Assert.That(result!.InnerException).IsNotNull();
@@ -431,7 +470,7 @@ public partial class RestServiceIntegrationTests
     /// <summary>Verifies cancellation before the response is read surfaces in the API response error.</summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Test]
-    public async Task RequestCanceledBeforeResponseReadWithIApiResponse()
+    public async Task RequestCanceledBeforeResponseReadWithIApiResponse_WhenNoTransportExceptionFactory()
     {
         using var cts = new CancellationTokenSource();
 
@@ -457,6 +496,49 @@ public partial class RestServiceIntegrationTests
         };
 
         var fixture = handler.CreateClient<IGitHubApi>(GitHubBaseUrl);
+
+        await Assert.That(
+            () => (Task)fixture.GetUserWithMetadata(OrgName, cts.Token)).ThrowsExactly<TaskCanceledException>();
+    }
+
+    /// <summary>Verifies cancellation before the response is read surfaces in the API response error. Providing a custom <see cref="RefitSettings.TransportExceptionFactory"/>.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task RequestCanceledBeforeResponseReadWithIApiResponse_WhenTransportExceptionFactory()
+    {
+        using var cts = new CancellationTokenSource();
+
+        var handler = new StubHttp
+        {
+            {
+                new RouteMatcher
+                {
+                    Method = HttpMethod.Get,
+                    Template = "https://api.github.com/users/github",
+                    Reusable = true
+                },
+                Reply.From(req =>
+                {
+                    // Cancel the request
+                    cts.Cancel();
+                    return new(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent(OrgMembersJson, Encoding.UTF8, JsonMediaType)
+                    };
+                })
+            },
+        };
+        var refitSettings = new RefitSettings
+        {
+            ContentSerializer = new NewtonsoftJsonContentSerializer(
+                new()
+                {
+                    ContractResolver = new SnakeCasePropertyNamesContractResolver()
+                })
+        };
+        refitSettings.TransportExceptionFactory = (req, ex) => new ApiRequestException(req, req.Method, refitSettings, ex);
+
+        var fixture = handler.CreateClient<IGitHubApi>(GitHubBaseUrl, refitSettings);
 
         var result = await fixture.GetUserWithMetadata(OrgName, cts.Token);
 

--- a/src/tests/Refit.Newtonsoft.Json.Tests/RestServiceIntegrationTests.GitHub.cs
+++ b/src/tests/Refit.Newtonsoft.Json.Tests/RestServiceIntegrationTests.GitHub.cs
@@ -454,7 +454,7 @@ public partial class RestServiceIntegrationTests
                     ContractResolver = new SnakeCasePropertyNamesContractResolver()
                 })
         };
-        refitSettings.TransportExceptionFactory = (req, ex) => new ApiRequestException(req, req.Method, refitSettings, ex);
+        refitSettings.TransportExceptionFactory = (req, ex, _) => new ApiRequestException(req, req.Method, refitSettings, ex);
         var fixture = handler.CreateClient<IGitHubApi>(GitHubBaseUrl, refitSettings);
 
         var result = await Assert.That(
@@ -536,7 +536,7 @@ public partial class RestServiceIntegrationTests
                     ContractResolver = new SnakeCasePropertyNamesContractResolver()
                 })
         };
-        refitSettings.TransportExceptionFactory = (req, ex) => new ApiRequestException(req, req.Method, refitSettings, ex);
+        refitSettings.TransportExceptionFactory = (req, ex, _) => new ApiRequestException(req, req.Method, refitSettings, ex);
 
         var fixture = handler.CreateClient<IGitHubApi>(GitHubBaseUrl, refitSettings);
 

--- a/src/tests/Refit.Tests/RestServiceIntegrationTests.Inheritance.cs
+++ b/src/tests/Refit.Tests/RestServiceIntegrationTests.Inheritance.cs
@@ -2,14 +2,9 @@
 // ReactiveUI and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Net;
-using System.Net.Http;
 using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 using Refit.Testing;
 
 namespace Refit.Tests;
@@ -784,8 +779,7 @@ public partial class RestServiceIntegrationTests
 
         await tokenSource.CancelAsync();
         var task = fixture.GetWithCancellationAndReturn(token);
-        var exception = await Assert.That(() => (Task)task).ThrowsExactly<ApiRequestException>();
-        await Assert.That(exception!.InnerException).IsTypeOf<TaskCanceledException>();
+        await Assert.That(() => (Task)task).ThrowsExactly<TaskCanceledException>();
     }
 
     /// <summary>Verifies a null cancellation token is ignored.</summary>


### PR DESCRIPTION

<!-- Please read our [Contribute guide](https://www.reactiveui.net/contribute/index.html) before opening a PR, and give this PR a title that follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `fix:`, `feat:`, `docs:`, `build:`). -->

## What kind of change does this PR introduce?
Bug fix. Fixes #2202 and #2188 

## What is the new behavior?
When the TransportExceptionFactory is specified avoid the exception to be thrown as ApiRequestException, and let the user decide the exception to be throw.
By default the OperationCanceledException is thrown but the user can overload the TransportExceptionFactory

## What is the current behavior?
The breaking change introduced in Refit 11, avoided an easy to migrate to new versions of Refit because the exceptions where shadowed as ApiRequestException

## What might this PR break?
N/A

## Checklist
- [X] I have read the [Contribute guide](https://www.reactiveui.net/contribute/index.html)
- [X] Tests have been added or updated (for bug fixes / features)
- [X] Docs have been added or updated (for bug fixes / features)
- [X] Changes target the `main` branch
- [X] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
