### PR TITLE
feat: add [Timeout] attribute for per-method request timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ lets you stub responses and verify requests with a declarative route table — s
     * [Support for Polly and Polly.Context](#support-for-polly-and-pollycontext)
     * [Target Interface type](#target-interface-type)
     * [MethodInfo of the method on the Refit client interface that was invoked](#methodinfo-of-the-method-on-the-refit-client-interface-that-was-invoked)
+* [Per-request timeouts](#per-request-timeouts)
 * [Multipart uploads](#multipart-uploads)
 * [Retrieving the response](#retrieving-the-response)
 * [Using generic interfaces](#using-generic-interfaces)
@@ -1479,6 +1480,29 @@ Note: in .NET 5 `HttpRequestMessage.Properties` has been marked `Obsolete` and R
 into the new `HttpRequestMessage.Options`. Refit provides `HttpRequestMessageOptions.InterfaceType` and
 `HttpRequestMessageOptions.RestMethodInfo` to respectively access the interface type and REST method info from the
 options.
+
+### Per-request timeouts
+
+Decorate a method with `[Timeout(milliseconds)]` to give that single call its own deadline, expressed in milliseconds:
+
+```csharp
+public interface IGitHubApi
+{
+    [Get("/users/{user}")]
+    [Timeout(5000)] // fail this call if it takes longer than 5 seconds
+    Task<User> GetUser(string user);
+}
+```
+
+When the deadline elapses the request is canceled and surfaces as an `OperationCanceledException` (typically a
+`TaskCanceledException`), the same way a lapsed `HttpClient.Timeout` reports. If the method also declares a
+`CancellationToken` parameter, both still work: whichever fires first — the caller's token or the timeout — cancels the
+call.
+
+The per-call timeout is independent of, and composes with, `HttpClient.Timeout` (the client-wide default) and any
+timeout enforced by Polly or a `DelegatingHandler`; whichever deadline elapses first wins. A value that is not positive
+leaves the method without a per-call deadline. Only a positive value adds one, so methods without `[Timeout]` pay no
+extra cost.
 
 ### Multipart uploads
 

--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -90,6 +90,13 @@ visible in three places.
 
 ### New in V14.x
 
+* **Per-method `[Timeout]` attribute.** Decorate a method with `[Timeout(milliseconds)]` to give that single call its
+  own deadline; when it elapses the request is canceled and surfaces as an `OperationCanceledException` (typically a
+  `TaskCanceledException`), the same way a lapsed `HttpClient.Timeout` reports. It is additive and layers onto the
+  request's effective cancellation token, so a caller-supplied `CancellationToken` still works alongside it and the
+  per-call deadline composes with `HttpClient.Timeout` and any Polly/`DelegatingHandler` timeout — whichever fires first
+  wins. Methods without `[Timeout]` are unaffected. Both request paths honor it (reflection and source-generated). See
+  [Per-request timeouts](../README.md#per-request-timeouts).
 * **Inline query-string generation.** Query parameters — auto-appended parameters, `[AliasAs]`, `[Query(Format = ...)]`,
   and scalar collections with every `CollectionFormat` — now generate reflection-free request construction, so the most
   common Refit method shapes work with generated-only clients (`AddRefitGeneratedClient`, `RestService.ForGenerated`)

--- a/src/InterfaceStubGenerator.Shared/Emitter.Inline.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.Inline.cs
@@ -196,17 +196,24 @@ internal static partial class Emitter
 
         var headerSource = BuildInlineHeaders(request, requestLocal);
         var requestPropertySource = BuildInlineRequestProperties(request, interfaceModel, requestLocal, settingsLocal);
+
+        // A method that declares a positive [Timeout] stashes it on the request so the send helpers apply it; every
+        // other method emits nothing here and pays no per-call timeout cost. Emitted inside the shared construction so
+        // the cold IObservable's per-subscription request is annotated too.
+        var timeoutSource = request.TimeoutMilliseconds > 0
+            ? $"{bodyIndent}global::Refit.GeneratedRequestRunner.SetRequestTimeout({requestLocal}, {request.TimeoutMilliseconds});\n"
+            : string.Empty;
         var methodIndent = Indent(MethodMemberIndentation);
         var opening = BuildMethodOpening(methodModel, isExplicit, isExplicit, interfaceModel.SupportsNullable);
         var methodPrefix = $"{plan.ParamInfoBuilder}{formFieldsSource}{httpMethodFieldSource}{opening}{bodyIndent}var {settingsLocal} = {settingsFieldName};\n";
 
-        // The request construction shared by every shape: prologue locals, the message, content, headers, and request
-        // properties. The configured HTTP version and version policy are applied by AddConfiguredRequestOptions in the
-        // request-property source. A cold IObservable wraps this in a per-subscription local function so a second
-        // subscription rebuilds and re-sends instead of reusing a disposed request.
+        // The request construction shared by every shape: prologue locals, the message, content, headers, request
+        // properties, and an optional per-call timeout. The configured HTTP version and version policy are applied by
+        // AddConfiguredRequestOptions in the request-property source. A cold IObservable wraps this in a per-subscription
+        // local function so a second subscription rebuilds and re-sends instead of reusing a disposed request.
         var requestConstruction = $$"""
             {{requestPrologueSource}}{{bodyIndent}}var {{requestLocal}} = new global::System.Net.Http.HttpRequestMessage({{httpMethodExpression}}, {{requestUriExpression}});
-            {{contentSource}}{{headerSource}}{{requestPropertySource}}
+            {{contentSource}}{{headerSource}}{{requestPropertySource}}{{timeoutSource}}
             """;
 
         if (methodModel.ReturnTypeMetadata == ReturnTypeInfo.Observable)

--- a/src/InterfaceStubGenerator.Shared/Models/RequestModel.cs
+++ b/src/InterfaceStubGenerator.Shared/Models/RequestModel.cs
@@ -54,4 +54,9 @@ internal sealed record RequestModel(
     /// absent. When set, the built path and query are re-encoded with this mode, matching the reflection builder's final
     /// <c>Uri.GetComponents(PathAndQuery, QueryUriFormat)</c> pass.</summary>
     public int? QueryUriFormat { get; init; }
+
+    /// <summary>Gets the per-call timeout in milliseconds from the method's <c>[Timeout]</c> attribute, or 0 when absent.
+    /// The value is emitted into the generated send call and layered onto the request's effective cancellation token,
+    /// mirroring the reflection builder's <c>RestMethodInfoInternal.TimeoutMilliseconds</c>.</summary>
+    public int TimeoutMilliseconds { get; init; }
 }

--- a/src/InterfaceStubGenerator.Shared/Parser.Request.Query.cs
+++ b/src/InterfaceStubGenerator.Shared/Parser.Request.Query.cs
@@ -59,6 +59,9 @@ internal static partial class Parser
     /// <summary>The metadata name of <c>Refit.QueryUriFormatAttribute</c>.</summary>
     private const string QueryUriFormatAttributeDisplayName = "QueryUriFormatAttribute";
 
+    /// <summary>The metadata name of <c>Refit.TimeoutAttribute</c>.</summary>
+    private const string TimeoutAttributeDisplayName = "TimeoutAttribute";
+
     /// <summary>The fully-qualified display name of the <c>EnumMember</c> attribute honored by the default formatter.</summary>
     private const string EnumMemberAttributeDisplayName = "System.Runtime.Serialization.EnumMemberAttribute";
 

--- a/src/InterfaceStubGenerator.Shared/Parser.Request.cs
+++ b/src/InterfaceStubGenerator.Shared/Parser.Request.cs
@@ -39,6 +39,7 @@ internal static partial class Parser
 
         var returnTypes = GetRequestReturnTypes(resultTypeSource, context);
         var queryUriFormat = ResolveQueryUriFormat(methodSymbol);
+        var timeoutMilliseconds = ResolveTimeout(methodSymbol);
 
         // A multipart method builds its parts inline; each part parameter is classified into a
         // MultipartFormDataContent entry instead of feeding the query string or an implicit body.
@@ -86,6 +87,7 @@ internal static partial class Parser
             IsMultipart = isMultipart,
             MultipartBoundary = multipartBoundary,
             QueryUriFormat = queryUriFormat,
+            TimeoutMilliseconds = timeoutMilliseconds,
         };
     }
 
@@ -322,6 +324,35 @@ internal static partial class Parser
         && attribute.ConstructorArguments.Length == 1
         && attribute.ConstructorArguments[0].Value is int uriFormat
             ? uriFormat
+            : null;
+
+    /// <summary>Reads the per-call timeout in milliseconds from a method's <c>[Timeout]</c> attribute.</summary>
+    /// <param name="methodSymbol">The method to inspect.</param>
+    /// <returns>The timeout in milliseconds, or 0 when the method has no <c>[Timeout]</c>.</returns>
+    private static int ResolveTimeout(IMethodSymbol methodSymbol)
+    {
+        foreach (var attribute in methodSymbol.GetAttributes())
+        {
+            if (TryReadTimeout(attribute) is { } timeoutMilliseconds)
+            {
+                return timeoutMilliseconds;
+            }
+        }
+
+        return 0;
+    }
+
+    /// <summary>Reads the milliseconds value from an attribute if it is <c>[Timeout]</c>.</summary>
+    /// <param name="attribute">The candidate attribute.</param>
+    /// <returns>The timeout in milliseconds, or null when the attribute is not <c>[Timeout]</c>.</returns>
+    /// <remarks>The single-<c>int</c>-argument guards match the attribute's only constructor and cannot fail for a
+    /// <c>[Timeout]</c> application that compiles.</remarks>
+    [ExcludeFromCodeCoverage]
+    private static int? TryReadTimeout(AttributeData attribute) =>
+        IsRefitAttribute(attribute.AttributeClass, TimeoutAttributeDisplayName)
+        && attribute.ConstructorArguments.Length == 1
+        && attribute.ConstructorArguments[0].Value is int milliseconds
+            ? milliseconds
             : null;
 
     /// <summary>Parses the static headers declared on inherited interfaces, the declaring interface, and the method.</summary>

--- a/src/Refit.Reflection/RequestBuilderImplementation.Execution.cs
+++ b/src/Refit.Reflection/RequestBuilderImplementation.Execution.cs
@@ -41,7 +41,7 @@ internal partial class RequestBuilderImplementation
                 .ConfigureAwait(false);
 
             await foreach (var item in RequestExecutionHelpers
-                .StreamResponseAsync<T>(client, request, _settings, false, linked.Token)
+                .StreamResponseAsync<T>(client, request, _settings, false, restMethod.TimeoutMilliseconds, linked.Token)
                 .ConfigureAwait(false))
             {
                 yield return item;
@@ -103,6 +103,7 @@ internal partial class RequestBuilderImplementation
                 _settings,
                 IsBodyBuffered(restMethod, request),
                 false,
+                restMethod.TimeoutMilliseconds,
                 cancellationToken)
             .ConfigureAwait(false);
     }
@@ -235,5 +236,6 @@ internal partial class RequestBuilderImplementation
                 restMethod.ShouldDisposeResponse,
                 IsBodyBuffered(restMethod, request),
                 false),
+            restMethod.TimeoutMilliseconds,
             cancellationToken);
 }

--- a/src/Refit.Reflection/RestMethodInfoInternal.cs
+++ b/src/Refit.Reflection/RestMethodInfoInternal.cs
@@ -94,6 +94,8 @@ internal partial class RestMethodInfoInternal
         QueryUriFormat = methodInfo.GetCustomAttribute<QueryUriFormatAttribute>()?.UriFormat
                          ?? UriFormat.UriEscaped;
 
+        TimeoutMilliseconds = methodInfo.GetCustomAttribute<TimeoutAttribute>(true)?.Milliseconds ?? 0;
+
         IsApiResponse = DetermineIsApiResponse(ReturnResultType);
     }
 
@@ -123,6 +125,9 @@ internal partial class RestMethodInfoInternal
 
     /// <summary>Gets the URI escaping format used for query parameters.</summary>
     public UriFormat QueryUriFormat { get; }
+
+    /// <summary>Gets the per-call timeout in milliseconds from the method's <see cref="TimeoutAttribute"/>, or 0 when absent.</summary>
+    public int TimeoutMilliseconds { get; }
 
     /// <summary>Gets the static headers associated with the method.</summary>
     public Dictionary<string, string?> Headers { get; }

--- a/src/Refit/GeneratedRequestRunner.Sending.cs
+++ b/src/Refit/GeneratedRequestRunner.Sending.cs
@@ -9,6 +9,9 @@ namespace Refit;
 /// <summary>Request-sending entry points that dispatch a built request and process, observe, or stream its response.</summary>
 public static partial class GeneratedRequestRunner
 {
+    /// <summary>The request-options key under which a method's <c>[Timeout]</c> value is stashed.</summary>
+    private const string TimeoutOptionKey = "Refit.Timeout";
+
     /// <summary>Sends a generated request with no response body, throwing on HTTP errors.</summary>
     /// <param name="client">The HTTP client to send with.</param>
     /// <param name="request">The generated request message.</param>
@@ -33,6 +36,7 @@ public static partial class GeneratedRequestRunner
                     settings,
                     bufferBody,
                     true,
+                    GetRequestTimeout(request),
                     cancellationToken)
                 .ConfigureAwait(false);
         }
