### PR TITLE
feat: add analyzer diagnostics for invalid Refit interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,8 @@ The main package also ships analyzers. They flag common interface issues at comp
 * route templates that use backslashes instead of forward slashes
 * methods with more than one `CancellationToken` parameter
 * `[HeaderCollection]` parameters that are not `IDictionary<string, string>`
+* methods with more than one `[Body]` parameter
+* `[Multipart]` methods that also declare a `[Body]` parameter
 
 Mechanical fixes ship as code fixes: replacing route backslashes with forward slashes, and changing an invalid
 `[HeaderCollection]` parameter to `IDictionary<string, string>`.

--- a/src/Refit.Analyzers.Shared/DiagnosticDescriptors.cs
+++ b/src/Refit.Analyzers.Shared/DiagnosticDescriptors.cs
@@ -87,6 +87,28 @@ internal static class DiagnosticDescriptors
             DiagnosticSeverity.Warning,
             true);
 
+    /// <summary>Diagnostic reported when a Refit method declares more than one Body parameter.</summary>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "RS2008", Justification = "Diagnostic IDs are stable and intentionally not tracked in an analyzer release-tracking file.")]
+    public static readonly DiagnosticDescriptor MultipleBodyParameters =
+        new(
+            DiagnosticIds.MultipleBodyParameters,
+            "Refit methods can only have one Body parameter",
+            "Method {0}.{1} has more than one Body parameter",
+            Category,
+            DiagnosticSeverity.Warning,
+            true);
+
+    /// <summary>Diagnostic reported when a multipart Refit method also declares a Body parameter.</summary>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "RS2008", Justification = "Diagnostic IDs are stable and intentionally not tracked in an analyzer release-tracking file.")]
+    public static readonly DiagnosticDescriptor MultipartBodyParameter =
+        new(
+            DiagnosticIds.MultipartBodyParameter,
+            "Multipart Refit methods cannot declare a Body parameter",
+            "Method {0}.{1} is multipart and cannot declare a Body parameter",
+            Category,
+            DiagnosticSeverity.Warning,
+            true);
+
     /// <summary>The diagnostic category for Refit analyzer diagnostics.</summary>
     private const string Category = "Refit";
 }

--- a/src/Refit.Analyzers.Shared/DiagnosticIds.cs
+++ b/src/Refit.Analyzers.Shared/DiagnosticIds.cs
@@ -26,4 +26,10 @@ internal static class DiagnosticIds
 
     /// <summary>Diagnostic reported when a Refit method declares more than one <c>[Authorize]</c> parameter.</summary>
     public const string MultipleAuthorizeParameters = "RF009";
+
+    /// <summary>Diagnostic reported when a Refit method declares more than one <c>[Body]</c> parameter.</summary>
+    public const string MultipleBodyParameters = "RF011";
+
+    /// <summary>Diagnostic reported when a multipart Refit method also declares a <c>[Body]</c> parameter.</summary>
+    public const string MultipartBodyParameter = "RF012";
 }

--- a/src/Refit.Analyzers.Shared/RefitInterfaceAnalyzer.cs
+++ b/src/Refit.Analyzers.Shared/RefitInterfaceAnalyzer.cs
@@ -22,7 +22,9 @@ public sealed class RefitInterfaceAnalyzer : DiagnosticAnalyzer
         DiagnosticDescriptors.InvalidHeaderCollectionParameter,
         DiagnosticDescriptors.GeneratedRequestBuildingFallback,
         DiagnosticDescriptors.MultipleHeaderCollections,
-        DiagnosticDescriptors.MultipleAuthorizeParameters
+        DiagnosticDescriptors.MultipleAuthorizeParameters,
+        DiagnosticDescriptors.MultipleBodyParameters,
+        DiagnosticDescriptors.MultipartBodyParameter
     ];
 #else
         CreateSupportedDiagnostics();
@@ -57,7 +59,7 @@ public sealed class RefitInterfaceAnalyzer : DiagnosticAnalyzer
     /// <returns>The supported diagnostics.</returns>
     private static ImmutableArray<DiagnosticDescriptor> CreateSupportedDiagnostics()
     {
-        const int supportedDiagnosticCount = 7;
+        const int supportedDiagnosticCount = 9;
         var builder = ImmutableArray.CreateBuilder<DiagnosticDescriptor>(supportedDiagnosticCount);
         builder.Add(DiagnosticDescriptors.InvalidRefitMember);
         builder.Add(DiagnosticDescriptors.InvalidRouteBackslash);
@@ -66,6 +68,8 @@ public sealed class RefitInterfaceAnalyzer : DiagnosticAnalyzer
         builder.Add(DiagnosticDescriptors.GeneratedRequestBuildingFallback);
         builder.Add(DiagnosticDescriptors.MultipleHeaderCollections);
         builder.Add(DiagnosticDescriptors.MultipleAuthorizeParameters);
+        builder.Add(DiagnosticDescriptors.MultipleBodyParameters);
+        builder.Add(DiagnosticDescriptors.MultipartBodyParameter);
         return builder.MoveToImmutable();
     }
 #endif
