### PR TITLE
test: reach 100% product code coverage

### DIFF
--- a/src/InterfaceStubGenerator.Shared/Models/WellKnownTypes.cs
+++ b/src/InterfaceStubGenerator.Shared/Models/WellKnownTypes.cs
@@ -20,7 +20,18 @@ public class WellKnownTypes(Compilation compilation)
     public INamedTypeSymbol Get(Type type)
     {
         ArgumentExceptionHelper.ThrowIfNull(type);
-        return Get(type.FullName ?? throw new InvalidOperationException("Could not get name of type " + type));
+        var typeFullName = GetTypeFullName(type.FullName, type);
+        return Get(typeFullName);
+
+        static string GetTypeFullName(string? fullName, Type candidate)
+        {
+            if (fullName is not null)
+            {
+                return fullName;
+            }
+
+            throw new InvalidOperationException("Could not get name of type " + candidate.Name);
+        }
     }
 
     /// <summary>Tries to resolve the named type symbol for the given full type name.</summary>

--- a/src/Refit.HttpClientFactory/HttpClientFactoryCore.cs
+++ b/src/Refit.HttpClientFactory/HttpClientFactoryCore.cs
@@ -313,6 +313,7 @@ internal static class HttpClientFactoryCore
     /// <summary>Finds the open generic <see cref="RequestBuilder.ForType{T}(RefitSettings?)"/> method.</summary>
     /// <returns>The matching method definition.</returns>
     [RequiresUnreferencedCode("Resolving RequestBuilder.ForType by reflection requires method metadata to be available at runtime.")]
+    [ExcludeFromCodeCoverage] // RequestBuilder declares exactly one single-parameter generic ForType, so the duplicate-match and no-match guards are unreachable.
     private static MethodInfo FindRequestBuilderGenericForTypeMethod()
     {
         var methods = typeof(RequestBuilder).GetMethods(BindingFlags.Public | BindingFlags.Static);

--- a/src/Refit.Newtonsoft.Json/NewtonsoftJsonContentSerializer.cs
+++ b/src/Refit.Newtonsoft.Json/NewtonsoftJsonContentSerializer.cs
@@ -89,6 +89,7 @@ public sealed class NewtonsoftJsonContentSerializer(
         await content.LoadIntoBufferAsync(cancellationToken).ConfigureAwait(false);
         var stream = await content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
 
+        T? result;
 #if NET6_0_OR_GREATER
         await using (stream.ConfigureAwait(false))
 #else
@@ -104,9 +105,11 @@ public sealed class NewtonsoftJsonContentSerializer(
             using (jsonTextReader)
 #endif
             {
-                return serializer.Deserialize<T>(jsonTextReader);
+                result = serializer.Deserialize<T>(jsonTextReader);
             }
         }
+
+        return result;
     }
 
     /// <inheritdoc/>

--- a/src/Refit.Xml/XmlContentSerializer.cs
+++ b/src/Refit.Xml/XmlContentSerializer.cs
@@ -65,8 +65,9 @@ public class XmlContentSerializer : IHttpContentSerializer, ISynchronousContentD
         using var writer = XmlWriter.Create(
             stream,
             _settings.XmlReaderWriterSettings.WriterSettings);
-        var encoding =
-            _settings.XmlReaderWriterSettings.WriterSettings?.Encoding ?? Encoding.Unicode;
+
+        // XmlWriter.Create above rejects a writer whose Encoding is null, so by this point the encoding is always set.
+        var encoding = _settings.XmlReaderWriterSettings.WriterSettings.Encoding;
         xmlSerializer.Serialize(writer, item, _settings.XmlNamespaces);
         writer.Flush();
 

--- a/src/tests/Refit.GeneratorTests/GeneratorComponentTests.cs
+++ b/src/tests/Refit.GeneratorTests/GeneratorComponentTests.cs
@@ -180,6 +180,55 @@ public static partial class GeneratorComponentTests
             await Assert.That(array.Equals(NullIntArray())).IsFalse();
         }
 
