### PR TITLE
feat: add per-type URL parameter formatter registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -670,6 +670,29 @@ var settings = new RefitSettings
 
 In the above example, the dictionary keys will be converted to uppercase.
 
+**Registering a formatter per type with `UrlParameterFormatterMap`**:
+
+To customize how one specific type is rendered into a URL without hand-rolling a type switch inside a custom
+`IUrlParameterFormatter`, register a formatter for that type in `RefitSettings.UrlParameterFormatterMap`. When a value
+is rendered into a path or query string, its runtime type is looked up in the map first; a registered formatter wins,
+and every other type falls back to `UrlParameterFormatter`.
+
+```csharp
+public class TemperatureUrlParameterFormatter : IUrlParameterFormatter
+{
+    public string? Format(object? value, ICustomAttributeProvider attributeProvider, Type type) =>
+        value is Temperature t ? $"{t.Celsius}deg" : value?.ToString();
+}
+
+var settings = new RefitSettings();
+settings.UrlParameterFormatterMap[typeof(Temperature)] = new TemperatureUrlParameterFormatter();
+```
+
+Matching is by exact runtime type only — there is no base-class or interface walking, so register the concrete type the
+value will have at runtime. The registry applies to path parameters, round-trip path segments, and query values (it does
+not affect header or body serialization), and both the reflection and source-generated request builders consult it
+identically.
+
 ### Body content
 
 One of the parameters in your method can be used as the body, by using the

