### PR TITLE
feat: optional auth header and scoped authorization token provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ lets you stub responses and verify requests with a declarative route table — s
     * [Static headers](#static-headers)
     * [Dynamic headers](#dynamic-headers)
     * [Bearer Authentication](#bearer-authentication)
+    * [Scoped (per-request) authorization tokens with dependency injection](#scoped-per-request-authorization-tokens-with-dependency-injection)
     * [Reducing header boilerplate with DelegatingHandlers (Authorization headers worked example)](#reducing-header-boilerplate-with-delegatinghandlers-authorization-headers-worked-example)
     * [Redefining headers](#redefining-headers)
     * [Removing headers](#removing-headers)
@@ -1137,6 +1138,37 @@ your app needs, so you don't have to pass a token into each method.
 `AuthorizationHeaderValueGetter` works whether you create clients with `RestService.For<T>("https://...")` or supply
 your own `HttpClient` via `RestService.For<T>(httpClient, settings)`. If your API methods accept a `CancellationToken`,
 that token is propagated to the getter delegate.
+
+If your getter returns `null`, an empty string, or whitespace, Refit omits the `Authorization` header for that request
+instead of sending a blank `Authorization: <scheme>` value. This lets a single client make both authenticated and
+anonymous calls: return a token when you have one, and return an empty string to skip auth for that request. Omitting
+the `Authorization` placeholder entirely (no `[Headers("Authorization: Bearer")]`) skips auth for the whole method.
+
+#### Scoped (per-request) authorization tokens with dependency injection
+
+When you register a client through `Refit.HttpClientFactory`, you can resolve the token from dependency injection with
+`AddAuthorizationHeaderValueProvider`:
+
+```csharp
+services.AddRefitClient<IMyApi>()
+    .ConfigureHttpClient(c => c.BaseAddress = new Uri("https://api.example.com"))
+    .AddAuthorizationHeaderValueProvider((serviceProvider, request, cancellationToken) =>
+    {
+        var tokenService = serviceProvider.GetRequiredService<IMyTokenService>();
+        return new ValueTask<string>(tokenService.GetTokenForCurrentRequest());
+    });
+```
+
+The delegate receives an `IServiceProvider`, the outgoing `HttpRequestMessage`, and a `CancellationToken`, and returns
+the token to place in the `Authorization` header (returning `null`/empty/whitespace skips auth for that request, exactly
+like `AuthorizationHeaderValueGetter`).
+
+Caveat: `IHttpClientFactory` pools message handlers for their configured lifetime, so a scoped service captured directly
+by a handler would bleed across requests. To keep the provider correctly per-request, this extension creates a fresh DI
+scope for every request and resolves your delegate from that scope's `IServiceProvider`, disposing the scope when the
+request completes. True per-request isolation therefore relies on either per-request state you read from the `request`
+argument, or ambient `AsyncLocal`-based state (such as a host-registered `IHttpContextAccessor`) that flows into the
+fresh scope. No `Microsoft.AspNetCore.*` reference is required.
 
 #### Reducing header boilerplate with DelegatingHandlers (Authorization headers worked example)
 

--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -88,6 +88,12 @@ visible in three places.
   `[JsonProperty]` when `Refit.Newtonsoft.Json` is installed. To keep the pre-V14 behavior, set
   `RefitSettings.HonorContentSerializerPropertyNamesInQuery = false`; `[AliasAs]` still takes precedence in either mode.
 
+* **An empty token from `AuthorizationHeaderValueGetter` now omits the `Authorization` header instead of sending a
+  blank one** (#1688). Previously a getter that returned `null`, an empty string, or whitespace produced a blank
+  `Authorization: <scheme>` header (and could throw for some scheme/value combinations). Refit now clears the header for
+  that request, so a single client can mix authenticated and anonymous calls by returning a token or an empty string. If
+  you relied on a blank header being sent, return a non-empty value.
+
 ### New in V14.x
 
 * **Inline query-string generation.** Query parameters — auto-appended parameters, `[AliasAs]`, `[Query(Format = ...)]`,
@@ -148,6 +154,12 @@ visible in three places.
   generator discovers adapters declared in your project at compile time and emits a direct `Adapt` call — no reflection,
   so adapter-backed methods stay trim and Native AOT clean; the reflection request builder resolves adapters registered
   in `RefitSettings.ReturnTypeAdapters`. See [Custom return types](../README.md#custom-return-types-ireturntypeadapter).
+* **Scoped (per-request) authorization tokens via DI (`AddAuthorizationHeaderValueProvider`).** A new
+  `IHttpClientBuilder` extension in `Refit.HttpClientFactory` resolves the `Authorization` token from dependency
+  injection per request. Because `IHttpClientFactory` pools message handlers, it creates a fresh DI scope for every
+  request and resolves your delegate `(IServiceProvider, HttpRequestMessage, CancellationToken) -> ValueTask<string>`
+  from that scope, disposing it when the request completes — no `Microsoft.AspNetCore.*` dependency required (#1679). See
+  [Scoped (per-request) authorization tokens with dependency injection](../README.md#scoped-per-request-authorization-tokens-with-dependency-injection).
 
 ## V13.x.x
 

--- a/src/Refit.HttpClientFactory/HttpClientFactoryExtensions.HttpClientBuilder.cs
+++ b/src/Refit.HttpClientFactory/HttpClientFactoryExtensions.HttpClientBuilder.cs
@@ -316,5 +316,31 @@ public static partial class HttpClientFactoryExtensions
                 settingsAction,
                 builder.Name);
         }
+
+        /// <summary>Adds a message handler that resolves each request's authorization token from a fresh dependency-injection scope.</summary>
+        /// <param name="getToken">
+        /// A delegate that resolves the authorization token from a per-request <see cref="IServiceProvider"/>, the outgoing
+        /// request, and a cancellation token. Returning null, empty, or whitespace omits the <c>Authorization</c> header for
+        /// that request.
+        /// </param>
+        /// <returns>The HTTP client builder for chaining.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="getToken"/> is null.</exception>
+        /// <remarks>
+        /// <see cref="IHttpClientFactory"/> pools message handlers for their configured lifetime, so a scoped token provider
+        /// captured directly would bleed across requests. This registers a handler that creates a fresh
+        /// <see cref="IServiceScope"/> per request, resolving <paramref name="getToken"/> from that scope's provider, so a
+        /// scoped service (or ambient <c>AsyncLocal</c> state such as a host-registered <c>IHttpContextAccessor</c>) resolves
+        /// correctly per request without any ASP.NET Core dependency.
+        /// </remarks>
+        public IHttpClientBuilder AddAuthorizationHeaderValueProvider(
+            Func<IServiceProvider, HttpRequestMessage, CancellationToken, ValueTask<string>> getToken)
+        {
+            ArgumentExceptionHelper.ThrowIfNull(builder);
+
+            ArgumentExceptionHelper.ThrowIfNull(getToken);
+
+            return builder.ConfigureAdditionalHttpMessageHandlers((handlers, serviceProvider) =>
+                handlers.Add(new ScopedAuthorizationHeaderHandler(serviceProvider, getToken)));
+        }
     }
 }

--- a/src/Refit.HttpClientFactory/PublicAPI/net10.0/PublicAPI.Shipped.txt
+++ b/src/Refit.HttpClientFactory/PublicAPI/net10.0/PublicAPI.Shipped.txt
@@ -1,6 +1,7 @@
 #nullable enable
 Refit.HttpClientFactoryExtensions
 Refit.HttpClientFactoryExtensions.extension(Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!)
+Refit.HttpClientFactoryExtensions.extension(Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!).AddAuthorizationHeaderValueProvider(System.Func<System.IServiceProvider!, System.Net.Http.HttpRequestMessage!, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<string!>>! getToken) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
 Refit.HttpClientFactoryExtensions.extension(Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!).AddKeyedRefitClient(System.Type! refitInterfaceType, object? serviceKey) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
 Refit.HttpClientFactoryExtensions.extension(Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!).AddKeyedRefitClient(System.Type! refitInterfaceType, object? serviceKey, Refit.RefitSettings? settings) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
 Refit.HttpClientFactoryExtensions.extension(Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!).AddKeyedRefitClient(System.Type! refitInterfaceType, object? serviceKey, System.Func<System.IServiceProvider!, Refit.RefitSettings?>? settingsAction) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
@@ -44,6 +45,7 @@ Refit.ISettingsFor.Settings.get -> Refit.RefitSettings?
 Refit.SettingsFor<T>
 Refit.SettingsFor<T>.Settings.get -> Refit.RefitSettings?
 Refit.SettingsFor<T>.SettingsFor(Refit.RefitSettings? settings) -> void
+static Refit.HttpClientFactoryExtensions.AddAuthorizationHeaderValueProvider(this Microsoft.Extensions.DependencyInjection.IHttpClientBuilder! builder, System.Func<System.IServiceProvider!, System.Net.Http.HttpRequestMessage!, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<string!>>! getToken) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
 static Refit.HttpClientFactoryExtensions.AddKeyedRefitClient(this Microsoft.Extensions.DependencyInjection.IHttpClientBuilder! builder, System.Type! refitInterfaceType, object? serviceKey) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
 static Refit.HttpClientFactoryExtensions.AddKeyedRefitClient(this Microsoft.Extensions.DependencyInjection.IHttpClientBuilder! builder, System.Type! refitInterfaceType, object? serviceKey, Refit.RefitSettings? settings) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
 static Refit.HttpClientFactoryExtensions.AddKeyedRefitClient(this Microsoft.Extensions.DependencyInjection.IHttpClientBuilder! builder, System.Type! refitInterfaceType, object? serviceKey, System.Func<System.IServiceProvider!, Refit.RefitSettings?>? settingsAction) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!

--- a/src/Refit.HttpClientFactory/PublicAPI/net11.0/PublicAPI.Shipped.txt
+++ b/src/Refit.HttpClientFactory/PublicAPI/net11.0/PublicAPI.Shipped.txt
@@ -1,6 +1,7 @@
 #nullable enable
 Refit.HttpClientFactoryExtensions
 Refit.HttpClientFactoryExtensions.extension(Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!)
+Refit.HttpClientFactoryExtensions.extension(Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!).AddAuthorizationHeaderValueProvider(System.Func<System.IServiceProvider!, System.Net.Http.HttpRequestMessage!, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<string!>>! getToken) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
 Refit.HttpClientFactoryExtensions.extension(Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!).AddKeyedRefitClient(System.Type! refitInterfaceType, object? serviceKey) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
 Refit.HttpClientFactoryExtensions.extension(Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!).AddKeyedRefitClient(System.Type! refitInterfaceType, object? serviceKey, Refit.RefitSettings? settings) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
 Refit.HttpClientFactoryExtensions.extension(Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!).AddKeyedRefitClient(System.Type! refitInterfaceType, object? serviceKey, System.Func<System.IServiceProvider!, Refit.RefitSettings?>? settingsAction) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
@@ -44,6 +45,7 @@ Refit.ISettingsFor.Settings.get -> Refit.RefitSettings?
 Refit.SettingsFor<T>
 Refit.SettingsFor<T>.Settings.get -> Refit.RefitSettings?
 Refit.SettingsFor<T>.SettingsFor(Refit.RefitSettings? settings) -> void
+static Refit.HttpClientFactoryExtensions.AddAuthorizationHeaderValueProvider(this Microsoft.Extensions.DependencyInjection.IHttpClientBuilder! builder, System.Func<System.IServiceProvider!, System.Net.Http.HttpRequestMessage!, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<string!>>! getToken) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
 static Refit.HttpClientFactoryExtensions.AddKeyedRefitClient(this Microsoft.Extensions.DependencyInjection.IHttpClientBuilder! builder, System.Type! refitInterfaceType, object? serviceKey) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
 static Refit.HttpClientFactoryExtensions.AddKeyedRefitClient(this Microsoft.Extensions.DependencyInjection.IHttpClientBuilder! builder, System.Type! refitInterfaceType, object? serviceKey, Refit.RefitSettings? settings) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
 static Refit.HttpClientFactoryExtensions.AddKeyedRefitClient(this Microsoft.Extensions.DependencyInjection.IHttpClientBuilder! builder, System.Type! refitInterfaceType, object? serviceKey, System.Func<System.IServiceProvider!, Refit.RefitSettings?>? settingsAction) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!

--- a/src/Refit.HttpClientFactory/PublicAPI/net462/PublicAPI.Shipped.txt
+++ b/src/Refit.HttpClientFactory/PublicAPI/net462/PublicAPI.Shipped.txt
@@ -1,6 +1,7 @@
 #nullable enable
 Refit.HttpClientFactoryExtensions
 Refit.HttpClientFactoryExtensions.extension(Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!)
+Refit.HttpClientFactoryExtensions.extension(Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!).AddAuthorizationHeaderValueProvider(System.Func<System.IServiceProvider!, System.Net.Http.HttpRequestMessage!, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<string!>>! getToken) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
 Refit.HttpClientFactoryExtensions.extension(Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!).AddKeyedRefitClient(System.Type! refitInterfaceType, object? serviceKey) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
 Refit.HttpClientFactoryExtensions.extension(Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!).AddKeyedRefitClient(System.Type! refitInterfaceType, object? serviceKey, Refit.RefitSettings? settings) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
 Refit.HttpClientFactoryExtensions.extension(Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!).AddKeyedRefitClient(System.Type! refitInterfaceType, object? serviceKey, System.Func<System.IServiceProvider!, Refit.RefitSettings?>? settingsAction) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
@@ -44,6 +45,7 @@ Refit.ISettingsFor.Settings.get -> Refit.RefitSettings?
 Refit.SettingsFor<T>
 Refit.SettingsFor<T>.Settings.get -> Refit.RefitSettings?
 Refit.SettingsFor<T>.SettingsFor(Refit.RefitSettings? settings) -> void
+static Refit.HttpClientFactoryExtensions.AddAuthorizationHeaderValueProvider(this Microsoft.Extensions.DependencyInjection.IHttpClientBuilder! builder, System.Func<System.IServiceProvider!, System.Net.Http.HttpRequestMessage!, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<string!>>! getToken) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
 static Refit.HttpClientFactoryExtensions.AddKeyedRefitClient(this Microsoft.Extensions.DependencyInjection.IHttpClientBuilder! builder, System.Type! refitInterfaceType, object? serviceKey) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
 static Refit.HttpClientFactoryExtensions.AddKeyedRefitClient(this Microsoft.Extensions.DependencyInjection.IHttpClientBuilder! builder, System.Type! refitInterfaceType, object? serviceKey, Refit.RefitSettings? settings) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
 static Refit.HttpClientFactoryExtensions.AddKeyedRefitClient(this Microsoft.Extensions.DependencyInjection.IHttpClientBuilder! builder, System.Type! refitInterfaceType, object? serviceKey, System.Func<System.IServiceProvider!, Refit.RefitSettings?>? settingsAction) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!

--- a/src/Refit.HttpClientFactory/PublicAPI/net470/PublicAPI.Shipped.txt
+++ b/src/Refit.HttpClientFactory/PublicAPI/net470/PublicAPI.Shipped.txt
@@ -1,6 +1,7 @@
 #nullable enable
 Refit.HttpClientFactoryExtensions
 Refit.HttpClientFactoryExtensions.extension(Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!)
+Refit.HttpClientFactoryExtensions.extension(Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!).AddAuthorizationHeaderValueProvider(System.Func<System.IServiceProvider!, System.Net.Http.HttpRequestMessage!, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<string!>>! getToken) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
 Refit.HttpClientFactoryExtensions.extension(Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!).AddKeyedRefitClient(System.Type! refitInterfaceType, object? serviceKey) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
 Refit.HttpClientFactoryExtensions.extension(Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!).AddKeyedRefitClient(System.Type! refitInterfaceType, object? serviceKey, Refit.RefitSettings? settings) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
 Refit.HttpClientFactoryExtensions.extension(Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!).AddKeyedRefitClient(System.Type! refitInterfaceType, object? serviceKey, System.Func<System.IServiceProvider!, Refit.RefitSettings?>? settingsAction) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
@@ -44,6 +45,7 @@ Refit.ISettingsFor.Settings.get -> Refit.RefitSettings?
 Refit.SettingsFor<T>
 Refit.SettingsFor<T>.Settings.get -> Refit.RefitSettings?
 Refit.SettingsFor<T>.SettingsFor(Refit.RefitSettings? settings) -> void
+static Refit.HttpClientFactoryExtensions.AddAuthorizationHeaderValueProvider(this Microsoft.Extensions.DependencyInjection.IHttpClientBuilder! builder, System.Func<System.IServiceProvider!, System.Net.Http.HttpRequestMessage!, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<string!>>! getToken) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
 static Refit.HttpClientFactoryExtensions.AddKeyedRefitClient(this Microsoft.Extensions.DependencyInjection.IHttpClientBuilder! builder, System.Type! refitInterfaceType, object? serviceKey) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
 static Refit.HttpClientFactoryExtensions.AddKeyedRefitClient(this Microsoft.Extensions.DependencyInjection.IHttpClientBuilder! builder, System.Type! refitInterfaceType, object? serviceKey, Refit.RefitSettings? settings) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
 static Refit.HttpClientFactoryExtensions.AddKeyedRefitClient(this Microsoft.Extensions.DependencyInjection.IHttpClientBuilder! builder, System.Type! refitInterfaceType, object? serviceKey, System.Func<System.IServiceProvider!, Refit.RefitSettings?>? settingsAction) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!

--- a/src/Refit.HttpClientFactory/PublicAPI/net471/PublicAPI.Shipped.txt
+++ b/src/Refit.HttpClientFactory/PublicAPI/net471/PublicAPI.Shipped.txt
@@ -1,6 +1,7 @@
 #nullable enable
 Refit.HttpClientFactoryExtensions
 Refit.HttpClientFactoryExtensions.extension(Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!)
+Refit.HttpClientFactoryExtensions.extension(Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!).AddAuthorizationHeaderValueProvider(System.Func<System.IServiceProvider!, System.Net.Http.HttpRequestMessage!, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<string!>>! getToken) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
 Refit.HttpClientFactoryExtensions.extension(Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!).AddKeyedRefitClient(System.Type! refitInterfaceType, object? serviceKey) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
 Refit.HttpClientFactoryExtensions.extension(Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!).AddKeyedRefitClient(System.Type! refitInterfaceType, object? serviceKey, Refit.RefitSettings? settings) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
 Refit.HttpClientFactoryExtensions.extension(Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!).AddKeyedRefitClient(System.Type! refitInterfaceType, object? serviceKey, System.Func<System.IServiceProvider!, Refit.RefitSettings?>? settingsAction) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
@@ -44,6 +45,7 @@ Refit.ISettingsFor.Settings.get -> Refit.RefitSettings?
 Refit.SettingsFor<T>
 Refit.SettingsFor<T>.Settings.get -> Refit.RefitSettings?
 Refit.SettingsFor<T>.SettingsFor(Refit.RefitSettings? settings) -> void
+static Refit.HttpClientFactoryExtensions.AddAuthorizationHeaderValueProvider(this Microsoft.Extensions.DependencyInjection.IHttpClientBuilder! builder, System.Func<System.IServiceProvider!, System.Net.Http.HttpRequestMessage!, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<string!>>! getToken) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
 static Refit.HttpClientFactoryExtensions.AddKeyedRefitClient(this Microsoft.Extensions.DependencyInjection.IHttpClientBuilder! builder, System.Type! refitInterfaceType, object? serviceKey) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
 static Refit.HttpClientFactoryExtensions.AddKeyedRefitClient(this Microsoft.Extensions.DependencyInjection.IHttpClientBuilder! builder, System.Type! refitInterfaceType, object? serviceKey, Refit.RefitSettings? settings) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
 static Refit.HttpClientFactoryExtensions.AddKeyedRefitClient(this Microsoft.Extensions.DependencyInjection.IHttpClientBuilder! builder, System.Type! refitInterfaceType, object? serviceKey, System.Func<System.IServiceProvider!, Refit.RefitSettings?>? settingsAction) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!

--- a/src/Refit.HttpClientFactory/PublicAPI/net472/PublicAPI.Shipped.txt
+++ b/src/Refit.HttpClientFactory/PublicAPI/net472/PublicAPI.Shipped.txt
@@ -1,6 +1,7 @@
 #nullable enable
 Refit.HttpClientFactoryExtensions
 Refit.HttpClientFactoryExtensions.extension(Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!)
+Refit.HttpClientFactoryExtensions.extension(Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!).AddAuthorizationHeaderValueProvider(System.Func<System.IServiceProvider!, System.Net.Http.HttpRequestMessage!, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<string!>>! getToken) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
 Refit.HttpClientFactoryExtensions.extension(Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!).AddKeyedRefitClient(System.Type! refitInterfaceType, object? serviceKey) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
 Refit.HttpClientFactoryExtensions.extension(Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!).AddKeyedRefitClient(System.Type! refitInterfaceType, object? serviceKey, Refit.RefitSettings? settings) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
 Refit.HttpClientFactoryExtensions.extension(Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!).AddKeyedRefitClient(System.Type! refitInterfaceType, object? serviceKey, System.Func<System.IServiceProvider!, Refit.RefitSettings?>? settingsAction) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
@@ -44,6 +45,7 @@ Refit.ISettingsFor.Settings.get -> Refit.RefitSettings?
 Refit.SettingsFor<T>
 Refit.SettingsFor<T>.Settings.get -> Refit.RefitSettings?
 Refit.SettingsFor<T>.SettingsFor(Refit.RefitSettings? settings) -> void
+static Refit.HttpClientFactoryExtensions.AddAuthorizationHeaderValueProvider(this Microsoft.Extensions.DependencyInjection.IHttpClientBuilder! builder, System.Func<System.IServiceProvider!, System.Net.Http.HttpRequestMessage!, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<string!>>! getToken) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
 static Refit.HttpClientFactoryExtensions.AddKeyedRefitClient(this Microsoft.Extensions.DependencyInjection.IHttpClientBuilder! builder, System.Type! refitInterfaceType, object? serviceKey) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
 static Refit.HttpClientFactoryExtensions.AddKeyedRefitClient(this Microsoft.Extensions.DependencyInjection.IHttpClientBuilder! builder, System.Type! refitInterfaceType, object? serviceKey, Refit.RefitSettings? settings) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
 static Refit.HttpClientFactoryExtensions.AddKeyedRefitClient(this Microsoft.Extensions.DependencyInjection.IHttpClientBuilder! builder, System.Type! refitInterfaceType, object? serviceKey, System.Func<System.IServiceProvider!, Refit.RefitSettings?>? settingsAction) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!

--- a/src/Refit.HttpClientFactory/PublicAPI/net48/PublicAPI.Shipped.txt
+++ b/src/Refit.HttpClientFactory/PublicAPI/net48/PublicAPI.Shipped.txt
@@ -1,6 +1,7 @@
 #nullable enable
 Refit.HttpClientFactoryExtensions
 Refit.HttpClientFactoryExtensions.extension(Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!)
+Refit.HttpClientFactoryExtensions.extension(Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!).AddAuthorizationHeaderValueProvider(System.Func<System.IServiceProvider!, System.Net.Http.HttpRequestMessage!, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<string!>>! getToken) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
 Refit.HttpClientFactoryExtensions.extension(Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!).AddKeyedRefitClient(System.Type! refitInterfaceType, object? serviceKey) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
 Refit.HttpClientFactoryExtensions.extension(Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!).AddKeyedRefitClient(System.Type! refitInterfaceType, object? serviceKey, Refit.RefitSettings? settings) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
 Refit.HttpClientFactoryExtensions.extension(Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!).AddKeyedRefitClient(System.Type! refitInterfaceType, object? serviceKey, System.Func<System.IServiceProvider!, Refit.RefitSettings?>? settingsAction) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
@@ -44,6 +45,7 @@ Refit.ISettingsFor.Settings.get -> Refit.RefitSettings?
 Refit.SettingsFor<T>
 Refit.SettingsFor<T>.Settings.get -> Refit.RefitSettings?
 Refit.SettingsFor<T>.SettingsFor(Refit.RefitSettings? settings) -> void
+static Refit.HttpClientFactoryExtensions.AddAuthorizationHeaderValueProvider(this Microsoft.Extensions.DependencyInjection.IHttpClientBuilder! builder, System.Func<System.IServiceProvider!, System.Net.Http.HttpRequestMessage!, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<string!>>! getToken) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
 static Refit.HttpClientFactoryExtensions.AddKeyedRefitClient(this Microsoft.Extensions.DependencyInjection.IHttpClientBuilder! builder, System.Type! refitInterfaceType, object? serviceKey) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
 static Refit.HttpClientFactoryExtensions.AddKeyedRefitClient(this Microsoft.Extensions.DependencyInjection.IHttpClientBuilder! builder, System.Type! refitInterfaceType, object? serviceKey, Refit.RefitSettings? settings) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
 static Refit.HttpClientFactoryExtensions.AddKeyedRefitClient(this Microsoft.Extensions.DependencyInjection.IHttpClientBuilder! builder, System.Type! refitInterfaceType, object? serviceKey, System.Func<System.IServiceProvider!, Refit.RefitSettings?>? settingsAction) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!

--- a/src/Refit.HttpClientFactory/PublicAPI/net481/PublicAPI.Shipped.txt
+++ b/src/Refit.HttpClientFactory/PublicAPI/net481/PublicAPI.Shipped.txt
@@ -1,6 +1,7 @@
 #nullable enable
 Refit.HttpClientFactoryExtensions
 Refit.HttpClientFactoryExtensions.extension(Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!)
+Refit.HttpClientFactoryExtensions.extension(Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!).AddAuthorizationHeaderValueProvider(System.Func<System.IServiceProvider!, System.Net.Http.HttpRequestMessage!, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<string!>>! getToken) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
 Refit.HttpClientFactoryExtensions.extension(Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!).AddKeyedRefitClient(System.Type! refitInterfaceType, object? serviceKey) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
 Refit.HttpClientFactoryExtensions.extension(Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!).AddKeyedRefitClient(System.Type! refitInterfaceType, object? serviceKey, Refit.RefitSettings? settings) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
 Refit.HttpClientFactoryExtensions.extension(Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!).AddKeyedRefitClient(System.Type! refitInterfaceType, object? serviceKey, System.Func<System.IServiceProvider!, Refit.RefitSettings?>? settingsAction) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
@@ -44,6 +45,7 @@ Refit.ISettingsFor.Settings.get -> Refit.RefitSettings?
 Refit.SettingsFor<T>
 Refit.SettingsFor<T>.Settings.get -> Refit.RefitSettings?
 Refit.SettingsFor<T>.SettingsFor(Refit.RefitSettings? settings) -> void
+static Refit.HttpClientFactoryExtensions.AddAuthorizationHeaderValueProvider(this Microsoft.Extensions.DependencyInjection.IHttpClientBuilder! builder, System.Func<System.IServiceProvider!, System.Net.Http.HttpRequestMessage!, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<string!>>! getToken) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
 static Refit.HttpClientFactoryExtensions.AddKeyedRefitClient(this Microsoft.Extensions.DependencyInjection.IHttpClientBuilder! builder, System.Type! refitInterfaceType, object? serviceKey) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
 static Refit.HttpClientFactoryExtensions.AddKeyedRefitClient(this Microsoft.Extensions.DependencyInjection.IHttpClientBuilder! builder, System.Type! refitInterfaceType, object? serviceKey, Refit.RefitSettings? settings) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
 static Refit.HttpClientFactoryExtensions.AddKeyedRefitClient(this Microsoft.Extensions.DependencyInjection.IHttpClientBuilder! builder, System.Type! refitInterfaceType, object? serviceKey, System.Func<System.IServiceProvider!, Refit.RefitSettings?>? settingsAction) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!

--- a/src/Refit.HttpClientFactory/PublicAPI/net8.0/PublicAPI.Shipped.txt
+++ b/src/Refit.HttpClientFactory/PublicAPI/net8.0/PublicAPI.Shipped.txt
@@ -1,6 +1,7 @@
 #nullable enable
 Refit.HttpClientFactoryExtensions
 Refit.HttpClientFactoryExtensions.extension(Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!)
+Refit.HttpClientFactoryExtensions.extension(Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!).AddAuthorizationHeaderValueProvider(System.Func<System.IServiceProvider!, System.Net.Http.HttpRequestMessage!, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<string!>>! getToken) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
 Refit.HttpClientFactoryExtensions.extension(Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!).AddKeyedRefitClient(System.Type! refitInterfaceType, object? serviceKey) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
 Refit.HttpClientFactoryExtensions.extension(Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!).AddKeyedRefitClient(System.Type! refitInterfaceType, object? serviceKey, Refit.RefitSettings? settings) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
 Refit.HttpClientFactoryExtensions.extension(Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!).AddKeyedRefitClient(System.Type! refitInterfaceType, object? serviceKey, System.Func<System.IServiceProvider!, Refit.RefitSettings?>? settingsAction) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
@@ -44,6 +45,7 @@ Refit.ISettingsFor.Settings.get -> Refit.RefitSettings?
 Refit.SettingsFor<T>
 Refit.SettingsFor<T>.Settings.get -> Refit.RefitSettings?
 Refit.SettingsFor<T>.SettingsFor(Refit.RefitSettings? settings) -> void
+static Refit.HttpClientFactoryExtensions.AddAuthorizationHeaderValueProvider(this Microsoft.Extensions.DependencyInjection.IHttpClientBuilder! builder, System.Func<System.IServiceProvider!, System.Net.Http.HttpRequestMessage!, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<string!>>! getToken) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
 static Refit.HttpClientFactoryExtensions.AddKeyedRefitClient(this Microsoft.Extensions.DependencyInjection.IHttpClientBuilder! builder, System.Type! refitInterfaceType, object? serviceKey) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
 static Refit.HttpClientFactoryExtensions.AddKeyedRefitClient(this Microsoft.Extensions.DependencyInjection.IHttpClientBuilder! builder, System.Type! refitInterfaceType, object? serviceKey, Refit.RefitSettings? settings) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
 static Refit.HttpClientFactoryExtensions.AddKeyedRefitClient(this Microsoft.Extensions.DependencyInjection.IHttpClientBuilder! builder, System.Type! refitInterfaceType, object? serviceKey, System.Func<System.IServiceProvider!, Refit.RefitSettings?>? settingsAction) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!

--- a/src/Refit.HttpClientFactory/PublicAPI/net9.0/PublicAPI.Shipped.txt
+++ b/src/Refit.HttpClientFactory/PublicAPI/net9.0/PublicAPI.Shipped.txt
@@ -1,6 +1,7 @@
 #nullable enable
 Refit.HttpClientFactoryExtensions
 Refit.HttpClientFactoryExtensions.extension(Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!)
+Refit.HttpClientFactoryExtensions.extension(Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!).AddAuthorizationHeaderValueProvider(System.Func<System.IServiceProvider!, System.Net.Http.HttpRequestMessage!, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<string!>>! getToken) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
 Refit.HttpClientFactoryExtensions.extension(Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!).AddKeyedRefitClient(System.Type! refitInterfaceType, object? serviceKey) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
 Refit.HttpClientFactoryExtensions.extension(Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!).AddKeyedRefitClient(System.Type! refitInterfaceType, object? serviceKey, Refit.RefitSettings? settings) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
 Refit.HttpClientFactoryExtensions.extension(Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!).AddKeyedRefitClient(System.Type! refitInterfaceType, object? serviceKey, System.Func<System.IServiceProvider!, Refit.RefitSettings?>? settingsAction) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
@@ -44,6 +45,7 @@ Refit.ISettingsFor.Settings.get -> Refit.RefitSettings?
 Refit.SettingsFor<T>
 Refit.SettingsFor<T>.Settings.get -> Refit.RefitSettings?
 Refit.SettingsFor<T>.SettingsFor(Refit.RefitSettings? settings) -> void
+static Refit.HttpClientFactoryExtensions.AddAuthorizationHeaderValueProvider(this Microsoft.Extensions.DependencyInjection.IHttpClientBuilder! builder, System.Func<System.IServiceProvider!, System.Net.Http.HttpRequestMessage!, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<string!>>! getToken) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
 static Refit.HttpClientFactoryExtensions.AddKeyedRefitClient(this Microsoft.Extensions.DependencyInjection.IHttpClientBuilder! builder, System.Type! refitInterfaceType, object? serviceKey) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
 static Refit.HttpClientFactoryExtensions.AddKeyedRefitClient(this Microsoft.Extensions.DependencyInjection.IHttpClientBuilder! builder, System.Type! refitInterfaceType, object? serviceKey, Refit.RefitSettings? settings) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!
 static Refit.HttpClientFactoryExtensions.AddKeyedRefitClient(this Microsoft.Extensions.DependencyInjection.IHttpClientBuilder! builder, System.Type! refitInterfaceType, object? serviceKey, System.Func<System.IServiceProvider!, Refit.RefitSettings?>? settingsAction) -> Microsoft.Extensions.DependencyInjection.IHttpClientBuilder!

--- a/src/Refit.HttpClientFactory/ScopedAuthorizationHeaderHandler.cs
+++ b/src/Refit.HttpClientFactory/ScopedAuthorizationHeaderHandler.cs
@@ -1,0 +1,64 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+using System.Net.Http.Headers;
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Refit;
+
+/// <summary>Resolves each request's authorization token from a fresh per-request dependency-injection scope.</summary>
+/// <remarks>
+/// <see cref="IHttpClientFactory"/> pools message handlers for their configured lifetime, so a scoped service captured
+/// directly by a handler would bleed across requests. Creating a scope here keeps the token provider correctly scoped
+/// to each request without taking any ASP.NET Core dependency. Ambient <c>AsyncLocal</c>-based state (such as a
+/// singleton <c>IHttpContextAccessor</c> registered by the host) still flows into the fresh scope, so the common
+/// ASP.NET case works; a provider that reads the request message directly works too.
+/// </remarks>
+internal sealed class ScopedAuthorizationHeaderHandler : DelegatingHandler
+{
+    /// <summary>The default authorization scheme applied when the request carries no scheme of its own.</summary>
+    private const string DefaultScheme = "Bearer";
+
+    /// <summary>The root service provider used to create a fresh scope for every request.</summary>
+    private readonly IServiceProvider _rootServiceProvider;
+
+    /// <summary>The delegate that resolves the token from a per-request service provider.</summary>
+    private readonly Func<IServiceProvider, HttpRequestMessage, CancellationToken, ValueTask<string>> _getToken;
+
+    /// <summary>Initializes a new instance of the <see cref="ScopedAuthorizationHeaderHandler"/> class.</summary>
+    /// <param name="rootServiceProvider">The root service provider used to create a per-request scope.</param>
+    /// <param name="getToken">The delegate that resolves the token from a per-request service provider.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="rootServiceProvider"/> or <paramref name="getToken"/> is null.</exception>
+    public ScopedAuthorizationHeaderHandler(
+        IServiceProvider rootServiceProvider,
+        Func<IServiceProvider, HttpRequestMessage, CancellationToken, ValueTask<string>> getToken)
+    {
+        ArgumentExceptionHelper.ThrowIfNull(rootServiceProvider);
+        ArgumentExceptionHelper.ThrowIfNull(getToken);
+        _rootServiceProvider = rootServiceProvider;
+        _getToken = getToken;
+    }
+
+    /// <inheritdoc/>
+    protected override async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        var scheme = request.Headers.Authorization?.Scheme ?? DefaultScheme;
+
+        var scope = _rootServiceProvider.CreateAsyncScope();
+        await using (scope.ConfigureAwait(false))
+        {
+            var token = await _getToken(scope.ServiceProvider, request, cancellationToken).ConfigureAwait(false);
+
+            // An empty token means "no credentials for this request": drop the header rather than
+            // sending a blank `Authorization: <scheme>` value (#1688).
+            request.Headers.Authorization = string.IsNullOrWhiteSpace(token)
+                ? null
+                : new AuthenticationHeaderValue(scheme, token);
+        }
+
+        return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/src/Refit/RequestExecutionHelpers.cs
+++ b/src/Refit/RequestExecutionHelpers.cs
@@ -172,7 +172,7 @@ internal static class RequestExecutionHelpers
             cancellationToken);
     }
 
-    /// <summary>Populates an empty Authorization header through the configured token getter.</summary>
+    /// <summary>Populates an empty Authorization header through the configured token getter, removing the header when the getter returns an empty token.</summary>
     /// <param name="request">The request to modify.</param>
     /// <param name="settings">The Refit settings to use.</param>
     /// <param name="cancellationToken">A token to cancel the token getter.</param>
@@ -195,7 +195,12 @@ internal static class RequestExecutionHelpers
 
         var token = await settings.AuthorizationHeaderValueGetter(request, cancellationToken)
             .ConfigureAwait(false);
-        request.Headers.Authorization = new(auth.Scheme, token);
+
+        // An empty token means "no credentials for this request": drop the header rather than
+        // sending a blank `Authorization: <scheme>` value (#1688).
+        request.Headers.Authorization = string.IsNullOrWhiteSpace(token)
+            ? null
+            : new(auth.Scheme, token);
     }
 
     /// <summary>

--- a/src/Shared/AuthenticatedHttpClientHandler.cs
+++ b/src/Shared/AuthenticatedHttpClientHandler.cs
@@ -63,7 +63,12 @@ internal sealed class AuthenticatedHttpClientHandler : DelegatingHandler
         if (auth is not null)
         {
             var token = await _getToken(request, cancellationToken).ConfigureAwait(false);
-            request.Headers.Authorization = new(auth.Scheme, token);
+
+            // An empty token means "no credentials for this request": drop the header rather than
+            // sending a blank `Authorization: <scheme>` value (#1688).
+            request.Headers.Authorization = string.IsNullOrWhiteSpace(token)
+                ? null
+                : new(auth.Scheme, token);
         }
 
         return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);

--- a/src/tests/Refit.Tests/AuthenticatedClientHandlerTests.cs
+++ b/src/tests/Refit.Tests/AuthenticatedClientHandlerTests.cs
@@ -257,6 +257,27 @@ public class AuthenticatedClientHandlerTests
         await Assert.That(result).IsEqualTo("Ok");
     }
 
+    /// <summary>Verifies the handler strips an already-present authorization header when the token getter yields an empty token (#1688).</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task AuthenticatedHandlerRemovesPresentAuthorizationHeaderWhenTokenIsEmpty()
+    {
+        var terminalHandler = new TestHttpMessageHandler();
+        var handler = new AuthenticatedHttpClientHandler(
+            terminalHandler,
+            static (_, _) => new ValueTask<string>(string.Empty));
+        var httpClient = new HttpClient(handler);
+        using var request = new HttpRequestMessage(HttpMethod.Get, AuthUrl)
+        {
+            Headers = { Authorization = new("Bearer", TokenValue) }
+        };
+
+        using var response = await httpClient.SendAsync(request);
+
+        await Assert.That(response.IsSuccessStatusCode).IsTrue();
+        await Assert.That(terminalHandler.RequestMessage!.Headers.Authorization).IsNull();
+    }
+
     /// <summary>Verifies authentication works when the token is supplied as a method parameter.</summary>
     /// <returns>A task that represents the asynchronous test operation.</returns>
     [Test]

--- a/src/tests/Refit.Tests/AuthenticatedClientHandlerTests.cs
+++ b/src/tests/Refit.Tests/AuthenticatedClientHandlerTests.cs
@@ -209,6 +209,54 @@ public class AuthenticatedClientHandlerTests
         await Assert.That(result).IsEqualTo("Ok");
     }
 
+    /// <summary>Verifies an empty token from the getter drops the authorization header (#1688).</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task AuthenticatedHandlerWithEmptyTokenSkipsAuth()
+    {
+        var handler = new StubHttp
+        {
+            {
+                new RouteMatcher { Method = HttpMethod.Get, Template = AuthUrl, Where = static msg => msg.Headers.Authorization is null },
+                Reply.Text("Ok", PlainTextContentType)
+            },
+        };
+        var fixture = handler.CreateClient<IMyAuthenticatedService>(BaseUrl, new RefitSettings
+        {
+            AuthorizationHeaderValueGetter = static (_, _) => new ValueTask<string>(string.Empty)
+        });
+
+        var result = await fixture.GetAuthenticated();
+
+        await handler.VerifyAllCalledAsync();
+
+        await Assert.That(result).IsEqualTo("Ok");
+    }
+
+    /// <summary>Verifies a whitespace token from the getter drops the authorization header (#1688).</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task AuthenticatedHandlerWithWhitespaceTokenSkipsAuth()
+    {
+        var handler = new StubHttp
+        {
+            {
+                new RouteMatcher { Method = HttpMethod.Get, Template = AuthUrl, Where = static msg => msg.Headers.Authorization is null },
+                Reply.Text("Ok", PlainTextContentType)
+            },
+        };
+        var fixture = handler.CreateClient<IMyAuthenticatedService>(BaseUrl, new RefitSettings
+        {
+            AuthorizationHeaderValueGetter = static (_, _) => new ValueTask<string>("   ")
+        });
+
+        var result = await fixture.GetAuthenticated();
+
+        await handler.VerifyAllCalledAsync();
+
+        await Assert.That(result).IsEqualTo("Ok");
+    }
+
     /// <summary>Verifies authentication works when the token is supplied as a method parameter.</summary>
     /// <returns>A task that represents the asynchronous test operation.</returns>
     [Test]
@@ -482,6 +530,60 @@ public class AuthenticatedClientHandlerTests
                 await Task.Yield();
                 return TokenValue;
             }
+        };
+
+        var fixture = RestService.For<IMyAuthenticatedService>(httpClient, settings);
+
+        var result = await fixture.GetAuthenticated();
+
+        await handler.VerifyAllCalledAsync();
+        await Assert.That(result).IsEqualTo("Ok");
+    }
+
+    /// <summary>Verifies an empty token from the getter drops the authorization header when supplying an explicit HTTP client (#1688).</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task AuthorizationHeaderValueGetterWithEmptyTokenSkipsAuthWhenSupplyingHttpClient()
+    {
+        var handler = new StubHttp
+        {
+            {
+                new RouteMatcher { Method = HttpMethod.Get, Template = AuthUrl, Where = static msg => msg.Headers.Authorization is null },
+                Reply.Text("Ok", PlainTextContentType)
+            },
+        };
+        var httpClient = new HttpClient(handler) { BaseAddress = new(BaseUrl) };
+
+        var settings = new RefitSettings
+        {
+            AuthorizationHeaderValueGetter = static (_, _) => new ValueTask<string>(string.Empty)
+        };
+
+        var fixture = RestService.For<IMyAuthenticatedService>(httpClient, settings);
+
+        var result = await fixture.GetAuthenticated();
+
+        await handler.VerifyAllCalledAsync();
+        await Assert.That(result).IsEqualTo("Ok");
+    }
+
+    /// <summary>Verifies a whitespace token from the getter drops the authorization header when supplying an explicit HTTP client (#1688).</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task AuthorizationHeaderValueGetterWithWhitespaceTokenSkipsAuthWhenSupplyingHttpClient()
+    {
+        var handler = new StubHttp
+        {
+            {
+                new RouteMatcher { Method = HttpMethod.Get, Template = AuthUrl, Where = static msg => msg.Headers.Authorization is null },
+                Reply.Text("Ok", PlainTextContentType)
+            },
+        };
+        var httpClient = new HttpClient(handler) { BaseAddress = new(BaseUrl) };
+
+        var settings = new RefitSettings
+        {
+            AuthorizationHeaderValueGetter = static (_, _) => new ValueTask<string>("   ")
         };
 
         var fixture = RestService.For<IMyAuthenticatedService>(httpClient, settings);

--- a/src/tests/Refit.Tests/HttpClientFactoryScopedAuthorizationTests.cs
+++ b/src/tests/Refit.Tests/HttpClientFactoryScopedAuthorizationTests.cs
@@ -81,6 +81,60 @@ public partial class HttpClientFactoryExtensionsTests
         await Assert.That(disposalTracker.DisposedCount).IsEqualTo(ConcurrentRequestCount);
     }
 