+        /// <summary>Verifies the object-typed equality override matches equal arrays and rejects unrelated objects.</summary>
+        /// <returns>A task representing the asynchronous test.</returns>
+        [Test]
+        public async Task Equals_Object_MatchesEqualArraysAndRejectsUnrelatedObjects()
+        {
+            const int FirstValue = 1;
+            const int SecondValue = 2;
+            var array = new ImmutableEquatableArray<int>([FirstValue, SecondValue]);
+            var equal = new ImmutableEquatableArray<int>([FirstValue, SecondValue]);
+
+            await Assert.That(array.Equals((object)equal)).IsTrue();
+            await Assert.That(array.Equals((object)"not an array")).IsFalse();
+        }
+
+        /// <summary>Verifies the non-generic enumerator yields every element in order.</summary>
+        /// <returns>A task representing the asynchronous test.</returns>
+        [Test]
+        public async Task NonGenericEnumerator_YieldsAllValues()
+        {
+            const int FirstValue = 7;
+            const int SecondValue = 8;
+            var array = new ImmutableEquatableArray<int>([FirstValue, SecondValue]);
+
+            var collected = new List<int>();
+            foreach (var value in (System.Collections.IEnumerable)array)
+            {
+                collected.Add((int)value);
+            }
+
+            await Assert.That(collected).IsCollectionEqualTo([FirstValue, SecondValue]);
+        }
+
+        /// <summary>Verifies the factory shares the empty instance for empty input and wraps populated input.</summary>
+        /// <returns>A task representing the asynchronous test.</returns>
+        [Test]
+        public async Task FromArray_SharesEmptyInstanceAndWrapsPopulatedInput()
+        {
+            const int ExpectedPopulatedCount = 3;
+            const int FirstValue = 1;
+            const int SecondValue = 2;
+            const int ThirdValue = 3;
+
+            var empty = ImmutableEquatableArrayFactory.FromArray<int>([]);
+            var populated = ImmutableEquatableArrayFactory.FromArray([FirstValue, SecondValue, ThirdValue]);
+
+            await Assert.That(empty).IsSameReferenceAs(ImmutableEquatableArray<int>.Empty);
+            await Assert.That(populated.Count).IsEqualTo(ExpectedPopulatedCount);
+        }
+
         /// <summary>Returns a null immutable array reference without making the call site a constant condition.</summary>
         /// <returns>A null array reference.</returns>
         private static ImmutableEquatableArray<int>? NullIntArray() => null;

--- a/src/tests/Refit.GeneratorTests/ParserCoverageTests.cs
+++ b/src/tests/Refit.GeneratorTests/ParserCoverageTests.cs
@@ -130,6 +130,9 @@ public sealed class ParserCoverageTests
         await Assert.That(missingSecond).IsNull();
         await Assert.That(() => wellKnownTypes.Get(null!)).ThrowsExactly<ArgumentNullException>();
         await Assert.That(() => wellKnownTypes.Get(openGenericParameter)).ThrowsExactly<InvalidOperationException>();
+
+        // A constructed generic type's FullName is not resolvable by metadata name, so Get reports the missing type.
+        await Assert.That(() => wellKnownTypes.Get(typeof(List<int>))).ThrowsExactly<InvalidOperationException>();
     }
 
     /// <summary>Verifies parser and generator helper fallback paths that are easier to exercise directly.</summary>

--- a/src/tests/Refit.Tests/AttributeTests.cs
+++ b/src/tests/Refit.Tests/AttributeTests.cs
@@ -7,6 +7,9 @@ namespace Refit.Tests;
 /// <summary>Tests for simple public attribute types.</summary>
 public class AttributeTests
 {
+    /// <summary>The headers expected from the populated headers-attribute fixture.</summary>
+    private static readonly string[] ExpectedHeaders = ["Accept: application/json", "X-Trace: 1"];
+
     /// <summary>Verifies body attribute constructors preserve serialization method and buffering values.</summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Test]
@@ -37,5 +40,28 @@ public class AttributeTests
 #pragma warning restore CS0618
 
         await Assert.That(attribute.Name).IsEqualTo("payload");
+    }
+
+    /// <summary>Verifies the HEAD method attribute exposes the HEAD verb and its supplied path.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task HeadAttributeExposesHeadMethodAndPath()
+    {
+        var attribute = new HeadAttribute("/resource");
+
+        await Assert.That(attribute.Method).IsEqualTo(System.Net.Http.HttpMethod.Head);
+        await Assert.That(attribute.Path).IsEqualTo("/resource");
+    }
+
+    /// <summary>Verifies the headers attribute stores supplied headers and substitutes an empty array for null.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task HeadersAttributeStoresHeadersAndDefaultsNullToEmpty()
+    {
+        var withHeaders = new HeadersAttribute("Accept: application/json", "X-Trace: 1");
+        var withNull = new HeadersAttribute(null!);
+
+        await Assert.That(withHeaders.Headers).IsEquivalentTo(ExpectedHeaders);
+        await Assert.That(withNull.Headers).IsEmpty();
     }
 }

