### PR TITLE
docs: document IQueryConverter and httpClientName client-name override

### DIFF
--- a/README.md
+++ b/README.md
@@ -604,6 +604,41 @@ object's `ToString()` under the parameter's own name, mark it with an explicit e
 Task<string> GetInfo([Query(Format = "")] Size size); // => ?size=medium  (uses size.ToString())
 ```
 
+**Custom query keys with `IQueryConverter<T>`**:
+
+When a parameter shape cannot be flattened from its declared type (an `object`, a polymorphic base type, a
+`Dictionary<string, object>`), or you simply need full control over the emitted keys, implement `IQueryConverter<T>`
+and attach it to the parameter with `[QueryConverter(typeof(...))]`. The converter writes query pairs straight into the
+pooled builder, so it can emit nested bracket keys such as `order[createdAt]=desc` without `[AliasAs("order[")]`-style
+hacks. This is a source-generator-only feature (the reflection request builder walks the value's runtime type instead);
+implementations must be stateless and have a public parameterless constructor.
+
+```csharp
+public sealed class SortOrderQueryConverter : IQueryConverter<IDictionary<string, string>>
+{
+    public void Flatten(
+        IDictionary<string, string> value,
+        string keyPrefix,          // the resolved [Query(Prefix)] for the parameter, or an empty string
+        ref GeneratedQueryStringBuilder builder,
+        RefitSettings settings)
+    {
+        foreach (var entry in value)
+        {
+            // AddPreEscapedKey appends the key verbatim, so the brackets stay literal while the value is
+            // still escaped. Use builder.Add(key, value, false) to percent-encode the key as well.
+            builder.AddPreEscapedKey($"{keyPrefix}order[{entry.Key}]", entry.Value, false);
+        }
+    }
+}
+
+[Get("/items")]
+Task<List<Item>> GetItems(
+    [QueryConverter(typeof(SortOrderQueryConverter))] IDictionary<string, string> order);
+
+GetItems(new Dictionary<string, string> { ["createdAt"] = "desc", ["priority"] = "asc" });
+>>> "/items?order[createdAt]=desc&order[priority]=asc"
+```
+
 #### Formatting URL Parameter Values with the `UrlParameterFormatter`
 
 In Refit, the `UrlParameterFormatter` property within `RefitSettings` allows you to customize how parameter values are
@@ -1894,6 +1929,15 @@ Refit registers each client with `IHttpClientFactory` under a deterministic name
 
 ```csharp
 services.AddHttpClient(UniqueName.ForType<IWebApi>())
+        .ConfigureHttpClient(c => c.BaseAddress = new Uri("https://api.example.com"));
+```
+
+If you would rather use a short, human-readable name, pass `httpClientName` to any `AddRefitClient` overload. That
+name becomes the `IHttpClientFactory` client name and the client's default `ILogger` logging category, so it shortens
+both without changing the assembly-qualified default that keeps registrations unique:
+
+```csharp
+services.AddRefitClient<IWebApi>(settings: null, httpClientName: "web-api")
         .ConfigureHttpClient(c => c.BaseAddress = new Uri("https://api.example.com"));
 ```
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Documentation only. It surfaces two existing extension points that were undocumented.

## What is the new behavior?

- The Querystrings section now documents `IQueryConverter<T>` and `[QueryConverter(typeof(...))]`. A short example shows a converter emitting nested bracket keys such as `order[createdAt]=desc` straight into the generated query builder, replacing `[AliasAs("order[")]`-style hacks. It notes this is a source-generator-only feature (the reflection path walks the value's runtime type).
- The `IHttpClientFactory` section now documents passing `httpClientName` to `AddRefitClient` to shorten the client name and its default `ILogger` logging category, while the assembly-qualified default that keeps registrations unique stays unchanged.

## What is the current behavior?

Both features already ship, but the README does not mention `IQueryConverter<T>`/`[QueryConverter]` at all, and only documents computing the default client name with `UniqueName.ForType<T>()`, not overriding it.

## What might this PR break?

Nothing. Documentation only; no code or public API changes.

## Checklist
- [x] I have read the [Contribute guide](https://www.reactiveui.net/contribute/index.html)
- [ ] Tests have been added or updated (for bug fixes / features)
- [x] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the main branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional information

Closes #1332
Closes #1467
