### PR TITLE
fix: flatten nested objects in url-encoded request bodies

### DIFF
--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -88,6 +88,31 @@ visible in three places.
   `[JsonProperty]` when `Refit.Newtonsoft.Json` is installed. To keep the pre-V14 behavior, set
   `RefitSettings.HonorContentSerializerPropertyNamesInQuery = false`; `[AliasAs]` still takes precedence in either mode.
 
+* **URL-encoded bodies flatten nested objects, dictionaries, and collections instead of emitting the type name.** A
+  `[Body(BodySerializationMethod.UrlEncoded)]` model whose property is a nested object, an `IDictionary`, or a plain
+  collection under the default collection format previously serialized the property's `ToString()` — the type name for
+  a complex object or dictionary. Those properties now flatten exactly like a flattened `[Query]` object: a nested
+  object contributes `parent.child=...` pairs, a dictionary contributes `parent.key=value` pairs, and a collection
+  joins its elements (comma-separated under the default format). Field naming keeps the existing precedence (`[AliasAs]`,
+  then the content serializer's property name, then the key formatter), and a nested property's `[Query(delimiter,
+  prefix)]` composes its keys.
+
+  ```csharp
+  public sealed class SignupForm
+  {
+      public string Name { get; set; }
+      public Address Detail { get; set; }
+      public Dictionary<string, string> Extra { get; set; }
+  }
+
+  Submit(new SignupForm { Name = "ada", Detail = new() { City = "Wien" }, Extra = new() { ["k"] = "v" } })
+  >>> "Name=ada&Detail.City=Wien&Extra.k=v"                       // V14: flattened
+  >>> "Name=ada&Detail=RefitGeneratorTest.Address&Extra=System..." // pre-V14: ToString
+  ```
+
+  This is a behavior change to previously unusable output, so it is extremely unlikely anyone depended on it. Complex
+  elements of a collection are still `ToString()`-ed per element (the same limitation as the query path).
+
 ### New in V14.x
 
 * **Inline query-string generation.** Query parameters — auto-appended parameters, `[AliasAs]`, `[Query(Format = ...)]`,

--- a/src/InterfaceStubGenerator.Shared/Parser.Request.Body.cs
+++ b/src/InterfaceStubGenerator.Shared/Parser.Request.Body.cs
@@ -36,6 +36,15 @@ internal static partial class Parser
             {
                 if (member is IPropertySymbol property && IsReadableFormProperty(property) && seen.Add(property.Name))
                 {
+                    // A nested complex object, dictionary, or collection of non-simple elements needs the reflection
+                    // path's recursive flattening (FormValueMultimap). Keep descriptors to the flat scalar and
+                    // collection-of-simple shapes and route the whole body through reflection otherwise, matching the
+                    // existing dictionary-body precedent.
+                    if (!IsDescriptorSafeFormProperty(property, context.FormattableSymbol))
+                    {
+                        return null;
+                    }
+
                     fields.Add(BuildFormFieldModel(property, context));
                 }
             }
@@ -43,6 +52,15 @@ internal static partial class Parser
 
         return ImmutableEquatableArrayFactory.FromList(fields);
     }
+
+    /// <summary>Determines whether a form property flattens straight-line without the reflection path's recursion.</summary>
+    /// <param name="property">The property to classify.</param>
+    /// <param name="formattableSymbol">The resolved <c>System.IFormattable</c> symbol, or null when unavailable.</param>
+    /// <returns><see langword="true"/> for a simple scalar or a collection of simple elements; <see langword="false"/> for
+    /// a dictionary, a nested complex object, or a collection of non-simple elements, all of which reflect at runtime.</returns>
+    private static bool IsDescriptorSafeFormProperty(IPropertySymbol property, INamedTypeSymbol? formattableSymbol) =>
+        IsSimpleType(property.Type, formattableSymbol)
+        || (TryGetEnumerableElementType(property.Type, out var elementType) && IsSimpleType(elementType!, formattableSymbol));
 
     /// <summary>Determines whether a property contributes a readable public instance form field.</summary>
     /// <param name="property">The property to inspect.</param>

--- a/src/Refit/FormValueMultimap.cs
+++ b/src/Refit/FormValueMultimap.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for full license information.
 using System.Collections;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
@@ -14,6 +15,12 @@ namespace Refit;
 /// same or different values.</remarks>
 internal sealed class FormValueMultimap : IEnumerable<KeyValuePair<string?, string?>>
 {
+    /// <summary>The maximum object-graph depth flattened before deeper nested values are dropped, guarding against runaway recursion.</summary>
+    private const int MaxNestingDepth = 32;
+
+    /// <summary>The default delimiter composing a nested field key from its parent key, matching the query-flattening default.</summary>
+    private const string DefaultNestingDelimiter = ".";
+
     /// <summary>Caches the readable public properties for each source type without keeping collectible types alive.</summary>
     private static readonly ConditionalWeakTable<Type, PropertyInfo[]> _propertyCache = new();
 
@@ -25,6 +32,9 @@ internal sealed class FormValueMultimap : IEnumerable<KeyValuePair<string?, stri
 
     /// <summary>The formatter applied to property names that are not explicitly aliased.</summary>
     private readonly IUrlParameterKeyFormatter _urlParameterKeyFormatter;
+
+    /// <summary>The complex values currently being flattened on the recursion path, guarding against reference cycles.</summary>
+    private List<object>? _ancestors;
 
     /// <summary>Initializes a new instance of the <see cref="FormValueMultimap"/> class from a source object.</summary>
     /// <param name="source">The source object or dictionary to convert into form entries.</param>
@@ -55,11 +65,11 @@ internal sealed class FormValueMultimap : IEnumerable<KeyValuePair<string?, stri
 
         if (source is IDictionary dictionary)
         {
-            AddDictionary(dictionary, settings);
+            AddDictionary(dictionary, settings, null, DefaultNestingDelimiter, 0);
             return;
         }
 
-        AddObject(source, declaredProperties ?? GetCachedProperties(source.GetType()), settings);
+        AddObject(source, declaredProperties ?? GetCachedProperties(source.GetType()), settings, null, DefaultNestingDelimiter, 0);
     }
 
     /// <summary>Gets a key for each entry. If multiple entries share the same key, the key is returned multiple times.</summary>
