### PR TITLE
test(refit.testing): cover retry and timeout scenarios

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -21,6 +21,7 @@ Because the library is Refit-aware, it does three things a general-purpose HTTP 
 - [Inspecting the request that was sent](#inspecting-the-request-that-was-sent)
 - [Sequenced and reusable routes](#sequenced-and-reusable-routes)
 - [Simulating network conditions](#simulating-network-conditions)
+- [Testing retries and timeouts](#testing-retries-and-timeouts)
 - [Unit-testing code that consumes `IApiResponse<T>`](#unit-testing-code-that-consumes-iapiresponset)
 - [API reference](#api-reference)
 
@@ -262,6 +263,47 @@ var http = new StubHttp(behavior)
 
 Seeding makes runs reproducible: the same seed produces the same sequence of delays and failures, so a flaky-path
 test is deterministic. Set `FailureFactory` to control the exception a simulated transport failure throws.
+
+## Testing retries and timeouts
+
+Sequenced one-shot routes are matched in declared order, so a transient fault followed by a success exercises a
+retry policy — a Polly handler, or any `DelegatingHandler` — stacked above the stub:
+
+```csharp
+var http = new StubHttp
+{
+    { Route.Get("/users/{id}"), Reply.Status(HttpStatusCode.ServiceUnavailable) },  // first attempt
+    { Route.Get("/users/{id}"), Reply.With(new User(7, "octocat")) },               // the retry
+};
+
+var settings = new RefitSettings { HttpMessageHandlerFactory = () => new MyRetryHandler(http) };
+var api = RestService.For<IUserApi>("https://api.test", settings);
+
+var user = await api.GetUser(7);        // succeeded on the retry
+Assert.Equal(2, http.Requests.Count);   // both attempts were made
+```
+
+To retry a *transport* fault rather than a status code, have the first reply throw:
+`Reply.From(HttpResponseMessage (_) => throw new HttpRequestException("boom"))`.
+
+Timeouts fall out of `NetworkBehavior.Delay`: make the injected latency exceed the client's `Timeout` and the
+request is aborted. Refit's transport-exception factory surfaces the resulting cancellation as an
+`ApiRequestException` whose `InnerException` is the `TaskCanceledException`:
+
+```csharp
+var http = new StubHttp(new NetworkBehavior { Delay = TimeSpan.FromSeconds(10), Variance = 0 })
+{
+    { Route.Get("/users/{id}"), Reply.With(new User(7, "octocat")) },
+};
+
+using var client = new HttpClient(http)
+{
+    BaseAddress = new Uri("https://api.test"),
+    Timeout = TimeSpan.FromMilliseconds(50),
+};
+
+await Assert.ThrowsAsync<ApiRequestException>(() => RestService.For<IUserApi>(client).GetUser(7));
+```
 
 ## Unit-testing code that consumes `IApiResponse<T>`
 

--- a/src/tests/Refit.Testing.Tests/RetryAndTimeoutTests.cs
+++ b/src/tests/Refit.Testing.Tests/RetryAndTimeoutTests.cs
@@ -1,0 +1,212 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Net;
+
+namespace Refit.Testing.Tests;
+
+/// <summary>
+/// Scenario tests showing the fault-injection surface driving the paths it exists for: a retry policy fed by
+/// transient stubbed faults, and a client timeout fed by <see cref="NetworkBehavior.Delay"/>.
+/// </summary>
+public sealed class RetryAndTimeoutTests
+{
+    /// <summary>The base address the sample client sends requests to.</summary>
+    private const string BaseUrl = "https://api.test";
+
+    /// <summary>The route template mirroring <see cref="IUserApi.GetUser"/>.</summary>
+    private const string UserTemplate = "/users/{id}";
+
+    /// <summary>The login carried by the stubbed user.</summary>
+    private const string SampleLogin = "octocat";
+
+    /// <summary>A sample user identifier exercised by these tests.</summary>
+    private const int SampleUserId = 7;
+
+    /// <summary>The number of attempts the retry handler makes before giving up.</summary>
+    private const int MaxAttempts = 3;
+
+    /// <summary>The number of requests a single retried-once call is expected to make.</summary>
+    private const int RetriedOnceRequestCount = 2;
+
+    /// <summary>Verifies a retry policy recovers when a one-shot route replies with a transient error status.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task RetryRecoversFromTransientErrorStatus()
+    {
+        // One-shot routes match in declared order, so the first attempt gets the 503 and the retry gets the user.
+        var handler = new StubHttp
+        {
+            {
+                Route.Get(UserTemplate),
+                Reply.Status(HttpStatusCode.ServiceUnavailable)
+            },
+            {
+                Route.Get(UserTemplate),
+                Reply.With(new User(SampleUserId, SampleLogin))
+            },
+        };
+
+        var api = CreateRetryingClient(handler);
+        var user = await api.GetUser(SampleUserId);
+
+        await Assert.That(user.Login).IsEqualTo(SampleLogin);
+        await Assert.That(handler.Requests.Count).IsEqualTo(RetriedOnceRequestCount);
+        await handler.VerifyAllCalledAsync();
+    }
+
+    /// <summary>Verifies a retry policy recovers when the first attempt faults with a simulated network failure.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task RetryRecoversFromSimulatedNetworkFailure()
+    {
+        // The same exception NetworkBehavior injects at its configured failure rate, forced onto the first attempt.
+        var failure = new NetworkBehavior().CreateFailure();
+        var handler = new StubHttp
+        {
+            {
+                Route.Get(UserTemplate),
+                Reply.From(HttpResponseMessage (_) => throw failure)
+            },
+            {
+                Route.Get(UserTemplate),
+                Reply.With(new User(SampleUserId, SampleLogin))
+            },
+        };
+
+        var api = CreateRetryingClient(handler);
+        var user = await api.GetUser(SampleUserId);
+
+        await Assert.That(user.Login).IsEqualTo(SampleLogin);
+        await Assert.That(handler.Requests.Count).IsEqualTo(RetriedOnceRequestCount);
+        await handler.VerifyAllCalledAsync();
+    }
+
+    /// <summary>Verifies a retry policy that exhausts its attempts surfaces the final error status as an <see cref="ApiException"/>.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task ExhaustedRetriesSurfaceApiException()
+    {
+        var handler = new StubHttp
+        {
+            {
+                new RouteMatcher { Method = HttpMethod.Get, Template = UserTemplate, Reusable = true },
+                Reply.Status(HttpStatusCode.ServiceUnavailable)
+            },
+        };
+
+        var api = CreateRetryingClient(handler);
+
+        var error = await Assert.That(async () => _ = await api.GetUser(SampleUserId)).ThrowsExactly<ApiException>();
+
+        await Assert.That(error!.StatusCode).IsEqualTo(HttpStatusCode.ServiceUnavailable);
+        await Assert.That(handler.Requests.Count).IsEqualTo(MaxAttempts);
+    }
+
+    /// <summary>
+    /// Verifies an injected delay longer than the client timeout aborts the request, and that the resulting
+    /// cancellation is surfaced through Refit's transport-exception factory as an <see cref="ApiRequestException"/>.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task RequestSlowerThanClientTimeoutThrowsApiRequestException()
+    {
+        var handler = CreateDelayedHandler(TimeSpan.FromSeconds(10));
+
+        using var client = new HttpClient(handler)
+        {
+            BaseAddress = new(BaseUrl),
+            Timeout = TimeSpan.FromMilliseconds(50),
+        };
+        var api = RestService.For<IUserApi>(client);
+
+        var error = await Assert.That(async () => _ = await api.GetUser(SampleUserId)).ThrowsExactly<ApiRequestException>();
+
+        await Assert.That(error!.InnerException).IsTypeOf<TaskCanceledException>();
+    }
+
+    /// <summary>Verifies a delay inside the client timeout still yields the stubbed response.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task RequestFasterThanClientTimeoutSucceeds()
+    {
+        var handler = CreateDelayedHandler(TimeSpan.FromMilliseconds(1));
+
+        using var client = new HttpClient(handler)
+        {
+            BaseAddress = new(BaseUrl),
+            Timeout = TimeSpan.FromSeconds(30),
+        };
+        var api = RestService.For<IUserApi>(client);
+
+        var user = await api.GetUser(SampleUserId);
+
+        await Assert.That(user.Login).IsEqualTo(SampleLogin);
+        await handler.VerifyAllCalledAsync();
+    }
+
+    /// <summary>Creates a stub that answers the user route after a fixed, fault-free injected delay.</summary>
+    /// <param name="delay">The latency to inject before replying.</param>
+    /// <returns>The configured stub handler.</returns>
+    private static StubHttp CreateDelayedHandler(TimeSpan delay)
+    {
+        var behavior = new NetworkBehavior
+        {
+            Delay = delay,
+            Variance = 0d,
+            FailurePercent = 0d,
+            ErrorPercent = 0d,
+        };
+
+        return new(behavior)
+        {
+            {
+                Route.Get(UserTemplate),
+                Reply.With(new User(SampleUserId, SampleLogin))
+            },
+        };
+    }
+
+    /// <summary>Creates a Refit client whose requests pass through a retrying handler stacked above the stub.</summary>
+    /// <param name="handler">The stub handler backing the client.</param>
+    /// <returns>A Refit client that retries transient faults.</returns>
+    private static IUserApi CreateRetryingClient(StubHttp handler)
+    {
+        // The stub is wrapped rather than used directly, so the retry policy sits where a Polly handler would.
+        var settings = new RefitSettings { HttpMessageHandlerFactory = () => new RetryHandler(handler) };
+        return RestService.For<IUserApi>(BaseUrl, settings);
+    }
+
+    /// <summary>A minimal retry policy that re-sends on a transport fault or a non-success status, standing in for Polly.</summary>
+    /// <remarks>Initializes a new instance of the <see cref="RetryHandler"/> class.</remarks>
+    /// <param name="inner">The handler to send through.</param>
+    private sealed class RetryHandler(HttpMessageHandler inner) : DelegatingHandler(inner)
+    {
+        /// <inheritdoc/>
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            for (var attempt = 1; attempt < MaxAttempts; attempt++)
+            {
+                try
+                {
+                    var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+                    if (response.IsSuccessStatusCode)
+                    {
+                        return response;
+                    }
+
+                    response.Dispose();
+                }
+                catch (HttpRequestException)
+                {
+                }
+            }
+
+            // The final attempt is unguarded: its status or transport fault is what the caller sees.
+            return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        }
+    }
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Tests and docs. Closes the last outstanding acceptance criteria on the `Refit.Testing` feature request.

## What is the new behavior?

`Refit.Testing.Tests` now covers the two scenarios the package's fault-injection surface exists to support:

- **Retry**: `RetryRecoversFromTransientErrorStatus` and `RetryRecoversFromSimulatedNetworkFailure` stack a retry `DelegatingHandler` (standing in for a Polly handler) above `StubHttp` and prove a transient 503, and a simulated transport fault, are both recovered from. Sequenced one-shot routes supply the fault then the success.
- **Retry exhaustion**: `ExhaustedRetriesSurfaceApiException` asserts a reusable always-503 route surfaces an `ApiException` once attempts run out.
- **Timeout**: `RequestSlowerThanClientTimeoutThrowsApiRequestException` drives `NetworkBehavior.Delay` past the client's `Timeout` and asserts Refit's transport-exception factory yields an `ApiRequestException` wrapping the `TaskCanceledException`. `RequestFasterThanClientTimeoutSucceeds` pins the other side.

`docs/testing.md` gains a **Testing retries and timeouts** section showing both patterns.

No production code changed, so there is no public API delta.

## What is the current behavior?

`Refit.Testing` shipped in #2184 with the package, `NetworkBehavior`, `StubApiResponse<T>`, README and docs, but no test demonstrated a retry policy, and the only "timeout" coverage was `VerifyAllCalledAsync`'s assertion timeout rather than a client HTTP timeout. The remaining acceptance criterion on the original request ("TUnit tests demonstrating retry/timeout/error scenarios") was therefore unmet, and the issue was never auto-closed because #2184 carried no closing keyword.

Closes #2166

## What might this PR break?

None. Tests and documentation only.

## Checklist
- [x] I have read the [Contribute guide](https://www.reactiveui.net/contribute/index.html)
- [x] Tests have been added or updated (for bug fixes / features)
- [x] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the `main` branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional information

`Refit.Testing.Tests` passes on every target framework (`net8.0`, `net9.0`, `net10.0`, `net11.0`): **248 tests, 0 failed**, 62 per TFM, up from 57. Analyzers are clean; no suppressions were added.