+    /// <summary>Verifies the scoped provider keeps the request's own authorization scheme rather than falling back to the default (#1679).</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task AddAuthorizationHeaderValueProviderPreservesRequestAuthorizationScheme()
+    {
+        const string customScheme = "Custom";
+        var capturingHandler = new CapturingAuthorizationHandler();
+        var services = new ServiceCollection();
+
+        var builder = services.AddRefitClient<IFooWithOtherAttribute>(
+            new RefitSettings { HttpMessageHandlerFactory = () => capturingHandler });
+        _ = builder.AddAuthorizationHeaderValueProvider(
+            static (_, _, _) => new ValueTask<string>(FirstRequestToken));
+
+        var serviceProvider = services.BuildServiceProvider();
+        var factory = serviceProvider.GetRequiredService<IHttpClientFactory>();
+        var client = factory.CreateClient(builder.Name);
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, new Uri(ScopedRequestUri))
+        {
+            Headers = { Authorization = new(customScheme) }
+        };
+        using var response = await client.SendAsync(request);
+
+        await Assert.That(capturingHandler.Scheme).IsEqualTo(customScheme);
+        await Assert.That(capturingHandler.Parameter).IsEqualTo(FirstRequestToken);
+    }
+
+    /// <summary>Verifies an empty resolved token drops the authorization header rather than sending a blank scheme (#1688).</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task AddAuthorizationHeaderValueProviderWithEmptyTokenRemovesAuthorizationHeader()
+    {
+        var capturingHandler = new CapturingAuthorizationHandler();
+        var services = new ServiceCollection();
+
+        var builder = services.AddRefitClient<IFooWithOtherAttribute>(
+            new RefitSettings { HttpMessageHandlerFactory = () => capturingHandler });
+        _ = builder.AddAuthorizationHeaderValueProvider(
+            static (_, _, _) => new ValueTask<string>(string.Empty));
+
+        var serviceProvider = services.BuildServiceProvider();
+        var factory = serviceProvider.GetRequiredService<IHttpClientFactory>();
+        var client = factory.CreateClient(builder.Name);
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, new Uri(ScopedRequestUri))
+        {
+            Headers = { Authorization = new("Bearer", "preset-token") }
+        };
+        using var response = await client.SendAsync(request);
+
+        await Assert.That(capturingHandler.HadAuthorizationHeader).IsFalse();
+    }
+
     /// <summary>Carries a per-request token through ambient <see cref="AsyncLocal{T}"/> state, standing in for a host-registered accessor.</summary>
     private sealed class AmbientToken
     {
@@ -133,6 +187,31 @@ public partial class HttpClientFactoryExtensionsTests
             var parameter = request.Headers.Authorization?.Parameter ?? string.Empty;
             await onRequest().ConfigureAwait(false);
             return new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(parameter) };
