### PR TITLE
ci: gate native AOT smoke test via shared reusable workflow

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -20,6 +20,30 @@ jobs:
         secrets:
             CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
+    # The shared build workflow only restores/builds/tests, so it never invokes ILC. This job runs a
+    # real `dotnet publish -r linux-x64` of the smoke project (PublishAot, TrimMode=full, IL codes
+    # promoted to errors in its csproj) and runs the produced native binary, so the ILC link plus a
+    # non-zero exit on mismatch gate the pipeline end-to-end. linux-x64 is the lean baseline; a
+    # win-x64 / osx-arm64 matrix is a straightforward follow-up.
+    native-aot-smoke:
+        name: Native AOT smoke (linux-x64)
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v5
+              with:
+                  fetch-depth: 0
+            - name: Setup .NET
+              uses: actions/setup-dotnet@v5
+              with:
+                  dotnet-version: 8.0.x
+            - name: Publish Native AOT smoke (linux-x64)
+              run: dotnet publish src/Refit.NativeAotSmoke/Refit.NativeAotSmoke.csproj -c Release -r linux-x64
+            - name: Run published native binary
+              run: src/Refit.NativeAotSmoke/bin/Release/net8.0/linux-x64/publish/Refit.NativeAotSmoke
+
     # PR metadata consumed by the fork-PR SonarCloud flow (see sonarcloud-fork.yml).
     save-pr-metadata:
         if: github.event_name == 'pull_request'

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -20,30 +20,6 @@ jobs:
         secrets:
             CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
-    # The shared build workflow only restores/builds/tests, so it never invokes ILC. This job runs a
-    # real `dotnet publish -r linux-x64` of the smoke project (PublishAot, TrimMode=full, IL codes
-    # promoted to errors in its csproj) and runs the produced native binary, so the ILC link plus a
-    # non-zero exit on mismatch gate the pipeline end-to-end. linux-x64 is the lean baseline; a
-    # win-x64 / osx-arm64 matrix is a straightforward follow-up.
-    native-aot-smoke:
-        name: Native AOT smoke (linux-x64)
-        runs-on: ubuntu-latest
-        permissions:
-            contents: read
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v5
-              with:
-                  fetch-depth: 0
-            - name: Setup .NET
-              uses: actions/setup-dotnet@v5
-              with:
-                  dotnet-version: 8.0.x
-            - name: Publish Native AOT smoke (linux-x64)
-              run: dotnet publish src/Refit.NativeAotSmoke/Refit.NativeAotSmoke.csproj -c Release -r linux-x64
-            - name: Run published native binary
-              run: src/Refit.NativeAotSmoke/bin/Release/net8.0/linux-x64/publish/Refit.NativeAotSmoke
-
     # PR metadata consumed by the fork-PR SonarCloud flow (see sonarcloud-fork.yml).
     save-pr-metadata:
         if: github.event_name == 'pull_request'

--- a/.github/workflows/native-aot.yml
+++ b/.github/workflows/native-aot.yml
@@ -1,0 +1,16 @@
+name: Native AOT
+
+on:
+    push:
+        branches: [ main ]
+    pull_request:
+        branches: [ main ]
+
+permissions:
+    contents: read
+
+jobs:
+    native-aot-smoke:
+        uses: reactiveui/actions-common/.github/workflows/workflow-common-aot-smoke.yml@main
+        with:
+            projectFile: src/Refit.NativeAotSmoke/Refit.NativeAotSmoke.csproj


### PR DESCRIPTION
## What this does

Adds a Native AOT smoke gate to CI, wired the same way as every other refit workflow - by calling a shared reusable workflow in reactiveui/actions-common rather than a bespoke local job.

- New refit workflow `native-aot.yml` calls `reactiveui/actions-common/.github/workflows/workflow-common-aot-smoke.yml`.
- The reusable workflow runs `dotnet publish -r <rid>` on `src/Refit.NativeAotSmoke` and runs the produced native binary as the pass/fail gate, across a cross-platform matrix: win-x64, linux-x64, osx-arm64.
- It reuses the standard `dotnet-environment` composite for SDK setup, so every target framework's SDK (including net11) is installed - fixing the net11 targeting error the earlier single-RID attempt hit - and installs clang/zlib on Linux so the ILC native link has its toolchain.

## Why

A plain build already runs the trim/AOT analyzers, but only a real native publish exercises the ILC compile/link and proves the binary runs. Keeping it in actions-common means every rxui repo can opt in with one `uses:` line.

Closes #2230