@@ -117,7 +127,7 @@ internal sealed class FormValueMultimap : IEnumerable<KeyValuePair<string?, stri
                 continue;
             }
 
-            map.AppendValue(fieldName, value, field.Format, field.CollectionFormat, settings);
+            map.AppendValue(fieldName, value, field.Format, field.CollectionFormat, settings, DefaultNestingDelimiter, 0);
         }
 
         return map;
@@ -151,14 +161,32 @@ internal sealed class FormValueMultimap : IEnumerable<KeyValuePair<string?, stri
     /// <summary>Gets the delimiter string for a delimited collection format.</summary>
     /// <param name="collectionFormat">The delimited collection format.</param>
     /// <returns>The delimiter string.</returns>
+    /// <remarks>Mirrors the query-flattening delimiter map: the default <see cref="CollectionFormat.RefitParameterFormatter"/>
+    /// and <see cref="CollectionFormat.Csv"/> both join with a comma.</remarks>
     private static string GetDelimiter(CollectionFormat collectionFormat) =>
         collectionFormat switch
         {
-            CollectionFormat.Csv => ",",
             CollectionFormat.Ssv => " ",
             CollectionFormat.Tsv => "\t",
-            _ => "|"
+            CollectionFormat.Pipes => "|",
+            _ => ","
         };
+
+    /// <summary>Determines whether a value renders directly through the form formatter instead of being flattened.</summary>
+    /// <param name="value">The non-null value to inspect.</param>
+    /// <returns><see langword="true"/> for the simple string/formattable types the query-flattening path emits directly.</returns>
+    /// <remarks>Mirrors the query path's simple-type predicate: string, bool, char, <see cref="IFormattable"/> (enums,
+    /// numbers, dates, <see cref="Guid"/>, ...), <see cref="Uri"/>, and <see cref="CultureInfo"/>.</remarks>
+    private static bool IsSimpleFormValue(object value) =>
+        value is string or bool or char or IFormattable or Uri or CultureInfo;
+
+    /// <summary>Composes a form field key from an optional parent prefix and a child name.</summary>
+    /// <param name="keyPrefix">The parent key prefix, or <see langword="null"/> at the top level.</param>
+    /// <param name="name">The child field name or dictionary key.</param>
+    /// <param name="delimiter">The delimiter placed between the prefix and the name.</param>
+    /// <returns>The composed key.</returns>
+    private static string? ComposeKey(string? keyPrefix, string? name, string? delimiter) =>
+        keyPrefix is null ? name : keyPrefix + delimiter + name;
 
     /// <summary>Formats and joins a collection-valued form field without LINQ adapters.</summary>
     /// <param name="enumerable">The collection to format.</param>
@@ -200,31 +228,52 @@ internal sealed class FormValueMultimap : IEnumerable<KeyValuePair<string?, stri
         }
     }
 
-    /// <summary>Adds the entries from an <see cref="IDictionary"/> source.</summary>
+    /// <summary>Adds the entries from an <see cref="IDictionary"/> source, flattening complex entry values.</summary>
     /// <param name="dictionary">The dictionary source.</param>
     /// <param name="settings">The Refit settings controlling formatting.</param>
-    private void AddDictionary(IDictionary dictionary, RefitSettings settings)
+    /// <param name="keyPrefix">The parent key prefix, or <see langword="null"/> for a top-level dictionary.</param>
+    /// <param name="delimiter">The delimiter composing an entry key under the prefix.</param>
+    /// <param name="depth">The current nesting depth.</param>
+    private void AddDictionary(
+        IDictionary dictionary,
+        RefitSettings settings,
+        string? keyPrefix,
+        string? delimiter,
+        int depth)
     {
         foreach (var key in dictionary.Keys)
         {
             var value = dictionary[key];
-            if (value is not null)
+            if (value is null)
             {
-                Add(
-                    key.ToString(),
-                    settings.FormUrlEncodedParameterFormatter.Format(value, null));
+                continue;
             }
+
+            AppendValue(
+                ComposeKey(keyPrefix, key.ToString(), delimiter),
+                value,
+                null,
+                null,
+                settings,
+                delimiter,
+                depth);
         }
     }
 
-    /// <summary>Adds the entries reflected from an object source.</summary>
+    /// <summary>Adds the entries reflected from an object source, composing nested keys under the given prefix.</summary>
     /// <param name="source">The object source.</param>
     /// <param name="properties">The properties to read from the source.</param>
     /// <param name="settings">The Refit settings controlling formatting.</param>