--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -148,6 +148,13 @@ visible in three places.
   generator discovers adapters declared in your project at compile time and emits a direct `Adapt` call — no reflection,
   so adapter-backed methods stay trim and Native AOT clean; the reflection request builder resolves adapters registered
   in `RefitSettings.ReturnTypeAdapters`. See [Custom return types](../README.md#custom-return-types-ireturntypeadapter).
+* **Per-type URL parameter formatters (`RefitSettings.UrlParameterFormatterMap`).** Register an `IUrlParameterFormatter`
+  for a specific CLR type instead of hand-rolling a type switch inside a single custom formatter. When a value is
+  rendered into a path or query string, its runtime type is looked up in the map first (exact type only, no base-class or
+  interface walking); a registered formatter wins, and every other type falls back to `UrlParameterFormatter`. Both the
+  reflection and source-generated request builders consult the map identically. This is a purely additive, opt-in setting
+  — an empty map (the default) changes no behavior. See
+  [Formatting URL Parameter Values](../README.md#formatting-url-parameter-values-with-the-urlparameterformatter).
 
 ## V13.x.x
 

--- a/src/InterfaceStubGenerator.Shared/Emitter.Inline.Path.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.Inline.Path.cs
@@ -132,7 +132,7 @@ internal static partial class Emitter
             ? $"{runner}({template}, {allowUnmatched}, ({start}, {end}), {valueExpression})"
             : $"{runner}({template}, {allowUnmatched}, ({start}, {end}), {valueExpression}, {ToNullableCSharpStringLiteral(valueFormat.Format)})";
         var customTuple =
-            $"(({start}, {end}), {settingsLocal}.UrlParameterFormatter.Format({valueExpression}, {providerField}, typeof({pathParameter.Type})))";
+            $"(({start}, {end}), {EmitFormatUrlParameter(valueExpression, providerField, $"typeof({pathParameter.Type})", emission)})";
         var customReplacements = WrapPathReplacements(customTuple, emission.SupportsCollectionExpressions);
         var customExpression = $"{runner}({template}, {allowUnmatched}{customReplacements})";
 

--- a/src/InterfaceStubGenerator.Shared/Emitter.Inline.Query.Dictionary.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.Inline.Query.Dictionary.cs
@@ -92,8 +92,7 @@ internal static partial class Emitter
         var dictionary = query.Dictionary!;
         var (entryLocal, keyLocal, valueLocal, indent) = entry;
         var keyTypeOf = $"typeof({dictionary.KeyTypeName})";
-        var customKey =
-            $"{emission.SettingsLocal}.UrlParameterFormatter.Format({entryLocal}.Key, {keyTypeOf}, {keyTypeOf})";
+        var customKey = EmitFormatUrlParameter($"{entryLocal}.Key", keyTypeOf, keyTypeOf, emission);
         var fastKey = BuildFastFormatExpression(entryLocal + ".Key", dictionary.KeyFormat, emission);
         var keyExpression = fastKey is null
             ? customKey

--- a/src/InterfaceStubGenerator.Shared/Emitter.Inline.Query.Object.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.Inline.Query.Object.cs
@@ -213,7 +213,7 @@ internal static partial class Emitter
         in InlineValueEmission emission)
     {
         var keyTypeOf = $"typeof({dictionary.KeyTypeName})";
-        var customKey = $"{emission.SettingsLocal}.UrlParameterFormatter.Format({entryLocal}.Key, {keyTypeOf}, {keyTypeOf})";
+        var customKey = EmitFormatUrlParameter($"{entryLocal}.Key", keyTypeOf, keyTypeOf, emission);
         var fastKey = BuildFastFormatExpression(entryLocal + ".Key", dictionary.KeyFormat, emission);
         var entryKeyExpression = fastKey is null
             ? customKey
@@ -439,7 +439,8 @@ internal static partial class Emitter
         {
             // An element with no reflection-free rendering (e.g. an enum with duplicate constants) still uses the
             // formatter, which under the pristine default renders it correctly; the type doubles as the provider.
-            return $"{emission.SettingsLocal}.UrlParameterFormatter.Format({elementLocal}, typeof({collection.PropertyTypeName}), typeof({collection.PropertyTypeName}))";
+            var elementTypeOf = $"typeof({collection.PropertyTypeName})";
+            return EmitFormatUrlParameter(elementLocal, elementTypeOf, elementTypeOf, emission);
         }
 
         // A string element renders itself, so a null element already renders as null; other formats guard first.
@@ -590,7 +591,21 @@ internal static partial class Emitter
         string parameterTypeName,
         string providerField,
         in InlineValueEmission emission) =>
-        $"{emission.SettingsLocal}.UrlParameterFormatter.Format({valueExpression}, {providerField}, typeof({parameterTypeName}))";
+        EmitFormatUrlParameter(valueExpression, providerField, $"typeof({parameterTypeName})", emission);
+
+    /// <summary>Emits a call to the shared runtime helper that renders a URL parameter value, consulting the per-type
+    /// formatter registry on the settings before the configured <c>IUrlParameterFormatter</c>.</summary>
+    /// <param name="valueExpression">The value expression to format.</param>
+    /// <param name="providerExpression">The attribute-provider expression passed to the formatter.</param>
+    /// <param name="typeExpression">The declared-type expression passed to the formatter.</param>
+    /// <param name="emission">The shared emission locals and helper state.</param>
+    /// <returns>The formatter call expression, keeping the reflection and generated paths in parity.</returns>
+    private static string EmitFormatUrlParameter(
+        string valueExpression,
+        string providerExpression,
+        string typeExpression,
+        in InlineValueEmission emission) =>
+        $"global::Refit.GeneratedRequestRunner.FormatUrlParameter({emission.SettingsLocal}, {valueExpression}, {providerExpression}, {typeExpression})";
 
     /// <summary>Builds the query key expression for one flattened property.</summary>
     /// <param name="property">The flattened property descriptor.</param>

--- a/src/InterfaceStubGenerator.Shared/Emitter.Inline.Query.Values.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.Inline.Query.Values.cs
@@ -31,7 +31,7 @@ internal static partial class Emitter
         // TreatAsString stringifies the raw value before the formatter runs, mirroring the reflection builder.
         var customValue = query.TreatAsString ? valueExpression + ToStringCall : valueExpression;
         var customExpression =
-            $"{emission.SettingsLocal}.UrlParameterFormatter.Format({customValue}, {providerField}, typeof({parameterTypeName}))";
+            EmitFormatUrlParameter(customValue, providerField, $"typeof({parameterTypeName})", emission);
 
         var fastExpression = query.TreatAsString
             ? valueExpression + ToStringCall
@@ -64,7 +64,7 @@ internal static partial class Emitter
         {
             // A {**param} catch-all: split the value on '/', format and escape each segment, keep the separators.
             var roundTripValue = parameter.CanBeNull ? $"@{parameter.Name}?.ToString()" : $"@{parameter.Name}.ToString()";
-            return $"global::Refit.GeneratedRequestRunner.RoundTripEscapePath({roundTripValue}, {emission.SettingsLocal}.UrlParameterFormatter, {providerField}, typeof({parameter.Type}))";
+            return $"global::Refit.GeneratedRequestRunner.RoundTripEscapePath({roundTripValue}, {emission.SettingsLocal}, {providerField}, typeof({parameter.Type}))";
         }
 
         return BuildPathValueExpressionCore(
@@ -93,7 +93,7 @@ internal static partial class Emitter
         in InlineValueEmission emission)
     {
         var customExpression =
-            $"{emission.SettingsLocal}.UrlParameterFormatter.Format({valueAccessor}, {providerField}, typeof({typeName}))";
+            EmitFormatUrlParameter(valueAccessor, providerField, $"typeof({typeName})", emission);
         var fastExpression = ComputeFastPathExpression(valueAccessor, valueFormat, emission);
         if (fastExpression is null)
         {

--- a/src/Refit.Reflection/RequestBuilderImplementation.Payload.cs
+++ b/src/Refit.Reflection/RequestBuilderImplementation.Payload.cs
@@ -362,7 +362,8 @@ internal partial class RequestBuilderImplementation
         queryParamsToAdd.Add(
             new(
                 queryPath,
-                _settings.UrlParameterFormatter.Format(
+                GeneratedRequestRunner.FormatUrlParameter(
+                    _settings,
                     param,
                     parameterInfo,
                     parameterInfo.ParameterType)));
@@ -394,7 +395,8 @@ internal partial class RequestBuilderImplementation
         {
             foreach (var paramValue in paramValues)
             {
-                yield return _settings.UrlParameterFormatter.Format(
+                yield return GeneratedRequestRunner.FormatUrlParameter(
+                    _settings,
                     paramValue,
                     customAttributeProvider,
                     type);
@@ -442,7 +444,8 @@ internal partial class RequestBuilderImplementation
 
             var builder = new ValueStringBuilder(stackalloc char[StackallocThreshold]);
             builder.Append(
-                _settings.UrlParameterFormatter.Format(
+                GeneratedRequestRunner.FormatUrlParameter(
+                    _settings,
                     enumerator.Current,
                     customAttributeProvider,
                     type));
@@ -451,7 +454,8 @@ internal partial class RequestBuilderImplementation
             {
                 builder.Append(delimiter);
                 builder.Append(
-                    _settings.UrlParameterFormatter.Format(
+                    GeneratedRequestRunner.FormatUrlParameter(
+                        _settings,
                         enumerator.Current,
                         customAttributeProvider,
                         type));

--- a/src/Refit.Reflection/RequestBuilderImplementation.QueryAndHeaders.cs
+++ b/src/Refit.Reflection/RequestBuilderImplementation.QueryAndHeaders.cs
@@ -334,7 +334,7 @@ internal partial class RequestBuilderImplementation
             }
 
             var keyType = key.GetType();
-            var formattedKey = _settings.UrlParameterFormatter.Format(key, keyType, keyType);
+            var formattedKey = GeneratedRequestRunner.FormatUrlParameter(_settings, key, keyType, keyType);
 
             if (string.IsNullOrWhiteSpace(formattedKey)) // blank keys can't be put in the query string
             {

--- a/src/Refit.Reflection/RequestBuilderImplementation.RequestBuilding.cs
+++ b/src/Refit.Reflection/RequestBuilderImplementation.RequestBuilding.cs
@@ -523,7 +523,8 @@ internal partial class RequestBuilderImplementation
             propertyObject = link.GetValue(propertyObject);
         }
 
-        vsb.Append(StringHelpers.EscapeDataString(_settings.UrlParameterFormatter.Format(
+        vsb.Append(StringHelpers.EscapeDataString(GeneratedRequestRunner.FormatUrlParameter(
+            _settings,
             propertyObject,
             property.PropertyInfo,
             property.PropertyInfo.PropertyType) ?? string.Empty));
@@ -548,7 +549,8 @@ internal partial class RequestBuilderImplementation
         if (parameterMapValue.Type == ParameterType.Normal)
         {
             vsb.Append(StringHelpers.EscapeDataString(
-                _settings.UrlParameterFormatter.Format(
+                GeneratedRequestRunner.FormatUrlParameter(
+                    _settings,
                     param,
                     parameterInfo,
                     parameterInfo.ParameterType) ?? string.Empty));
@@ -564,7 +566,8 @@ internal partial class RequestBuilderImplementation
         {
             vsb.Append(
                 StringHelpers.EscapeDataString(
-                    _settings.UrlParameterFormatter.Format(
+                    GeneratedRequestRunner.FormatUrlParameter(
+                        _settings,
                         paramValue,
                         parameterInfo,
                         parameterInfo.ParameterType) ?? string.Empty));
@@ -587,7 +590,8 @@ internal partial class RequestBuilderImplementation
             var section = paramValue.Substring(sectionStart, i - sectionStart);
             vsb.Append(
                 StringHelpers.EscapeDataString(
-                    _settings.UrlParameterFormatter.Format(
+                    GeneratedRequestRunner.FormatUrlParameter(
+                        _settings,
                         section,
                         parameterInfo,
                         parameterInfo.ParameterType) ?? string.Empty));

--- a/src/Refit/GeneratedRequestRunner.cs
+++ b/src/Refit/GeneratedRequestRunner.cs
@@ -237,19 +237,19 @@ public static partial class GeneratedRequestRunner
     /// <summary>Round-trips a catch-all <c>{**param}</c> path value: each <c>/</c>-separated section is formatted and
     /// escaped while the separators are preserved, matching the reflection request builder.</summary>
     /// <param name="value">The value's string form (from <c>ToString</c>), or null.</param>
-    /// <param name="formatter">The configured URL parameter formatter.</param>
+    /// <param name="settings">The Refit settings supplying the URL parameter formatter registry and default.</param>
     /// <param name="attributeProvider">The parameter's attribute provider passed to the formatter.</param>
     /// <param name="type">The parameter's declared type passed to the formatter.</param>
     /// <returns>The round-trip-escaped path fragment, ready to append verbatim.</returns>
     public static string RoundTripEscapePath(
         string? value,
-        IUrlParameterFormatter formatter,
+        RefitSettings settings,
         ICustomAttributeProvider attributeProvider,
         Type type)
     {
         if (value is null)
         {
-            return StringHelpers.EscapeDataString(formatter.Format(null, attributeProvider, type) ?? string.Empty);
+            return StringHelpers.EscapeDataString(FormatUrlParameter(settings, null, attributeProvider, type) ?? string.Empty);
         }
 
         var sb = new StringBuilder(value.Length);
@@ -267,19 +267,37 @@ public static partial class GeneratedRequestRunner
             }
 
             var section = value.Substring(sectionStart, i - sectionStart);
-            _ = sb.Append(StringHelpers.EscapeDataString(formatter.Format(section, attributeProvider, type) ?? string.Empty));
+            _ = sb.Append(StringHelpers.EscapeDataString(FormatUrlParameter(settings, section, attributeProvider, type) ?? string.Empty));
             sectionStart = i + 1;
         }
 
         return sb.ToString();
     }
 
+    /// <summary>Resolves the <see cref="IUrlParameterFormatter"/> for a value, consulting the per-type registry on the
+    /// settings before falling back to the configured default, then formats the value with it.</summary>
+    /// <param name="settings">The Refit settings supplying the registry and default formatter.</param>
+    /// <param name="value">The value to render into the URL, or null.</param>
+    /// <param name="attributeProvider">The attribute provider passed to the formatter.</param>
+    /// <param name="type">The declared type passed to the formatter.</param>
+    /// <returns>The formatted value, or null when <paramref name="value"/> is null.</returns>
+    /// <remarks>This is the single point both the reflection and source-generated request builders call, so a formatter
+    /// registered in <see cref="RefitSettings.UrlParameterFormatterMap"/> is applied identically by both. Lookup is by
+    /// exact runtime type; every other value uses <see cref="RefitSettings.UrlParameterFormatter"/>.</remarks>
+    public static string? FormatUrlParameter(
+        RefitSettings settings,
+        object? value,
+        ICustomAttributeProvider attributeProvider,
+        Type type) =>
+        ResolveUrlParameterFormatter(settings, value).Format(value, attributeProvider, type);
+
     /// <summary>Determines whether the settings use the pristine default URL parameter formatter, letting
     /// generated code format statically-known values inline without calling the formatter.</summary>
     /// <param name="settings">The Refit settings to inspect.</param>
     /// <returns><see langword="true"/> when generated inline formatting matches the configured formatter.</returns>
     public static bool UsesDefaultUrlParameterFormatting(RefitSettings settings) =>
-        settings.UrlParameterFormatter is DefaultUrlParameterFormatter formatter
+        settings.UrlParameterFormatterMap.Count == 0
+        && settings.UrlParameterFormatter is DefaultUrlParameterFormatter formatter
         && formatter.IsPristineDefault;
 
     /// <summary>Determines whether the settings use the pristine default form-url-encoded parameter formatter.</summary>
@@ -371,21 +389,20 @@ public static partial class GeneratedRequestRunner
             return;
         }
 
-        var formatter = settings.UrlParameterFormatter;
         var element = formatting.ElementProviderType;
         if (collectionFormat == CollectionFormat.Multi)
         {
             foreach (var value in values)
             {
-                var formatted = formatter.Format(value, element, element);
-                builder.Add(key, formatter.Format(formatted, formatting.JoinedProvider, formatting.JoinedType), preEncoded);
+                var formatted = FormatUrlParameter(settings, value, element, element);
+                builder.Add(key, FormatUrlParameter(settings, formatted, formatting.JoinedProvider, formatting.JoinedType), preEncoded);
             }
 
             return;
         }
 
-        var joined = JoinFormattedElements(values, formatter, element, CollectionDelimiter(collectionFormat));
-        builder.Add(key, formatter.Format(joined, formatting.JoinedProvider, formatting.JoinedType), preEncoded);
+        var joined = JoinFormattedElements(values, settings, element, CollectionDelimiter(collectionFormat));
+        builder.Add(key, FormatUrlParameter(settings, joined, formatting.JoinedProvider, formatting.JoinedType), preEncoded);
     }
 
     /// <summary>Sets, replaces, or removes a generated request header.</summary>
@@ -532,7 +549,7 @@ public static partial class GeneratedRequestRunner
 
     /// <summary>Formats each element with the property's provider and type and joins them with the delimiter.</summary>
     /// <param name="values">The collection value.</param>
-    /// <param name="formatter">The URL parameter formatter.</param>
+    /// <param name="settings">The Refit settings supplying the URL parameter formatter registry and default.</param>
     /// <param name="elementProviderType">The declared property type used as the attribute provider and type.</param>
     /// <param name="delimiter">The delimiter between formatted values.</param>
     /// <returns>The joined formatted values, empty when the collection has no elements.</returns>
@@ -542,7 +559,7 @@ public static partial class GeneratedRequestRunner
         Justification = "ValueStringBuilder.ToString() disposes the builder and returns its pooled buffer; Dispose is idempotent.")]
     private static string JoinFormattedElements(
         IEnumerable values,
-        IUrlParameterFormatter formatter,
+        RefitSettings settings,
         Type elementProviderType,
         char delimiter)
     {
@@ -556,11 +573,22 @@ public static partial class GeneratedRequestRunner
             }
 
             first = false;
-            builder.Append(formatter.Format(value, elementProviderType, elementProviderType));
+            builder.Append(FormatUrlParameter(settings, value, elementProviderType, elementProviderType));
         }
 
         return builder.ToString();
     }
+
+    /// <summary>Resolves the formatter for a value: its <see cref="RefitSettings.UrlParameterFormatterMap"/> entry, else <see cref="RefitSettings.UrlParameterFormatter"/>.</summary>
+    /// <param name="settings">The Refit settings supplying the registry and default formatter.</param>
+    /// <param name="value">The value about to be formatted, or null.</param>
+    /// <returns>The registered formatter for the value's exact runtime type, or the configured default formatter.</returns>
+    private static IUrlParameterFormatter ResolveUrlParameterFormatter(RefitSettings settings, object? value) =>
+        value is not null
+        && settings.UrlParameterFormatterMap.Count > 0
+        && settings.UrlParameterFormatterMap.TryGetValue(value.GetType(), out var formatter)
+            ? formatter
+            : settings.UrlParameterFormatter;
 
     /// <summary>Throws when the expanded path still contains a placeholder and unmatched parameters are not allowed.</summary>
     /// <param name="path">The expanded request path to validate.</param>

--- a/src/Refit/PublicAPI/net10.0/PublicAPI.Shipped.txt
+++ b/src/Refit/PublicAPI/net10.0/PublicAPI.Shipped.txt
@@ -478,5 +478,3 @@ Refit.SystemTextJsonQueryConverter<T>.Flatten(T value, string! keyPrefix, ref Re
 Refit.IReturnTypeAdapter<TReturn, TResult>
 Refit.IReturnTypeAdapter<TReturn, TResult>.Adapt(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<TResult>!>! invoke) -> TReturn
 Refit.RefitSettings.ReturnTypeAdapters.get -> System.Collections.Generic.IList<System.Type!>!
-static Refit.GeneratedRequestRunner.FormatUrlParameter(Refit.RefitSettings! settings, object? value, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string?
-static Refit.GeneratedRequestRunner.RoundTripEscapePath(string? value, Refit.RefitSettings! settings, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string!

--- a/src/Refit/PublicAPI/net10.0/PublicAPI.Shipped.txt
+++ b/src/Refit/PublicAPI/net10.0/PublicAPI.Shipped.txt
@@ -301,6 +301,7 @@ Refit.RefitSettings.TransportExceptionFactory.get -> System.Func<System.Net.Http
 Refit.RefitSettings.TransportExceptionFactory.set -> void
 Refit.RefitSettings.UrlParameterFormatter.get -> Refit.IUrlParameterFormatter!
 Refit.RefitSettings.UrlParameterFormatter.set -> void
+Refit.RefitSettings.UrlParameterFormatterMap.get -> System.Collections.Generic.IDictionary<System.Type!, Refit.IUrlParameterFormatter!>!
 Refit.RefitSettings.UrlParameterKeyFormatter.get -> Refit.IUrlParameterKeyFormatter!
 Refit.RefitSettings.UrlParameterKeyFormatter.set -> void
 Refit.RefitSettings.UrlResolution.get -> Refit.UrlResolutionMode
@@ -477,3 +478,5 @@ Refit.SystemTextJsonQueryConverter<T>.Flatten(T value, string! keyPrefix, ref Re
 Refit.IReturnTypeAdapter<TReturn, TResult>
 Refit.IReturnTypeAdapter<TReturn, TResult>.Adapt(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<TResult>!>! invoke) -> TReturn
 Refit.RefitSettings.ReturnTypeAdapters.get -> System.Collections.Generic.IList<System.Type!>!
+static Refit.GeneratedRequestRunner.FormatUrlParameter(Refit.RefitSettings! settings, object? value, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string?
+static Refit.GeneratedRequestRunner.RoundTripEscapePath(string? value, Refit.RefitSettings! settings, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string!

--- a/src/Refit/PublicAPI/net10.0/PublicAPI.Unshipped.txt
+++ b/src/Refit/PublicAPI/net10.0/PublicAPI.Unshipped.txt
@@ -4,7 +4,6 @@ Refit.GeneratedQueryStringBuilder.AddFormatted<T>(string! name, T value, string?
 static Refit.GeneratedRequestRunner.CanUnrollForm(object? body) -> bool
 static Refit.GeneratedRequestRunner.BuildRequestPath<T>(string! relativePathTemplate, bool allowUnmatchedParameter, (int startIdx, int endIdx) range, T value) -> string!
 static Refit.GeneratedRequestRunner.BuildRequestPath<T>(string! relativePathTemplate, bool allowUnmatchedParameter, (int startIdx, int endIdx) range, T value, string? format) -> string!
-static Refit.GeneratedRequestRunner.RoundTripEscapePath(string? value, Refit.IUrlParameterFormatter! formatter, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string!
 Refit.GeneratedQueryStringBuilder.GeneratedQueryStringBuilder(string! relativePath, bool hasQuery) -> void
 static readonly Refit.GeneratedParameterAttributeProvider.Empty -> Refit.GeneratedParameterAttributeProvider!
 static Refit.GeneratedRequestRunner.BuildRequestPath(string! relativePathTemplate, bool allowUnmatchedParameter, System.ReadOnlySpan<((int startIdx, int endIdx) range, string? value)> uriParams) -> string!

--- a/src/Refit/PublicAPI/net10.0/PublicAPI.Unshipped.txt
+++ b/src/Refit/PublicAPI/net10.0/PublicAPI.Unshipped.txt
@@ -4,6 +4,8 @@ Refit.GeneratedQueryStringBuilder.AddFormatted<T>(string! name, T value, string?
 static Refit.GeneratedRequestRunner.CanUnrollForm(object? body) -> bool
 static Refit.GeneratedRequestRunner.BuildRequestPath<T>(string! relativePathTemplate, bool allowUnmatchedParameter, (int startIdx, int endIdx) range, T value) -> string!
 static Refit.GeneratedRequestRunner.BuildRequestPath<T>(string! relativePathTemplate, bool allowUnmatchedParameter, (int startIdx, int endIdx) range, T value, string? format) -> string!
+static Refit.GeneratedRequestRunner.RoundTripEscapePath(string? value, Refit.RefitSettings! settings, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string!
+static Refit.GeneratedRequestRunner.FormatUrlParameter(Refit.RefitSettings! settings, object? value, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string?
 Refit.GeneratedQueryStringBuilder.GeneratedQueryStringBuilder(string! relativePath, bool hasQuery) -> void
 static readonly Refit.GeneratedParameterAttributeProvider.Empty -> Refit.GeneratedParameterAttributeProvider!
 static Refit.GeneratedRequestRunner.BuildRequestPath(string! relativePathTemplate, bool allowUnmatchedParameter, System.ReadOnlySpan<((int startIdx, int endIdx) range, string? value)> uriParams) -> string!

--- a/src/Refit/PublicAPI/net11.0/PublicAPI.Shipped.txt
+++ b/src/Refit/PublicAPI/net11.0/PublicAPI.Shipped.txt
@@ -478,5 +478,3 @@ Refit.SystemTextJsonQueryConverter<T>.Flatten(T value, string! keyPrefix, ref Re
 Refit.IReturnTypeAdapter<TReturn, TResult>
 Refit.IReturnTypeAdapter<TReturn, TResult>.Adapt(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<TResult>!>! invoke) -> TReturn
 Refit.RefitSettings.ReturnTypeAdapters.get -> System.Collections.Generic.IList<System.Type!>!
-static Refit.GeneratedRequestRunner.FormatUrlParameter(Refit.RefitSettings! settings, object? value, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string?
-static Refit.GeneratedRequestRunner.RoundTripEscapePath(string? value, Refit.RefitSettings! settings, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string!

--- a/src/Refit/PublicAPI/net11.0/PublicAPI.Shipped.txt
+++ b/src/Refit/PublicAPI/net11.0/PublicAPI.Shipped.txt
@@ -301,6 +301,7 @@ Refit.RefitSettings.TransportExceptionFactory.get -> System.Func<System.Net.Http
 Refit.RefitSettings.TransportExceptionFactory.set -> void
 Refit.RefitSettings.UrlParameterFormatter.get -> Refit.IUrlParameterFormatter!
 Refit.RefitSettings.UrlParameterFormatter.set -> void
+Refit.RefitSettings.UrlParameterFormatterMap.get -> System.Collections.Generic.IDictionary<System.Type!, Refit.IUrlParameterFormatter!>!
 Refit.RefitSettings.UrlParameterKeyFormatter.get -> Refit.IUrlParameterKeyFormatter!
 Refit.RefitSettings.UrlParameterKeyFormatter.set -> void
 Refit.RefitSettings.UrlResolution.get -> Refit.UrlResolutionMode
@@ -477,3 +478,5 @@ Refit.SystemTextJsonQueryConverter<T>.Flatten(T value, string! keyPrefix, ref Re
 Refit.IReturnTypeAdapter<TReturn, TResult>
 Refit.IReturnTypeAdapter<TReturn, TResult>.Adapt(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<TResult>!>! invoke) -> TReturn
 Refit.RefitSettings.ReturnTypeAdapters.get -> System.Collections.Generic.IList<System.Type!>!
+static Refit.GeneratedRequestRunner.FormatUrlParameter(Refit.RefitSettings! settings, object? value, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string?
+static Refit.GeneratedRequestRunner.RoundTripEscapePath(string? value, Refit.RefitSettings! settings, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string!

--- a/src/Refit/PublicAPI/net11.0/PublicAPI.Unshipped.txt
+++ b/src/Refit/PublicAPI/net11.0/PublicAPI.Unshipped.txt
@@ -4,7 +4,6 @@ Refit.GeneratedQueryStringBuilder.AddFormatted<T>(string! name, T value, string?
 static Refit.GeneratedRequestRunner.CanUnrollForm(object? body) -> bool
 static Refit.GeneratedRequestRunner.BuildRequestPath<T>(string! relativePathTemplate, bool allowUnmatchedParameter, (int startIdx, int endIdx) range, T value) -> string!
 static Refit.GeneratedRequestRunner.BuildRequestPath<T>(string! relativePathTemplate, bool allowUnmatchedParameter, (int startIdx, int endIdx) range, T value, string? format) -> string!
-static Refit.GeneratedRequestRunner.RoundTripEscapePath(string? value, Refit.IUrlParameterFormatter! formatter, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string!
 Refit.GeneratedQueryStringBuilder.GeneratedQueryStringBuilder(string! relativePath, bool hasQuery) -> void
 static readonly Refit.GeneratedParameterAttributeProvider.Empty -> Refit.GeneratedParameterAttributeProvider!
 static Refit.GeneratedRequestRunner.BuildRequestPath(string! relativePathTemplate, bool allowUnmatchedParameter, System.ReadOnlySpan<((int startIdx, int endIdx) range, string? value)> uriParams) -> string!

--- a/src/Refit/PublicAPI/net11.0/PublicAPI.Unshipped.txt
+++ b/src/Refit/PublicAPI/net11.0/PublicAPI.Unshipped.txt
@@ -4,6 +4,8 @@ Refit.GeneratedQueryStringBuilder.AddFormatted<T>(string! name, T value, string?
 static Refit.GeneratedRequestRunner.CanUnrollForm(object? body) -> bool
 static Refit.GeneratedRequestRunner.BuildRequestPath<T>(string! relativePathTemplate, bool allowUnmatchedParameter, (int startIdx, int endIdx) range, T value) -> string!
 static Refit.GeneratedRequestRunner.BuildRequestPath<T>(string! relativePathTemplate, bool allowUnmatchedParameter, (int startIdx, int endIdx) range, T value, string? format) -> string!
+static Refit.GeneratedRequestRunner.RoundTripEscapePath(string? value, Refit.RefitSettings! settings, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string!
+static Refit.GeneratedRequestRunner.FormatUrlParameter(Refit.RefitSettings! settings, object? value, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string?
 Refit.GeneratedQueryStringBuilder.GeneratedQueryStringBuilder(string! relativePath, bool hasQuery) -> void
 static readonly Refit.GeneratedParameterAttributeProvider.Empty -> Refit.GeneratedParameterAttributeProvider!
 static Refit.GeneratedRequestRunner.BuildRequestPath(string! relativePathTemplate, bool allowUnmatchedParameter, System.ReadOnlySpan<((int startIdx, int endIdx) range, string? value)> uriParams) -> string!

--- a/src/Refit/PublicAPI/net462/PublicAPI.Shipped.txt
+++ b/src/Refit/PublicAPI/net462/PublicAPI.Shipped.txt
@@ -301,6 +301,7 @@ Refit.RefitSettings.TransportExceptionFactory.get -> System.Func<System.Net.Http
 Refit.RefitSettings.TransportExceptionFactory.set -> void
 Refit.RefitSettings.UrlParameterFormatter.get -> Refit.IUrlParameterFormatter!
 Refit.RefitSettings.UrlParameterFormatter.set -> void
+Refit.RefitSettings.UrlParameterFormatterMap.get -> System.Collections.Generic.IDictionary<System.Type!, Refit.IUrlParameterFormatter!>!
 Refit.RefitSettings.UrlParameterKeyFormatter.get -> Refit.IUrlParameterKeyFormatter!
 Refit.RefitSettings.UrlParameterKeyFormatter.set -> void
 Refit.RefitSettings.UrlResolution.get -> Refit.UrlResolutionMode
@@ -473,3 +474,5 @@ Refit.SystemTextJsonQueryConverter<T>.Flatten(T value, string! keyPrefix, ref Re
 Refit.IReturnTypeAdapter<TReturn, TResult>
 Refit.IReturnTypeAdapter<TReturn, TResult>.Adapt(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<TResult>!>! invoke) -> TReturn
 Refit.RefitSettings.ReturnTypeAdapters.get -> System.Collections.Generic.IList<System.Type!>!
+static Refit.GeneratedRequestRunner.FormatUrlParameter(Refit.RefitSettings! settings, object? value, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string?
+static Refit.GeneratedRequestRunner.RoundTripEscapePath(string? value, Refit.RefitSettings! settings, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string!

--- a/src/Refit/PublicAPI/net462/PublicAPI.Shipped.txt
+++ b/src/Refit/PublicAPI/net462/PublicAPI.Shipped.txt
@@ -474,5 +474,3 @@ Refit.SystemTextJsonQueryConverter<T>.Flatten(T value, string! keyPrefix, ref Re
 Refit.IReturnTypeAdapter<TReturn, TResult>
 Refit.IReturnTypeAdapter<TReturn, TResult>.Adapt(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<TResult>!>! invoke) -> TReturn
 Refit.RefitSettings.ReturnTypeAdapters.get -> System.Collections.Generic.IList<System.Type!>!
-static Refit.GeneratedRequestRunner.FormatUrlParameter(Refit.RefitSettings! settings, object? value, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string?
-static Refit.GeneratedRequestRunner.RoundTripEscapePath(string? value, Refit.RefitSettings! settings, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string!

--- a/src/Refit/PublicAPI/net462/PublicAPI.Unshipped.txt
+++ b/src/Refit/PublicAPI/net462/PublicAPI.Unshipped.txt
@@ -1,6 +1,5 @@
 #nullable enable
 static Refit.GeneratedRequestRunner.CanUnrollForm(object? body) -> bool
-static Refit.GeneratedRequestRunner.RoundTripEscapePath(string? value, Refit.IUrlParameterFormatter! formatter, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string!
 Refit.GeneratedQueryStringBuilder.GeneratedQueryStringBuilder(string! relativePath, bool hasQuery) -> void
 static readonly Refit.GeneratedParameterAttributeProvider.Empty -> Refit.GeneratedParameterAttributeProvider!
 static Refit.GeneratedRequestRunner.BuildRequestPath(string! relativePathTemplate, bool allowUnmatchedParameter, System.ReadOnlySpan<((int startIdx, int endIdx) range, string? value)> uriParams) -> string!

--- a/src/Refit/PublicAPI/net462/PublicAPI.Unshipped.txt
+++ b/src/Refit/PublicAPI/net462/PublicAPI.Unshipped.txt
@@ -1,5 +1,7 @@
 #nullable enable
 static Refit.GeneratedRequestRunner.CanUnrollForm(object? body) -> bool
+static Refit.GeneratedRequestRunner.RoundTripEscapePath(string? value, Refit.RefitSettings! settings, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string!
+static Refit.GeneratedRequestRunner.FormatUrlParameter(Refit.RefitSettings! settings, object? value, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string?
 Refit.GeneratedQueryStringBuilder.GeneratedQueryStringBuilder(string! relativePath, bool hasQuery) -> void
 static readonly Refit.GeneratedParameterAttributeProvider.Empty -> Refit.GeneratedParameterAttributeProvider!
 static Refit.GeneratedRequestRunner.BuildRequestPath(string! relativePathTemplate, bool allowUnmatchedParameter, System.ReadOnlySpan<((int startIdx, int endIdx) range, string? value)> uriParams) -> string!

--- a/src/Refit/PublicAPI/net470/PublicAPI.Shipped.txt
+++ b/src/Refit/PublicAPI/net470/PublicAPI.Shipped.txt
@@ -301,6 +301,7 @@ Refit.RefitSettings.TransportExceptionFactory.get -> System.Func<System.Net.Http
 Refit.RefitSettings.TransportExceptionFactory.set -> void
 Refit.RefitSettings.UrlParameterFormatter.get -> Refit.IUrlParameterFormatter!
 Refit.RefitSettings.UrlParameterFormatter.set -> void
+Refit.RefitSettings.UrlParameterFormatterMap.get -> System.Collections.Generic.IDictionary<System.Type!, Refit.IUrlParameterFormatter!>!
 Refit.RefitSettings.UrlParameterKeyFormatter.get -> Refit.IUrlParameterKeyFormatter!
 Refit.RefitSettings.UrlParameterKeyFormatter.set -> void
 Refit.RefitSettings.UrlResolution.get -> Refit.UrlResolutionMode
@@ -473,3 +474,5 @@ Refit.SystemTextJsonQueryConverter<T>.Flatten(T value, string! keyPrefix, ref Re
 Refit.IReturnTypeAdapter<TReturn, TResult>
 Refit.IReturnTypeAdapter<TReturn, TResult>.Adapt(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<TResult>!>! invoke) -> TReturn
 Refit.RefitSettings.ReturnTypeAdapters.get -> System.Collections.Generic.IList<System.Type!>!
+static Refit.GeneratedRequestRunner.FormatUrlParameter(Refit.RefitSettings! settings, object? value, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string?
+static Refit.GeneratedRequestRunner.RoundTripEscapePath(string? value, Refit.RefitSettings! settings, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string!

--- a/src/Refit/PublicAPI/net470/PublicAPI.Shipped.txt
+++ b/src/Refit/PublicAPI/net470/PublicAPI.Shipped.txt
@@ -474,5 +474,3 @@ Refit.SystemTextJsonQueryConverter<T>.Flatten(T value, string! keyPrefix, ref Re
 Refit.IReturnTypeAdapter<TReturn, TResult>
 Refit.IReturnTypeAdapter<TReturn, TResult>.Adapt(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<TResult>!>! invoke) -> TReturn
 Refit.RefitSettings.ReturnTypeAdapters.get -> System.Collections.Generic.IList<System.Type!>!
-static Refit.GeneratedRequestRunner.FormatUrlParameter(Refit.RefitSettings! settings, object? value, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string?
-static Refit.GeneratedRequestRunner.RoundTripEscapePath(string? value, Refit.RefitSettings! settings, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string!

--- a/src/Refit/PublicAPI/net470/PublicAPI.Unshipped.txt
+++ b/src/Refit/PublicAPI/net470/PublicAPI.Unshipped.txt
@@ -1,6 +1,5 @@
 #nullable enable
 static Refit.GeneratedRequestRunner.CanUnrollForm(object? body) -> bool
-static Refit.GeneratedRequestRunner.RoundTripEscapePath(string? value, Refit.IUrlParameterFormatter! formatter, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string!
 Refit.GeneratedQueryStringBuilder.GeneratedQueryStringBuilder(string! relativePath, bool hasQuery) -> void
 static readonly Refit.GeneratedParameterAttributeProvider.Empty -> Refit.GeneratedParameterAttributeProvider!
 static Refit.GeneratedRequestRunner.BuildRequestPath(string! relativePathTemplate, bool allowUnmatchedParameter, System.ReadOnlySpan<((int startIdx, int endIdx) range, string? value)> uriParams) -> string!

--- a/src/Refit/PublicAPI/net470/PublicAPI.Unshipped.txt
+++ b/src/Refit/PublicAPI/net470/PublicAPI.Unshipped.txt
@@ -1,5 +1,7 @@
 #nullable enable
 static Refit.GeneratedRequestRunner.CanUnrollForm(object? body) -> bool
+static Refit.GeneratedRequestRunner.RoundTripEscapePath(string? value, Refit.RefitSettings! settings, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string!
+static Refit.GeneratedRequestRunner.FormatUrlParameter(Refit.RefitSettings! settings, object? value, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string?
 Refit.GeneratedQueryStringBuilder.GeneratedQueryStringBuilder(string! relativePath, bool hasQuery) -> void
 static readonly Refit.GeneratedParameterAttributeProvider.Empty -> Refit.GeneratedParameterAttributeProvider!
 static Refit.GeneratedRequestRunner.BuildRequestPath(string! relativePathTemplate, bool allowUnmatchedParameter, System.ReadOnlySpan<((int startIdx, int endIdx) range, string? value)> uriParams) -> string!

--- a/src/Refit/PublicAPI/net471/PublicAPI.Shipped.txt
+++ b/src/Refit/PublicAPI/net471/PublicAPI.Shipped.txt
@@ -301,6 +301,7 @@ Refit.RefitSettings.TransportExceptionFactory.get -> System.Func<System.Net.Http
 Refit.RefitSettings.TransportExceptionFactory.set -> void
 Refit.RefitSettings.UrlParameterFormatter.get -> Refit.IUrlParameterFormatter!
 Refit.RefitSettings.UrlParameterFormatter.set -> void
+Refit.RefitSettings.UrlParameterFormatterMap.get -> System.Collections.Generic.IDictionary<System.Type!, Refit.IUrlParameterFormatter!>!
 Refit.RefitSettings.UrlParameterKeyFormatter.get -> Refit.IUrlParameterKeyFormatter!
 Refit.RefitSettings.UrlParameterKeyFormatter.set -> void
 Refit.RefitSettings.UrlResolution.get -> Refit.UrlResolutionMode
@@ -473,3 +474,5 @@ Refit.SystemTextJsonQueryConverter<T>.Flatten(T value, string! keyPrefix, ref Re
 Refit.IReturnTypeAdapter<TReturn, TResult>
 Refit.IReturnTypeAdapter<TReturn, TResult>.Adapt(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<TResult>!>! invoke) -> TReturn
 Refit.RefitSettings.ReturnTypeAdapters.get -> System.Collections.Generic.IList<System.Type!>!
+static Refit.GeneratedRequestRunner.FormatUrlParameter(Refit.RefitSettings! settings, object? value, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string?
+static Refit.GeneratedRequestRunner.RoundTripEscapePath(string? value, Refit.RefitSettings! settings, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string!

--- a/src/Refit/PublicAPI/net471/PublicAPI.Shipped.txt
+++ b/src/Refit/PublicAPI/net471/PublicAPI.Shipped.txt
@@ -474,5 +474,3 @@ Refit.SystemTextJsonQueryConverter<T>.Flatten(T value, string! keyPrefix, ref Re
 Refit.IReturnTypeAdapter<TReturn, TResult>
 Refit.IReturnTypeAdapter<TReturn, TResult>.Adapt(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<TResult>!>! invoke) -> TReturn
 Refit.RefitSettings.ReturnTypeAdapters.get -> System.Collections.Generic.IList<System.Type!>!
-static Refit.GeneratedRequestRunner.FormatUrlParameter(Refit.RefitSettings! settings, object? value, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string?
-static Refit.GeneratedRequestRunner.RoundTripEscapePath(string? value, Refit.RefitSettings! settings, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string!

--- a/src/Refit/PublicAPI/net471/PublicAPI.Unshipped.txt
+++ b/src/Refit/PublicAPI/net471/PublicAPI.Unshipped.txt
@@ -1,6 +1,5 @@
 #nullable enable
 static Refit.GeneratedRequestRunner.CanUnrollForm(object? body) -> bool
-static Refit.GeneratedRequestRunner.RoundTripEscapePath(string? value, Refit.IUrlParameterFormatter! formatter, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string!
 Refit.GeneratedQueryStringBuilder.GeneratedQueryStringBuilder(string! relativePath, bool hasQuery) -> void
 static readonly Refit.GeneratedParameterAttributeProvider.Empty -> Refit.GeneratedParameterAttributeProvider!
 static Refit.GeneratedRequestRunner.BuildRequestPath(string! relativePathTemplate, bool allowUnmatchedParameter, System.ReadOnlySpan<((int startIdx, int endIdx) range, string? value)> uriParams) -> string!

--- a/src/Refit/PublicAPI/net471/PublicAPI.Unshipped.txt
+++ b/src/Refit/PublicAPI/net471/PublicAPI.Unshipped.txt
@@ -1,5 +1,7 @@
 #nullable enable
 static Refit.GeneratedRequestRunner.CanUnrollForm(object? body) -> bool
+static Refit.GeneratedRequestRunner.RoundTripEscapePath(string? value, Refit.RefitSettings! settings, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string!
+static Refit.GeneratedRequestRunner.FormatUrlParameter(Refit.RefitSettings! settings, object? value, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string?
 Refit.GeneratedQueryStringBuilder.GeneratedQueryStringBuilder(string! relativePath, bool hasQuery) -> void
 static readonly Refit.GeneratedParameterAttributeProvider.Empty -> Refit.GeneratedParameterAttributeProvider!
 static Refit.GeneratedRequestRunner.BuildRequestPath(string! relativePathTemplate, bool allowUnmatchedParameter, System.ReadOnlySpan<((int startIdx, int endIdx) range, string? value)> uriParams) -> string!

--- a/src/Refit/PublicAPI/net472/PublicAPI.Shipped.txt
+++ b/src/Refit/PublicAPI/net472/PublicAPI.Shipped.txt
@@ -301,6 +301,7 @@ Refit.RefitSettings.TransportExceptionFactory.get -> System.Func<System.Net.Http
 Refit.RefitSettings.TransportExceptionFactory.set -> void
 Refit.RefitSettings.UrlParameterFormatter.get -> Refit.IUrlParameterFormatter!
 Refit.RefitSettings.UrlParameterFormatter.set -> void
+Refit.RefitSettings.UrlParameterFormatterMap.get -> System.Collections.Generic.IDictionary<System.Type!, Refit.IUrlParameterFormatter!>!
 Refit.RefitSettings.UrlParameterKeyFormatter.get -> Refit.IUrlParameterKeyFormatter!
 Refit.RefitSettings.UrlParameterKeyFormatter.set -> void
 Refit.RefitSettings.UrlResolution.get -> Refit.UrlResolutionMode
@@ -473,3 +474,5 @@ Refit.SystemTextJsonQueryConverter<T>.Flatten(T value, string! keyPrefix, ref Re
 Refit.IReturnTypeAdapter<TReturn, TResult>
 Refit.IReturnTypeAdapter<TReturn, TResult>.Adapt(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<TResult>!>! invoke) -> TReturn
 Refit.RefitSettings.ReturnTypeAdapters.get -> System.Collections.Generic.IList<System.Type!>!
+static Refit.GeneratedRequestRunner.FormatUrlParameter(Refit.RefitSettings! settings, object? value, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string?
+static Refit.GeneratedRequestRunner.RoundTripEscapePath(string? value, Refit.RefitSettings! settings, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string!

--- a/src/Refit/PublicAPI/net472/PublicAPI.Shipped.txt
+++ b/src/Refit/PublicAPI/net472/PublicAPI.Shipped.txt
@@ -474,5 +474,3 @@ Refit.SystemTextJsonQueryConverter<T>.Flatten(T value, string! keyPrefix, ref Re
 Refit.IReturnTypeAdapter<TReturn, TResult>
 Refit.IReturnTypeAdapter<TReturn, TResult>.Adapt(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<TResult>!>! invoke) -> TReturn
 Refit.RefitSettings.ReturnTypeAdapters.get -> System.Collections.Generic.IList<System.Type!>!
-static Refit.GeneratedRequestRunner.FormatUrlParameter(Refit.RefitSettings! settings, object? value, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string?
-static Refit.GeneratedRequestRunner.RoundTripEscapePath(string? value, Refit.RefitSettings! settings, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string!

--- a/src/Refit/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/Refit/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -1,6 +1,5 @@
 #nullable enable
 static Refit.GeneratedRequestRunner.CanUnrollForm(object? body) -> bool
-static Refit.GeneratedRequestRunner.RoundTripEscapePath(string? value, Refit.IUrlParameterFormatter! formatter, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string!
 Refit.GeneratedQueryStringBuilder.GeneratedQueryStringBuilder(string! relativePath, bool hasQuery) -> void
 static readonly Refit.GeneratedParameterAttributeProvider.Empty -> Refit.GeneratedParameterAttributeProvider!
 static Refit.GeneratedRequestRunner.BuildRequestPath(string! relativePathTemplate, bool allowUnmatchedParameter, System.ReadOnlySpan<((int startIdx, int endIdx) range, string? value)> uriParams) -> string!

--- a/src/Refit/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/Refit/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -1,5 +1,7 @@
 #nullable enable
 static Refit.GeneratedRequestRunner.CanUnrollForm(object? body) -> bool
+static Refit.GeneratedRequestRunner.RoundTripEscapePath(string? value, Refit.RefitSettings! settings, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string!
+static Refit.GeneratedRequestRunner.FormatUrlParameter(Refit.RefitSettings! settings, object? value, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string?
 Refit.GeneratedQueryStringBuilder.GeneratedQueryStringBuilder(string! relativePath, bool hasQuery) -> void
 static readonly Refit.GeneratedParameterAttributeProvider.Empty -> Refit.GeneratedParameterAttributeProvider!
 static Refit.GeneratedRequestRunner.BuildRequestPath(string! relativePathTemplate, bool allowUnmatchedParameter, System.ReadOnlySpan<((int startIdx, int endIdx) range, string? value)> uriParams) -> string!

--- a/src/Refit/PublicAPI/net48/PublicAPI.Shipped.txt
+++ b/src/Refit/PublicAPI/net48/PublicAPI.Shipped.txt
@@ -301,6 +301,7 @@ Refit.RefitSettings.TransportExceptionFactory.get -> System.Func<System.Net.Http
 Refit.RefitSettings.TransportExceptionFactory.set -> void
 Refit.RefitSettings.UrlParameterFormatter.get -> Refit.IUrlParameterFormatter!
 Refit.RefitSettings.UrlParameterFormatter.set -> void
+Refit.RefitSettings.UrlParameterFormatterMap.get -> System.Collections.Generic.IDictionary<System.Type!, Refit.IUrlParameterFormatter!>!
 Refit.RefitSettings.UrlParameterKeyFormatter.get -> Refit.IUrlParameterKeyFormatter!
 Refit.RefitSettings.UrlParameterKeyFormatter.set -> void
 Refit.RefitSettings.UrlResolution.get -> Refit.UrlResolutionMode
@@ -473,3 +474,5 @@ Refit.SystemTextJsonQueryConverter<T>.Flatten(T value, string! keyPrefix, ref Re
 Refit.IReturnTypeAdapter<TReturn, TResult>
 Refit.IReturnTypeAdapter<TReturn, TResult>.Adapt(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<TResult>!>! invoke) -> TReturn
 Refit.RefitSettings.ReturnTypeAdapters.get -> System.Collections.Generic.IList<System.Type!>!
+static Refit.GeneratedRequestRunner.FormatUrlParameter(Refit.RefitSettings! settings, object? value, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string?
+static Refit.GeneratedRequestRunner.RoundTripEscapePath(string? value, Refit.RefitSettings! settings, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string!

--- a/src/Refit/PublicAPI/net48/PublicAPI.Shipped.txt
+++ b/src/Refit/PublicAPI/net48/PublicAPI.Shipped.txt
@@ -474,5 +474,3 @@ Refit.SystemTextJsonQueryConverter<T>.Flatten(T value, string! keyPrefix, ref Re
 Refit.IReturnTypeAdapter<TReturn, TResult>
 Refit.IReturnTypeAdapter<TReturn, TResult>.Adapt(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<TResult>!>! invoke) -> TReturn
 Refit.RefitSettings.ReturnTypeAdapters.get -> System.Collections.Generic.IList<System.Type!>!
-static Refit.GeneratedRequestRunner.FormatUrlParameter(Refit.RefitSettings! settings, object? value, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string?
-static Refit.GeneratedRequestRunner.RoundTripEscapePath(string? value, Refit.RefitSettings! settings, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string!

--- a/src/Refit/PublicAPI/net48/PublicAPI.Unshipped.txt
+++ b/src/Refit/PublicAPI/net48/PublicAPI.Unshipped.txt
@@ -1,6 +1,5 @@
 #nullable enable
 static Refit.GeneratedRequestRunner.CanUnrollForm(object? body) -> bool
-static Refit.GeneratedRequestRunner.RoundTripEscapePath(string? value, Refit.IUrlParameterFormatter! formatter, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string!
 Refit.GeneratedQueryStringBuilder.GeneratedQueryStringBuilder(string! relativePath, bool hasQuery) -> void
 static readonly Refit.GeneratedParameterAttributeProvider.Empty -> Refit.GeneratedParameterAttributeProvider!
 static Refit.GeneratedRequestRunner.BuildRequestPath(string! relativePathTemplate, bool allowUnmatchedParameter, System.ReadOnlySpan<((int startIdx, int endIdx) range, string? value)> uriParams) -> string!

--- a/src/Refit/PublicAPI/net48/PublicAPI.Unshipped.txt
+++ b/src/Refit/PublicAPI/net48/PublicAPI.Unshipped.txt
@@ -1,5 +1,7 @@
 #nullable enable
 static Refit.GeneratedRequestRunner.CanUnrollForm(object? body) -> bool
+static Refit.GeneratedRequestRunner.RoundTripEscapePath(string? value, Refit.RefitSettings! settings, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string!
+static Refit.GeneratedRequestRunner.FormatUrlParameter(Refit.RefitSettings! settings, object? value, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string?
 Refit.GeneratedQueryStringBuilder.GeneratedQueryStringBuilder(string! relativePath, bool hasQuery) -> void
 static readonly Refit.GeneratedParameterAttributeProvider.Empty -> Refit.GeneratedParameterAttributeProvider!
 static Refit.GeneratedRequestRunner.BuildRequestPath(string! relativePathTemplate, bool allowUnmatchedParameter, System.ReadOnlySpan<((int startIdx, int endIdx) range, string? value)> uriParams) -> string!

--- a/src/Refit/PublicAPI/net481/PublicAPI.Shipped.txt
+++ b/src/Refit/PublicAPI/net481/PublicAPI.Shipped.txt
@@ -301,6 +301,7 @@ Refit.RefitSettings.TransportExceptionFactory.get -> System.Func<System.Net.Http
 Refit.RefitSettings.TransportExceptionFactory.set -> void
 Refit.RefitSettings.UrlParameterFormatter.get -> Refit.IUrlParameterFormatter!
 Refit.RefitSettings.UrlParameterFormatter.set -> void
+Refit.RefitSettings.UrlParameterFormatterMap.get -> System.Collections.Generic.IDictionary<System.Type!, Refit.IUrlParameterFormatter!>!
 Refit.RefitSettings.UrlParameterKeyFormatter.get -> Refit.IUrlParameterKeyFormatter!
 Refit.RefitSettings.UrlParameterKeyFormatter.set -> void
 Refit.RefitSettings.UrlResolution.get -> Refit.UrlResolutionMode
@@ -473,3 +474,5 @@ Refit.SystemTextJsonQueryConverter<T>.Flatten(T value, string! keyPrefix, ref Re
 Refit.IReturnTypeAdapter<TReturn, TResult>
 Refit.IReturnTypeAdapter<TReturn, TResult>.Adapt(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<TResult>!>! invoke) -> TReturn
 Refit.RefitSettings.ReturnTypeAdapters.get -> System.Collections.Generic.IList<System.Type!>!
+static Refit.GeneratedRequestRunner.FormatUrlParameter(Refit.RefitSettings! settings, object? value, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string?
+static Refit.GeneratedRequestRunner.RoundTripEscapePath(string? value, Refit.RefitSettings! settings, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string!

--- a/src/Refit/PublicAPI/net481/PublicAPI.Shipped.txt
+++ b/src/Refit/PublicAPI/net481/PublicAPI.Shipped.txt
@@ -474,5 +474,3 @@ Refit.SystemTextJsonQueryConverter<T>.Flatten(T value, string! keyPrefix, ref Re
 Refit.IReturnTypeAdapter<TReturn, TResult>
 Refit.IReturnTypeAdapter<TReturn, TResult>.Adapt(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<TResult>!>! invoke) -> TReturn
 Refit.RefitSettings.ReturnTypeAdapters.get -> System.Collections.Generic.IList<System.Type!>!
-static Refit.GeneratedRequestRunner.FormatUrlParameter(Refit.RefitSettings! settings, object? value, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string?
-static Refit.GeneratedRequestRunner.RoundTripEscapePath(string? value, Refit.RefitSettings! settings, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string!

--- a/src/Refit/PublicAPI/net481/PublicAPI.Unshipped.txt
+++ b/src/Refit/PublicAPI/net481/PublicAPI.Unshipped.txt
@@ -1,6 +1,5 @@
 #nullable enable
 static Refit.GeneratedRequestRunner.CanUnrollForm(object? body) -> bool
-static Refit.GeneratedRequestRunner.RoundTripEscapePath(string? value, Refit.IUrlParameterFormatter! formatter, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string!
 Refit.GeneratedQueryStringBuilder.GeneratedQueryStringBuilder(string! relativePath, bool hasQuery) -> void
 static readonly Refit.GeneratedParameterAttributeProvider.Empty -> Refit.GeneratedParameterAttributeProvider!
 static Refit.GeneratedRequestRunner.BuildRequestPath(string! relativePathTemplate, bool allowUnmatchedParameter, System.ReadOnlySpan<((int startIdx, int endIdx) range, string? value)> uriParams) -> string!

--- a/src/Refit/PublicAPI/net481/PublicAPI.Unshipped.txt
+++ b/src/Refit/PublicAPI/net481/PublicAPI.Unshipped.txt
@@ -1,5 +1,7 @@
 #nullable enable
 static Refit.GeneratedRequestRunner.CanUnrollForm(object? body) -> bool
+static Refit.GeneratedRequestRunner.RoundTripEscapePath(string? value, Refit.RefitSettings! settings, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string!
+static Refit.GeneratedRequestRunner.FormatUrlParameter(Refit.RefitSettings! settings, object? value, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string?
 Refit.GeneratedQueryStringBuilder.GeneratedQueryStringBuilder(string! relativePath, bool hasQuery) -> void
 static readonly Refit.GeneratedParameterAttributeProvider.Empty -> Refit.GeneratedParameterAttributeProvider!
 static Refit.GeneratedRequestRunner.BuildRequestPath(string! relativePathTemplate, bool allowUnmatchedParameter, System.ReadOnlySpan<((int startIdx, int endIdx) range, string? value)> uriParams) -> string!

--- a/src/Refit/PublicAPI/net8.0/PublicAPI.Shipped.txt
+++ b/src/Refit/PublicAPI/net8.0/PublicAPI.Shipped.txt
@@ -478,5 +478,3 @@ Refit.SystemTextJsonQueryConverter<T>.Flatten(T value, string! keyPrefix, ref Re
 Refit.IReturnTypeAdapter<TReturn, TResult>
 Refit.IReturnTypeAdapter<TReturn, TResult>.Adapt(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<TResult>!>! invoke) -> TReturn
 Refit.RefitSettings.ReturnTypeAdapters.get -> System.Collections.Generic.IList<System.Type!>!
-static Refit.GeneratedRequestRunner.FormatUrlParameter(Refit.RefitSettings! settings, object? value, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string?
-static Refit.GeneratedRequestRunner.RoundTripEscapePath(string? value, Refit.RefitSettings! settings, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string!

--- a/src/Refit/PublicAPI/net8.0/PublicAPI.Shipped.txt
+++ b/src/Refit/PublicAPI/net8.0/PublicAPI.Shipped.txt
@@ -301,6 +301,7 @@ Refit.RefitSettings.TransportExceptionFactory.get -> System.Func<System.Net.Http
 Refit.RefitSettings.TransportExceptionFactory.set -> void
 Refit.RefitSettings.UrlParameterFormatter.get -> Refit.IUrlParameterFormatter!
 Refit.RefitSettings.UrlParameterFormatter.set -> void
+Refit.RefitSettings.UrlParameterFormatterMap.get -> System.Collections.Generic.IDictionary<System.Type!, Refit.IUrlParameterFormatter!>!
 Refit.RefitSettings.UrlParameterKeyFormatter.get -> Refit.IUrlParameterKeyFormatter!
 Refit.RefitSettings.UrlParameterKeyFormatter.set -> void
 Refit.RefitSettings.UrlResolution.get -> Refit.UrlResolutionMode
@@ -477,3 +478,5 @@ Refit.SystemTextJsonQueryConverter<T>.Flatten(T value, string! keyPrefix, ref Re
 Refit.IReturnTypeAdapter<TReturn, TResult>
 Refit.IReturnTypeAdapter<TReturn, TResult>.Adapt(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<TResult>!>! invoke) -> TReturn
 Refit.RefitSettings.ReturnTypeAdapters.get -> System.Collections.Generic.IList<System.Type!>!
+static Refit.GeneratedRequestRunner.FormatUrlParameter(Refit.RefitSettings! settings, object? value, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string?
+static Refit.GeneratedRequestRunner.RoundTripEscapePath(string? value, Refit.RefitSettings! settings, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string!

--- a/src/Refit/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/Refit/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -3,6 +3,8 @@ Refit.GeneratedQueryStringBuilder.AddCollectionValueFormatted<T>(T value) -> voi
 Refit.GeneratedQueryStringBuilder.AddFormatted<T>(string! name, T value, string? format, bool preEncoded) -> void
 static Refit.GeneratedRequestRunner.CanUnrollForm(object? body) -> bool
 static Refit.GeneratedRequestRunner.BuildRequestPath<T>(string! relativePathTemplate, bool allowUnmatchedParameter, (int startIdx, int endIdx) range, T value) -> string!
+static Refit.GeneratedRequestRunner.RoundTripEscapePath(string? value, Refit.RefitSettings! settings, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string!
+static Refit.GeneratedRequestRunner.FormatUrlParameter(Refit.RefitSettings! settings, object? value, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string?
 Refit.GeneratedQueryStringBuilder.GeneratedQueryStringBuilder(string! relativePath, bool hasQuery) -> void
 static readonly Refit.GeneratedParameterAttributeProvider.Empty -> Refit.GeneratedParameterAttributeProvider!
 static Refit.GeneratedRequestRunner.BuildRequestPath(string! relativePathTemplate, bool allowUnmatchedParameter, System.ReadOnlySpan<((int startIdx, int endIdx) range, string? value)> uriParams) -> string!

--- a/src/Refit/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/Refit/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -3,7 +3,6 @@ Refit.GeneratedQueryStringBuilder.AddCollectionValueFormatted<T>(T value) -> voi
 Refit.GeneratedQueryStringBuilder.AddFormatted<T>(string! name, T value, string? format, bool preEncoded) -> void
 static Refit.GeneratedRequestRunner.CanUnrollForm(object? body) -> bool
 static Refit.GeneratedRequestRunner.BuildRequestPath<T>(string! relativePathTemplate, bool allowUnmatchedParameter, (int startIdx, int endIdx) range, T value) -> string!
-static Refit.GeneratedRequestRunner.RoundTripEscapePath(string? value, Refit.IUrlParameterFormatter! formatter, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string!
 Refit.GeneratedQueryStringBuilder.GeneratedQueryStringBuilder(string! relativePath, bool hasQuery) -> void
 static readonly Refit.GeneratedParameterAttributeProvider.Empty -> Refit.GeneratedParameterAttributeProvider!
 static Refit.GeneratedRequestRunner.BuildRequestPath(string! relativePathTemplate, bool allowUnmatchedParameter, System.ReadOnlySpan<((int startIdx, int endIdx) range, string? value)> uriParams) -> string!

--- a/src/Refit/PublicAPI/net9.0/PublicAPI.Shipped.txt
+++ b/src/Refit/PublicAPI/net9.0/PublicAPI.Shipped.txt
@@ -478,5 +478,3 @@ Refit.SystemTextJsonQueryConverter<T>.Flatten(T value, string! keyPrefix, ref Re
 Refit.IReturnTypeAdapter<TReturn, TResult>
 Refit.IReturnTypeAdapter<TReturn, TResult>.Adapt(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<TResult>!>! invoke) -> TReturn
 Refit.RefitSettings.ReturnTypeAdapters.get -> System.Collections.Generic.IList<System.Type!>!
-static Refit.GeneratedRequestRunner.FormatUrlParameter(Refit.RefitSettings! settings, object? value, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string?
-static Refit.GeneratedRequestRunner.RoundTripEscapePath(string? value, Refit.RefitSettings! settings, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string!

--- a/src/Refit/PublicAPI/net9.0/PublicAPI.Shipped.txt
+++ b/src/Refit/PublicAPI/net9.0/PublicAPI.Shipped.txt
@@ -301,6 +301,7 @@ Refit.RefitSettings.TransportExceptionFactory.get -> System.Func<System.Net.Http
 Refit.RefitSettings.TransportExceptionFactory.set -> void
 Refit.RefitSettings.UrlParameterFormatter.get -> Refit.IUrlParameterFormatter!
 Refit.RefitSettings.UrlParameterFormatter.set -> void
+Refit.RefitSettings.UrlParameterFormatterMap.get -> System.Collections.Generic.IDictionary<System.Type!, Refit.IUrlParameterFormatter!>!
 Refit.RefitSettings.UrlParameterKeyFormatter.get -> Refit.IUrlParameterKeyFormatter!
 Refit.RefitSettings.UrlParameterKeyFormatter.set -> void
 Refit.RefitSettings.UrlResolution.get -> Refit.UrlResolutionMode
@@ -477,3 +478,5 @@ Refit.SystemTextJsonQueryConverter<T>.Flatten(T value, string! keyPrefix, ref Re
 Refit.IReturnTypeAdapter<TReturn, TResult>
 Refit.IReturnTypeAdapter<TReturn, TResult>.Adapt(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<TResult>!>! invoke) -> TReturn
 Refit.RefitSettings.ReturnTypeAdapters.get -> System.Collections.Generic.IList<System.Type!>!
+static Refit.GeneratedRequestRunner.FormatUrlParameter(Refit.RefitSettings! settings, object? value, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string?
+static Refit.GeneratedRequestRunner.RoundTripEscapePath(string? value, Refit.RefitSettings! settings, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string!

--- a/src/Refit/PublicAPI/net9.0/PublicAPI.Unshipped.txt
+++ b/src/Refit/PublicAPI/net9.0/PublicAPI.Unshipped.txt
@@ -4,7 +4,6 @@ Refit.GeneratedQueryStringBuilder.AddFormatted<T>(string! name, T value, string?
 static Refit.GeneratedRequestRunner.CanUnrollForm(object? body) -> bool
 static Refit.GeneratedRequestRunner.BuildRequestPath<T>(string! relativePathTemplate, bool allowUnmatchedParameter, (int startIdx, int endIdx) range, T value) -> string!
 static Refit.GeneratedRequestRunner.BuildRequestPath<T>(string! relativePathTemplate, bool allowUnmatchedParameter, (int startIdx, int endIdx) range, T value, string? format) -> string!
-static Refit.GeneratedRequestRunner.RoundTripEscapePath(string? value, Refit.IUrlParameterFormatter! formatter, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string!
 Refit.GeneratedQueryStringBuilder.GeneratedQueryStringBuilder(string! relativePath, bool hasQuery) -> void
 static readonly Refit.GeneratedParameterAttributeProvider.Empty -> Refit.GeneratedParameterAttributeProvider!
 static Refit.GeneratedRequestRunner.BuildRequestPath(string! relativePathTemplate, bool allowUnmatchedParameter, System.ReadOnlySpan<((int startIdx, int endIdx) range, string? value)> uriParams) -> string!

--- a/src/Refit/PublicAPI/net9.0/PublicAPI.Unshipped.txt
+++ b/src/Refit/PublicAPI/net9.0/PublicAPI.Unshipped.txt
@@ -4,6 +4,8 @@ Refit.GeneratedQueryStringBuilder.AddFormatted<T>(string! name, T value, string?
 static Refit.GeneratedRequestRunner.CanUnrollForm(object? body) -> bool
 static Refit.GeneratedRequestRunner.BuildRequestPath<T>(string! relativePathTemplate, bool allowUnmatchedParameter, (int startIdx, int endIdx) range, T value) -> string!
 static Refit.GeneratedRequestRunner.BuildRequestPath<T>(string! relativePathTemplate, bool allowUnmatchedParameter, (int startIdx, int endIdx) range, T value, string? format) -> string!
+static Refit.GeneratedRequestRunner.RoundTripEscapePath(string? value, Refit.RefitSettings! settings, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string!
+static Refit.GeneratedRequestRunner.FormatUrlParameter(Refit.RefitSettings! settings, object? value, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string?
 Refit.GeneratedQueryStringBuilder.GeneratedQueryStringBuilder(string! relativePath, bool hasQuery) -> void
 static readonly Refit.GeneratedParameterAttributeProvider.Empty -> Refit.GeneratedParameterAttributeProvider!
 static Refit.GeneratedRequestRunner.BuildRequestPath(string! relativePathTemplate, bool allowUnmatchedParameter, System.ReadOnlySpan<((int startIdx, int endIdx) range, string? value)> uriParams) -> string!

--- a/src/Refit/RefitSettings.cs
+++ b/src/Refit/RefitSettings.cs
@@ -136,6 +136,19 @@ public class RefitSettings
     /// <summary>Gets or sets the <see cref="IUrlParameterFormatter"/> instance to use (defaults to <see cref="DefaultUrlParameterFormatter"/>).</summary>
     public IUrlParameterFormatter UrlParameterFormatter { get; set; }
 
+    /// <summary>Gets a registry of <see cref="IUrlParameterFormatter"/> instances keyed by the CLR type they format,
+    /// consulted before <see cref="UrlParameterFormatter"/> when rendering a value into a path or query string.</summary>
+    /// <remarks>
+    /// When a value is rendered into a URL (a path parameter, a round-trip path segment, or a query value), its runtime
+    /// type (<see cref="object.GetType"/>) is looked up here first; a registered formatter is used for that value, and
+    /// any other type falls back to <see cref="UrlParameterFormatter"/>. Matching is by exact runtime type only - no base
+    /// class or interface walking - so register the concrete type the value will have at runtime. Both the reflection and
+    /// source-generated request builders consult this registry identically. It does not affect header or body
+    /// serialization. Registering any entry opts a request out of the generator's inline formatting fast path.
+    /// </remarks>
+    public IDictionary<Type, IUrlParameterFormatter> UrlParameterFormatterMap { get; } =
+        new Dictionary<Type, IUrlParameterFormatter>();
+
     /// <summary>Gets or sets the <see cref="IFormUrlEncodedParameterFormatter"/> instance to use (defaults to <see cref="DefaultFormUrlEncodedParameterFormatter"/>).</summary>
     public IFormUrlEncodedParameterFormatter FormUrlEncodedParameterFormatter { get; set; }
 

--- a/src/tests/Refit.GeneratorTests/_snapshots/InterfaceStubGeneratorTests.FindInterfacesSmokeTest#IGitHubApi.g.verified.cs
+++ b/src/tests/Refit.GeneratorTests/_snapshots/InterfaceStubGeneratorTests.FindInterfacesSmokeTest#IGitHubApi.g.verified.cs
@@ -53,7 +53,7 @@ namespace Refit.Implementation
             {
                 var refitSettings = _settings;
                 var refitUseDefaultFormatting = global::Refit.GeneratedRequestRunner.UsesDefaultUrlParameterFormatting(refitSettings);
-                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, global::Refit.GeneratedRequestRunner.BuildRelativeUri(this.Client, global::Refit.GeneratedRequestRunner.BuildRequestPath("/users/{username}", refitSettings.AllowUnmatchedRouteParameters, [((7, 17), refitUseDefaultFormatting ? (@userName) : refitSettings.UrlParameterFormatter.Format(@userName, ______userNameAttributeProvider, typeof(string)))]), refitSettings.UrlResolution));
+                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, global::Refit.GeneratedRequestRunner.BuildRelativeUri(this.Client, global::Refit.GeneratedRequestRunner.BuildRequestPath("/users/{username}", refitSettings.AllowUnmatchedRouteParameters, [((7, 17), refitUseDefaultFormatting ? (@userName) : global::Refit.GeneratedRequestRunner.FormatUrlParameter(refitSettings, @userName, ______userNameAttributeProvider, typeof(string)))]), refitSettings.UrlResolution));
                 global::Refit.GeneratedRequestRunner.SetHeader(refitRequest, "User-Agent", "Refit Integration Tests");
                 global::Refit.GeneratedRequestRunner.AddConfiguredRequestOptions(refitRequest, refitSettings, typeof(global::Refit.Tests.IGitHubApi));
                 return global::Refit.GeneratedRequestRunner.SendAsync<global::Refit.Tests.User, global::Refit.Tests.User>(
@@ -76,7 +76,7 @@ namespace Refit.Implementation
                 global::System.Net.Http.HttpRequestMessage BuildRefitRequest()
                 {
                 var refitUseDefaultFormatting = global::Refit.GeneratedRequestRunner.UsesDefaultUrlParameterFormatting(refitSettings);
-                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, global::Refit.GeneratedRequestRunner.BuildRelativeUri(this.Client, global::Refit.GeneratedRequestRunner.BuildRequestPath("/users/{username}", refitSettings.AllowUnmatchedRouteParameters, [((7, 17), refitUseDefaultFormatting ? (@userName) : refitSettings.UrlParameterFormatter.Format(@userName, ______userNameAttributeProvider0, typeof(string)))]), refitSettings.UrlResolution));
+                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, global::Refit.GeneratedRequestRunner.BuildRelativeUri(this.Client, global::Refit.GeneratedRequestRunner.BuildRequestPath("/users/{username}", refitSettings.AllowUnmatchedRouteParameters, [((7, 17), refitUseDefaultFormatting ? (@userName) : global::Refit.GeneratedRequestRunner.FormatUrlParameter(refitSettings, @userName, ______userNameAttributeProvider0, typeof(string)))]), refitSettings.UrlResolution));
                 global::Refit.GeneratedRequestRunner.SetHeader(refitRequest, "User-Agent", "Refit Integration Tests");
                 global::Refit.GeneratedRequestRunner.AddConfiguredRequestOptions(refitRequest, refitSettings, typeof(global::Refit.Tests.IGitHubApi));
                     return refitRequest;
@@ -101,7 +101,7 @@ namespace Refit.Implementation
                 global::System.Net.Http.HttpRequestMessage BuildRefitRequest()
                 {
                 var refitUseDefaultFormatting = global::Refit.GeneratedRequestRunner.UsesDefaultUrlParameterFormatting(refitSettings);
-                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, global::Refit.GeneratedRequestRunner.BuildRelativeUri(this.Client, global::Refit.GeneratedRequestRunner.BuildRequestPath("/users/{userName}", refitSettings.AllowUnmatchedRouteParameters, [((7, 17), refitUseDefaultFormatting ? (@userName) : refitSettings.UrlParameterFormatter.Format(@userName, ______userNameAttributeProvider1, typeof(string)))]), refitSettings.UrlResolution));
+                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, global::Refit.GeneratedRequestRunner.BuildRelativeUri(this.Client, global::Refit.GeneratedRequestRunner.BuildRequestPath("/users/{userName}", refitSettings.AllowUnmatchedRouteParameters, [((7, 17), refitUseDefaultFormatting ? (@userName) : global::Refit.GeneratedRequestRunner.FormatUrlParameter(refitSettings, @userName, ______userNameAttributeProvider1, typeof(string)))]), refitSettings.UrlResolution));
                 global::Refit.GeneratedRequestRunner.SetHeader(refitRequest, "User-Agent", "Refit Integration Tests");
                 global::Refit.GeneratedRequestRunner.AddConfiguredRequestOptions(refitRequest, refitSettings, typeof(global::Refit.Tests.IGitHubApi));
                     return refitRequest;
@@ -124,7 +124,7 @@ namespace Refit.Implementation
             {
                 var refitSettings = _settings;
                 var refitUseDefaultFormatting = global::Refit.GeneratedRequestRunner.UsesDefaultUrlParameterFormatting(refitSettings);
-                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, global::Refit.GeneratedRequestRunner.BuildRelativeUri(this.Client, global::Refit.GeneratedRequestRunner.BuildRequestPath("/orgs/{orgname}/members", refitSettings.AllowUnmatchedRouteParameters, [((6, 15), refitUseDefaultFormatting ? (@orgName) : refitSettings.UrlParameterFormatter.Format(@orgName, ______orgNameAttributeProvider, typeof(string)))]), refitSettings.UrlResolution));
+                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, global::Refit.GeneratedRequestRunner.BuildRelativeUri(this.Client, global::Refit.GeneratedRequestRunner.BuildRequestPath("/orgs/{orgname}/members", refitSettings.AllowUnmatchedRouteParameters, [((6, 15), refitUseDefaultFormatting ? (@orgName) : global::Refit.GeneratedRequestRunner.FormatUrlParameter(refitSettings, @orgName, ______orgNameAttributeProvider, typeof(string)))]), refitSettings.UrlResolution));
                 global::Refit.GeneratedRequestRunner.SetHeader(refitRequest, "User-Agent", "Refit Integration Tests");
                 global::Refit.GeneratedRequestRunner.AddConfiguredRequestOptions(refitRequest, refitSettings, typeof(global::Refit.Tests.IGitHubApi));
                 return global::Refit.GeneratedRequestRunner.SendAsync<global::System.Collections.Generic.List<global::Refit.Tests.User>, global::System.Collections.Generic.List<global::Refit.Tests.User>>(
@@ -148,7 +148,7 @@ namespace Refit.Implementation
                 var refitQueryBuilder = new global::Refit.GeneratedQueryStringBuilder("/search/users", false);
                 if (@q != null)
                 {
-                    refitQueryBuilder.AddPreEscapedKey("q", refitUseDefaultFormatting ? (@q) : refitSettings.UrlParameterFormatter.Format(@q, ______qAttributeProvider, typeof(string)), false);
+                    refitQueryBuilder.AddPreEscapedKey("q", refitUseDefaultFormatting ? (@q) : global::Refit.GeneratedRequestRunner.FormatUrlParameter(refitSettings, @q, ______qAttributeProvider, typeof(string)), false);
                 }
                 var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, global::Refit.GeneratedRequestRunner.BuildRelativeUri(this.Client, refitQueryBuilder.Build(), refitSettings.UrlResolution));
                 global::Refit.GeneratedRequestRunner.SetHeader(refitRequest, "User-Agent", "Refit Integration Tests");
@@ -243,7 +243,7 @@ namespace Refit.Implementation
             {
                 var refitSettings = _settings;
                 var refitUseDefaultFormatting = global::Refit.GeneratedRequestRunner.UsesDefaultUrlParameterFormatting(refitSettings);
-                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, global::Refit.GeneratedRequestRunner.BuildRelativeUri(this.Client, global::Refit.GeneratedRequestRunner.BuildRequestPath("/users/{username}", refitSettings.AllowUnmatchedRouteParameters, [((7, 17), refitUseDefaultFormatting ? (@userName) : refitSettings.UrlParameterFormatter.Format(@userName, ______userNameAttributeProvider2, typeof(string)))]), refitSettings.UrlResolution));
+                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, global::Refit.GeneratedRequestRunner.BuildRelativeUri(this.Client, global::Refit.GeneratedRequestRunner.BuildRequestPath("/users/{username}", refitSettings.AllowUnmatchedRouteParameters, [((7, 17), refitUseDefaultFormatting ? (@userName) : global::Refit.GeneratedRequestRunner.FormatUrlParameter(refitSettings, @userName, ______userNameAttributeProvider2, typeof(string)))]), refitSettings.UrlResolution));
                 global::Refit.GeneratedRequestRunner.SetHeader(refitRequest, "User-Agent", "Refit Integration Tests");
                 global::Refit.GeneratedRequestRunner.AddConfiguredRequestOptions(refitRequest, refitSettings, typeof(global::Refit.Tests.IGitHubApi));
                 return global::Refit.GeneratedRequestRunner.SendAsync<global::Refit.ApiResponse<global::Refit.Tests.User>, global::Refit.Tests.User>(
@@ -266,7 +266,7 @@ namespace Refit.Implementation
                 global::System.Net.Http.HttpRequestMessage BuildRefitRequest()
                 {
                 var refitUseDefaultFormatting = global::Refit.GeneratedRequestRunner.UsesDefaultUrlParameterFormatting(refitSettings);
-                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, global::Refit.GeneratedRequestRunner.BuildRelativeUri(this.Client, global::Refit.GeneratedRequestRunner.BuildRequestPath("/users/{username}", refitSettings.AllowUnmatchedRouteParameters, [((7, 17), refitUseDefaultFormatting ? (@userName) : refitSettings.UrlParameterFormatter.Format(@userName, ______userNameAttributeProvider3, typeof(string)))]), refitSettings.UrlResolution));
+                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, global::Refit.GeneratedRequestRunner.BuildRelativeUri(this.Client, global::Refit.GeneratedRequestRunner.BuildRequestPath("/users/{username}", refitSettings.AllowUnmatchedRouteParameters, [((7, 17), refitUseDefaultFormatting ? (@userName) : global::Refit.GeneratedRequestRunner.FormatUrlParameter(refitSettings, @userName, ______userNameAttributeProvider3, typeof(string)))]), refitSettings.UrlResolution));
                 global::Refit.GeneratedRequestRunner.SetHeader(refitRequest, "User-Agent", "Refit Integration Tests");
                 global::Refit.GeneratedRequestRunner.AddConfiguredRequestOptions(refitRequest, refitSettings, typeof(global::Refit.Tests.IGitHubApi));
                     return refitRequest;
@@ -291,7 +291,7 @@ namespace Refit.Implementation
                 global::System.Net.Http.HttpRequestMessage BuildRefitRequest()
                 {
                 var refitUseDefaultFormatting = global::Refit.GeneratedRequestRunner.UsesDefaultUrlParameterFormatting(refitSettings);
-                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, global::Refit.GeneratedRequestRunner.BuildRelativeUri(this.Client, global::Refit.GeneratedRequestRunner.BuildRequestPath("/users/{username}", refitSettings.AllowUnmatchedRouteParameters, [((7, 17), refitUseDefaultFormatting ? (@userName) : refitSettings.UrlParameterFormatter.Format(@userName, ______userNameAttributeProvider4, typeof(string)))]), refitSettings.UrlResolution));
+                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, global::Refit.GeneratedRequestRunner.BuildRelativeUri(this.Client, global::Refit.GeneratedRequestRunner.BuildRequestPath("/users/{username}", refitSettings.AllowUnmatchedRouteParameters, [((7, 17), refitUseDefaultFormatting ? (@userName) : global::Refit.GeneratedRequestRunner.FormatUrlParameter(refitSettings, @userName, ______userNameAttributeProvider4, typeof(string)))]), refitSettings.UrlResolution));
                 global::Refit.GeneratedRequestRunner.SetHeader(refitRequest, "User-Agent", "Refit Integration Tests");
                 global::Refit.GeneratedRequestRunner.AddConfiguredRequestOptions(refitRequest, refitSettings, typeof(global::Refit.Tests.IGitHubApi));
                     return refitRequest;

--- a/src/tests/Refit.GeneratorTests/_snapshots/InterfaceStubGeneratorTests.FindInterfacesSmokeTest#INestedGitHubApi.g.verified.cs
+++ b/src/tests/Refit.GeneratorTests/_snapshots/InterfaceStubGeneratorTests.FindInterfacesSmokeTest#INestedGitHubApi.g.verified.cs
@@ -53,7 +53,7 @@ namespace Refit.Implementation
             {
                 var refitSettings = _settings;
                 var refitUseDefaultFormatting = global::Refit.GeneratedRequestRunner.UsesDefaultUrlParameterFormatting(refitSettings);
-                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, global::Refit.GeneratedRequestRunner.BuildRelativeUri(this.Client, global::Refit.GeneratedRequestRunner.BuildRequestPath("/users/{username}", refitSettings.AllowUnmatchedRouteParameters, [((7, 17), refitUseDefaultFormatting ? (@userName) : refitSettings.UrlParameterFormatter.Format(@userName, ______userNameAttributeProvider, typeof(string)))]), refitSettings.UrlResolution));
+                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, global::Refit.GeneratedRequestRunner.BuildRelativeUri(this.Client, global::Refit.GeneratedRequestRunner.BuildRequestPath("/users/{username}", refitSettings.AllowUnmatchedRouteParameters, [((7, 17), refitUseDefaultFormatting ? (@userName) : global::Refit.GeneratedRequestRunner.FormatUrlParameter(refitSettings, @userName, ______userNameAttributeProvider, typeof(string)))]), refitSettings.UrlResolution));
                 global::Refit.GeneratedRequestRunner.SetHeader(refitRequest, "User-Agent", "Refit Integration Tests");
                 global::Refit.GeneratedRequestRunner.AddConfiguredRequestOptions(refitRequest, refitSettings, typeof(global::Refit.Tests.TestNested.INestedGitHubApi));
                 return global::Refit.GeneratedRequestRunner.SendAsync<global::Refit.Tests.User, global::Refit.Tests.User>(
@@ -76,7 +76,7 @@ namespace Refit.Implementation
                 global::System.Net.Http.HttpRequestMessage BuildRefitRequest()
                 {
                 var refitUseDefaultFormatting = global::Refit.GeneratedRequestRunner.UsesDefaultUrlParameterFormatting(refitSettings);
-                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, global::Refit.GeneratedRequestRunner.BuildRelativeUri(this.Client, global::Refit.GeneratedRequestRunner.BuildRequestPath("/users/{username}", refitSettings.AllowUnmatchedRouteParameters, [((7, 17), refitUseDefaultFormatting ? (@userName) : refitSettings.UrlParameterFormatter.Format(@userName, ______userNameAttributeProvider0, typeof(string)))]), refitSettings.UrlResolution));
+                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, global::Refit.GeneratedRequestRunner.BuildRelativeUri(this.Client, global::Refit.GeneratedRequestRunner.BuildRequestPath("/users/{username}", refitSettings.AllowUnmatchedRouteParameters, [((7, 17), refitUseDefaultFormatting ? (@userName) : global::Refit.GeneratedRequestRunner.FormatUrlParameter(refitSettings, @userName, ______userNameAttributeProvider0, typeof(string)))]), refitSettings.UrlResolution));
                 global::Refit.GeneratedRequestRunner.SetHeader(refitRequest, "User-Agent", "Refit Integration Tests");
                 global::Refit.GeneratedRequestRunner.AddConfiguredRequestOptions(refitRequest, refitSettings, typeof(global::Refit.Tests.TestNested.INestedGitHubApi));
                     return refitRequest;
@@ -101,7 +101,7 @@ namespace Refit.Implementation
                 global::System.Net.Http.HttpRequestMessage BuildRefitRequest()
                 {
                 var refitUseDefaultFormatting = global::Refit.GeneratedRequestRunner.UsesDefaultUrlParameterFormatting(refitSettings);
-                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, global::Refit.GeneratedRequestRunner.BuildRelativeUri(this.Client, global::Refit.GeneratedRequestRunner.BuildRequestPath("/users/{userName}", refitSettings.AllowUnmatchedRouteParameters, [((7, 17), refitUseDefaultFormatting ? (@userName) : refitSettings.UrlParameterFormatter.Format(@userName, ______userNameAttributeProvider1, typeof(string)))]), refitSettings.UrlResolution));
+                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, global::Refit.GeneratedRequestRunner.BuildRelativeUri(this.Client, global::Refit.GeneratedRequestRunner.BuildRequestPath("/users/{userName}", refitSettings.AllowUnmatchedRouteParameters, [((7, 17), refitUseDefaultFormatting ? (@userName) : global::Refit.GeneratedRequestRunner.FormatUrlParameter(refitSettings, @userName, ______userNameAttributeProvider1, typeof(string)))]), refitSettings.UrlResolution));
                 global::Refit.GeneratedRequestRunner.SetHeader(refitRequest, "User-Agent", "Refit Integration Tests");
                 global::Refit.GeneratedRequestRunner.AddConfiguredRequestOptions(refitRequest, refitSettings, typeof(global::Refit.Tests.TestNested.INestedGitHubApi));
                     return refitRequest;
@@ -124,7 +124,7 @@ namespace Refit.Implementation
             {
                 var refitSettings = _settings;
                 var refitUseDefaultFormatting = global::Refit.GeneratedRequestRunner.UsesDefaultUrlParameterFormatting(refitSettings);
-                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, global::Refit.GeneratedRequestRunner.BuildRelativeUri(this.Client, global::Refit.GeneratedRequestRunner.BuildRequestPath("/orgs/{orgname}/members", refitSettings.AllowUnmatchedRouteParameters, [((6, 15), refitUseDefaultFormatting ? (@orgName) : refitSettings.UrlParameterFormatter.Format(@orgName, ______orgNameAttributeProvider, typeof(string)))]), refitSettings.UrlResolution));
+                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, global::Refit.GeneratedRequestRunner.BuildRelativeUri(this.Client, global::Refit.GeneratedRequestRunner.BuildRequestPath("/orgs/{orgname}/members", refitSettings.AllowUnmatchedRouteParameters, [((6, 15), refitUseDefaultFormatting ? (@orgName) : global::Refit.GeneratedRequestRunner.FormatUrlParameter(refitSettings, @orgName, ______orgNameAttributeProvider, typeof(string)))]), refitSettings.UrlResolution));
                 global::Refit.GeneratedRequestRunner.SetHeader(refitRequest, "User-Agent", "Refit Integration Tests");
                 global::Refit.GeneratedRequestRunner.AddConfiguredRequestOptions(refitRequest, refitSettings, typeof(global::Refit.Tests.TestNested.INestedGitHubApi));
                 return global::Refit.GeneratedRequestRunner.SendAsync<global::System.Collections.Generic.List<global::Refit.Tests.User>, global::System.Collections.Generic.List<global::Refit.Tests.User>>(
@@ -148,7 +148,7 @@ namespace Refit.Implementation
                 var refitQueryBuilder = new global::Refit.GeneratedQueryStringBuilder("/search/users", false);
                 if (@q != null)
                 {
-                    refitQueryBuilder.AddPreEscapedKey("q", refitUseDefaultFormatting ? (@q) : refitSettings.UrlParameterFormatter.Format(@q, ______qAttributeProvider, typeof(string)), false);
+                    refitQueryBuilder.AddPreEscapedKey("q", refitUseDefaultFormatting ? (@q) : global::Refit.GeneratedRequestRunner.FormatUrlParameter(refitSettings, @q, ______qAttributeProvider, typeof(string)), false);
                 }
                 var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, global::Refit.GeneratedRequestRunner.BuildRelativeUri(this.Client, refitQueryBuilder.Build(), refitSettings.UrlResolution));
                 global::Refit.GeneratedRequestRunner.SetHeader(refitRequest, "User-Agent", "Refit Integration Tests");

--- a/src/tests/Refit.GeneratorTests/_snapshots/ParameterTests.NullableRouteParameter#IGeneratedClient.g.verified.cs
+++ b/src/tests/Refit.GeneratorTests/_snapshots/ParameterTests.NullableRouteParameter#IGeneratedClient.g.verified.cs
@@ -53,7 +53,7 @@ namespace Refit.Implementation
             {
                 var refitSettings = _settings;
                 var refitUseDefaultFormatting = global::Refit.GeneratedRequestRunner.UsesDefaultUrlParameterFormatting(refitSettings);
-                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, global::Refit.GeneratedRequestRunner.BuildRelativeUri(this.Client, global::Refit.GeneratedRequestRunner.BuildRequestPath("/users/{user}", refitSettings.AllowUnmatchedRouteParameters, [((7, 13), refitUseDefaultFormatting ? (@user) : refitSettings.UrlParameterFormatter.Format(@user, ______userAttributeProvider, typeof(string)))]), refitSettings.UrlResolution));
+                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, global::Refit.GeneratedRequestRunner.BuildRelativeUri(this.Client, global::Refit.GeneratedRequestRunner.BuildRequestPath("/users/{user}", refitSettings.AllowUnmatchedRouteParameters, [((7, 13), refitUseDefaultFormatting ? (@user) : global::Refit.GeneratedRequestRunner.FormatUrlParameter(refitSettings, @user, ______userAttributeProvider, typeof(string)))]), refitSettings.UrlResolution));
                 global::Refit.GeneratedRequestRunner.AddConfiguredRequestOptions(refitRequest, refitSettings, typeof(global::RefitGeneratorTest.IGeneratedClient));
                 return global::Refit.GeneratedRequestRunner.SendAsync<string, string>(
                     this.Client,

--- a/src/tests/Refit.GeneratorTests/_snapshots/ParameterTests.NullableValueTypeRouteParameter#IGeneratedClient.g.verified.cs
+++ b/src/tests/Refit.GeneratorTests/_snapshots/ParameterTests.NullableValueTypeRouteParameter#IGeneratedClient.g.verified.cs
@@ -53,7 +53,7 @@ namespace Refit.Implementation
             {
                 var refitSettings = _settings;
                 var refitUseDefaultFormatting = global::Refit.GeneratedRequestRunner.UsesDefaultUrlParameterFormatting(refitSettings);
-                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, global::Refit.GeneratedRequestRunner.BuildRelativeUri(this.Client, global::Refit.GeneratedRequestRunner.BuildRequestPath("/users/{user}", refitSettings.AllowUnmatchedRouteParameters, [((7, 13), refitUseDefaultFormatting ? (@user == null ? null : global::Refit.GeneratedRequestRunner.FormatInvariant(@user.Value, null)) : refitSettings.UrlParameterFormatter.Format(@user, ______userAttributeProvider, typeof(int?)))]), refitSettings.UrlResolution));
+                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, global::Refit.GeneratedRequestRunner.BuildRelativeUri(this.Client, global::Refit.GeneratedRequestRunner.BuildRequestPath("/users/{user}", refitSettings.AllowUnmatchedRouteParameters, [((7, 13), refitUseDefaultFormatting ? (@user == null ? null : global::Refit.GeneratedRequestRunner.FormatInvariant(@user.Value, null)) : global::Refit.GeneratedRequestRunner.FormatUrlParameter(refitSettings, @user, ______userAttributeProvider, typeof(int?)))]), refitSettings.UrlResolution));
                 global::Refit.GeneratedRequestRunner.AddConfiguredRequestOptions(refitRequest, refitSettings, typeof(global::RefitGeneratorTest.IGeneratedClient));
                 return global::Refit.GeneratedRequestRunner.SendAsync<string, string>(
                     this.Client,

--- a/src/tests/Refit.GeneratorTests/_snapshots/ParameterTests.RouteParameter#IGeneratedClient.g.verified.cs
+++ b/src/tests/Refit.GeneratorTests/_snapshots/ParameterTests.RouteParameter#IGeneratedClient.g.verified.cs
@@ -53,7 +53,7 @@ namespace Refit.Implementation
             {
                 var refitSettings = _settings;
                 var refitUseDefaultFormatting = global::Refit.GeneratedRequestRunner.UsesDefaultUrlParameterFormatting(refitSettings);
-                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, global::Refit.GeneratedRequestRunner.BuildRelativeUri(this.Client, global::Refit.GeneratedRequestRunner.BuildRequestPath("/users/{user}", refitSettings.AllowUnmatchedRouteParameters, [((7, 13), refitUseDefaultFormatting ? (@user) : refitSettings.UrlParameterFormatter.Format(@user, ______userAttributeProvider, typeof(string)))]), refitSettings.UrlResolution));
+                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, global::Refit.GeneratedRequestRunner.BuildRelativeUri(this.Client, global::Refit.GeneratedRequestRunner.BuildRequestPath("/users/{user}", refitSettings.AllowUnmatchedRouteParameters, [((7, 13), refitUseDefaultFormatting ? (@user) : global::Refit.GeneratedRequestRunner.FormatUrlParameter(refitSettings, @user, ______userAttributeProvider, typeof(string)))]), refitSettings.UrlResolution));
                 global::Refit.GeneratedRequestRunner.AddConfiguredRequestOptions(refitRequest, refitSettings, typeof(global::RefitGeneratorTest.IGeneratedClient));
                 return global::Refit.GeneratedRequestRunner.SendAsync<string, string>(
                     this.Client,

--- a/src/tests/Refit.GeneratorTests/_snapshots/ParameterTests.ValueTypeRouteParameter#IGeneratedClient.g.verified.cs
+++ b/src/tests/Refit.GeneratorTests/_snapshots/ParameterTests.ValueTypeRouteParameter#IGeneratedClient.g.verified.cs
@@ -53,7 +53,7 @@ namespace Refit.Implementation
             {
                 var refitSettings = _settings;
                 var refitUseDefaultFormatting = global::Refit.GeneratedRequestRunner.UsesDefaultUrlParameterFormatting(refitSettings);
-                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, global::Refit.GeneratedRequestRunner.BuildRelativeUri(this.Client, (refitUseDefaultFormatting ? global::Refit.GeneratedRequestRunner.BuildRequestPath("/users/{user}", refitSettings.AllowUnmatchedRouteParameters, (7, 13), @user) : global::Refit.GeneratedRequestRunner.BuildRequestPath("/users/{user}", refitSettings.AllowUnmatchedRouteParameters, [((7, 13), refitSettings.UrlParameterFormatter.Format(@user, ______userAttributeProvider, typeof(int)))])), refitSettings.UrlResolution));
+                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, global::Refit.GeneratedRequestRunner.BuildRelativeUri(this.Client, (refitUseDefaultFormatting ? global::Refit.GeneratedRequestRunner.BuildRequestPath("/users/{user}", refitSettings.AllowUnmatchedRouteParameters, (7, 13), @user) : global::Refit.GeneratedRequestRunner.BuildRequestPath("/users/{user}", refitSettings.AllowUnmatchedRouteParameters, [((7, 13), global::Refit.GeneratedRequestRunner.FormatUrlParameter(refitSettings, @user, ______userAttributeProvider, typeof(int)))])), refitSettings.UrlResolution));
                 global::Refit.GeneratedRequestRunner.AddConfiguredRequestOptions(refitRequest, refitSettings, typeof(global::RefitGeneratorTest.IGeneratedClient));
                 return global::Refit.GeneratedRequestRunner.SendAsync<string, string>(
                     this.Client,

--- a/src/tests/Refit.GeneratorTests/_snapshots/ParameterTests.ValueTypeRouteParameterInQueryWithAttribute#IGeneratedClient.g.verified.cs
+++ b/src/tests/Refit.GeneratorTests/_snapshots/ParameterTests.ValueTypeRouteParameterInQueryWithAttribute#IGeneratedClient.g.verified.cs
@@ -53,7 +53,7 @@ namespace Refit.Implementation
             {
                 var refitSettings = _settings;
                 var refitUseDefaultFormatting = global::Refit.GeneratedRequestRunner.UsesDefaultUrlParameterFormatting(refitSettings);
-                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, global::Refit.GeneratedRequestRunner.BuildRelativeUri(this.Client, global::Refit.GeneratedRequestRunner.BuildRequestPath("/todos?q={q}", refitSettings.AllowUnmatchedRouteParameters, [((9, 12), refitUseDefaultFormatting ? (@q) : refitSettings.UrlParameterFormatter.Format(@q, ______qAttributeProvider, typeof(string)))]), refitSettings.UrlResolution));
+                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, global::Refit.GeneratedRequestRunner.BuildRelativeUri(this.Client, global::Refit.GeneratedRequestRunner.BuildRequestPath("/todos?q={q}", refitSettings.AllowUnmatchedRouteParameters, [((9, 12), refitUseDefaultFormatting ? (@q) : global::Refit.GeneratedRequestRunner.FormatUrlParameter(refitSettings, @q, ______qAttributeProvider, typeof(string)))]), refitSettings.UrlResolution));
                 global::Refit.GeneratedRequestRunner.AddConfiguredRequestOptions(refitRequest, refitSettings, typeof(global::RefitGeneratorTest.IGeneratedClient));
                 return global::Refit.GeneratedRequestRunner.SendAsync<string[], string[]>(
                     this.Client,

--- a/src/tests/Refit.GeneratorTests/_snapshots/ParameterTests.ValueTypeRouteParameterInQueryWithoutAttribute#IGeneratedClient.g.verified.cs
+++ b/src/tests/Refit.GeneratorTests/_snapshots/ParameterTests.ValueTypeRouteParameterInQueryWithoutAttribute#IGeneratedClient.g.verified.cs
@@ -53,7 +53,7 @@ namespace Refit.Implementation
             {
                 var refitSettings = _settings;
                 var refitUseDefaultFormatting = global::Refit.GeneratedRequestRunner.UsesDefaultUrlParameterFormatting(refitSettings);
-                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, global::Refit.GeneratedRequestRunner.BuildRelativeUri(this.Client, global::Refit.GeneratedRequestRunner.BuildRequestPath("/todos?q={q}", refitSettings.AllowUnmatchedRouteParameters, [((9, 12), refitUseDefaultFormatting ? (@q) : refitSettings.UrlParameterFormatter.Format(@q, ______qAttributeProvider, typeof(string)))]), refitSettings.UrlResolution));
+                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, global::Refit.GeneratedRequestRunner.BuildRelativeUri(this.Client, global::Refit.GeneratedRequestRunner.BuildRequestPath("/todos?q={q}", refitSettings.AllowUnmatchedRouteParameters, [((9, 12), refitUseDefaultFormatting ? (@q) : global::Refit.GeneratedRequestRunner.FormatUrlParameter(refitSettings, @q, ______qAttributeProvider, typeof(string)))]), refitSettings.UrlResolution));
                 global::Refit.GeneratedRequestRunner.AddConfiguredRequestOptions(refitRequest, refitSettings, typeof(global::RefitGeneratorTest.IGeneratedClient));
                 return global::Refit.GeneratedRequestRunner.SendAsync<string[], string[]>(
                     this.Client,

--- a/src/tests/Refit.GeneratorTests/_snapshots/ParameterTests.ValueTypeRouteParameterWithAttribute#IGeneratedClient.g.verified.cs
+++ b/src/tests/Refit.GeneratorTests/_snapshots/ParameterTests.ValueTypeRouteParameterWithAttribute#IGeneratedClient.g.verified.cs
@@ -53,7 +53,7 @@ namespace Refit.Implementation
             {
                 var refitSettings = _settings;
                 var refitUseDefaultFormatting = global::Refit.GeneratedRequestRunner.UsesDefaultUrlParameterFormatting(refitSettings);
-                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, global::Refit.GeneratedRequestRunner.BuildRelativeUri(this.Client, global::Refit.GeneratedRequestRunner.BuildRequestPath("/todos/{id}", refitSettings.AllowUnmatchedRouteParameters, [((7, 11), refitUseDefaultFormatting ? (@id == null ? null : global::Refit.GeneratedRequestRunner.FormatInvariant(@id.Value, "00")) : refitSettings.UrlParameterFormatter.Format(@id, ______idAttributeProvider, typeof(int?)))]), refitSettings.UrlResolution));
+                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, global::Refit.GeneratedRequestRunner.BuildRelativeUri(this.Client, global::Refit.GeneratedRequestRunner.BuildRequestPath("/todos/{id}", refitSettings.AllowUnmatchedRouteParameters, [((7, 11), refitUseDefaultFormatting ? (@id == null ? null : global::Refit.GeneratedRequestRunner.FormatInvariant(@id.Value, "00")) : global::Refit.GeneratedRequestRunner.FormatUrlParameter(refitSettings, @id, ______idAttributeProvider, typeof(int?)))]), refitSettings.UrlResolution));
                 global::Refit.GeneratedRequestRunner.AddConfiguredRequestOptions(refitRequest, refitSettings, typeof(global::RefitGeneratorTest.IGeneratedClient));
                 return global::Refit.GeneratedRequestRunner.SendAsync<string, string>(
                     this.Client,

--- a/src/tests/Refit.GeneratorTests/_snapshots/ReturnTypeTests.ReturnIObservable#IGeneratedClient.g.verified.cs
+++ b/src/tests/Refit.GeneratorTests/_snapshots/ReturnTypeTests.ReturnIObservable#IGeneratedClient.g.verified.cs
@@ -55,7 +55,7 @@ namespace Refit.Implementation
                 global::System.Net.Http.HttpRequestMessage BuildRefitRequest()
                 {
                 var refitUseDefaultFormatting = global::Refit.GeneratedRequestRunner.UsesDefaultUrlParameterFormatting(refitSettings);
-                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, global::Refit.GeneratedRequestRunner.BuildRelativeUri(this.Client, global::Refit.GeneratedRequestRunner.BuildRequestPath("/users/{user}", refitSettings.AllowUnmatchedRouteParameters, [((7, 13), refitUseDefaultFormatting ? (@user) : refitSettings.UrlParameterFormatter.Format(@user, ______userAttributeProvider, typeof(string)))]), refitSettings.UrlResolution));
+                var refitRequest = new global::System.Net.Http.HttpRequestMessage(global::System.Net.Http.HttpMethod.Get, global::Refit.GeneratedRequestRunner.BuildRelativeUri(this.Client, global::Refit.GeneratedRequestRunner.BuildRequestPath("/users/{user}", refitSettings.AllowUnmatchedRouteParameters, [((7, 13), refitUseDefaultFormatting ? (@user) : global::Refit.GeneratedRequestRunner.FormatUrlParameter(refitSettings, @user, ______userAttributeProvider, typeof(string)))]), refitSettings.UrlResolution));
                 global::Refit.GeneratedRequestRunner.AddConfiguredRequestOptions(refitRequest, refitSettings, typeof(global::RefitGeneratorTest.IGeneratedClient));
                     return refitRequest;
                 }

--- a/src/tests/Refit.Tests/GeneratedRequestRunnerTests.cs
+++ b/src/tests/Refit.Tests/GeneratedRequestRunnerTests.cs
@@ -420,9 +420,10 @@ public partial class GeneratedRequestRunnerTests
     [Test]
     public async Task RoundTripEscapePathSubstitutesEmptyForNullFormattedSection()
     {
+        var settings = new RefitSettings { UrlParameterFormatter = new NullUrlParameterFormatter() };
         var result = GeneratedRequestRunner.RoundTripEscapePath(
             "a/b",
-            new NullUrlParameterFormatter(),
+            settings,
             typeof(string),
             typeof(string));
 

--- a/src/tests/Refit.Tests/IFormatterMapApi.cs
+++ b/src/tests/Refit.Tests/IFormatterMapApi.cs
@@ -1,0 +1,23 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Refit.Tests;
+
+/// <summary>An API whose path and query parameters exercise the per-type URL parameter formatter registry.</summary>
+public interface IFormatterMapApi
+{
+    /// <summary>Binds a formatter-rendered value and a plain string into the path.</summary>
+    /// <param name="temp">The value rendered through the per-type formatter.</param>
+    /// <param name="city">A plain string path value with no registry entry.</param>
+    /// <returns>The response body.</returns>
+    [Get("/weather/{temp}/{city}")]
+    Task<string> GetByPath(Temperature temp, string city);
+
+    /// <summary>Binds a formatter-rendered value and a plain integer into the query string.</summary>
+    /// <param name="temp">The value rendered through the per-type formatter.</param>
+    /// <param name="count">A plain integer query value with no registry entry.</param>
+    /// <returns>The response body.</returns>
+    [Get("/weather")]
+    Task<string> GetByQuery(Temperature temp, int count);
+}

--- a/src/tests/Refit.Tests/Temperature.cs
+++ b/src/tests/Refit.Tests/Temperature.cs
@@ -1,0 +1,51 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Globalization;
+
+namespace Refit.Tests;
+
+/// <summary>A domain value whose default <see cref="IFormattable"/> rendering differs from its custom URL rendering.</summary>
+/// <remarks>Implementing <see cref="IFormattable"/> makes both request builders treat it as a URL scalar rather than an
+/// object to flatten, so the whole value passes through the URL parameter formatter.</remarks>
+public readonly struct Temperature : IFormattable, IEquatable<Temperature>
+{
+    /// <summary>Initializes a new instance of the <see cref="Temperature"/> struct.</summary>
+    /// <param name="celsius">The temperature in degrees Celsius.</param>
+    public Temperature(int celsius) => Celsius = celsius;
+
+    /// <summary>Gets the temperature in degrees Celsius.</summary>
+    public int Celsius { get; }
+
+    /// <summary>Determines whether two temperatures are equal.</summary>
+    /// <param name="left">The first temperature.</param>
+    /// <param name="right">The second temperature.</param>
+    /// <returns><see langword="true"/> when both temperatures are equal.</returns>
+    public static bool operator ==(Temperature left, Temperature right) => left.Equals(right);
+
+    /// <summary>Determines whether two temperatures are not equal.</summary>
+    /// <param name="left">The first temperature.</param>
+    /// <param name="right">The second temperature.</param>
+    /// <returns><see langword="true"/> when the temperatures differ.</returns>
+    public static bool operator !=(Temperature left, Temperature right) => !left.Equals(right);
+
+    /// <summary>Renders the temperature as its invariant Celsius number, the default formatter's output.</summary>
+    /// <param name="format">The format string, ignored.</param>
+    /// <param name="formatProvider">The format provider used to render the number.</param>
+    /// <returns>The Celsius value as a string.</returns>
+    public string ToString(string? format, IFormatProvider? formatProvider) =>
+        Celsius.ToString(formatProvider ?? CultureInfo.InvariantCulture);
+
+    /// <inheritdoc/>
+    public override string ToString() => ToString(null, CultureInfo.InvariantCulture);
+
+    /// <inheritdoc/>
+    public bool Equals(Temperature other) => Celsius == other.Celsius;
+
+    /// <inheritdoc/>
+    public override bool Equals(object? obj) => obj is Temperature other && Equals(other);
+
+    /// <inheritdoc/>
+    public override int GetHashCode() => Celsius;
+}

--- a/src/tests/Refit.Tests/TemperatureUrlParameterFormatter.cs
+++ b/src/tests/Refit.Tests/TemperatureUrlParameterFormatter.cs
@@ -1,0 +1,16 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Reflection;
+
+namespace Refit.Tests;
+
+/// <summary>A URL parameter formatter that renders a <see cref="Temperature"/> with a trailing <c>deg</c> suffix,
+/// registered per type so no hand-rolled type switch is needed.</summary>
+public sealed class TemperatureUrlParameterFormatter : IUrlParameterFormatter
+{
+    /// <inheritdoc/>
+    public string? Format(object? value, ICustomAttributeProvider attributeProvider, Type type) =>
+        value is Temperature temperature ? $"{temperature.Celsius}deg" : value?.ToString();
+}

--- a/src/tests/Refit.Tests/UrlParameterFormatterMapTests.cs
+++ b/src/tests/Refit.Tests/UrlParameterFormatterMapTests.cs
@@ -1,0 +1,120 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Refit.Tests;
+
+/// <summary>
+/// Verifies that a per-type formatter registered in <see cref="RefitSettings.UrlParameterFormatterMap"/> renders a
+/// value into path and query strings, that unregistered types fall back to the default formatter, and that the
+/// reflection and source-generated request builders produce identical URLs.
+/// </summary>
+public class UrlParameterFormatterMapTests
+{
+    /// <summary>The base address used by every client under test.</summary>
+    private const string BaseAddress = "http://api/";
+
+    /// <summary>An unregistered string path value that must fall back to the default formatter.</summary>
+    private const string SampleCity = "paris";
+
+    /// <summary>The temperature value whose custom rendering is asserted.</summary>
+    private const int SampleCelsius = 21;
+
+    /// <summary>The unregistered integer query value that must fall back to the default formatter.</summary>
+    private const int SampleCount = 5;
+
+    /// <summary>Verifies a registered formatter renders a path value while an unregistered path value uses the default.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task RegisteredFormatterRendersPathValueInBothPaths()
+    {
+        var settings = CreateSettingsWithTemperatureFormatter();
+        var temperature = new Temperature(SampleCelsius);
+
+        var generated = await SendGeneratedAsync(settings, api => api.GetByPath(temperature, SampleCity));
+        var reflected = await new RequestBuilderImplementation<IFormatterMapApi>(settings)
+            .BuildRequestFactoryForMethod(nameof(IFormatterMapApi.GetByPath))([temperature, SampleCity]);
+
+        // 21deg comes from the registered formatter; paris is a string, which has no registry entry and uses the default.
+        await Assert.That(generated).IsEqualTo("/weather/21deg/paris");
+        await Assert.That(reflected.RequestUri!.PathAndQuery).IsEqualTo("/weather/21deg/paris");
+    }
+
+    /// <summary>Verifies a registered formatter renders a query value while an unregistered query value uses the default.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task RegisteredFormatterRendersQueryValueInBothPaths()
+    {
+        var settings = CreateSettingsWithTemperatureFormatter();
+        var temperature = new Temperature(SampleCelsius);
+
+        var generated = await SendGeneratedAsync(settings, api => api.GetByQuery(temperature, SampleCount));
+        var reflected = await new RequestBuilderImplementation<IFormatterMapApi>(settings)
+            .BuildRequestFactoryForMethod(nameof(IFormatterMapApi.GetByQuery))([temperature, SampleCount]);
+
+        // temp uses the registered formatter; count is an int with no registry entry and falls back to the default.
+        await Assert.That(generated).IsEqualTo("/weather?temp=21deg&count=5");
+        await Assert.That(reflected.RequestUri!.PathAndQuery).IsEqualTo("/weather?temp=21deg&count=5");
+    }
+
+    /// <summary>Verifies that with no registry entry the value renders through the default formatter in both paths.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task UnregisteredTypeFallsBackToDefaultFormatter()
+    {
+        var settings = new RefitSettings();
+        var temperature = new Temperature(SampleCelsius);
+
+        var generated = await SendGeneratedAsync(settings, api => api.GetByPath(temperature, SampleCity));
+        var reflected = await new RequestBuilderImplementation<IFormatterMapApi>(settings)
+            .BuildRequestFactoryForMethod(nameof(IFormatterMapApi.GetByPath))([temperature, SampleCity]);
+
+        // The default formatter renders Temperature through IFormattable, so no "deg" suffix is applied.
+        await Assert.That(generated).IsEqualTo("/weather/21/paris");
+        await Assert.That(reflected.RequestUri!.PathAndQuery).IsEqualTo("/weather/21/paris");
+    }
+
+    /// <summary>Verifies the generated and reflection builders produce identical URLs when a per-type formatter is registered.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task GeneratedAndReflectionUrlsMatchWithRegisteredFormatter()
+    {
+        var settings = CreateSettingsWithTemperatureFormatter();
+        var temperature = new Temperature(SampleCelsius);
+
+        var generatedPath = await SendGeneratedAsync(settings, api => api.GetByPath(temperature, SampleCity));
+        var reflectedPath = await new RequestBuilderImplementation<IFormatterMapApi>(settings)
+            .BuildRequestFactoryForMethod(nameof(IFormatterMapApi.GetByPath))([temperature, SampleCity]);
+
+        var generatedQuery = await SendGeneratedAsync(settings, api => api.GetByQuery(temperature, SampleCount));
+        var reflectedQuery = await new RequestBuilderImplementation<IFormatterMapApi>(settings)
+            .BuildRequestFactoryForMethod(nameof(IFormatterMapApi.GetByQuery))([temperature, SampleCount]);
+
+        await Assert.That(generatedPath).IsEqualTo(reflectedPath.RequestUri!.PathAndQuery);
+        await Assert.That(generatedQuery).IsEqualTo(reflectedQuery.RequestUri!.PathAndQuery);
+    }
+
+    /// <summary>Builds settings that render <see cref="Temperature"/> through a per-type formatter.</summary>
+    /// <returns>The configured settings.</returns>
+    private static RefitSettings CreateSettingsWithTemperatureFormatter()
+    {
+        var settings = new RefitSettings();
+        settings.UrlParameterFormatterMap[typeof(Temperature)] = new TemperatureUrlParameterFormatter();
+        return settings;
+    }
+
+    /// <summary>Sends one request through the source-generated client and returns the relative URI it produced.</summary>
+    /// <param name="settings">The settings to build the client with.</param>
+    /// <param name="call">The interface method to invoke.</param>
+    /// <returns>The generated request's path and query.</returns>
+    private static async Task<string> SendGeneratedAsync(RefitSettings settings, Func<IFormatterMapApi, Task<string>> call)
+    {
+        var handler = new TestHttpMessageHandler();
+        using var client = new HttpClient(handler) { BaseAddress = new(BaseAddress) };
+        var api = RestService.ForGenerated<IFormatterMapApi>(client, settings);
+
+        _ = await call(api);
+
+        return handler.RequestMessage!.RequestUri!.PathAndQuery;
+    }
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature (additive, opt-in) - a per-type URL parameter formatter registry on `RefitSettings`.

## What is the new behavior?

- New `RefitSettings.UrlParameterFormatterMap` - an `IDictionary<Type, IUrlParameterFormatter>` (empty by default) keyed by the CLR type it formats.
- When a value is rendered into a URL (path parameter, round-trip `{**param}` segment, or query value), its runtime type (`value.GetType()`) is looked up in the map first. A registered formatter wins; every other type falls back to the existing `UrlParameterFormatter`.
- Matching is by exact runtime type only - no base-class or interface walking - so you register the concrete type the value will have at runtime.
- Resolution is centralized in one place (`GeneratedRequestRunner.FormatUrlParameter`) that BOTH request paths call, so the reflection request builder and the source-generated request builder produce identical URLs. AOT/trim-safe: `value.GetType()` only, no reflection over members.
- Registering any entry opts a request out of the generator's inline formatting fast path (the value goes through the formatter, which consults the registry).

```csharp
var settings = new RefitSettings();
settings.UrlParameterFormatterMap[typeof(Temperature)] = new TemperatureUrlParameterFormatter();
```

## What is the current behavior?

Every path/query value is formatted through the single `RefitSettings.UrlParameterFormatter` (falling back to `ToString()`). To customize one specific type you must write a custom `IUrlParameterFormatter` that switches on `value.GetType()` for every call.

Closes #2219

## What might this PR break?

Nothing for existing code. The default map is empty, which changes no behavior - `FormatUrlParameter` resolves to the configured `UrlParameterFormatter` exactly as before. The only signature change is the internal generator-support helper `GeneratedRequestRunner.RoundTripEscapePath` (marked `[EditorBrowsable(Never)]`, only called by generated code), which now takes `RefitSettings` instead of `IUrlParameterFormatter`; generated output is regenerated to match.

## Checklist
- [ ] I have read the Contribute guide
- [x] Tests have been added or updated (for bug fixes / features)
- [x] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the `main` branch
- [x] PR title follows Conventional Commits

## Additional information

- Reflection and source-generated paths kept in parity via a single shared resolution helper; applies to path parameters, round-trip path segments, and query values; does not affect header/body serialization.
- Tests added: registered type used for path and query values, unregistered types fall back to the default, and a generated-vs-reflection parity test.
- Public API recorded (`RefitSettings.UrlParameterFormatterMap`, `GeneratedRequestRunner.FormatUrlParameter`); generator snapshots reviewed and updated (custom formatting branch now routes through `FormatUrlParameter`).
- Documented in the README and `docs/breaking-changes.md`.
- Full solution builds clean (0 warnings, analyzers satisfied); Refit.Tests (1018) and Refit.GeneratorTests (408) pass on net8.0.
- Central resolver lives on `GeneratedRequestRunner` (the existing hidden, `[EditorBrowsable(Never)]` shared runtime-helper class) so the visible public surface added to `RefitSettings` is just the map. Registering a per-type formatter for the collection/round-trip cases applies per element/section by the element's runtime type, matching the reflection builder.