+        }
+    }
+
+    /// <summary>Terminal handler that records the authorization header exactly as the scoped handler left it.</summary>
+    private sealed class CapturingAuthorizationHandler : HttpMessageHandler
+    {
+        /// <summary>Gets a value indicating whether the request still carried an authorization header.</summary>
+        public bool HadAuthorizationHeader { get; private set; }
+
+        /// <summary>Gets the scheme of the received authorization header, or null when none was sent.</summary>
+        public string? Scheme { get; private set; }
+
+        /// <summary>Gets the parameter of the received authorization header, or null when none was sent.</summary>
+        public string? Parameter { get; private set; }
+
+        /// <inheritdoc/>
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            var authorization = request.Headers.Authorization;
+            HadAuthorizationHeader = authorization is not null;
+            Scheme = authorization?.Scheme;
+            Parameter = authorization?.Parameter;
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
         }
     }
 }

--- a/src/tests/Refit.Tests/HttpClientFactoryScopedAuthorizationTests.cs
+++ b/src/tests/Refit.Tests/HttpClientFactoryScopedAuthorizationTests.cs
@@ -1,0 +1,138 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Refit.Tests;
+
+/// <summary>Tests for the scope-aware authorization header value provider registered via <c>AddAuthorizationHeaderValueProvider</c> (#1679).</summary>
+public partial class HttpClientFactoryExtensionsTests
+{
+    /// <summary>The number of concurrent requests driven through the scoped provider.</summary>
+    private const int ConcurrentRequestCount = 2;
+
+    /// <summary>The ambient token carried by the first concurrent request.</summary>
+    private const string FirstRequestToken = "token-a";
+
+    /// <summary>The ambient token carried by the second concurrent request.</summary>
+    private const string SecondRequestToken = "token-b";
+
+    /// <summary>The request URI targeted by the scoped-authorization requests.</summary>
+    private const string ScopedRequestUri = "https://scoped.example";
+
+    /// <summary>The upper bound on how long a request waits for its concurrent peer to arrive.</summary>
+    private static readonly TimeSpan GateTimeout = TimeSpan.FromSeconds(30);
+
+    /// <summary>Verifies the scoped authorization provider resolves a fresh per-request token and disposes each request scope (#1679).</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task AddAuthorizationHeaderValueProviderResolvesPerRequestTokenAndDisposesScopes()
+    {
+        var arrivals = 0;
+        var bothArrived = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var echoHandler = new EchoAuthorizationHandler(async () =>
+        {
+            if (Interlocked.Increment(ref arrivals) == ConcurrentRequestCount)
+            {
+                bothArrived.SetResult();
+            }
+
+            await bothArrived.Task.WaitAsync(GateTimeout);
+        });
+
+        var disposalTracker = new ScopeDisposalTracker();
+        var services = new ServiceCollection();
+        _ = services.AddSingleton<AmbientToken>();
+        _ = services.AddSingleton(disposalTracker);
+        _ = services.AddScoped<ScopedTokenProvider>();
+
+        var builder = services.AddRefitClient<IFooWithOtherAttribute>(
+            new RefitSettings { HttpMessageHandlerFactory = () => echoHandler });
+        _ = builder.AddAuthorizationHeaderValueProvider(
+            static (serviceProvider, _, _) =>
+                new ValueTask<string>(serviceProvider.GetRequiredService<ScopedTokenProvider>().Token));
+
+        var serviceProvider = services.BuildServiceProvider();
+        var ambient = serviceProvider.GetRequiredService<AmbientToken>();
+        var factory = serviceProvider.GetRequiredService<IHttpClientFactory>();
+
+        // Each call sets an ambient token in its own async flow, mirroring how IHttpContextAccessor carries
+        // per-request state; the handler's fresh scope must observe its own request's token, never the other's.
+        async Task<string> CallWithTokenAsync(string token)
+        {
+            ambient.Write(token);
+            var client = factory.CreateClient(builder.Name);
+            using var response = await client.GetAsync(new Uri(ScopedRequestUri));
+            return await response.Content.ReadAsStringAsync();
+        }
+
+        var results = await Task.WhenAll(
+            CallWithTokenAsync(FirstRequestToken),
+            CallWithTokenAsync(SecondRequestToken));
+
+        await Assert.That(results[0]).IsEqualTo(FirstRequestToken);
+        await Assert.That(results[1]).IsEqualTo(SecondRequestToken);
+        await Assert.That(disposalTracker.DisposedCount).IsEqualTo(ConcurrentRequestCount);
+    }
+
+    /// <summary>Carries a per-request token through ambient <see cref="AsyncLocal{T}"/> state, standing in for a host-registered accessor.</summary>
+    private sealed class AmbientToken
+    {
+        /// <summary>The ambient token value flowing with the current asynchronous request.</summary>
+        private readonly AsyncLocal<string?> _current = new();
+
+        /// <summary>Reads the ambient token value for the current asynchronous flow.</summary>
+        /// <returns>The ambient token, or null when none is set.</returns>
+        public string? Read() => _current.Value;
+
+        /// <summary>Sets the ambient token value for the current asynchronous flow.</summary>
+        /// <param name="value">The token to flow with the current request.</param>
+        public void Write(string? value) => _current.Value = value;
+    }
+
+    /// <summary>Counts how many per-request scopes the handler has disposed.</summary>
+    private sealed class ScopeDisposalTracker
+    {
+        /// <summary>The number of scopes disposed so far.</summary>
+        private int _disposedCount;
+
+        /// <summary>Gets the number of scopes disposed so far.</summary>
+        public int DisposedCount => Volatile.Read(ref _disposedCount);
+
+        /// <summary>Records that a scope has been disposed.</summary>
+        public void MarkDisposed() => Interlocked.Increment(ref _disposedCount);
+    }
+
+    /// <summary>A scoped service that reads the ambient token and reports its own disposal to verify per-request scope lifetime.</summary>
+    /// <param name="ambient">The ambient token source read for each request.</param>
+    /// <param name="tracker">The tracker notified when this scoped instance is disposed.</param>
+    private sealed class ScopedTokenProvider(AmbientToken ambient, ScopeDisposalTracker tracker) : IDisposable
+    {
+        /// <summary>Gets the token for the current request.</summary>
+        public string Token => ambient.Read() ?? string.Empty;
+
+        /// <inheritdoc/>
+        public void Dispose() => tracker.MarkDisposed();
+    }
+
+    /// <summary>Terminal handler that echoes the received authorization parameter after both concurrent requests arrive.</summary>
+    /// <param name="onRequest">A gate awaited after the authorization parameter is captured, used to force concurrent overlap.</param>
+    private sealed class EchoAuthorizationHandler(Func<Task> onRequest) : HttpMessageHandler
+    {
+        /// <inheritdoc/>
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            var parameter = request.Headers.Authorization?.Parameter ?? string.Empty;
+            await onRequest().ConfigureAwait(false);
+            return new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(parameter) };
+        }
+    }
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature plus a small behavior change to authorization handling.