+    /// <param name="keyPrefix">The parent key prefix, or <see langword="null"/> for a top-level object.</param>
+    /// <param name="delimiter">The delimiter composing each property key under the prefix.</param>
+    /// <param name="depth">The current nesting depth.</param>
     private void AddObject(
         object source,
         PropertyInfo[] properties,
-        RefitSettings settings)
+        RefitSettings settings,
+        string? keyPrefix,
+        string? delimiter,
+        int depth)
     {
         for (var i = 0; i < properties.Length; i++)
         {
@@ -234,40 +283,49 @@ internal sealed class FormValueMultimap : IEnumerable<KeyValuePair<string?, stri
             // see if there's a query attribute
             var attrib = property.GetCustomAttribute<QueryAttribute>(true);
 
+            var fieldName = ComposeKey(keyPrefix, GetFieldNameForProperty(property), delimiter);
+
             if (value is null)
             {
                 if (attrib?.SerializeNull == true)
                 {
-                    Add(GetFieldNameForProperty(property), string.Empty);
+                    Add(fieldName, string.Empty);
                 }
 
                 continue;
             }
 
-            var fieldName = GetFieldNameForProperty(property);
             var collectionFormat = attrib?.IsCollectionFormatSpecified == true
                 ? attrib.CollectionFormat
                 : (CollectionFormat?)null;
 
-            AppendValue(fieldName, value, attrib?.Format, collectionFormat, settings);
+            // A nested object/dictionary composes its children under this property's key using this property's own
+            // [Query] delimiter when present, otherwise the inherited delimiter (matching the query-flattening path).
+            var nestedDelimiter = attrib is not null ? attrib.Delimiter : (delimiter ?? DefaultNestingDelimiter);
+
+            AppendValue(fieldName, value, attrib?.Format, collectionFormat, settings, nestedDelimiter, depth);
         }
     }
 
-    /// <summary>Adds a non-null property or descriptor value, choosing scalar or collection handling.</summary>
+    /// <summary>Adds a non-null property or descriptor value, choosing scalar, collection, dictionary, or nested-object handling.</summary>
     /// <param name="fieldName">The resolved form field name.</param>
     /// <param name="value">The non-null value to add.</param>
     /// <param name="format">The value format string, if any.</param>
     /// <param name="explicitCollectionFormat">The explicit collection format, or <see langword="null"/> to use the settings default.</param>
     /// <param name="settings">The Refit settings controlling formatting.</param>
+    /// <param name="delimiter">The delimiter composing nested keys under this field.</param>
+    /// <param name="depth">The current nesting depth.</param>
     private void AppendValue(
         string? fieldName,
         object value,
         string? format,
         CollectionFormat? explicitCollectionFormat,
-        RefitSettings settings)
+        RefitSettings settings,
+        string? delimiter,
+        int depth)
     {
-        // add strings/non enumerable properties
-        if (value is not IEnumerable enumerable || value is string)
+        // Simple scalar and formattable values (including strings) render directly through the form formatter.
+        if (IsSimpleFormValue(value))
         {
             Add(
                 fieldName,
@@ -275,9 +333,66 @@ internal sealed class FormValueMultimap : IEnumerable<KeyValuePair<string?, stri
             return;
         }
 
-        var collectionFormat = explicitCollectionFormat ?? settings.CollectionFormat;
-        AddCollection(fieldName, enumerable, value, format, collectionFormat, settings);
+        // A dictionary flattens to "field<delimiter>key" entries, recursing into complex entry values.
+        if (value is IDictionary dictionary)
+        {
+            if (TryEnterComplex(value, depth))
+            {
+                AddDictionary(dictionary, settings, fieldName, delimiter, depth + 1);
+                ExitComplex();
+            }
+
+            return;
+        }
+
+        // A collection formats and joins (or repeats) its elements per the resolved collection format.
+        if (value is IEnumerable enumerable)
+        {
+            var collectionFormat = explicitCollectionFormat ?? settings.CollectionFormat;
+            AddCollection(fieldName, enumerable, value, format, collectionFormat, settings);
+            return;
+        }
+
+        // A nested complex object flattens its public properties under "field<delimiter>child".
+        if (!TryEnterComplex(value, depth))
+        {
+            return;
+        }
+
+        AddObject(value, GetCachedProperties(value.GetType()), settings, fieldName, delimiter, depth + 1);
+        ExitComplex();
     }
+
+    /// <summary>Enters a complex value on the recursion path, enforcing the depth cap and reference-cycle guard.</summary>
+    /// <param name="value">The complex value about to be flattened.</param>
+    /// <param name="depth">The current nesting depth.</param>
+    /// <returns><see langword="true"/> when flattening may proceed; <see langword="false"/> when the value is too deep
+    /// or already being flattened on this path, in which case it is dropped.</returns>
+    private bool TryEnterComplex(object value, int depth)
+    {
+        if (depth >= MaxNestingDepth)
+        {
+            return false;
+        }
+
+        _ancestors ??= [];
+        for (var i = 0; i < _ancestors.Count; i++)
+        {
+            if (ReferenceEquals(_ancestors[i], value))
+            {
+                return false;
+            }
+        }
+
+        _ancestors.Add(value);
+        return true;
+    }
+
+    /// <summary>Leaves the most recently entered complex value, restoring the recursion path for the next sibling.</summary>
+    private void ExitComplex() =>
+
+        // _ancestors is non-null here: TryEnterComplex allocated it and pushed the matching value.
+        _ancestors!.RemoveAt(_ancestors.Count - 1);
 
     /// <summary>Adds a collection-valued property using the resolved collection format.</summary>
     /// <param name="fieldName">The resolved form field name.</param>
@@ -310,7 +425,8 @@ internal sealed class FormValueMultimap : IEnumerable<KeyValuePair<string?, stri
                 break;
             }
 
