### PR TITLE
perf: `AllAttributesCache` replace `Lazy` with laziliy initialised code

### DIFF
--- a/src/Refit/GeneratedParameterAttributeProvider.cs
+++ b/src/Refit/GeneratedParameterAttributeProvider.cs
@@ -2,6 +2,7 @@
 // ReactiveUI and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 
 namespace Refit;
@@ -10,20 +11,41 @@ namespace Refit;
 /// <param name="attributes">The attribute information.</param>
 public sealed class GeneratedParameterAttributeProvider(Dictionary<Type, object[]> attributes) : ICustomAttributeProvider
 {
-    /// <summary>List of all attributes.</summary>
-    private readonly Lazy<object[]> _allAttributesCache = new(() =>
+    /// <summary>Gets a lazily initialised array of all attributes.</summary>
+    private object[] AllAttributesCache
     {
-        var allAttributes = new List<object>();
-        foreach (var value in attributes.Values)
+        [SuppressMessage("StyleCop.Analyzers", "SST1443:ReduceNestedFlowComplexity", Justification = "The nested logic is necessary here to avoid LINQ usage.")]
+        get
         {
-            allAttributes.AddRange(value);
-        }
+            if (field is not null)
+            {
+                return field;
+            }
 
-        return allAttributes.ToArray();
-    });
+            var totalCount = 0;
+            foreach (var attributeArray in attributes.Values)
+            {
+                totalCount += attributeArray.Length;
+            }
+
+            var allAttributes = new object[totalCount];
+            var index = 0;
+            foreach (var attributeArray in attributes.Values)
+            {
+                foreach (var item in attributeArray)
+                {
+                    allAttributes[index++] = item;
+                }
+            }
+
+            _ = Interlocked.CompareExchange(ref field, allAttributes, null);
+
+            return field;
+        }
+    }
 
     /// <inheritdoc/>
-    public object[] GetCustomAttributes(bool inherit) => _allAttributesCache.Value;
+    public object[] GetCustomAttributes(bool inherit) => AllAttributesCache;
 
     /// <inheritdoc/>
     public object[] GetCustomAttributes(Type attributeType, bool inherit)


### PR DESCRIPTION
Replace `Lazy<object[]>` with manual lazily initialised logic

- When not called `Lazy` is a reference type using up 40 bytes, with an additional allocation of a 32 byte `LazyHelper` when called
- Pre calculate the array length to avoid allocating an intermediary `List`.
  - If we are being performance obsessed here we could use a `ValueListBuilder` to avoid double looping `Values`.
- `Interlocked.CompareExchange` might not be needed here, can remove.