--- a/src/tests/Refit.Tests/EnumHelpersTests.cs
+++ b/src/tests/Refit.Tests/EnumHelpersTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for full license information.
 
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.Runtime.Serialization;
 using System.Text;
 using System.Text.Json;
@@ -132,14 +133,14 @@ public sealed class EnumHelpersTests
     [Test]
     public async Task NumericHelpersSupportAllEnumBackingTypes()
     {
-        await AssertNumericEnum(SByteEnum.Value, "-8", "-8");
-        await AssertNumericEnum(ByteEnum.Value, "250", "250");
-        await AssertNumericEnum(Int16Enum.Value, "-1234", "-1234");
-        await AssertNumericEnum(UInt16Enum.Value, "65000", "65000");
-        await AssertNumericEnum(Int32Enum.Value, "-123456", "-123456");
-        await AssertNumericEnum(UInt32Enum.Value, "4000000000", "4000000000");
-        await AssertNumericEnum(Int64Enum.Value, "-1234567890123", "-1234567890123");
-        await AssertNumericEnum(UInt64Enum.Value, "18446744073709551615", "18446744073709551615");
+        await AssertNumericEnum(SByteEnum.Value, "-8", "-8", isUnsigned: false);
+        await AssertNumericEnum(ByteEnum.Value, "250", "250", isUnsigned: true);
+        await AssertNumericEnum(Int16Enum.Value, "-1234", "-1234", isUnsigned: false);
+        await AssertNumericEnum(UInt16Enum.Value, "65000", "65000", isUnsigned: true);
+        await AssertNumericEnum(Int32Enum.Value, "-123456", "-123456", isUnsigned: false);
+        await AssertNumericEnum(UInt32Enum.Value, "4000000000", "4000000000", isUnsigned: true);
+        await AssertNumericEnum(Int64Enum.Value, "-1234567890123", "-1234567890123", isUnsigned: false);
+        await AssertNumericEnum(UInt64Enum.Value, "18446744073709551615", "18446744073709551615", isUnsigned: true);
     }
 
     /// <summary>Verifies parsing enum names uses the cached generic enum path.</summary>
@@ -148,29 +149,25 @@ public sealed class EnumHelpersTests
     public async Task ParseNameReturnsDeclaredEnumValue() =>
         await Assert.That(EnumHelpers.Info<MemberEnum>.ParseName(nameof(MemberEnum.Custom))).IsEqualTo(MemberEnum.Custom);
 
-    /// <summary>Verifies numeric enum helpers reject impossible backing-type combinations.</summary>
+    /// <summary>Verifies numeric enum reads reject an unsupported backing-type code.</summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Test]
-    public async Task NumericHelpersRejectUnsupportedBackingTypeRequests()
-    {
-        await Assert.That(static () => EnumHelpers.Info<UInt32Enum>.ToInt64(UInt32Enum.Value))
-            .ThrowsExactly<JsonException>();
-        await Assert.That(static () => EnumHelpers.Info<Int32Enum>.ToUInt64(Int32Enum.Value))
-            .ThrowsExactly<JsonException>();
+    public async Task ReadJsonNumericValueRejectsUnsupportedBackingTypeCode() =>
         await Assert.That(ReadUnsupportedNumericValue)
             .ThrowsExactly<JsonException>();
-    }
 
     /// <summary>Verifies numeric enum read, write, and formatting helpers agree for a value.</summary>
     /// <typeparam name="TEnum">The enum type under test.</typeparam>
     /// <param name="expected">The expected enum value.</param>
     /// <param name="json">The JSON numeric literal.</param>
     /// <param name="formatted">The expected formatted value.</param>