-            case CollectionFormat.Csv
+            case CollectionFormat.RefitParameterFormatter
+                or CollectionFormat.Csv
                 or CollectionFormat.Ssv
                 or CollectionFormat.Tsv
                 or CollectionFormat.Pipes:
@@ -323,6 +439,7 @@ internal sealed class FormValueMultimap : IEnumerable<KeyValuePair<string?, stri
 
             default:
             {
+                // A genuinely out-of-range CollectionFormat value falls back to formatting the collection object itself.
                 Add(
                     fieldName,
                     settings.FormUrlEncodedParameterFormatter.Format(

--- a/src/tests/Refit.GeneratorTests/RequestGenerationCoverageTests.FormBody.cs
+++ b/src/tests/Refit.GeneratorTests/RequestGenerationCoverageTests.FormBody.cs
@@ -174,6 +174,50 @@ public sealed partial class RequestGenerationCoverageTests
         await Assert.That(generated).DoesNotContain("global::Refit.FormField<");
     }
 
+    /// <summary>Verifies a form body carrying a nested object, dictionary, or complex-element collection property routes
+    /// the whole body through the reflection content path (which flattens recursively) instead of emitting descriptors.</summary>
+    /// <param name="property">The complex property declaration forcing the reflection fallback.</param>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    [Arguments("public Nested Detail { get; set; }")]
+    [Arguments("public System.Collections.Generic.Dictionary<string, string> Extra { get; set; }")]
+    [Arguments("public System.Collections.Generic.List<Nested> Items { get; set; }")]
+    public async Task ComplexFormBodyPropertyUsesReflectionContent(string property)
+    {
+        var source =
+            $$"""
+            using System.Threading.Tasks;
+            using Refit;
+
+            namespace RefitGeneratorTest;
+
+            public class Nested
+            {
+                public string Email { get; set; }
+            }
+
+            public class ComplexForm
+            {
+                public string Name { get; set; }
+                {{property}}
+            }
+
+            public interface IGeneratedClient
+            {
+                [Post("/f")]
+                Task Submit([Body(BodySerializationMethod.UrlEncoded)] ComplexForm form);
+            }
+            """;
+
+        var result = Fixture.RunGenerator(source, generatedRequestBuilding: true);
+        var generated = result.GeneratedSources[GeneratedClientHintName];
+
+        await Assert.That(result.CompilesWithoutErrors).IsTrue();
+        await Assert.That(generated).Contains(
+            "global::Refit.GeneratedRequestRunner.CreateUrlEncodedBodyContent<global::RefitGeneratorTest.ComplexForm>(");
+        await Assert.That(generated).DoesNotContain("global::Refit.FormField<");
+    }
+
     /// <summary>Verifies url-encoded form bodies covering nullable collection entries and escaped field names.</summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Test]

--- a/src/tests/Refit.Tests/FormValueMultimapTests.cs
+++ b/src/tests/Refit.Tests/FormValueMultimapTests.cs
@@ -37,6 +37,18 @@ public class FormValueMultimapTests
     /// <summary>The second element in the sample double collection.</summary>
     private const double SecondSampleDouble = 1.0;
 
+    /// <summary>Sample scalar name value shared by the nested-flattening fixtures.</summary>
+    private const string SampleName = "ada";
+
+    /// <summary>Field key for the shared scalar name value.</summary>
+    private const string NameFieldKey = "Name";
+
+    /// <summary>Nested email value shared by the nested-flattening fixtures.</summary>
+    private const string NestedEmail = "a@b.com";
+
+    /// <summary>Scalar value shared by the cycle-guard fixture.</summary>
+    private const string CycleRootValue = "root";
+
     /// <summary>The default settings used to construct the multimap under test.</summary>
     private readonly RefitSettings _settings = new();
 
@@ -370,6 +382,135 @@ public class FormValueMultimapTests
         await Assert.That(actual).IsCollectionEqualTo(ToNullableKvps(expected));
     }
 
+    /// <summary>Verifies a nested complex property flattens to dotted parent.child keys.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task NestedObjectFlattensToDottedKeys()
+    {
+        const int age = 42;
+        var source = new ObjectWithNestedDetail
+        {
+            Name = SampleName,
+            Detail = new() { Email = NestedEmail, Age = age }
+        };
+        var expected = new KeyValuePair<string?, string?>[]
+        {
+            new(NameFieldKey, SampleName),
+            new("Detail.Email", NestedEmail),
+            new("Detail.Age", "42")
+        };
+
+        var actual = new FormValueMultimap(source, _settings);
+
+        await Assert.That(actual).IsCollectionEqualTo(expected);
+    }
+
+    /// <summary>Verifies a null nested complex property is omitted rather than emitting an empty or type-name value.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task NullNestedObjectIsOmitted()
+    {
+        var source = new ObjectWithNestedDetail { Name = SampleName, Detail = null };
+        var expected = new KeyValuePair<string?, string?>[] { new(NameFieldKey, SampleName) };
+
+        var actual = new FormValueMultimap(source, _settings);
+
+        await Assert.That(actual).IsCollectionEqualTo(expected);
+    }
+
+    /// <summary>Verifies a dictionary-typed property flattens to prefixed field.key entries instead of its type name.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task DictionaryPropertyFlattensToPrefixedKeys()
+    {
+        var source = new ObjectWithDictionary
+        {
+            Name = SampleName,
+            Extra = new() { { "key", "val" } }
+        };
+        var expected = new KeyValuePair<string?, string?>[]
+        {
+            new(NameFieldKey, SampleName),
+            new("Extra.key", "val")
+        };
+
+        var actual = new FormValueMultimap(source, _settings);
+
+        await Assert.That(actual).IsCollectionEqualTo(expected);
+    }
+
+    /// <summary>Verifies a dictionary of complex values recurses so each entry expands under field.key.child.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task DictionaryWithComplexValuesFlattensRecursively()
+    {
+        const int age = 42;
+        var source = new ObjectWithComplexDictionary
+        {
+            Items = new() { { "first", new() { Email = NestedEmail, Age = age } } }
+        };
+        var expected = new KeyValuePair<string?, string?>[]
+        {
+            new("Items.first.Email", NestedEmail),
+            new("Items.first.Age", "42")
+        };
+
+        var actual = new FormValueMultimap(source, _settings);
+
+        await Assert.That(actual).IsCollectionEqualTo(expected);
+    }
+
+    /// <summary>Verifies a plain collection under the default format joins its elements with commas instead of emitting its type name.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task CollectionUnderDefaultFormatJoinsWithCommas()
+    {
+        var source = new ObjectWithDefaultCollection { Numbers = [1, SecondSampleInt, ThirdSampleInt] };
+        var expected = new KeyValuePair<string?, string?>[] { new("Numbers", "1,2,3") };
+
+        var actual = new FormValueMultimap(source, _settings);
+
+        await Assert.That(actual).IsCollectionEqualTo(expected);
+    }
+
+    /// <summary>Verifies a nested property honors its <see cref="QueryAttribute"/> prefix/delimiter and nested <see cref="AliasAsAttribute"/> when composing keys.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task NestedPrefixAndAliasComposeKeys()
+    {
+        var source = new ObjectWithPrefixedNested
+        {
+            Detail = new() { Zip = "1010", City = "Wien" }
+        };
+        var expected = new KeyValuePair<string?, string?>[]
+        {
+            new("addr-Detail-z", "1010"),
+            new("addr-Detail-City", "Wien")
+        };
+
+        var actual = new FormValueMultimap(source, _settings);
+
+        await Assert.That(actual).IsCollectionEqualTo(expected);
+    }
+
+    /// <summary>Verifies a self-referential model flattens to a bounded set of entries rather than overflowing the stack.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task SelfReferentialObjectStopsAtCycleWithoutOverflow()
+    {
+        var source = new SelfReferentialForm { Value = CycleRootValue };
+        source.Self = source;
+        var expected = new KeyValuePair<string?, string?>[]
+        {
+            new("Value", CycleRootValue),
+            new("Self.Value", CycleRootValue)
+        };
+
+        var actual = new FormValueMultimap(source, _settings);
+
+        await Assert.That(actual).IsCollectionEqualTo(expected);
+    }
+
     /// <summary>Projects a sequence of non-nullable key/value pairs to nullable key/value pairs.</summary>
     /// <param name="source">The non-nullable key/value pairs to project.</param>
     /// <returns>The equivalent sequence with nullable key and value types.</returns>
@@ -473,5 +614,78 @@ public class FormValueMultimapTests
         [Query("-", "prefix", "0.0")]
         [AliasAs("fr")]
         public int? Frob { get; set; }
+    }
+
+    /// <summary>Test fixture with a nested complex property that flattens to dotted keys.</summary>
+    public class ObjectWithNestedDetail
+    {
+        /// <summary>Gets or sets the scalar name value.</summary>
+        public string? Name { get; set; }
+
+        /// <summary>Gets or sets the nested detail flattened under its property name.</summary>
+        public NestedDetail? Detail { get; set; }
+    }
+
+    /// <summary>Nested detail object flattened by the enclosing fixtures.</summary>
+    public class NestedDetail
+    {
+        /// <summary>Gets or sets the email value.</summary>
+        public string? Email { get; set; }
+
+        /// <summary>Gets or sets the age value.</summary>
+        public int Age { get; set; }
+    }
+
+    /// <summary>Test fixture with a dictionary-typed property that flattens to prefixed entry keys.</summary>
+    public class ObjectWithDictionary
+    {
+        /// <summary>Gets or sets the scalar name value.</summary>
+        public string? Name { get; set; }
+
+        /// <summary>Gets the extra values flattened under their property name.</summary>
+        public Dictionary<string, string>? Extra { get; init; }
+    }
+
+    /// <summary>Test fixture with a dictionary of complex values that recurses into each entry.</summary>
+    public class ObjectWithComplexDictionary
+    {
+        /// <summary>Gets the items keyed by name and flattened per entry.</summary>
+        public Dictionary<string, NestedDetail>? Items { get; init; }
+    }
+
+    /// <summary>Test fixture with a collection property carrying no explicit collection format.</summary>
+    public class ObjectWithDefaultCollection
+    {
+        /// <summary>Gets the numbers joined using the default collection format.</summary>
+        public List<int>? Numbers { get; init; }
+    }
+
+    /// <summary>Test fixture whose nested property carries a <see cref="QueryAttribute"/> prefix and delimiter.</summary>
+    public class ObjectWithPrefixedNested
+    {
+        /// <summary>Gets or sets the nested detail whose keys compose under the query prefix and delimiter.</summary>
+        [Query("-", "addr")]
+        public PrefixedNestedDetail? Detail { get; set; }
+    }
+
+    /// <summary>Nested detail with an aliased property used to verify nested key composition.</summary>
+    public class PrefixedNestedDetail
+    {
+        /// <summary>Gets or sets the postal code renamed via <see cref="AliasAsAttribute"/>.</summary>
+        [AliasAs("z")]
+        public string? Zip { get; set; }
+
+        /// <summary>Gets or sets the city value.</summary>
+        public string? City { get; set; }
+    }
+
+    /// <summary>Test fixture that references itself to exercise the cycle guard.</summary>
+    public class SelfReferentialForm
+    {
+        /// <summary>Gets or sets the scalar value.</summary>
+        public string? Value { get; set; }
+
+        /// <summary>Gets or sets the self reference that must not cause unbounded recursion.</summary>
+        public SelfReferentialForm? Self { get; set; }
     }
 }