@@ -215,6 +219,7 @@ public sealed class RefitInterfaceAnalyzer : DiagnosticAnalyzer
                 method.Name));
         }
 
+        ReportMultipartBodyDiagnostic(method, reportDiagnostic);
         ReportParameterShapeDiagnostics(method, reportDiagnostic);
 
         // The eligibility decision is the source generator's own classifier, compiled into this assembly,
@@ -411,6 +416,7 @@ public sealed class RefitInterfaceAnalyzer : DiagnosticAnalyzer
         var cancellationTokenCount = 0;
         var headerCollectionCount = 0;
         var authorizeCount = 0;
+        var bodyCount = 0;
         foreach (var parameter in method.Parameters)
         {
             ReportParameterShapeDiagnostics(
@@ -419,7 +425,8 @@ public sealed class RefitInterfaceAnalyzer : DiagnosticAnalyzer
                 reportDiagnostic,
                 ref cancellationTokenCount,
                 ref headerCollectionCount,
-                ref authorizeCount);
+                ref authorizeCount,
+                ref bodyCount);
         }
     }
 
@@ -430,13 +437,15 @@ public sealed class RefitInterfaceAnalyzer : DiagnosticAnalyzer
     /// <param name="cancellationTokenCount">The running count of cancellation-token parameters seen so far.</param>
     /// <param name="headerCollectionCount">The running count of header-collection parameters seen so far.</param>
     /// <param name="authorizeCount">The running count of authorize parameters seen so far.</param>
+    /// <param name="bodyCount">The running count of body parameters seen so far.</param>
     private static void ReportParameterShapeDiagnostics(
         IMethodSymbol method,
         IParameterSymbol parameter,
         Action<Diagnostic> reportDiagnostic,
         ref int cancellationTokenCount,
         ref int headerCollectionCount,
-        ref int authorizeCount)
+        ref int authorizeCount,
+        ref int bodyCount)
     {
         if (IsCancellationToken(parameter.Type))
         {
@@ -466,6 +475,16 @@ public sealed class RefitInterfaceAnalyzer : DiagnosticAnalyzer
             }
 
             headerCollectionCount++;
+        }
+
+        if (HasBodyAttribute(parameter))
+        {
+            if (bodyCount > 0)
+            {
+                reportDiagnostic(MethodShapeDiagnostic(DiagnosticDescriptors.MultipleBodyParameters, method, parameter));
+            }
+
+            bodyCount++;
         }
 
         if (!HasAuthorizeAttribute(parameter))