## What is the new behavior?

- When `AuthorizationHeaderValueGetter` returns `null`, an empty string, or whitespace, Refit now omits the `Authorization` header for that request instead of sending a blank `Authorization: <scheme>` value. A single client can mix authenticated and anonymous calls by returning a token or an empty string. This applies to both request paths (reflection and source-generated).
- New `IHttpClientBuilder` extension in `Refit.HttpClientFactory`: `AddAuthorizationHeaderValueProvider((serviceProvider, request, cancellationToken) -> ValueTask<string>)`. It resolves the `Authorization` token from dependency injection per request and reuses the same empty -> omit behavior.
- Because `IHttpClientFactory` pools message handlers, the extension creates a fresh DI scope for each request, resolves the delegate from that scope's `IServiceProvider`, and disposes the scope when the request completes. No `Microsoft.AspNetCore.*` reference or `IHttpContextAccessor` compile dependency is added; ambient `AsyncLocal`-based state (such as a host-registered `IHttpContextAccessor`) still flows into the fresh scope.

## What is the current behavior?

- An empty/whitespace token produced a blank `Authorization: <scheme>` header (and could throw for some scheme/value combinations).
- There was no built-in way to resolve a scoped, per-request authorization token from DI without either taking an ASP.NET dependency or writing a custom handler that risks scoped-state bleed across pooled handlers.

Closes #1688
Closes #1679

## What might this PR break?

- Behavior change: callers that relied on an empty token producing a blank `Authorization` header will now see the header omitted. Return a non-empty value to keep sending the header. Documented in `docs/breaking-changes.md`.
- No breaking public API change for #1688. #1679 only adds new public API (promoted to Shipped for every target framework).

## Checklist
- [ ] I have read the Contribute guide
- [x] Tests have been added or updated (for bug fixes / features)
- [x] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the `main` branch
- [x] PR title follows Conventional Commits

## Additional information

- Both request paths were changed identically for the empty-token behavior: `src/Shared/AuthenticatedHttpClientHandler.cs` and `src/Refit/RequestExecutionHelpers.cs`.
- The scope-aware handler lives in `src/Refit.HttpClientFactory/ScopedAuthorizationHeaderHandler.cs` and is registered via `ConfigureAdditionalHttpMessageHandlers`.
- Tests: empty/whitespace token on both client paths; per-request scope isolation and disposal.
- Verified: all affected projects build clean across every target framework (analyzers are a hard gate here), and the full `Refit.Tests` suite passes on net8.0 (1019 tests).