--- a/src/tests/Refit.Tests/FormValueMultimapTests.cs
+++ b/src/tests/Refit.Tests/FormValueMultimapTests.cs
@@ -4,6 +4,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.Linq;
 using System.Runtime.Serialization;
 using System.Text.Json.Serialization;
@@ -48,6 +49,12 @@ public class FormValueMultimapTests
 
     /// <summary>Scalar value shared by the cycle-guard fixture.</summary>
     private const string CycleRootValue = "root";
+
+    /// <summary>The object-graph depth beyond which the flattener drops deeper nested values; mirrors <c>FormValueMultimap.MaxNestingDepth</c>.</summary>
+    private const int MaxNestingDepth = 32;
+
+    /// <summary>Extra nodes appended past the nesting cap so the depth-cap drop path is exercised with margin.</summary>
+    private const int ExtraNodesBeyondNestingCap = 5;
 
     /// <summary>The default settings used to construct the multimap under test.</summary>
     private readonly RefitSettings _settings = new();
@@ -511,12 +518,71 @@ public class FormValueMultimapTests
         await Assert.That(actual).IsCollectionEqualTo(expected);
     }
 
+    /// <summary>Verifies an acyclic object graph deeper than the nesting cap flattens the values up to the cap and drops everything below it.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task DeeplyNestedObjectDropsValuesBeyondNestingCap()
+    {
+        var source = BuildDeepChain(MaxNestingDepth + ExtraNodesBeyondNestingCap);
+
+        var values = new FormValueMultimap(source, _settings)
+            .Select(static entry => entry.Value)
+            .ToArray();
+
+        await Assert.That(values.Length).IsEqualTo(MaxNestingDepth + 1);
+        await Assert.That(values.Contains(DeepNodeValue(MaxNestingDepth))).IsTrue();
+        await Assert.That(values.Contains(DeepNodeValue(MaxNestingDepth + 1))).IsFalse();
+    }
+
+    /// <summary>Verifies a nested object inheriting a null <see cref="QueryAttribute"/> delimiter falls back to the default delimiter when composing its own children.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task NestedObjectUnderNullQueryDelimiterFallsBackToDefaultDelimiter()
+    {
+        const int age = 42;
+        var source = new ObjectWithNullDelimiterQuery
+        {
+            Detail = new() { Email = NestedEmail, Age = age }
+        };
+        var expected = new KeyValuePair<string?, string?>[]
+        {
+            new("DetailEmail", NestedEmail),
+            new("DetailAge", "42")
+        };
+
+        var actual = new FormValueMultimap(source, _settings);
+
+        await Assert.That(actual).IsCollectionEqualTo(expected);
+    }
+
     /// <summary>Projects a sequence of non-nullable key/value pairs to nullable key/value pairs.</summary>
     /// <param name="source">The non-nullable key/value pairs to project.</param>
     /// <returns>The equivalent sequence with nullable key and value types.</returns>
     private static IEnumerable<KeyValuePair<string?, string?>> ToNullableKvps(
         IEnumerable<KeyValuePair<string, string>> source) =>
         source.Select(static pair => new KeyValuePair<string?, string?>(pair.Key, pair.Value));