@@ -515,6 +534,62 @@ public sealed class RefitInterfaceAnalyzer : DiagnosticAnalyzer
         foreach (var attribute in parameter.GetAttributes())
         {
             if (attribute.AttributeClass!.ToDisplayString() == "Refit.AuthorizeAttribute")
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>Determines whether a parameter carries the <c>[Body]</c> attribute.</summary>
+    /// <param name="parameter">The parameter to inspect.</param>
+    /// <returns><see langword="true"/> when the parameter has the attribute.</returns>
+    private static bool HasBodyAttribute(IParameterSymbol parameter)
+    {
+        foreach (var attribute in parameter.GetAttributes())
+        {
+            if (attribute.AttributeClass!.ToDisplayString() == "Refit.BodyAttribute")
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>Reports RF012 when a multipart method also declares a <c>[Body]</c> parameter.</summary>
+    /// <param name="method">The Refit method.</param>
+    /// <param name="reportDiagnostic">The diagnostic reporting callback.</param>
+    private static void ReportMultipartBodyDiagnostic(IMethodSymbol method, Action<Diagnostic> reportDiagnostic)
+    {
+        if (!HasMultipartAttribute(method))
+        {
+            return;
+        }
+
+        foreach (var parameter in method.Parameters)
+        {
+            if (HasBodyAttribute(parameter))
+            {
+                reportDiagnostic(Diagnostic.Create(
+                    DiagnosticDescriptors.MultipartBodyParameter,
+                    FirstLocation(parameter),
+                    method.ContainingType.Name,
+                    method.Name));
+                return;
+            }
+        }
+    }
+
+    /// <summary>Determines whether a method carries the <c>[Multipart]</c> attribute.</summary>
+    /// <param name="method">The method to inspect.</param>
+    /// <returns><see langword="true"/> when the method has the attribute.</returns>
+    private static bool HasMultipartAttribute(IMethodSymbol method)
+    {
+        foreach (var attribute in method.GetAttributes())
+        {
+            if (attribute.AttributeClass!.ToDisplayString() == "Refit.MultipartAttribute")
             {
                 return true;
             }

--- a/src/tests/Refit.Analyzers.Tests/RefitInterfaceAnalyzerTests.cs
+++ b/src/tests/Refit.Analyzers.Tests/RefitInterfaceAnalyzerTests.cs
@@ -111,6 +111,48 @@ public sealed class RefitInterfaceAnalyzerTests
         await Assert.That(diagnosticIds).Contains("RF009");
     }
 
+    /// <summary>Verifies multiple Body parameters and multipart methods with a Body parameter are reported.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task ReportsBodyParameterShapeDiagnostics()
+    {
+        var diagnostics = await AnalyzerFixture.RunForBody(
+            """
+            [Post("/users")]
+            Task<string> TwoBodies([Body] string first, [Body] string second);
+
+            [Multipart]
+            [Post("/upload")]
+            Task<string> MultipartWithBody([Body] string payload);
+            """);
+
+        var diagnosticIds = diagnostics.Select(static diagnostic => diagnostic.Id).ToArray();
+
+        await Assert.That(diagnosticIds).Contains("RF011");
+        await Assert.That(diagnosticIds).Contains("RF012");
+    }
+
+    /// <summary>Verifies a single Body parameter and a multipart method without a Body parameter are not reported.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task DoesNotReportValidBodyAndMultipartShapes()
+    {
+        var diagnostics = await AnalyzerFixture.RunForBody(
+            """
+            [Post("/users")]
+            Task<string> SingleBody([Body] string payload);
+
+            [Multipart]
+            [Post("/upload")]
+            Task<string> MultipartWithoutBody([AliasAs("file")] StreamPart stream);
+            """);
+
+        var diagnosticIds = diagnostics.Select(static diagnostic => diagnostic.Id).ToArray();
+
+        await Assert.That(diagnosticIds).DoesNotContain("RF011");
+        await Assert.That(diagnosticIds).DoesNotContain("RF012");
+    }
+
     /// <summary>Verifies non-Refit members on Refit interfaces are reported.</summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Test]


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature - two new Refit interface analyzer diagnostics (no runtime behavior change).

## What is the new behavior?

The Refit analyzer now flags two more invalid interface shapes at compile time:

- RF011 - a Refit method that declares more than one `[Body]` parameter. Message: `Method {0}.{1} has more than one Body parameter`.
- RF012 - a `[Multipart]` method that also declares a `[Body]` parameter. Message: `Method {0}.{1} is multipart and cannot declare a Body parameter`.

Both are Warning severity, so they surface the mistake in the editor and build output without failing the build unless the consumer opts into treat-warnings-as-errors. Both are documented in the README analyzer list.

## What is the current behavior?

These interface mistakes were not diagnosed. A method with two `[Body]` parameters, or a multipart method that also carries a `[Body]` parameter, was only caught (if at all) at request-build time, and produced no analyzer signal.

Closes #1885

## What might this PR break?

Nothing by default. The new diagnostics are Warning severity and add no public API (the descriptors and IDs are internal). Consumers who run treat-warnings-as-errors and already have one of these invalid shapes will see a new build warning surface as an error - which is the intended signal.

## Checklist
- [ ] I have read the Contribute guide
- [x] Tests have been added or updated (for bug fixes / features)
- [x] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the `main` branch
- [x] PR title follows Conventional Commits

## Additional information

- Both diagnostics live in the analyzer project `src/Refit.Analyzers.Shared`, mirroring the existing per-method / per-parameter diagnostics (RF004, RF008, RF009). RF011 slots into the parameter-shape counter loop next to the existing CancellationToken / HeaderCollection / Authorize counters; RF012 is a pure attribute check on the method.
- All builds pass (analyzer projects + code-fix projects, Roslyn 4.8 and 5.0); all tests pass (`RefitInterfaceAnalyzerTests`, net8.0). No public API changes (internal descriptors/IDs).
- A third candidate, RF010 (unsupported return type), was evaluated and descoped. Refit supports runtime-registered `IReturnTypeAdapter` implementations (via `RefitSettings.ReturnTypeAdapters`) that can make an otherwise-unrecognized return type - even a closed adapter over `string`/`int` - valid at runtime. The analyzer cannot see runtime-registered adapters, and the source generator itself never rejects an unknown return type (it falls back to the reflection request builder, already surfaced by RF006). A return-type diagnostic would therefore risk false positives on valid adapter-backed methods, so it was left out.