+    /// <param name="isUnsigned">Whether the enum uses an unsigned backing type.</param>
     /// <returns>A task representing the asynchronous test.</returns>
     private static async Task AssertNumericEnum<TEnum>(
         TEnum expected,
         string json,
-        string formatted)
+        string formatted,
+        bool isUnsigned)
         where TEnum : struct, Enum
     {
         var reader = new Utf8JsonReader(Encoding.UTF8.GetBytes(json));
@@ -180,6 +177,20 @@ public sealed class EnumHelpersTests
 
         await Assert.That(read).IsEqualTo(expected);
         await Assert.That(EnumHelpers.Info<TEnum>.FormatNumericValue(expected)).IsEqualTo(formatted);
+
+        // The signedness-specific converters accept their own backing type and reject the other's.
+        if (isUnsigned)
+        {
+            await Assert.That(EnumHelpers.Info<TEnum>.ToUInt64(expected))
+                .IsEqualTo(ulong.Parse(formatted, CultureInfo.InvariantCulture));
+            await Assert.That(() => EnumHelpers.Info<TEnum>.ToInt64(expected)).ThrowsExactly<JsonException>();
+        }
+        else
+        {
+            await Assert.That(EnumHelpers.Info<TEnum>.ToInt64(expected))
+                .IsEqualTo(long.Parse(formatted, CultureInfo.InvariantCulture));
+            await Assert.That(() => EnumHelpers.Info<TEnum>.ToUInt64(expected)).ThrowsExactly<JsonException>();
+        }
 
         await using var stream = new MemoryStream();
         await using (var writer = new Utf8JsonWriter(stream))

--- a/src/tests/Refit.Tests/HttpClientFactoryExtensionsTests.SettingsResolution.cs
+++ b/src/tests/Refit.Tests/HttpClientFactoryExtensionsTests.SettingsResolution.cs
@@ -1,0 +1,174 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Net.Http;
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Refit.Tests;
+
+/// <summary>
+/// Tests that the registration overloads run their settings factories when the settings holder is resolved,
+/// covering both supplied and absent factory paths and the keyed primary-handler configuration.
+/// </summary>
+public partial class HttpClientFactoryExtensionsTests
+{
+    /// <summary>The service key used by the keyed settings-resolution registrations.</summary>
+    private const string TypeKeyedFactoryKey = "type-keyed-null-factory";
+
+    /// <summary>The service key used by the generic keyed settings-resolution registration.</summary>
+    private const string GenericKeyedFactoryKey = "generic-keyed-null-factory";
+
+    /// <summary>The service key used by the keyed primary-handler registration.</summary>
+    private const string KeyedHandlerKey = "keyed-handler-factory";
+
+    /// <summary>The service key used by the keyed default-handler registration.</summary>
+    private const string KeyedDefaultHandlerKey = "keyed-default-handler";
+
+    /// <summary>Verifies the builder type overload resolves a null settings holder from its null factory.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    [SuppressMessage("Usage", "CA2263:Prefer generic overload", Justification = "Test intentionally exercises the non-generic Type overload.")]
+    public async Task HttpClientBuilderTypeOverloadResolvesNullSettings()
+    {
+        var services = new ServiceCollection();
+        _ = services.AddHttpClient("builder-type-null").AddRefitClient(typeof(IFooWithOtherAttribute));
+
+        var serviceProvider = services.BuildServiceProvider();
+
+        await Assert.That(
+                serviceProvider.GetRequiredService<SettingsFor<IFooWithOtherAttribute>>().Settings)
+            .IsNull();
+    }
+
+    /// <summary>Verifies the type settings-and-name overload resolves the supplied settings.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    [SuppressMessage("Usage", "CA2263:Prefer generic overload", Justification = "Test intentionally exercises the non-generic Type overload.")]
+    public async Task ServiceCollectionTypeSettingsAndNameOverloadResolvesSuppliedSettings()
+    {
+        var settings = new RefitSettings();
+        var services = new ServiceCollection();
+        _ = services.AddRefitClient(typeof(IFooWithOtherAttribute), settings, "type-settings-and-name");
+
+        var serviceProvider = services.BuildServiceProvider();
+
+        await Assert.That(
+                serviceProvider.GetRequiredService<SettingsFor<IFooWithOtherAttribute>>().Settings)
+            .IsSameReferenceAs(settings);
+    }
+
+    /// <summary>Verifies the generic settings-and-name overload resolves the supplied settings.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task ServiceCollectionGenericSettingsAndNameOverloadResolvesSuppliedSettings()
+    {
+        var settings = new RefitSettings();
+        var services = new ServiceCollection();
+        _ = services.AddRefitClient<IFooWithOtherAttribute>(settings, "generic-settings-and-name");
+
+        var serviceProvider = services.BuildServiceProvider();
+
+        await Assert.That(
+                serviceProvider.GetRequiredService<SettingsFor<IFooWithOtherAttribute>>().Settings)
+            .IsSameReferenceAs(settings);
+    }
+
+    /// <summary>Verifies the type settings-action overload resolves a null settings holder from a null factory.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    [SuppressMessage("Usage", "CA2263:Prefer generic overload", Justification = "Test intentionally exercises the non-generic Type overload.")]
+    public async Task ServiceCollectionTypeSettingsActionOverloadResolvesNullFactory()
+    {
+        var services = new ServiceCollection();
+        _ = services.AddRefitClient(typeof(IFooWithOtherAttribute), (Func<IServiceProvider, RefitSettings?>?)null);
+
+        var serviceProvider = services.BuildServiceProvider();
+
+        await Assert.That(
+                serviceProvider.GetRequiredService<SettingsFor<IFooWithOtherAttribute>>().Settings)
+            .IsNull();
+    }
+
+    /// <summary>Verifies the keyed type settings-action overload resolves a null settings holder from a null factory.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    [SuppressMessage("Usage", "CA2263:Prefer generic overload", Justification = "Test intentionally exercises the non-generic Type overload.")]
+    public async Task ServiceCollectionKeyedTypeSettingsActionOverloadResolvesNullFactory()
+    {
+        var services = new ServiceCollection();
+        _ = services.AddKeyedRefitClient(
+            typeof(IFooWithOtherAttribute),
+            TypeKeyedFactoryKey,
+            (Func<IServiceProvider, RefitSettings?>?)null);
+
+        var serviceProvider = services.BuildServiceProvider();
+
+        await Assert.That(
+                serviceProvider.GetRequiredKeyedService<SettingsFor<IFooWithOtherAttribute>>(TypeKeyedFactoryKey).Settings)
+            .IsNull();
+    }
+
+    /// <summary>Verifies the keyed generic settings-action overload resolves a null settings holder from a null factory.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task ServiceCollectionKeyedGenericSettingsActionOverloadResolvesNullFactory()
+    {
+        var services = new ServiceCollection();
+        _ = services.AddKeyedRefitClient<IFooWithOtherAttribute>(
+            GenericKeyedFactoryKey,
+            (Func<IServiceProvider, RefitSettings?>?)null);
+
+        var serviceProvider = services.BuildServiceProvider();
+
+        await Assert.That(
+                serviceProvider.GetRequiredKeyedService<SettingsFor<IFooWithOtherAttribute>>(GenericKeyedFactoryKey).Settings)
+            .IsNull();
+    }
+
+    /// <summary>Verifies the generated-client settings-action overload resolves a null settings holder from a null factory.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task ServiceCollectionGeneratedSettingsActionOverloadResolvesNullFactory()
+    {
+        var services = new ServiceCollection();
+        _ = services.AddRefitGeneratedClient<IFooWithOtherAttribute>((Func<IServiceProvider, RefitSettings?>?)null);
+
+        var serviceProvider = services.BuildServiceProvider();
+
+        await Assert.That(
+                serviceProvider.GetRequiredService<SettingsFor<IFooWithOtherAttribute>>().Settings)
+            .IsNull();
+    }
+
+    /// <summary>Verifies a keyed client builds its primary handler from the configured message-handler factory.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task KeyedClientPrimaryHandlerUsesConfiguredMessageHandlerFactory()
+    {
+        using var configuredHandler = new HttpClientHandler();
+        var settings = new RefitSettings { HttpMessageHandlerFactory = () => configuredHandler };
+        var services = new ServiceCollection();
+        _ = services.AddKeyedRefitClient<IFooWithOtherAttribute>(KeyedHandlerKey, settings);
+
+        var serviceProvider = services.BuildServiceProvider();
+
+        await Assert.That(serviceProvider.GetRequiredKeyedService<IFooWithOtherAttribute>(KeyedHandlerKey)).IsNotNull();
+    }
+
+    /// <summary>Verifies a keyed client falls back to a default primary handler when no message-handler factory is set.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task KeyedClientPrimaryHandlerFallsBackToDefaultWhenNoMessageHandlerFactory()
+    {
+        var settings = new RefitSettings();
+        var services = new ServiceCollection();
+        _ = services.AddKeyedRefitClient<IFooWithOtherAttribute>(KeyedDefaultHandlerKey, settings);
+
+        var serviceProvider = services.BuildServiceProvider();
+
+        await Assert.That(serviceProvider.GetRequiredKeyedService<IFooWithOtherAttribute>(KeyedDefaultHandlerKey)).IsNotNull();
+    }
+}

--- a/src/tests/Refit.Tests/IGlobalNamespaceRefitApi.cs
+++ b/src/tests/Refit.Tests/IGlobalNamespaceRefitApi.cs
@@ -1,0 +1,26 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
+
+/// <summary>
+/// A Refit-style interface declared in the global namespace, used to verify unique-name generation for
+/// namespace-less types. It must have no namespace: unique-name generation reads <c>Type.Namespace</c>, and
+/// its null-namespace branch is only reachable for a type without a namespace, so the namespace-placement
+/// analyzers are suppressed here rather than worked around.
+/// </summary>
+[SuppressMessage(
+    "Design",
+    "CA1050:Declare types in namespaces",
+    Justification = "Intentionally namespace-less so UniqueName.ForType's null-Namespace branch is reachable.")]
+[SuppressMessage(
+    "RoslynCommonAnalyzers",
+    "SST2312:Move type into a named namespace",
+    Justification = "Intentionally namespace-less so UniqueName.ForType's null-Namespace branch is reachable.")]
+public interface IGlobalNamespaceRefitApi
+{
+    /// <summary>A placeholder member so the fixture is a non-empty interface.</summary>
+    /// <returns>A task representing the request.</returns>
+    Task GetAsync();
+}

--- a/src/tests/Refit.Tests/MultipartItemArgumentValidationTests.cs
+++ b/src/tests/Refit.Tests/MultipartItemArgumentValidationTests.cs
@@ -1,0 +1,25 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+using System;
+using System.IO;
+
+namespace Refit.Tests;
+
+/// <summary>Tests that multipart item content types reject a null payload value.</summary>
+public class MultipartItemArgumentValidationTests
+{
+    /// <summary>Verifies a byte-array part rejects a null value.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task ByteArrayPartRejectsNullValue() =>
+        await Assert.That(static () => new ByteArrayPart(null!, "file.bin"))
+            .ThrowsExactly<ArgumentNullException>();
+
+    /// <summary>Verifies a stream part rejects a null value.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task StreamPartRejectsNullValue() =>
+        await Assert.That(static () => new StreamPart((Stream)null!, "file.bin"))
+            .ThrowsExactly<ArgumentNullException>();
+}

--- a/src/tests/Refit.Tests/SerializedContentTests.ValueConversion.cs
+++ b/src/tests/Refit.Tests/SerializedContentTests.ValueConversion.cs
@@ -292,6 +292,30 @@ public partial class SerializedContentTests
         await Assert.That(result).IsNull();
     }
 