+
+    /// <summary>Builds an acyclic chain of distinct <see cref="DeepNode"/> instances, each carrying a depth-tagged value.</summary>
+    /// <param name="length">The number of nodes in the chain.</param>
+    /// <returns>The head node of the chain.</returns>
+    private static DeepNode BuildDeepChain(int length)
+    {
+        var head = new DeepNode { Value = DeepNodeValue(0) };
+        var current = head;
+        for (var i = 1; i < length; i++)
+        {
+            var next = new DeepNode { Value = DeepNodeValue(i) };
+            current.Child = next;
+            current = next;
+        }
+
+        return head;
+    }
+
+    /// <summary>Formats the value carried by the <see cref="DeepNode"/> at the given depth.</summary>
+    /// <param name="depth">The zero-based depth of the node.</param>
+    /// <returns>The depth-tagged value.</returns>
+    private static string DeepNodeValue(int depth) => "v" + depth.ToString(CultureInfo.InvariantCulture);
 
     /// <summary>Test fixture with simple string properties used to verify object property loading.</summary>
     public class ObjectTestClass
@@ -687,5 +753,23 @@ public class FormValueMultimapTests
 
         /// <summary>Gets or sets the self reference that must not cause unbounded recursion.</summary>
         public SelfReferentialForm? Self { get; set; }
+    }
+
+    /// <summary>Recursive test fixture used to build an acyclic graph deeper than the nesting cap.</summary>
+    public class DeepNode
+    {
+        /// <summary>Gets or sets the depth-tagged scalar value flattened at this level.</summary>
+        public string? Value { get; set; }
+
+        /// <summary>Gets or sets the next distinct node in the chain, or <see langword="null"/> at the tail.</summary>
+        public DeepNode? Child { get; set; }
+    }
+
+    /// <summary>Test fixture whose nested property carries a <see cref="QueryAttribute"/> with a null delimiter, exercising the default-delimiter fallback for its children.</summary>
+    public class ObjectWithNullDelimiterQuery
+    {
+        /// <summary>Gets or sets the nested detail whose children inherit the null query delimiter.</summary>
+        [Query(null!)]
+        public NestedDetail? Detail { get; set; }
     }
 }

