### PR TITLE
feat: inline constrained-generic path-bound objects in the source generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,20 @@ class UserGroupRequest{
 
 ```
 
+When the bound object is a generic method's type parameter, the placeholders are
+resolved against a class constraint at compile time, so a constrained generic
+method is generated inline (no reflection fallback, no `RF006`):
+
+```csharp
+// Generated inline: {request.groupId}/{request.userId} bind against UserGroupRequest.
+[Get("/group/{request.groupId}/users/{request.userId}")]
+Task<List<User>> GroupList<T>(T request) where T : UserGroupRequest;
+```
+
+An *unconstrained* generic parameter (`GroupList<T>(T request)`) still falls back
+to the reflection request builder, because the concrete type - and its bound
+properties - are only known at call time.
+
 Parameters that are not specified as a URL substitution will automatically be
 used as query parameters. This is different than Retrofit, where all
 parameters must be explicitly specified.

--- a/src/InterfaceStubGenerator.Shared/Parser.Request.Path.cs
+++ b/src/InterfaceStubGenerator.Shared/Parser.Request.Path.cs
@@ -68,9 +68,14 @@ internal static partial class Parser
         var data = ParseParameterQueryData(parameter);
         var parameterPrefixSegment = string.IsNullOrWhiteSpace(data.Prefix) ? null : data.Prefix + data.Delimiter;
 
+        // A constrained generic parameter flattens its residual properties against the constraint's class type - the
+        // same declared shape the reflection builder walks once the generic method is closed over its argument. An
+        // unconstrained or interface-only parameter has no class type to flatten, so it keeps using reflection.
+        var flattenType = ResolveConstraintClassType(parameter.Type);
+
         // A path-bound property is always a simple scalar, so it flattens here without issue; a null result therefore
         // means a residual property has an unsupported shape, which falls the whole parameter back to reflection.
-        var properties = TryBuildQueryObjectProperties(parameter.Type, parameterPrefixSegment, formattableSymbol, context);
+        var properties = TryBuildQueryObjectProperties(flattenType, parameterPrefixSegment, formattableSymbol, context);
         if (properties is null)
         {
             return false;
@@ -97,7 +102,7 @@ internal static partial class Parser
             HasParameterAttribute(parameter, EncodedAttributeDisplayName),
             data.CollectionFormatValue,
             ElementCanBeNull: false,
-            BuildValueFormat(parameter.Type, null, formattableSymbol, context),
+            BuildValueFormat(flattenType, null, formattableSymbol, context),
             residual.ToImmutableEquatableArray(),
             NestingDelimiter: string.IsNullOrEmpty(data.Delimiter) ? "." : data.Delimiter);
         return true;
@@ -202,6 +207,22 @@ internal static partial class Parser
     /// <returns>The matching property, or null when none is readable.</returns>
     private static IPropertySymbol? FindReadablePathProperty(ITypeSymbol type, string propertyName)
     {
+        // A generic type parameter has no members of its own; the reflection builder binds against the closed generic
+        // method's concrete argument. A class or interface constraint exposes those members at compile time, so resolve
+        // the placeholder against each constraint type exactly as a declared type is resolved.
+        if (type is ITypeParameterSymbol typeParameter)
+        {
+            foreach (var constraintType in typeParameter.ConstraintTypes)
+            {
+                if (FindReadablePathProperty(constraintType, propertyName) is { } constraintProperty)
+                {
+                    return constraintProperty;
+                }
+            }
+
+            return null;
+        }
+
         for (var current = type; current is not null && current.SpecialType != SpecialType.System_Object; current = current.BaseType)
         {
             foreach (var member in current.GetMembers())
@@ -216,6 +237,34 @@ internal static partial class Parser
         }
 
         return null;
+    }
+
+    /// <summary>Resolves a generic type parameter to the class constraint used to flatten its residual query properties.</summary>
+    /// <param name="type">The declared parameter type.</param>
+    /// <returns>The constraint's class type when <paramref name="type"/> is a type parameter so constrained; otherwise the type unchanged.</returns>
+    /// <remarks>
+    /// Only a class constraint exposes a statically-known, flattenable property set. A type parameter can carry at most
+    /// one class constraint, so the resolution is unambiguous; an interface-only or unconstrained parameter resolves to
+    /// itself, which the query flattener rejects, keeping it on the reflection request builder.
+    /// </remarks>
+    private static ITypeSymbol ResolveConstraintClassType(ITypeSymbol type)
+    {
+        if (type is not ITypeParameterSymbol typeParameter)
+        {
+            return type;
+        }
+
+        foreach (var constraintType in typeParameter.ConstraintTypes)
+        {
+            // A constraint may itself be a type parameter (where T : U), so resolve through it to the underlying class.
+            var resolved = ResolveConstraintClassType(constraintType);
+            if (resolved.TypeKind == TypeKind.Class && resolved.SpecialType != SpecialType.System_Object)
+            {
+                return resolved;
+            }
+        }
+
+        return type;
     }
 
     /// <summary>Builds the path parameter model for an object whose dotted placeholders bind its properties.</summary>

--- a/src/tests/Refit.GeneratorTests/GeneratedRequestBuildingFallbackContractTests.cs
+++ b/src/tests/Refit.GeneratorTests/GeneratedRequestBuildingFallbackContractTests.cs
@@ -50,18 +50,73 @@ public sealed class GeneratedRequestBuildingFallbackContractTests
     public Task FallbackMethodsAreFlagged(string body, string methodName) =>
         AssertGeneratorAndAnalyzerAgree(body, methodName, expectedFallback: true);
 
+    /// <summary>Verifies a constrained generic path-bound method is generated inline and is not flagged by RF006, while an
+    /// otherwise-identical unconstrained method still falls back to reflection and is flagged (issue #2218).</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task ConstrainedGenericPathBoundMethodIsNotFlaggedWhileUnconstrainedIs()
+    {
+        const string constrainedSource =
+            """
+            using System.Threading.Tasks;
+            using Refit;
+
+            namespace RefitGeneratorTest;
+
+            public class PathBoundObject
+            {
+                public int SomeProperty { get; init; }
+
+                public string? SomeProperty2 { get; init; }
+            }
+
+            public interface IGeneratedClient
+            {
+                [Get("/foos/{request.someProperty}/bar/{request.someProperty2}")]
+                Task Sample<T>(T request)
+                    where T : PathBoundObject;
+            }
+            """;
+
+        const string unconstrainedSource =
+            """
+            using System.Threading.Tasks;
+            using Refit;
+
+            namespace RefitGeneratorTest;
+
+            public interface IGeneratedClient
+            {
+                [Get("/foos/{request.someProperty}/bar/{request.someProperty2}")]
+                Task Sample<T>(T request);
+            }
+            """;
+
+        await AssertGeneratorAndAnalyzerAgree(Fixture.RunGenerator(constrainedSource, null), "Sample", expectedFallback: false);
+        await AssertGeneratorAndAnalyzerAgree(Fixture.RunGenerator(unconstrainedSource, null), "Sample", expectedFallback: true);
+    }
+
     /// <summary>Asserts the generator and analyzer produce the same reflection-fallback verdict for a method.</summary>
     /// <param name="body">The interface member body source.</param>
     /// <param name="methodName">The method whose fallback state is checked.</param>
     /// <param name="expectedFallback">The expected fallback verdict.</param>
     /// <returns>A task representing the asynchronous test.</returns>
-    private static async Task AssertGeneratorAndAnalyzerAgree(
+    private static Task AssertGeneratorAndAnalyzerAgree(
         string body,
+        string methodName,
+        bool expectedFallback) =>
+        AssertGeneratorAndAnalyzerAgree(Fixture.RunGeneratorForBody(body, null), methodName, expectedFallback);
+
+    /// <summary>Asserts the generator and analyzer agree on the reflection-fallback verdict for a generated result.</summary>
+    /// <param name="result">The generator result to inspect.</param>
+    /// <param name="methodName">The method whose fallback state is checked.</param>
+    /// <param name="expectedFallback">The expected fallback verdict.</param>
+    /// <returns>A task representing the asynchronous test.</returns>
+    private static async Task AssertGeneratorAndAnalyzerAgree(
+        GeneratorTestResult result,
         string methodName,
         bool expectedFallback)
     {
-        var result = Fixture.RunGeneratorForBody(body, null);
-
         var generatedText = string.Concat(result.GeneratedSources.Values);
         var generatorFallsBack = generatedText.Contains(
             $"BuildRestResultFuncForMethod(\"{methodName}\"",

--- a/src/tests/Refit.GeneratorTests/PathObjectBindingGenerationTests.cs
+++ b/src/tests/Refit.GeneratorTests/PathObjectBindingGenerationTests.cs
@@ -281,6 +281,138 @@ public sealed class PathObjectBindingGenerationTests
         await Assert.That(generated).Contains("pfx-");
     }
 
+    /// <summary>Verifies a dotted placeholder on a constrained generic parameter binds against the constraint type and
+    /// is generated inline, without falling back to the reflection request builder (issue #2218).</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task ConstrainedGenericDottedPathBindsInline()
+    {
+        const string source =
+            """
+            using System.Threading.Tasks;
+            using Refit;
+
+            namespace RefitGeneratorTest;
+
+            public class PathBoundObject
+            {
+                public int SomeProperty { get; init; }
+
+                public string? SomeProperty2 { get; init; }
+            }
+
+            public interface IGeneratedClient
+            {
+                [Get("/foos/{request.someProperty}/bar/{request.someProperty2}")]
+                Task Sample<T>(T request)
+                    where T : PathBoundObject;
+            }
+            """;
+
+        var result = Fixture.RunGenerator(source, generatedRequestBuilding: true);
+        var generated = result.GeneratedSources[GeneratedClientHintName];
+
+        await Assert.That(result.CompilesWithoutErrors).IsTrue();
+        await Assert.That(generated).DoesNotContain(ReflectiveRequestBuilderCall);
+        await Assert.That(generated).Contains("@request.SomeProperty");
+        await Assert.That(generated).Contains("@request.SomeProperty2");
+    }
+
+    /// <summary>Verifies a constrained generic parameter whose constraint carries an unbound property flattens it into
+    /// the query inline, matching the reflection builder's split of a path-bound object.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task ConstrainedGenericDottedPathFlattensResidualQueryInline()
+    {
+        const string source =
+            """
+            using System.Threading.Tasks;
+            using Refit;
+
+            namespace RefitGeneratorTest;
+
+            public class PathBoundObject
+            {
+                public int SomeProperty { get; init; }
+
+                public string? Note { get; init; }
+            }
+
+            public interface IGeneratedClient
+            {
+                [Get("/foos/{request.someProperty}")]
+                Task Sample<T>(T request)
+                    where T : PathBoundObject;
+            }
+            """;
+
+        var result = Fixture.RunGenerator(source, generatedRequestBuilding: true);
+        var generated = result.GeneratedSources[GeneratedClientHintName];
+
+        await Assert.That(result.CompilesWithoutErrors).IsTrue();
+        await Assert.That(generated).DoesNotContain(ReflectiveRequestBuilderCall);
+        await Assert.That(generated).Contains("@request.SomeProperty");
+        await Assert.That(generated).Contains("@request.Note");
+    }
+
+    /// <summary>Verifies an unconstrained generic parameter keeps falling back to the reflection request builder, because
+    /// the concrete argument type - and its bound properties - are unknown at compile time (issue #2218).</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task UnconstrainedGenericDottedPathFallsBack()
+    {
+        const string source =
+            """
+            using System.Threading.Tasks;
+            using Refit;
+
+            namespace RefitGeneratorTest;
+
+            public interface IGeneratedClient
+            {
+                [Get("/foos/{request.someProperty}/bar/{request.someProperty2}")]
+                Task Sample<T>(T request);
+            }
+            """;
+
+        var result = Fixture.RunGenerator(source, generatedRequestBuilding: true);
+        var generated = result.GeneratedSources[GeneratedClientHintName];
+
+        await Assert.That(generated).Contains(ReflectiveRequestBuilderCall);
+    }
+
+    /// <summary>Verifies a generic parameter constrained only to an interface keeps falling back, because an interface has
+    /// no class shape to flatten the path-bound object's residual properties against.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task InterfaceConstrainedGenericDottedPathFallsBack()
+    {
+        const string source =
+            """
+            using System.Threading.Tasks;
+            using Refit;
+
+            namespace RefitGeneratorTest;
+
+            public interface IPathBound
+            {
+                int SomeProperty { get; }
+            }
+
+            public interface IGeneratedClient
+            {
+                [Get("/foos/{request.someProperty}")]
+                Task Sample<T>(T request)
+                    where T : IPathBound;
+            }
+            """;
+
+        var result = Fixture.RunGenerator(source, generatedRequestBuilding: true);
+        var generated = result.GeneratedSources[GeneratedClientHintName];
+
+        await Assert.That(generated).Contains(ReflectiveRequestBuilderCall);
+    }
+
     /// <summary>Verifies a dotted placeholder on an interface-typed parameter whose property chain cannot resolve walks
     /// the type's (empty) base chain to its end and falls the parameter back.</summary>
     /// <returns>A task representing the asynchronous test.</returns>

--- a/src/tests/Refit.Tests/IApiBindPathToObject.cs
+++ b/src/tests/Refit.Tests/IApiBindPathToObject.cs
@@ -37,6 +37,14 @@ public interface IApiBindPathToObject
     [Get("/foos/{request.someProperty}/bar/{request.someProperty2}")]
     Task GetFooBarsGeneric<T>(T request);
 
+    /// <summary>Gets foo bars binding a constrained generic request object's properties, resolved against the constraint type.</summary>
+    /// <typeparam name="T">The request type, constrained to a type that exposes the bound properties at compile time.</typeparam>
+    /// <param name="request">The request whose properties bind to the path.</param>
+    /// <returns>A task that completes when the request finishes.</returns>
+    [Get("/foos/{request.someProperty}/bar/{request.someProperty2}")]
+    Task GetFooBarsGenericConstrained<T>(T request)
+        where T : PathBoundObject;
+
     /// <summary>Gets foo bars where the path tokens use different casing from the property names.</summary>
     /// <param name="requestParams">The request whose properties bind to the path.</param>
     /// <returns>A task that completes when the request finishes.</returns>

--- a/src/tests/Refit.Tests/RestServiceIntegrationTests.RequestUrlConstruction.cs
+++ b/src/tests/Refit.Tests/RestServiceIntegrationTests.RequestUrlConstruction.cs
@@ -50,6 +50,27 @@ public partial class RestServiceIntegrationTests
         await handler.VerifyAllCalledAsync();
     }
 
+    /// <summary>Verifies a constrained generic path-bound parameter binds dotted <c>{obj.Prop}</c> placeholders against
+    /// the constraint type, producing the same URL as the reflection path while being generated inline (issue #2218).</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task GetWithGenericConstrainedPathBoundObject()
+    {
+        var handler = new StubHttp
+        {
+            {
+                new RouteMatcher { Method = HttpMethod.Get, Template = FoosBarBarNoneUrl, ExactQuery = string.Empty },
+                Reply.Json("Ok")
+            },
+        };
+
+        var fixture = handler.CreateClient<IApiBindPathToObject>(BaseUrl);
+
+        await fixture.GetFooBarsGenericConstrained(
+            new PathBoundObject { SomeProperty = 1, SomeProperty2 = BarNoneValue });
+        await handler.VerifyAllCalledAsync();
+    }
+
     /// <summary>Verifies a long path-bound value is mapped into the path.</summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Test]


### PR DESCRIPTION
## What kind of change does this PR introduce?

Source-generator enhancement (feature).

## What is the new behavior?

- Binding a `{request.Property}` route placeholder against a *constrained* generic method parameter (`GetFooBars<T>(T request) where T : PathBoundObject`) is now generated inline. The generator resolves the placeholder - and any nested `{a.b.c}` chain or `[AliasAs]` - against the type parameter's class constraint at compile time, so there is no reflection fallback and no `RF006` for that method.
- A constrained generic's residual (unbound) properties flatten into the query against the constraint's class type, matching how the reflection builder splits a path-bound object between the path and the query.
- The generated method stays generic; the property access binds through the constraint, so it produces the same URL as the reflection path (`/foos/1/bar/barNone`).

## What is the current behavior?

Under source generation a `{request.Property}` placeholder on any generic parameter is not inline-eligible (the concrete type of `T` is unknown at compile time), so the generated stub falls back to the reflection request builder and the generator reports `RF006`.

Closes #2218

## What might this PR break?

- Nothing is expected to break. Unconstrained generic parameters, and parameters constrained only to an interface, keep the existing reflection-fallback behavior (still `RF006`). The change is scoped to the dotted path-object binding path; no public API changes.
- As with all inline path/query object flattening, the constraint type is treated as the declared shape: a runtime subtype's extra properties are not contributed to the query (the same accepted declared-type divergence Refit already applies to non-generic query objects).

## Checklist
- [ ] I have read the Contribute guide
- [x] Tests have been added or updated (for bug fixes / features)
- [x] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the `main` branch
- [x] PR title follows Conventional Commits

## Additional information

- Tests added/updated: generator + analyzer agreement, residual-query flattening, unconstrained/interface-only fallback, and a URL-parity execution test.
- Generator, Refit, Refit.Reflection, and the generator + Refit test projects build clean (analyzers satisfied); full generator test suite and full Refit.Tests suite pass on net8.0. README updated (custom-object path binding section).
- Reflection reference: `RestMethodInfoInternal.CloseGenericMethodIfNeeded` already closes the generic method over its argument, so the reflection path handled this shape; this PR brings the source generator up to parity for the constrained case.
- Key change: `Parser.Request.Path.cs` - `FindReadablePathProperty` now searches `ITypeParameterSymbol.ConstraintTypes`, and residual-query flattening resolves the type parameter to its class constraint.