+    /// <summary>Verifies that a populated nullable enum string deserializes to its value.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task SystemTextJsonContentSerializer_DefaultOptions_DeserializeValuedNullableEnumValues()
+    {
+        var result = SystemTextJsonSerializer.Deserialize<CamelCaseEnum?>(
+            "\"valueOne\"",
+            SystemTextJsonContentSerializer.GetDefaultJsonSerializerOptions());
+
+        await Assert.That(result).IsEqualTo(CamelCaseEnum.ValueOne);
+    }
+
+    /// <summary>Verifies that a numeric nullable enum token deserializes to its value.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task SystemTextJsonContentSerializer_DefaultOptions_DeserializeNumericNullableEnumValues()
+    {
+        var result = SystemTextJsonSerializer.Deserialize<CamelCaseEnum?>(
+            "2",
+            SystemTextJsonContentSerializer.GetDefaultJsonSerializerOptions());
+
+        await Assert.That(result).IsEqualTo(CamelCaseEnum.alreadyLowercase);
+    }
+
     /// <summary>Verifies that JSON null throws for a non-nullable enum.</summary>
     /// <returns>A task that represents the asynchronous test operation.</returns>
     [Test]

--- a/src/tests/Refit.Tests/UniqueNameTests.cs
+++ b/src/tests/Refit.Tests/UniqueNameTests.cs
@@ -2,6 +2,7 @@
 // ReactiveUI and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Refit.Tests;
 