--- a/src/tests/Refit.Tests/GeneratedRequestRunnerTests.cs
+++ b/src/tests/Refit.Tests/GeneratedRequestRunnerTests.cs
@@ -352,6 +352,33 @@ public partial class GeneratedRequestRunnerTests
         await Assert.That(descriptor).IsEqualTo(reflection);
     }
 
+    /// <summary>Verifies a nested URL-encoded body flattens byte-identically through the generated reflection content
+    /// overload and the reflection request builder's <see cref="FormValueMultimap"/>.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task NestedFormBodyFlattensIdenticallyAcrossPaths()
+    {
+        const int age = 42;
+        var settings = new RefitSettings();
+        var body = new NestedParityForm
+        {
+            Name = "ada",
+            Detail = new() { Email = "a@b.com", Age = age },
+            Extra = new() { { "k", "v" } }
+        };
+
+        // The generated path for a complex body emits the reflection content overload; the reflection request builder
+        // wraps the same FormValueMultimap directly. Both must produce identical wire content.
+        var generated = await GeneratedRequestRunner
+            .CreateUrlEncodedBodyContent<NestedParityForm>(settings, body)
+            .ReadAsStringAsync();
+        var reflection = await new FormUrlEncodedContent(new FormValueMultimap(body, settings))
+            .ReadAsStringAsync();
+
+        await Assert.That(generated).IsEqualTo(reflection);
+        await Assert.That(generated).IsEqualTo("Name=ada&Detail.Email=a%40b.com&Detail.Age=42&Extra.k=v");
+    }
+
     /// <summary>Verifies that unsupported body serialization modes are rejected.</summary>
     /// <returns>A task that represents the asynchronous operation.</returns>
     [Test]
@@ -609,6 +636,29 @@ public partial class GeneratedRequestRunnerTests
         /// <summary>Gets or sets a multi-value collection property.</summary>
         [Query(CollectionFormat.Multi)]
         public List<string>? Roles { get; set; }
+    }
+
+    /// <summary>Nested form model used to compare the generated reflection overload and the reflection request builder.</summary>
+    private sealed class NestedParityForm
+    {
+        /// <summary>Gets or sets the scalar name.</summary>
+        public string? Name { get; set; }
+
+        /// <summary>Gets or sets the nested detail flattened under its property name.</summary>
+        public NestedParityDetail? Detail { get; set; }
+
+        /// <summary>Gets the extra values flattened under their property name.</summary>
+        public Dictionary<string, string>? Extra { get; init; }
+    }
+
+    /// <summary>Nested detail for the cross-path parity fixture.</summary>
+    private sealed class NestedParityDetail
+    {
+        /// <summary>Gets or sets the email value.</summary>
+        public string? Email { get; set; }
+
+        /// <summary>Gets or sets the age value.</summary>
+        public int Age { get; set; }
     }
 
     /// <summary>Simple deserialized response model for generated runtime tests.</summary>

--- a/src/tests/Refit.Tests/RequestBuilderTests.Queries.cs
+++ b/src/tests/Refit.Tests/RequestBuilderTests.Queries.cs
@@ -55,6 +55,12 @@ public partial class RequestBuilderTests
     /// <summary>The numeric value assigned to the <c>Bar</c> field of the URL-encoded body samples.</summary>
     private const int SampleBarValue = 100;
 
+    /// <summary>The numeric value assigned to the nested <c>Age</c> field of the nested URL-encoded body sample.</summary>
+    private const int SampleNestedAge = 42;
+
+    /// <summary>The value assigned to the <c>Foo</c> field of the URL-encoded body samples.</summary>
+    private const string SampleFooValue = "Something";
+
     /// <summary>Reads string content with metadata.</summary>
     /// <returns>A task that represents the asynchronous operation.</returns>
     [Test]
