### PR TITLE
docs: make v12 Error.Content migration discoverable and add interface composition example

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ lets you stub responses and verify requests with a declarative route table — s
 * [Retrieving the response](#retrieving-the-response)
 * [Using generic interfaces](#using-generic-interfaces)
 * [Interface inheritance](#interface-inheritance)
+    * [Composing multiple APIs into one client](#composing-multiple-apis-into-one-client)
     * [Headers inheritance](#headers-inheritance)
 * [Default Interface Methods](#default-interface-methods)
 * [Using HttpClientFactory](#using-httpclientfactory)
@@ -1758,6 +1759,48 @@ public interface IDerivedServiceB : IBaseService
 In this example, the `IDerivedServiceA` interface will expose both the `GetResource` and `DeleteResource` APIs, while
 `IDerivedServiceB` will expose `GetResource` and `AddResource`.
 
+#### Composing multiple APIs into one client
+
+The generator walks the full interface hierarchy, so you can split a large API by resource area into focused interfaces
+and then aggregate them into a single client that declares nothing of its own:
+
+```csharp
+public interface IUsersApi
+{
+    [Get("/users/{user}")]
+    Task<User> GetUser(string user);
+}
+
+public interface IReposApi
+{
+    [Get("/users/{user}/repos")]
+    Task<List<Repo>> GetRepos(string user);
+}
+
+// The aggregate client has no members of its own; it just composes the two APIs.
+public interface IGitHubApi : IUsersApi, IReposApi;
+```
+
+The composed client exposes every method from both base interfaces:
+
+```csharp
+var api = RestService.For<IGitHubApi>("https://api.github.com");
+
+var user = await api.GetUser("octocat");     // from IUsersApi
+var repos = await api.GetRepos("octocat");   // from IReposApi
+```
+
+It works the same way with `HttpClientFactory` and dependency injection:
+
+```csharp
+builder.Services
+    .AddRefitClient<IGitHubApi>()
+    .ConfigureHttpClient(c => c.BaseAddress = new Uri("https://api.github.com"));
+```
+
+Each sub-interface (`IUsersApi`, `IReposApi`) can also be registered independently if some consumers only need one area,
+and the header-attribute precedence rules described just below still apply to the composed client.
+
 #### Headers inheritance
 
 When using inheritance, existing header attributes will be passed along as well, and the inner-most ones will have
@@ -2058,6 +2101,13 @@ else
     _logger.LogError(response.Error, "An error occurred while calling the API.");
 }
 ```
+
+> [!NOTE]
+> Migrating from v8-v11? `response.Error.Content` no longer compiles since v12. `Error` is now typed as
+> `ApiExceptionBase?` (request-side context only), so the response body moved to the derived `ApiException`. Read it via
+> `response.HasResponseError(out var apiException)` (as shown above) and then `apiException.Content`, or cast with
+> `(response.Error as ApiException)?.Content`. See the
+> [V12.x.x breaking changes](docs/breaking-changes.md#v12xx) for the full before/after.
 
 > [!NOTE]
 > The `IsSuccessful` property checks whether the response status code is in the range 200-299 and there wasn't any other

--- a/README.md
+++ b/README.md
@@ -1960,6 +1960,30 @@ public class HomeController : Controller
 }
 ```
 
+#### Sharing one connection pool across multiple interfaces
+
+If you split one API across several interfaces (for example `ISomeSiteAuth` and `ISomeSiteData`) but want them to
+share a single underlying handler and connection pool, register them under the **same** client name. Interfaces that
+resolve the same named `HttpClient` share the same `IHttpClientFactory`-managed, lifetime-rotated handler:
+
+```csharp
+services.AddRefitClient<ISomeSiteAuth>((RefitSettings?)null, "somesite")
+        .ConfigureHttpClient(c => c.BaseAddress = new Uri("https://api.example.com"));
+
+services.AddRefitClient<ISomeSiteData>((RefitSettings?)null, "somesite")
+        .ConfigureHttpClient(c => c.BaseAddress = new Uri("https://api.example.com"));
+```
+
+You do not need to do this for correctness. By default each interface gets its own factory-managed named client, and
+`IHttpClientFactory` already pools and rotates the underlying handlers, so there is no socket exhaustion or DNS-staleness
+concern. Sharing a name simply collapses the interfaces onto one pool (and one shared `ConfigureHttpClient`/handler
+configuration) when they target the same host.
+
+Outside DI you can share a single `HttpClient` directly by passing the same instance to multiple
+`RestService.For<T>(client)` calls (see [Providing a custom HttpClient](#providing-a-custom-httpclient) below). Prefer
+sharing the pooled handler over caching long-lived `HttpClient` instances yourself, so handler rotation and DNS refresh
+keep working.
+
 ### Providing a custom HttpClient
 
 You can supply a custom `HttpClient` instance by simply passing it as a parameter to the `RestService.For<T>` method:

--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -201,6 +201,23 @@ Two breaking changes are called out for migration:
   members still binds to the inherited base members, but assemblies compiled against v8-v11 should be recompiled.
   If you used `IsSuccessful` to narrow `Content` to non-null on an `IApiResponse<T>` value, use `HasContent` or
   `IsSuccessfulWithContent` instead.
+
+  Because the shadow is gone, `Error` is now typed as `ApiExceptionBase?`, which exposes only request-side context
+  (`RequestContent`, `HttpMethod`, `Uri`, `RequestMessage`). The response body lives on the derived `ApiException`, so
+  `response.Error.Content` no longer compiles. The feature was not removed; the body simply moved to the derived type.
+  Migrate like this:
+
+  ```csharp
+  // Before (v8-v11)
+  var content = response.Error.Content;
+
+  // After (v12+) - null-safe typed access to the response body
+  if (response.HasResponseError(out var apiException))
+      logger.LogError(apiException, apiException.Content);
+
+  // Or, as a shorthand cast when you just want the body
+  var content = (response.Error as ApiException)?.Content;
+  ```
 * The default `System.Text.Json` serializer now reads numbers from JSON strings by setting
   `JsonNumberHandling.AllowReadingFromString`. To opt back out, set `NumberHandling = JsonNumberHandling.Strict` on
   your `JsonSerializerOptions`.


### PR DESCRIPTION
## What kind of change does this PR introduce?
- Documentation.

## What is the new behavior?
- The V12 breaking-changes section now explains why `response.Error.Content` no longer compiles and shows the exact migration: `HasResponseError(out var apiException)` then `apiException.Content`, or the shorthand `(response.Error as ApiException)?.Content`.
- The README "Handling exceptions" example now carries a searchable `Error.Content` NOTE that states it does not compile since v12, points to the working alternatives, and links to the V12 breaking-changes section.
- The README "Interface inheritance" section has a new "Composing multiple APIs into one client" subsection: split an API by resource area (`IUsersApi`, `IReposApi`), aggregate into `public interface IGitHubApi : IUsersApi, IReposApi;`, and call methods from either base via both `RestService.For<T>` and `AddRefitClient<T>` DI. A matching TOC entry was added.

## What is the current behavior?
- The v12 change that moved the response body from `Error` (now `ApiExceptionBase?`) to the derived `ApiException` was undocumented, so users hitting the `response.Error.Content` compile break assumed the feature was removed.
- There was no worked example showing that a member-less aggregate interface composing multiple Refit interfaces is supported.
- Closes #2189
- Closes #1691

## What might this PR break?
- None. Documentation only.

## Checklist
- [x] I have read the Contribute guide
- [ ] Tests have been added or updated (for bug fixes / features) - N/A, docs only
- [x] Docs have been added or updated
- [x] Changes target the `main` branch
- [x] PR title follows Conventional Commits

## Additional information
- No code changes; markdown fences verified balanced.


- Also documents how to share one `HttpClient`/connection pool across multiple Refit interfaces (same `httpClientName`, or a shared `HttpClient` passed to `RestService.For<T>`). Refs #918.