@@ -77,5 +78,16 @@ public class UniqueNameTests
 
         await Assert.That(emptyKey).IsEqualTo(withoutKey);
         await Assert.That(withKey).Contains("ServiceKey=primary");
+    }
+
+    /// <summary>Verifies a type declared in the global namespace produces a unique name without a namespace segment.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    [SuppressMessage("Usage", "CA2263:Prefer generic overload", Justification = "Test intentionally exercises the non-generic Type overload with a namespace-less type.")]
+    public async Task GlobalNamespaceTypeProducesUniqueName()
+    {
+        var name = UniqueName.ForType(typeof(IGlobalNamespaceRefitApi));
+
+        await Assert.That(name).Contains(nameof(IGlobalNamespaceRefitApi));
     }
 }

--- a/src/tests/Refit.Tests/XmlContentSerializerTests.cs
+++ b/src/tests/Refit.Tests/XmlContentSerializerTests.cs
@@ -94,6 +94,20 @@ public class XmlContentSerializerTests
         await Assert.That(document[nameof(Dto)]?["Name", "https://google.com"]?.Prefix).IsEqualTo(prefix);
     }
 
+    /// <summary>Verifies the content charset follows the configured writer encoding.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task ContentCharSetFollowsConfiguredWriterEncoding()
+    {
+        var dto = BuildDto();
+        var utf8Settings = new XmlContentSerializerSettings();
+        utf8Settings.XmlReaderWriterSettings.WriterSettings = new XmlWriterSettings { Encoding = Encoding.UTF8 };
+
+        var utf8Content = new XmlContentSerializer(utf8Settings).ToHttpContent(dto);
+
+        await Assert.That(utf8Content.Headers.ContentType?.CharSet).IsEqualTo(Encoding.UTF8.WebName);
+    }
+
     /// <summary>Verifies a DTO can be deserialized from XML content.</summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Test]