@@ -355,13 +361,13 @@ public partial class RequestBuilderTests
     public async Task BodyContentGetsUrlEncoded()
     {
         var fixture = new RequestBuilderImplementation<IDummyHttpApi>();
-        var factory = fixture.RunRequest("PostSomeUrlEncodedStuff");
+        var factory = fixture.RunRequest(nameof(IDummyHttpApi.PostSomeUrlEncodedStuff));
         var output = await factory(
             [
                 SampleId,
 
                 // Baz is intentionally blank to verify empty values are preserved rather than stripped.
-                new UrlEncodedBody(Foo: "Something", Bar: SampleBarValue, Baz: string.Empty)
+                new UrlEncodedBody(Foo: SampleFooValue, Bar: SampleBarValue, Baz: string.Empty)
             ]);
 
         await Assert.That(output.SendContent).IsEqualTo("Foo=Something&Bar=100&Baz=");
@@ -374,16 +380,36 @@ public partial class RequestBuilderTests
     {
         var settings = new RefitSettings { CollectionFormat = CollectionFormat.Csv };
         var fixture = new RequestBuilderImplementation<IDummyHttpApi>(settings);
-        var factory = fixture.RunRequest("PostSomeUrlEncodedStuff");
+        var factory = fixture.RunRequest(nameof(IDummyHttpApi.PostSomeUrlEncodedStuff));
         var output = await factory(
             [
                 SampleId,
 
                 // Baz is intentionally blank to verify empty values are preserved rather than stripped.
-                new UrlEncodedBodyWithCollection(Foo: "Something", Bar: SampleBarValue, FooBar: _intArray57, Baz: string.Empty)
+                new UrlEncodedBodyWithCollection(Foo: SampleFooValue, Bar: SampleBarValue, FooBar: _intArray57, Baz: string.Empty)
             ]);
 
         await Assert.That(output.SendContent).IsEqualTo("Foo=Something&Bar=100&FooBar=5%2C7&Baz=");
+    }
+
+    /// <summary>A nested object and dictionary in a URL-encoded body flatten to dotted field names.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task BodyContentGetsUrlEncodedWithNestedObjectFlattened()
+    {
+        var fixture = new RequestBuilderImplementation<IDummyHttpApi>();
+        var factory = fixture.RunRequest(nameof(IDummyHttpApi.PostSomeUrlEncodedStuff));
+        var output = await factory(
+            [
+                SampleId,
+                new UrlEncodedBodyWithNestedObject(
+                    Foo: SampleFooValue,
+                    Detail: new(Email: "a@b.com", Age: SampleNestedAge),
+                    Extra: new Dictionary<string, string> { { "k", "v" } })
+            ]);
+
+        await Assert.That(output.SendContent)
+            .IsEqualTo("Foo=Something&Detail.Email=a%40b.com&Detail.Age=42&Extra.k=v");
     }
 
     /// <summary>A form field gets aliased.</summary>
@@ -470,4 +496,18 @@ public partial class RequestBuilderTests
     /// <param name="FooBar">The collection value.</param>
     /// <param name="Baz">A blank value used to verify empty fields are preserved rather than stripped.</param>
     private sealed record UrlEncodedBodyWithCollection(string Foo, int Bar, int[] FooBar, string Baz);
+
+    /// <summary>Body payload with a nested object and dictionary for the URL-encoded flattening test.</summary>
+    /// <param name="Foo">The scalar value.</param>
+    /// <param name="Detail">The nested object flattened under its property name.</param>
+    /// <param name="Extra">The dictionary flattened under its property name.</param>
+    private sealed record UrlEncodedBodyWithNestedObject(
+        string Foo,
+        NestedFormDetail Detail,
+        Dictionary<string, string> Extra);
+
+    /// <summary>Nested detail object for the URL-encoded flattening test.</summary>
+    /// <param name="Email">The email value.</param>
+    /// <param name="Age">The numeric age value.</param>
+    private sealed record NestedFormDetail(string Email, int Age);
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (with a small, well-scoped behaviour change) for URL-encoded request bodies.

## What is the new behavior?

A `[Body(BodySerializationMethod.UrlEncoded)]` model whose property is a nested object, an `IDictionary`, or a plain collection is now flattened to real form fields instead of the property's type name:

- nested object -> `parent.child=value` pairs
- dictionary -> `parent.key=value` pairs
- collection under the default format -> comma-joined values

This mirrors the existing `[Query]` object-flattening path:

- field naming keeps the same precedence: `[AliasAs]`, then the content serializer's property name (`[JsonPropertyName]` / `[JsonProperty]`), then the URL parameter key formatter
- a nested property's `[Query(delimiter, prefix)]` composes its keys
- flattening is bounded by a depth cap (32) and a reference-cycle guard, so a self-referential model no longer risks a stack overflow

Both request builders stay in parity:

- reflection path: `FormValueMultimap` now recurses instead of calling `ToString()`
- source-generated path: a body with any nested / dictionary / complex-collection property routes the whole body through the reflection content overload (the descriptor fast path is kept for flat scalar and collection-of-simple bodies)

Example:

```
Name=ada&Detail.Email=a%40b.com&Detail.Age=42&Extra.k=v
```

## What is the current behavior?

The nested object or dictionary was serialized via `ToString()`, emitting the type name, for example `Detail=Namespace.Inner` or `Extra=System.Collections.Generic.Dictionary...`. A plain collection under the default `RefitParameterFormatter` format emitted the collection's type name as well.

Closes #1795

## What might this PR break?

- URL-encoded bodies that relied on the old type-name output. This was previously unusable output, so it is extremely unlikely anyone depended on it.
- Collections under the default format now comma-join their elements (matching the query path) instead of emitting the collection type name. Complex elements of a collection are still `ToString()`-ed per element (the same limitation as the query path).
- The genuinely out-of-range `CollectionFormat` ToString fallback is preserved; explicit `[Query(CollectionFormat)]` behaviour is unchanged; all-scalar bodies still take the generated descriptor / unroll fast path.

## Checklist
- [ ] I have read the Contribute guide
- [x] Tests have been added or updated (for bug fixes / features)
- [x] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the `main` branch
- [x] PR title follows Conventional Commits

## Additional information

- The runtime fix lives in `src/Refit/FormValueMultimap.cs`; the generator routing change in `src/InterfaceStubGenerator.Shared/Parser.Request.Body.cs`.
- No public API surface changed; `FormValueMultimap` is internal.
- Tests: reflection flattening (dictionary/collection/prefix/cycle cases), reflection <-> generated parity, and generator routing.
- Breaking-changes note added to `docs/breaking-changes.md`.
- Verified on net8.0: `FormValueMultimapTests`, `RequestBuilderTests`, `GeneratedRequestRunnerTests`, `QueryObjectFlatteningTests`, `ReflectionRequestBuildingTests`, and the full `Refit.GeneratorTests` project all pass; no generator snapshots changed. Builds clean (all Refit target frameworks) with analyzers satisfied.