@@ -75,6 +79,7 @@ public static partial class GeneratedRequestRunner
                         shouldDisposeResponse,
                         bufferBody,
                         true),
+                    GetRequestTimeout(request),
                     cancellationToken)
                 .ConfigureAwait(false);
         }
@@ -108,7 +113,8 @@ public static partial class GeneratedRequestRunner
         new ReactiveUI.Primitives.Advanced.FromAsyncSignal<T?>(async subscriptionToken =>
         {
             // Link the method's CancellationToken argument (if any) with the per-subscription token, allocating a linked
-            // source only when both can cancel - mirroring StreamAsync.
+            // source only when both can cancel - mirroring StreamAsync. The per-call timeout (read from the per-subscription
+            // request built by requestFactory) is layered on inside SendAsync.
             var (token, linked) = ResolveRequestCancellationToken(methodCancellationToken, subscriptionToken);
 
             try
@@ -148,6 +154,10 @@ public static partial class GeneratedRequestRunner
     {
         RequestExecutionHelpers.ThrowIfBaseAddressMissing(client);
 
+        // Read the per-call timeout before enumeration so the request is still readable; StreamResponseAsync layers it
+        // onto the effective token.
+        var timeoutMilliseconds = GetRequestTimeout(request);
+
         // Only allocate a linked source when both tokens can actually cancel; linking a non-cancelable token is a
         // no-op, so when the method has no CancellationToken parameter or the consumer enumerates without
         // WithCancellation the request runs against whichever token can cancel (or none) with no CTS allocation.
@@ -156,7 +166,7 @@ public static partial class GeneratedRequestRunner
         try
         {
             await foreach (var item in RequestExecutionHelpers
-                               .StreamResponseAsync<T>(client, request, settings, true, token)
+                               .StreamResponseAsync<T>(client, request, settings, true, timeoutMilliseconds, token)
                                .ConfigureAwait(false))
             {
                 yield return item;
@@ -167,6 +177,13 @@ public static partial class GeneratedRequestRunner
             linked?.Dispose();
         }
     }
+
+    /// <summary>Stashes a method's <c>[Timeout]</c> value on the request for the send helpers to apply.</summary>
+    /// <param name="request">The generated request message to annotate.</param>
+    /// <param name="timeoutMilliseconds">The per-call timeout in milliseconds.</param>
+    /// <remarks>Emitted by the source generator only for methods that declare a positive timeout.</remarks>
+    public static void SetRequestTimeout(HttpRequestMessage request, int timeoutMilliseconds) =>
+        AddRequestProperty(request, TimeoutOptionKey, timeoutMilliseconds);
 
     /// <summary>Resolves the effective cancellation token for a request, linking the method-argument token with the
     /// per-subscription or enumeration token into a new source only when both can cancel.</summary>
@@ -186,4 +203,18 @@ public static partial class GeneratedRequestRunner
 
         return (methodCancellationToken.CanBeCanceled ? methodCancellationToken : consumerCancellationToken, null);
     }
+
+    /// <summary>Reads the per-call timeout stashed by <see cref="SetRequestTimeout"/>, or 0 when none was set.</summary>
+    /// <param name="request">The generated request message to inspect.</param>
+    /// <returns>The per-call timeout in milliseconds, or 0 when none was set.</returns>
+    private static int GetRequestTimeout(HttpRequestMessage request) =>
+#if NET6_0_OR_GREATER
+        request.Options.TryGetValue(new HttpRequestOptionsKey<int>(TimeoutOptionKey), out var timeoutMilliseconds)
+            ? timeoutMilliseconds
+            : 0;
+#else
+        request.Properties.TryGetValue(TimeoutOptionKey, out var value) && value is int timeoutMilliseconds
+            ? timeoutMilliseconds
+            : 0;
+#endif
 }

--- a/src/Refit/PublicAPI/net10.0/PublicAPI.Shipped.txt
+++ b/src/Refit/PublicAPI/net10.0/PublicAPI.Shipped.txt
@@ -477,3 +477,7 @@ Refit.SystemTextJsonQueryConverter<T>.Flatten(T value, string! keyPrefix, ref Re
 Refit.IReturnTypeAdapter<TReturn, TResult>
 Refit.IReturnTypeAdapter<TReturn, TResult>.Adapt(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<TResult>!>! invoke) -> TReturn
 Refit.RefitSettings.ReturnTypeAdapters.get -> System.Collections.Generic.IList<System.Type!>!
+Refit.TimeoutAttribute
+Refit.TimeoutAttribute.Milliseconds.get -> int
+Refit.TimeoutAttribute.TimeoutAttribute(int milliseconds) -> void
+static Refit.GeneratedRequestRunner.SetRequestTimeout(System.Net.Http.HttpRequestMessage! request, int timeoutMilliseconds) -> void

--- a/src/Refit/PublicAPI/net11.0/PublicAPI.Shipped.txt
+++ b/src/Refit/PublicAPI/net11.0/PublicAPI.Shipped.txt
@@ -477,3 +477,7 @@ Refit.SystemTextJsonQueryConverter<T>.Flatten(T value, string! keyPrefix, ref Re
 Refit.IReturnTypeAdapter<TReturn, TResult>
 Refit.IReturnTypeAdapter<TReturn, TResult>.Adapt(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<TResult>!>! invoke) -> TReturn
 Refit.RefitSettings.ReturnTypeAdapters.get -> System.Collections.Generic.IList<System.Type!>!
+Refit.TimeoutAttribute
+Refit.TimeoutAttribute.Milliseconds.get -> int
+Refit.TimeoutAttribute.TimeoutAttribute(int milliseconds) -> void
+static Refit.GeneratedRequestRunner.SetRequestTimeout(System.Net.Http.HttpRequestMessage! request, int timeoutMilliseconds) -> void

--- a/src/Refit/PublicAPI/net462/PublicAPI.Shipped.txt
+++ b/src/Refit/PublicAPI/net462/PublicAPI.Shipped.txt
@@ -473,3 +473,7 @@ Refit.SystemTextJsonQueryConverter<T>.Flatten(T value, string! keyPrefix, ref Re
 Refit.IReturnTypeAdapter<TReturn, TResult>
 Refit.IReturnTypeAdapter<TReturn, TResult>.Adapt(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<TResult>!>! invoke) -> TReturn
 Refit.RefitSettings.ReturnTypeAdapters.get -> System.Collections.Generic.IList<System.Type!>!
+Refit.TimeoutAttribute
+Refit.TimeoutAttribute.Milliseconds.get -> int
+Refit.TimeoutAttribute.TimeoutAttribute(int milliseconds) -> void
+static Refit.GeneratedRequestRunner.SetRequestTimeout(System.Net.Http.HttpRequestMessage! request, int timeoutMilliseconds) -> void

--- a/src/Refit/PublicAPI/net470/PublicAPI.Shipped.txt
+++ b/src/Refit/PublicAPI/net470/PublicAPI.Shipped.txt
@@ -473,3 +473,7 @@ Refit.SystemTextJsonQueryConverter<T>.Flatten(T value, string! keyPrefix, ref Re
 Refit.IReturnTypeAdapter<TReturn, TResult>
 Refit.IReturnTypeAdapter<TReturn, TResult>.Adapt(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<TResult>!>! invoke) -> TReturn
 Refit.RefitSettings.ReturnTypeAdapters.get -> System.Collections.Generic.IList<System.Type!>!
+Refit.TimeoutAttribute
+Refit.TimeoutAttribute.Milliseconds.get -> int
+Refit.TimeoutAttribute.TimeoutAttribute(int milliseconds) -> void
+static Refit.GeneratedRequestRunner.SetRequestTimeout(System.Net.Http.HttpRequestMessage! request, int timeoutMilliseconds) -> void

--- a/src/Refit/PublicAPI/net471/PublicAPI.Shipped.txt
+++ b/src/Refit/PublicAPI/net471/PublicAPI.Shipped.txt
@@ -473,3 +473,7 @@ Refit.SystemTextJsonQueryConverter<T>.Flatten(T value, string! keyPrefix, ref Re
 Refit.IReturnTypeAdapter<TReturn, TResult>
 Refit.IReturnTypeAdapter<TReturn, TResult>.Adapt(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<TResult>!>! invoke) -> TReturn
 Refit.RefitSettings.ReturnTypeAdapters.get -> System.Collections.Generic.IList<System.Type!>!
+Refit.TimeoutAttribute
+Refit.TimeoutAttribute.Milliseconds.get -> int
+Refit.TimeoutAttribute.TimeoutAttribute(int milliseconds) -> void
+static Refit.GeneratedRequestRunner.SetRequestTimeout(System.Net.Http.HttpRequestMessage! request, int timeoutMilliseconds) -> void

--- a/src/Refit/PublicAPI/net472/PublicAPI.Shipped.txt
+++ b/src/Refit/PublicAPI/net472/PublicAPI.Shipped.txt
@@ -473,3 +473,7 @@ Refit.SystemTextJsonQueryConverter<T>.Flatten(T value, string! keyPrefix, ref Re
 Refit.IReturnTypeAdapter<TReturn, TResult>
 Refit.IReturnTypeAdapter<TReturn, TResult>.Adapt(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<TResult>!>! invoke) -> TReturn
 Refit.RefitSettings.ReturnTypeAdapters.get -> System.Collections.Generic.IList<System.Type!>!
+Refit.TimeoutAttribute
+Refit.TimeoutAttribute.Milliseconds.get -> int
+Refit.TimeoutAttribute.TimeoutAttribute(int milliseconds) -> void
+static Refit.GeneratedRequestRunner.SetRequestTimeout(System.Net.Http.HttpRequestMessage! request, int timeoutMilliseconds) -> void

--- a/src/Refit/PublicAPI/net48/PublicAPI.Shipped.txt
+++ b/src/Refit/PublicAPI/net48/PublicAPI.Shipped.txt
@@ -473,3 +473,7 @@ Refit.SystemTextJsonQueryConverter<T>.Flatten(T value, string! keyPrefix, ref Re
 Refit.IReturnTypeAdapter<TReturn, TResult>
 Refit.IReturnTypeAdapter<TReturn, TResult>.Adapt(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<TResult>!>! invoke) -> TReturn
 Refit.RefitSettings.ReturnTypeAdapters.get -> System.Collections.Generic.IList<System.Type!>!
+Refit.TimeoutAttribute
+Refit.TimeoutAttribute.Milliseconds.get -> int
+Refit.TimeoutAttribute.TimeoutAttribute(int milliseconds) -> void
+static Refit.GeneratedRequestRunner.SetRequestTimeout(System.Net.Http.HttpRequestMessage! request, int timeoutMilliseconds) -> void

--- a/src/Refit/PublicAPI/net481/PublicAPI.Shipped.txt
+++ b/src/Refit/PublicAPI/net481/PublicAPI.Shipped.txt
@@ -473,3 +473,7 @@ Refit.SystemTextJsonQueryConverter<T>.Flatten(T value, string! keyPrefix, ref Re
 Refit.IReturnTypeAdapter<TReturn, TResult>
 Refit.IReturnTypeAdapter<TReturn, TResult>.Adapt(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<TResult>!>! invoke) -> TReturn
 Refit.RefitSettings.ReturnTypeAdapters.get -> System.Collections.Generic.IList<System.Type!>!
+Refit.TimeoutAttribute
+Refit.TimeoutAttribute.Milliseconds.get -> int
+Refit.TimeoutAttribute.TimeoutAttribute(int milliseconds) -> void
+static Refit.GeneratedRequestRunner.SetRequestTimeout(System.Net.Http.HttpRequestMessage! request, int timeoutMilliseconds) -> void

--- a/src/Refit/PublicAPI/net8.0/PublicAPI.Shipped.txt
+++ b/src/Refit/PublicAPI/net8.0/PublicAPI.Shipped.txt
@@ -477,3 +477,7 @@ Refit.SystemTextJsonQueryConverter<T>.Flatten(T value, string! keyPrefix, ref Re
 Refit.IReturnTypeAdapter<TReturn, TResult>
 Refit.IReturnTypeAdapter<TReturn, TResult>.Adapt(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<TResult>!>! invoke) -> TReturn
 Refit.RefitSettings.ReturnTypeAdapters.get -> System.Collections.Generic.IList<System.Type!>!
+Refit.TimeoutAttribute
+Refit.TimeoutAttribute.Milliseconds.get -> int
+Refit.TimeoutAttribute.TimeoutAttribute(int milliseconds) -> void
+static Refit.GeneratedRequestRunner.SetRequestTimeout(System.Net.Http.HttpRequestMessage! request, int timeoutMilliseconds) -> void

--- a/src/Refit/PublicAPI/net9.0/PublicAPI.Shipped.txt
+++ b/src/Refit/PublicAPI/net9.0/PublicAPI.Shipped.txt
@@ -477,3 +477,7 @@ Refit.SystemTextJsonQueryConverter<T>.Flatten(T value, string! keyPrefix, ref Re
 Refit.IReturnTypeAdapter<TReturn, TResult>
 Refit.IReturnTypeAdapter<TReturn, TResult>.Adapt(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<TResult>!>! invoke) -> TReturn
 Refit.RefitSettings.ReturnTypeAdapters.get -> System.Collections.Generic.IList<System.Type!>!
+Refit.TimeoutAttribute
+Refit.TimeoutAttribute.Milliseconds.get -> int
+Refit.TimeoutAttribute.TimeoutAttribute(int milliseconds) -> void
+static Refit.GeneratedRequestRunner.SetRequestTimeout(System.Net.Http.HttpRequestMessage! request, int timeoutMilliseconds) -> void

--- a/src/Refit/RequestExecutionHelpers.Streaming.cs
+++ b/src/Refit/RequestExecutionHelpers.Streaming.cs
@@ -1,0 +1,96 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+namespace Refit;
+
+/// <summary>Streaming send and framing helpers for the shared request execution pipeline.</summary>
+internal static partial class RequestExecutionHelpers
+{
+    /// <summary>Sends the request and streams its body, throwing on HTTP errors and disposing the request when done.</summary>
+    /// <typeparam name="T">The element type yielded to the caller.</typeparam>
+    /// <param name="client">The HTTP client to send with.</param>
+    /// <param name="request">The request message; disposed when streaming completes.</param>
+    /// <param name="settings">The Refit settings to use.</param>
+    /// <param name="streamingSerializer">The streaming-capable content serializer.</param>
+    /// <param name="applyAuthorizationHeader">Whether to apply the configured authorization getter before sending.</param>
+    /// <param name="timeoutSource">The per-call timeout source to dispose when streaming completes, or null when no timeout was applied.</param>
+    /// <param name="cancellationToken">A token to cancel streaming.</param>
+    /// <returns>An asynchronous sequence of deserialized elements.</returns>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Design",
+        "SST2307:Generic method type parameters should be inferable from the parameters",
+        Justification = "Type parameter intentionally specified explicitly by generated and reflection callers.")]
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage] // async-iterator dispose-mode epilogue: the compiler-generated <>w__disposeMode false-edge cannot be exercised or removed.
+    private static async IAsyncEnumerable<T?> StreamResponseIteratorAsync<T>(
+        HttpClient client,
+        HttpRequestMessage request,
+        RefitSettings settings,
+        IStreamingContentSerializer streamingSerializer,
+        bool applyAuthorizationHeader,
+        CancellationTokenSource? timeoutSource,
+        [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        try
+        {
+            using (request)
+            {
+                if (applyAuthorizationHeader)
+                {
+                    await AddAuthorizationHeaderFromGetterAsync(request, settings, cancellationToken)
+                        .ConfigureAwait(false);
+                }
+
+                using var response = await client
+                    .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                    .ConfigureAwait(false);
+
+                var exception = await settings.ExceptionFactory(response).ConfigureAwait(false);
+                if (exception is not null)
+                {
+                    throw exception;
+                }
+
+                var content = EnsureResponseContent(response);
+                var format = DetectStreamingFormat(content);
+
+#if NET6_0_OR_GREATER
+                var stream = await content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+                await using (stream.ConfigureAwait(false))
+                {
+                    await foreach (var item in streamingSerializer
+                        .DeserializeStreamAsync<T>(stream, format, cancellationToken)
+                        .ConfigureAwait(false))
+                    {
+                        yield return item;
+                    }
+                }
+#else
+                using var stream = await content.ReadAsStreamAsync().ConfigureAwait(false);
+                await foreach (var item in streamingSerializer
+                    .DeserializeStreamAsync<T>(stream, format, cancellationToken)
+                    .ConfigureAwait(false))
+                {
+                    yield return item;
+                }
+#endif
+            }
+        }
+        finally
+        {
+            timeoutSource?.Dispose();
+        }
+    }
+
+    /// <summary>Chooses the streaming frame format from the response content type.</summary>
+    /// <param name="content">The response content whose media type is inspected.</param>
+    /// <returns>The detected streaming format.</returns>
+    private static StreamingContentFormat DetectStreamingFormat(HttpContent content)
+    {
+        var mediaType = content.Headers.ContentType?.MediaType;
+        return string.Equals(mediaType, "application/jsonl", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(mediaType, "application/x-ndjson", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(mediaType, "application/x-jsonlines", StringComparison.OrdinalIgnoreCase)
+            ? StreamingContentFormat.JsonLines
+            : StreamingContentFormat.JsonArray;
+    }
+}

--- a/src/Refit/RequestExecutionHelpers.cs
+++ b/src/Refit/RequestExecutionHelpers.cs
@@ -4,7 +4,7 @@
 namespace Refit;
 
 /// <summary>Shared send and response-processing helpers for generated and reflection-built requests.</summary>
-internal static class RequestExecutionHelpers
+internal static partial class RequestExecutionHelpers
 {
     /// <summary>The message used when content cannot be deserialized into the requested type.</summary>
     private const string DeserializationErrorMessage = "An error occured deserializing the response.";
@@ -25,12 +25,32 @@ internal static class RequestExecutionHelpers
         throw new InvalidOperationException(BaseAddressRequiredMessage);
     }
 
+    /// <summary>Builds the token a request runs against, applying a per-call timeout on top of the effective token.</summary>
+    /// <param name="timeoutMilliseconds">The per-call timeout in milliseconds; values that are not positive disable it.</param>
+    /// <param name="cancellationToken">The already-resolved effective cancellation token for the request.</param>
+    /// <returns>The token the request should run against, and the timeout source to dispose once the request completes
+    /// (null when no timeout was applied).</returns>
+    public static (CancellationToken Token, CancellationTokenSource? TimeoutSource) CreateTimeoutToken(
+        int timeoutMilliseconds,
+        CancellationToken cancellationToken)
+    {
+        if (timeoutMilliseconds <= 0)
+        {
+            return (cancellationToken, null);
+        }
+
+        var timeoutSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeoutSource.CancelAfter(timeoutMilliseconds);
+        return (timeoutSource.Token, timeoutSource);
+    }
+
     /// <summary>Sends a request with no response body, throwing on HTTP errors.</summary>
     /// <param name="client">The HTTP client to send with.</param>
     /// <param name="request">The request message.</param>
     /// <param name="settings">The Refit settings to use.</param>
     /// <param name="bufferBody">Whether request content should be buffered before sending.</param>
     /// <param name="applyAuthorizationHeader">Whether to apply the configured authorization getter before sending.</param>
+    /// <param name="timeoutMilliseconds">The per-call timeout in milliseconds; values that are not positive disable it.</param>
     /// <param name="cancellationToken">A token to cancel the request.</param>
     /// <returns>A task that completes when the request finishes.</returns>
     public static async Task SendVoidAsync(
@@ -39,32 +59,41 @@ internal static class RequestExecutionHelpers
         RefitSettings settings,
         bool bufferBody,
         bool applyAuthorizationHeader,
+        int timeoutMilliseconds,
         CancellationToken cancellationToken)
     {
-        if (bufferBody && request.Content is not null)
+        var (token, timeoutSource) = CreateTimeoutToken(timeoutMilliseconds, cancellationToken);
+        try
         {
-            await request.Content.LoadIntoBufferAsync(cancellationToken).ConfigureAwait(false);
-        }
+            if (bufferBody && request.Content is not null)
+            {
+                await request.Content.LoadIntoBufferAsync(token).ConfigureAwait(false);
+            }
 
-        await CaptureRequestContentAsync(request, settings, cancellationToken).ConfigureAwait(false);
+            await CaptureRequestContentAsync(request, settings, token).ConfigureAwait(false);
 
-        if (applyAuthorizationHeader)
-        {
-            await AddAuthorizationHeaderFromGetterAsync(request, settings, cancellationToken)
+            if (applyAuthorizationHeader)
+            {
+                await AddAuthorizationHeaderFromGetterAsync(request, settings, token)
+                    .ConfigureAwait(false);
+            }
+
+            using var response = await client
+                .SendAsync(request, token)
                 .ConfigureAwait(false);
+
+            var exception = await settings.ExceptionFactory(response).ConfigureAwait(false);
+            if (exception is null)
+            {
+                return;
+            }
+
+            throw exception;
         }
-
-        using var response = await client
-            .SendAsync(request, cancellationToken)
-            .ConfigureAwait(false);
-
-        var exception = await settings.ExceptionFactory(response).ConfigureAwait(false);
-        if (exception is null)
+        finally
         {
-            return;
+            timeoutSource?.Dispose();
         }
-
-        throw exception;
     }
 
     /// <summary>Buffers, sends, and processes the response for a request.</summary>
@@ -74,6 +103,7 @@ internal static class RequestExecutionHelpers
     /// <param name="request">The request message.</param>
     /// <param name="settings">The Refit settings to use.</param>
     /// <param name="options">The send and response-processing options.</param>
+    /// <param name="timeoutMilliseconds">The per-call timeout in milliseconds; values that are not positive disable it.</param>
     /// <param name="cancellationToken">A token to cancel the request.</param>
     /// <returns>The deserialized or wrapped response.</returns>
     [System.Diagnostics.CodeAnalysis.SuppressMessage(
@@ -89,21 +119,23 @@ internal static class RequestExecutionHelpers
         HttpRequestMessage request,
         RefitSettings settings,
         RequestExecutionOptions options,
+        int timeoutMilliseconds,
         CancellationToken cancellationToken)
     {
+        var (token, timeoutSource) = CreateTimeoutToken(timeoutMilliseconds, cancellationToken);
         HttpResponseMessage? response = null;
         HttpContent? content = null;
         var disposeResponse = true;
         try
         {
-            await PrepareRequestAsync(request, settings, options, cancellationToken).ConfigureAwait(false);
+            await PrepareRequestAsync(request, settings, options, token).ConfigureAwait(false);
 
             var sendResult = await SendOrCaptureExceptionAsync<T, TBody>(
                     client,
                     request,
                     settings,
                     options.IsApiResponse,
-                    cancellationToken)
+                    token)
                 .ConfigureAwait(false);
             if (!sendResult.HasResponse)
             {
@@ -124,7 +156,7 @@ internal static class RequestExecutionHelpers
                 disposeResponse = false;
             }
 
-            return await DispatchResponseAsync<T, TBody>(request, response, content, settings, options, exception, cancellationToken)
+            return await DispatchResponseAsync<T, TBody>(request, response, content, settings, options, exception, token)
                 .ConfigureAwait(false);
         }
         finally
@@ -134,6 +166,8 @@ internal static class RequestExecutionHelpers
                 response?.Dispose();
                 content?.Dispose();
             }
+
+            timeoutSource?.Dispose();
         }
     }
 
@@ -143,6 +177,7 @@ internal static class RequestExecutionHelpers
     /// <param name="request">The request message; disposed when streaming completes.</param>
     /// <param name="settings">The Refit settings to use.</param>
     /// <param name="applyAuthorizationHeader">Whether to apply the configured authorization getter before sending.</param>
+    /// <param name="timeoutMilliseconds">The per-call timeout in milliseconds; values that are not positive disable it.</param>
     /// <param name="cancellationToken">A token to cancel streaming.</param>
     /// <returns>An asynchronous sequence of deserialized elements.</returns>
     [System.Diagnostics.CodeAnalysis.SuppressMessage(
@@ -154,6 +189,7 @@ internal static class RequestExecutionHelpers
         HttpRequestMessage request,
         RefitSettings settings,
         bool applyAuthorizationHeader,
+        int timeoutMilliseconds,
         CancellationToken cancellationToken)
     {
         if (settings.ContentSerializer is not IStreamingContentSerializer streamingSerializer)
@@ -163,13 +199,16 @@ internal static class RequestExecutionHelpers
                 $"The configured {nameof(IHttpContentSerializer)} does not support streaming responses. Implement {nameof(IStreamingContentSerializer)} to return an IAsyncEnumerable<T>.");
         }
 
+        var (token, timeoutSource) = CreateTimeoutToken(timeoutMilliseconds, cancellationToken);
+
         return StreamResponseIteratorAsync<T>(
             client,
             request,
             settings,
             streamingSerializer,
             applyAuthorizationHeader,
-            cancellationToken);
+            timeoutSource,
+            token);
     }
 
     /// <summary>Populates an empty Authorization header through the configured token getter.</summary>
@@ -263,85 +302,6 @@ internal static class RequestExecutionHelpers
 
         await AddAuthorizationHeaderFromGetterAsync(request, settings, cancellationToken)
             .ConfigureAwait(false);
-    }
-
-    /// <summary>Sends the request and streams its body, throwing on HTTP errors and disposing the request when done.</summary>
-    /// <typeparam name="T">The element type yielded to the caller.</typeparam>
-    /// <param name="client">The HTTP client to send with.</param>
-    /// <param name="request">The request message; disposed when streaming completes.</param>
-    /// <param name="settings">The Refit settings to use.</param>
-    /// <param name="streamingSerializer">The streaming-capable content serializer.</param>
-    /// <param name="applyAuthorizationHeader">Whether to apply the configured authorization getter before sending.</param>
-    /// <param name="cancellationToken">A token to cancel streaming.</param>
-    /// <returns>An asynchronous sequence of deserialized elements.</returns>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "Design",
-        "SST2307:Generic method type parameters should be inferable from the parameters",
-        Justification = "Type parameter intentionally specified explicitly by generated and reflection callers.")]
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage] // async-iterator dispose-mode epilogue: the compiler-generated <>w__disposeMode false-edge cannot be exercised or removed.
-    private static async IAsyncEnumerable<T?> StreamResponseIteratorAsync<T>(
-        HttpClient client,
-        HttpRequestMessage request,
-        RefitSettings settings,
-        IStreamingContentSerializer streamingSerializer,
-        bool applyAuthorizationHeader,
-        [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken)
-    {
-        using (request)
-        {
-            if (applyAuthorizationHeader)
-            {
-                await AddAuthorizationHeaderFromGetterAsync(request, settings, cancellationToken)
-                    .ConfigureAwait(false);
-            }
-
-            using var response = await client
-                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-                .ConfigureAwait(false);
-
-            var exception = await settings.ExceptionFactory(response).ConfigureAwait(false);
-            if (exception is not null)
-            {
-                throw exception;
-            }
-
-            var content = EnsureResponseContent(response);
-            var format = DetectStreamingFormat(content);
-
-#if NET6_0_OR_GREATER
-            var stream = await content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
-            await using (stream.ConfigureAwait(false))
-            {
-                await foreach (var item in streamingSerializer
-                    .DeserializeStreamAsync<T>(stream, format, cancellationToken)
-                    .ConfigureAwait(false))
-                {
-                    yield return item;
-                }
-            }
-#else
-            using var stream = await content.ReadAsStreamAsync().ConfigureAwait(false);
-            await foreach (var item in streamingSerializer
-                .DeserializeStreamAsync<T>(stream, format, cancellationToken)
-                .ConfigureAwait(false))
-            {
-                yield return item;
-            }
-#endif
-        }
-    }
-
-    /// <summary>Chooses the streaming frame format from the response content type.</summary>
-    /// <param name="content">The response content whose media type is inspected.</param>
-    /// <returns>The detected streaming format.</returns>
-    private static StreamingContentFormat DetectStreamingFormat(HttpContent content)
-    {
-        var mediaType = content.Headers.ContentType?.MediaType;
-        return string.Equals(mediaType, "application/jsonl", StringComparison.OrdinalIgnoreCase)
-            || string.Equals(mediaType, "application/x-ndjson", StringComparison.OrdinalIgnoreCase)
-            || string.Equals(mediaType, "application/x-jsonlines", StringComparison.OrdinalIgnoreCase)
-            ? StreamingContentFormat.JsonLines
-            : StreamingContentFormat.JsonArray;
     }
 
     /// <summary>Sends the request, capturing a transport failure as an API response when required.</summary>

--- a/src/Refit/TimeoutAttribute.cs
+++ b/src/Refit/TimeoutAttribute.cs
@@ -1,0 +1,22 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Refit;
+
+/// <summary>Applies a per-call timeout, in milliseconds, to a Refit interface method.</summary>
+/// <remarks>
+/// The timeout is layered on top of the request's effective cancellation token: when it elapses the request is
+/// canceled, surfacing as an <see cref="OperationCanceledException"/> (typically a
+/// <see cref="System.Threading.Tasks.TaskCanceledException"/>), consistent with how
+/// <see cref="HttpClient.Timeout"/> reports a lapsed deadline. It composes with, and is independent
+/// of, <see cref="HttpClient.Timeout"/> and any handler-based timeout: whichever fires first cancels
+/// the call. A value that is not positive is ignored, leaving the request without a per-call deadline.
+/// </remarks>
+/// <param name="milliseconds">The timeout, in milliseconds. Must be positive to take effect.</param>
+[AttributeUsage(AttributeTargets.Method)]
+public sealed class TimeoutAttribute(int milliseconds) : Attribute
+{
+    /// <summary>Gets the timeout, in milliseconds, applied to the decorated method's request.</summary>
+    public int Milliseconds { get; } = milliseconds;
+}

--- a/src/tests/Refit.GeneratorTests/GeneratedRequestBuildingTests.Timeout.cs
+++ b/src/tests/Refit.GeneratorTests/GeneratedRequestBuildingTests.Timeout.cs
@@ -1,0 +1,44 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+namespace Refit.GeneratorTests;
+
+/// <summary>Generator tests for the per-call <c>[Timeout]</c> attribute emission.</summary>
+public partial class GeneratedRequestBuildingTests
+{
+    /// <summary>The generated call that stashes a method's per-call timeout on the request.</summary>
+    private const string SetRequestTimeoutCall = "GeneratedRequestRunner.SetRequestTimeout(refitRequest, 50)";
+
+    /// <summary>An eligible GET method that declares a per-call timeout.</summary>
+    private const string TimeoutGetMethod =
+        """
+        [Get("/users")]
+        [Timeout(50)]
+        Task<string> Get(CancellationToken cancellationToken);
+        """;
+
+    /// <summary>Verifies a method with <c>[Timeout]</c> emits the timeout stash before sending.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task TimeoutAttributeEmitsSetRequestTimeout()
+    {
+        var generated = Fixture.GenerateForBody(
+            TimeoutGetMethod,
+            GeneratedClientHintName);
+
+        await Assert.That(generated).Contains(SetRequestTimeoutCall);
+        await Assert.That(generated).Contains(GeneratedRequestRunnerSendAsync);
+    }
+
+    /// <summary>Verifies a method without <c>[Timeout]</c> emits no timeout stash.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task WithoutTimeoutAttributeEmitsNoSetRequestTimeout()
+    {
+        var generated = Fixture.GenerateForBody(
+            SimpleGetMethod,
+            GeneratedClientHintName);
+
+        await Assert.That(generated).DoesNotContain("SetRequestTimeout");
+    }
+}

--- a/src/tests/Refit.Tests/DelayingHttpMessageHandler.cs
+++ b/src/tests/Refit.Tests/DelayingHttpMessageHandler.cs
@@ -1,0 +1,30 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Net;
+
+namespace Refit.Tests;
+
+/// <summary>A test handler that waits for a fixed delay (honoring cancellation) before returning canned content, used to
+/// exercise per-call <see cref="TimeoutAttribute"/> deadlines.</summary>
+/// <param name="delay">The delay before responding. Use <see cref="Timeout.InfiniteTimeSpan"/> to block until the request
+/// is canceled, or <see cref="TimeSpan.Zero"/> to respond immediately.</param>
+public sealed class DelayingHttpMessageHandler(TimeSpan delay) : HttpMessageHandler
+{
+    /// <summary>Gets the number of requests the handler has received.</summary>
+    public int RequestCount { get; private set; }
+
+    /// <summary>Waits for the configured delay, honoring cancellation, then returns a successful response.</summary>
+    /// <param name="request">The HTTP request message being sent.</param>
+    /// <param name="cancellationToken">The cancellation token for the request.</param>
+    /// <returns>A successful HTTP response with canned content.</returns>
+    protected override async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        RequestCount++;
+        await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
+        return new(HttpStatusCode.OK) { Content = new StringContent("ok") };
+    }
+}

--- a/src/tests/Refit.Tests/ITimeoutApi.cs
+++ b/src/tests/Refit.Tests/ITimeoutApi.cs
@@ -1,0 +1,41 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Refit.Tests;
+
+/// <summary>API surface exercising the per-call <see cref="TimeoutAttribute"/> across void, value, and cancellable
+/// methods for both the reflection and source-generated request paths.</summary>
+public interface ITimeoutApi
+{
+    /// <summary>Gets a resource with a short per-call timeout and no response body.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Get("/")]
+    [Timeout(50)]
+    Task GetVoidShortTimeout();
+
+    /// <summary>Gets a resource with a short per-call timeout and a string response body.</summary>
+    /// <returns>A task that resolves to the response content.</returns>
+    [Get("/")]
+    [Timeout(50)]
+    Task<string> GetStringShortTimeout();
+
+    /// <summary>Gets a resource with a long per-call timeout and no response body.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Get("/")]
+    [Timeout(60_000)]
+    Task GetVoidLongTimeout();
+
+    /// <summary>Gets a resource with a long per-call timeout and a string response body.</summary>
+    /// <returns>A task that resolves to the response content.</returns>
+    [Get("/")]
+    [Timeout(60_000)]
+    Task<string> GetStringLongTimeout();
+
+    /// <summary>Gets a resource with a long per-call timeout alongside a caller cancellation token.</summary>
+    /// <param name="cancellationToken">A token used to cancel the request.</param>
+    /// <returns>A task that resolves to the response content.</returns>
+    [Get("/")]
+    [Timeout(60_000)]
+    Task<string> GetStringLongTimeoutCancellable(CancellationToken cancellationToken);
+}

--- a/src/tests/Refit.Tests/TimeoutAttributeTests.cs
+++ b/src/tests/Refit.Tests/TimeoutAttributeTests.cs
@@ -1,0 +1,138 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Refit.Tests;
+
+/// <summary>Verifies the per-call <see cref="TimeoutAttribute"/> for both the source-generated and reflection request
+/// paths: a slow response over the deadline cancels, a fast response under it succeeds, and a caller cancellation token
+/// still cancels alongside the timeout.</summary>
+public sealed class TimeoutAttributeTests
+{
+    /// <summary>The base address used to build the request messages.</summary>
+    private const string BaseAddress = "http://localhost/";
+
+    /// <summary>Source-generated: a void method whose response outlasts its short timeout is canceled.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task SourceGenVoidTimeoutCancelsSlowResponse()
+    {
+        using var handler = new DelayingHttpMessageHandler(Timeout.InfiniteTimeSpan);
+        using var client = new HttpClient(handler) { BaseAddress = new(BaseAddress) };
+        var api = RestService.For<ITimeoutApi>(client);
+
+        await Assert.That(() => api.GetVoidShortTimeout()).Throws<OperationCanceledException>();
+    }
+
+    /// <summary>Source-generated: a value-returning method whose response outlasts its short timeout is canceled.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task SourceGenValueTimeoutCancelsSlowResponse()
+    {
+        using var handler = new DelayingHttpMessageHandler(Timeout.InfiniteTimeSpan);
+        using var client = new HttpClient(handler) { BaseAddress = new(BaseAddress) };
+        var api = RestService.For<ITimeoutApi>(client);
+
+        await Assert.That(() => (Task)api.GetStringShortTimeout()).Throws<OperationCanceledException>();
+    }
+
+    /// <summary>Source-generated: a void method that responds under its timeout completes normally.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task SourceGenVoidTimeoutAllowsFastResponse()
+    {
+        using var handler = new DelayingHttpMessageHandler(TimeSpan.Zero);
+        using var client = new HttpClient(handler) { BaseAddress = new(BaseAddress) };
+        var api = RestService.For<ITimeoutApi>(client);
+
+        await api.GetVoidLongTimeout();
+
+        await Assert.That(handler.RequestCount).IsEqualTo(1);
+    }
+
+    /// <summary>Source-generated: a value-returning method that responds under its timeout returns its content.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task SourceGenValueTimeoutAllowsFastResponse()
+    {
+        using var handler = new DelayingHttpMessageHandler(TimeSpan.Zero);
+        using var client = new HttpClient(handler) { BaseAddress = new(BaseAddress) };
+        var api = RestService.For<ITimeoutApi>(client);
+
+        var result = await api.GetStringLongTimeout();
+
+        await Assert.That(result).IsEqualTo("ok");
+    }
+
+    /// <summary>Source-generated: a caller cancellation token still cancels a request that also declares a timeout.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task SourceGenCallerCancellationCancelsAlongsideTimeout()
+    {
+        using var handler = new DelayingHttpMessageHandler(Timeout.InfiniteTimeSpan);
+        using var client = new HttpClient(handler) { BaseAddress = new(BaseAddress) };
+        var api = RestService.For<ITimeoutApi>(client);
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        await Assert
+            .That(() => (Task)api.GetStringLongTimeoutCancellable(cts.Token))
+            .Throws<OperationCanceledException>();
+    }
+
+    /// <summary>Reflection: a void method whose response outlasts its short timeout is canceled.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task ReflectionVoidTimeoutCancelsSlowResponse()
+    {
+        var fixture = new RequestBuilderImplementation<ITimeoutApi>();
+        var factory = fixture.BuildRestResultFuncForMethod(nameof(ITimeoutApi.GetVoidShortTimeout));
+        using var handler = new DelayingHttpMessageHandler(Timeout.InfiniteTimeSpan);
+        using var client = new HttpClient(handler) { BaseAddress = new(BaseAddress) };
+
+        await Assert.That(() => (Task)factory(client, [])!).Throws<OperationCanceledException>();
+    }
+
+    /// <summary>Reflection: a value-returning method whose response outlasts its short timeout is canceled.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task ReflectionValueTimeoutCancelsSlowResponse()
+    {
+        var fixture = new RequestBuilderImplementation<ITimeoutApi>();
+        var factory = fixture.BuildRestResultFuncForMethod(nameof(ITimeoutApi.GetStringShortTimeout));
+        using var handler = new DelayingHttpMessageHandler(Timeout.InfiniteTimeSpan);
+        using var client = new HttpClient(handler) { BaseAddress = new(BaseAddress) };
+
+        await Assert.That(() => (Task)factory(client, [])!).Throws<OperationCanceledException>();
+    }
+
+    /// <summary>Reflection: a value-returning method that responds under its timeout returns its content.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task ReflectionValueTimeoutAllowsFastResponse()
+    {
+        var fixture = new RequestBuilderImplementation<ITimeoutApi>();
+        var factory = fixture.BuildRestResultFuncForMethod(nameof(ITimeoutApi.GetStringLongTimeout));
+        using var handler = new DelayingHttpMessageHandler(TimeSpan.Zero);
+        using var client = new HttpClient(handler) { BaseAddress = new(BaseAddress) };
+
+        var result = await (Task<string?>)factory(client, [])!;
+
+        await Assert.That(result).IsEqualTo("ok");
+    }
+
+    /// <summary>Reflection: a caller cancellation token still cancels a request that also declares a timeout.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task ReflectionCallerCancellationCancelsAlongsideTimeout()
+    {
+        var fixture = new RequestBuilderImplementation<ITimeoutApi>();
+        var factory = fixture.BuildRestResultFuncForMethod(nameof(ITimeoutApi.GetStringLongTimeoutCancellable));
+        using var handler = new DelayingHttpMessageHandler(Timeout.InfiniteTimeSpan);
+        using var client = new HttpClient(handler) { BaseAddress = new(BaseAddress) };
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        await Assert.That(() => (Task)factory(client, [cts.Token])!).Throws<OperationCanceledException>();
+    }
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature.

## What is the new behavior?

Adds a public `[Timeout(milliseconds)]` method attribute that gives a single Refit call its own deadline.

```csharp
[Get("/users/{user}")]
[Timeout(5000)] // cancel this call if it takes longer than 5 seconds
Task<User> GetUser(string user);
```

- The timeout layers onto the request's already-resolved effective cancellation token via a linked `CancellationTokenSource` + `CancelAfter`, disposed in a `finally`.
- A lapsed deadline surfaces as an `OperationCanceledException` (typically a `TaskCanceledException`), the same way a lapsed `HttpClient.Timeout` reports.
- It is independent of, and composes with, `HttpClient.Timeout` and any Polly/`DelegatingHandler` timeout -> whichever deadline elapses first wins.
- A caller-supplied `CancellationToken` still works alongside it.
- A value that is not positive adds no deadline, and methods without `[Timeout]` pay no extra cost.
- Honored in both request paths for parity: reflection (parsed into `RestMethodInfoInternal`) and source-generated (the generator stashes the value on the request only for methods that declare a positive timeout; the shared send helpers read and apply it). Methods without `[Timeout]` generate byte-identical code to before.
- Value shape is milliseconds as an `int`, matching common usage and documented in the README.

## What is the current behavior?

There is no per-call deadline. Timeouts are only the client-wide `HttpClient.Timeout` plus any caller `CancellationToken` linked per request; a single slow method could not be given its own deadline.

Closes #1590

## What might this PR break?

None. The change is additive: a new attribute and new public helpers only, with no changes to existing public method signatures. A README "Per-request timeouts" section and a `docs/breaking-changes.md` additive note are included.

## Checklist
- [x] I have read the [Contribute guide](https://www.reactiveui.net/contribute/index.html)
- [x] Tests have been added or updated (for bug fixes / features)
- [x] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the `main` branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional information

- New tests cover both request paths: a slow response over the deadline cancels, a fast response under it succeeds, and a caller cancellation cancels alongside the timeout.
- 100% line and branch patch coverage on the changed runtime files; all test projects pass.