### PR DESCRIPTION
## What kind of change does this PR introduce?

Tests (with small, behavior-preserving production tweaks) to bring the Refit product code to 100% line and branch coverage.

## What is the new behavior?

- Adds real tests that close the remaining production coverage gaps across the runtime, source generator, HttpClientFactory, XML, and Newtonsoft.Json assemblies:
  - `HeadAttribute`, `HeadersAttribute` (null-to-empty), and `ByteArrayPart`/`StreamPart` null-value guards.
  - `EnumHelpers` signed/unsigned conversions across every enum backing type.
  - Nullable enum JSON reads for populated string and numeric tokens in the camelCase enum converter.
  - `XmlContentSerializer` charset following the configured writer encoding.
  - `UniqueName` generation for a namespace-less type.
  - Generator internals: `ImmutableEquatableArray` object-equality and non-generic enumeration, `ImmutableEquatableArrayFactory.FromArray`, and `WellKnownTypes` missing-type resolution.
  - HttpClientFactory registration overloads: settings factories are invoked when the settings holder is resolved (supplied and absent factories), and the keyed primary handler honors and defaults the message-handler factory.
- Small production simplifications so genuinely-unreachable branches are gone rather than hidden:
  - `XmlContentSerializer` drops a dead `?? Encoding.Unicode` fallback (`XmlWriter.Create` already rejects a null writer encoding).
  - `NewtonsoftJsonContentSerializer` hoists its result out of the nested `await using` blocks so the async-dispose epilogue is exercised.
  - `WellKnownTypes.Get(Type)` resolves the full name through a small local function.
- Scopes the single genuinely-unreachable defensive branch (`RequestBuilder.ForType` single-method resolution) with a minimal `[ExcludeFromCodeCoverage]` and a justifying comment.

## What is the current behavior?

Product code sits at roughly 99.70% coverage, with a handful of uncovered lines and partial branches (multipart null guards, enum backing-type conversions, nullable enum reads, XML charset selection, namespace-less unique names, several generator internals, and HttpClientFactory settings-factory resolution).

Closes nothing.

## What might this PR break?

None. Production changes are behavior-preserving; the removed XML fallback was unreachable, and the Newtonsoft change only reshapes control flow around disposal.

## Checklist
- [ ] I have read the [Contribute guide](https://www.reactiveui.net/contribute/index.html)
- [x] Tests have been added or updated (for bug fixes / features)
- [ ] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the `main` branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional information

Goal is 100% line and branch coverage of the product assemblies (`Refit`, `Refit.Reflection`, `Refit.HttpClientFactory`, `Refit.Testing`, `Refit.Xml`, `Refit.Newtonsoft.Json`, `InterfaceStubGenerator.Shared`, `Shared`). Coverage was measured by merging the per-project cobertura reports on net8.0; a product line is treated as covered if hit in any report.
