### PR TITLE
feat: opt-in [FormObject] flattens a model into multipart form fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -1884,6 +1884,47 @@ someApiInstance.UploadPhoto(id, new StreamPart(myPhotoStream, "photo.jpg", "imag
 Note: The `AttachmentName` attribute that was previously described in this section has been deprecated and its use is
 not recommended.
 
+#### Flattening a model into form fields with `[FormObject]`
+
+By default a complex object passed to a multipart method is added as a **single** serialized part (for example one
+`application/json` body) named after the parameter. That single part cannot be bound field by field by a server that
+expects form fields (such as an ASP.NET `[FromForm]` model).
+
+Opt in to per-property flattening by decorating the parameter with `[FormObject]`. Each public property is then sent as
+its own `multipart/form-data` text field:
+
+```csharp
+public class SetupModel
+{
+    [AliasAs("full_name")]
+    public string Name { get; set; }
+
+    public int Age { get; set; }
+
+    public string[] Roles { get; set; }
+}
+
+public interface IUploadApi
+{
+    [Multipart]
+    [Post("/setup")]
+    Task SetupAsync([FormObject] SetupModel model, [AliasAs("recipe")] StreamPart recipe);
+}
+```
+
+The call above sends `full_name`, `Age` and `Roles` as individual form fields alongside the `recipe` file part.
+
+- **Field names** are resolved per property: `[AliasAs]` first, then the content serializer's field name (for example
+  `[JsonPropertyName]`), then the `UrlParameterKeyFormatter`.
+- **Values** are rendered as plain text through the `FormUrlEncodedParameterFormatter`, and collections are joined per
+  the `CollectionFormat` (the default joins with commas), mirroring url-encoded body flattening.
+- **Nested objects** are flattened into composed `parent.child` field names (bounded by a nesting-depth cap and a
+  reference-cycle guard).
+- **Files** (`byte[]`, `Stream`, `FileInfo` and the `ByteArrayPart` / `StreamPart` / `FileInfoPart` wrappers) are not
+  converted by `[FormObject]`; keep passing those as their own separate part parameters.
+
+Without `[FormObject]` the existing single-serialized-part behaviour is unchanged.
+
 ### Retrieving the response
 
 Note that in Refit unlike in Retrofit, there is no option for a synchronous

--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -141,6 +141,14 @@ visible in three places.
   per-call deadline composes with `HttpClient.Timeout` and any Polly/`DelegatingHandler` timeout — whichever fires first
   wins. Methods without `[Timeout]` are unaffected. Both request paths honor it (reflection and source-generated). See
   [Per-request timeouts](../README.md#per-request-timeouts).
+* **`[FormObject]` flattens a model into individual multipart fields.** In a `[Multipart]` method, decorating a
+  complex-object parameter with `[FormObject]` sends each of its public properties as its own `multipart/form-data` text
+  field instead of the default single serialized part, so a server model bound from the form (such as an ASP.NET
+  `[FromForm]` model) binds field by field. Field names resolve with the form-encoded precedence (`[AliasAs]`, then the
+  content serializer's property name, then the key formatter), values render through the `FormUrlEncodedParameterFormatter`,
+  collections honor `CollectionFormat`, and nested objects compose `parent.child` field names. File-typed members are
+  left as separate part parameters. The default (no attribute) single-part behavior is unchanged. See
+  [Flattening a model into form fields with `[FormObject]`](../README.md#flattening-a-model-into-form-fields-with-formobject).
 * **Inline query-string generation.** Query parameters — auto-appended parameters, `[AliasAs]`, `[Query(Format = ...)]`,
   and scalar collections with every `CollectionFormat` — now generate reflection-free request construction, so the most
   common Refit method shapes work with generated-only clients (`AddRefitGeneratedClient`, `RestService.ForGenerated`)

--- a/src/InterfaceStubGenerator.Shared/Parser.Request.Multipart.cs
+++ b/src/InterfaceStubGenerator.Shared/Parser.Request.Multipart.cs
@@ -12,12 +12,16 @@ namespace Refit.Generator;
 /// <c>AddMultiPart</c>/<c>AddMultipartItem</c> dispatch and its part name/file-name selection, resolved statically from
 /// each parameter's declared type. A part whose declared type is not statically dispatchable (an <c>object</c>, an
 /// interface, an open type parameter, or a type that would fall through to the content serializer) makes the whole
-/// method fall back to the reflection request builder.
+/// method fall back to the reflection request builder, as does an opt-in <c>[FormObject]</c> parameter whose properties
+/// the reflection builder flattens into individual form-data parts.
 /// </content>
 internal static partial class Parser
 {
     /// <summary>The metadata name of the obsolete <c>Refit.AttachmentNameAttribute</c>.</summary>
     private const string AttachmentNameAttributeDisplayName = "AttachmentNameAttribute";
+
+    /// <summary>The metadata name of <c>Refit.FormObjectAttribute</c>.</summary>
+    private const string FormObjectAttributeDisplayName = "FormObjectAttribute";
 
     /// <summary>The default multipart boundary, matching <c>new MultipartAttribute().BoundaryText</c>.</summary>
     private const string DefaultMultipartBoundary = "----MyGreatBoundary";
@@ -104,6 +108,13 @@ internal static partial class Parser
     /// <returns>The part descriptor, or <see langword="null"/> when the type is not statically dispatchable.</returns>
     private static MultipartPartModel? TryBuildMultipartPart(IParameterSymbol parameter, in LooseParameterContext context)
     {
+        // An opt-in [FormObject] parameter is flattened per-property by the reflection request builder; returning null
+        // routes the whole method to that one authoritative implementation instead of duplicating the flattening here.
+        if (HasParameterAttribute(parameter, FormObjectAttributeDisplayName))
+        {
+            return null;
+        }
+
         if (ClassifyPartType(parameter.Type) is not { } classified)
         {
             return null;

--- a/src/Refit.Reflection/RequestBuilderImplementation.Payload.cs
+++ b/src/Refit.Reflection/RequestBuilderImplementation.Payload.cs
@@ -203,6 +203,14 @@ internal partial class RequestBuilderImplementation
         string itemName;
         string parameterName;
 
+        // An opt-in [FormObject] parameter is flattened into one text form-data part per property (resolved field name +
+        // formatted value) so server-side form model binding sees individual fields instead of a single serialized part.
+        if (restMethod.ParameterInfoArray[i].GetCustomAttribute<FormObjectAttribute>(true) is not null)
+        {
+            AddFlattenedFormObject(multiPartContent!, param);
+            return;
+        }
+
         if (!restMethod.AttachmentNameMap.TryGetValue(i, out var attachment))
         {
             itemName = restMethod.QueryParameterMap[i];
@@ -225,6 +233,27 @@ internal partial class RequestBuilderImplementation
         else
         {
             AddMultipartItem(multiPartContent!, itemName, parameterName, param);
+        }
+    }
+
+    /// <summary>Flattens a complex object's properties into one text multipart part each for a <c>[FormObject]</c> parameter.</summary>
+    /// <param name="multiPartContent">The multipart content to add to.</param>
+    /// <param name="param">The object (or dictionary) whose fields become individual form-data parts.</param>
+    /// <remarks>Reuses <see cref="FormValueMultimap"/> so field-name resolution (alias, serializer, key formatter),
+    /// value formatting, collection handling and nested <c>parent.child</c> composition match url-encoded body
+    /// flattening. Each entry is added as its own text <see cref="StringContent"/> under the resolved field name.</remarks>
+    private void AddFlattenedFormObject(MultipartFormDataContent multiPartContent, object param)
+    {
+        foreach (var field in new FormValueMultimap(param, _settings))
+        {
+            // A field with no resolvable name cannot be a valid form-data part (the framework rejects an empty
+            // content-disposition name), so it is skipped rather than allowed to throw mid-request.
+            if (string.IsNullOrWhiteSpace(field.Key))
+            {
+                continue;
+            }
+
+            multiPartContent.Add(new StringContent(field.Value ?? string.Empty), field.Key!);
         }
     }
 

--- a/src/Refit/FormObjectAttribute.cs
+++ b/src/Refit/FormObjectAttribute.cs
@@ -1,0 +1,41 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Refit;
+
+/// <summary>
+/// Marks a complex-object parameter of a <c>[Multipart]</c> method so its public properties are written as individual
+/// <c>multipart/form-data</c> text parts (one part per property) instead of the default single serialized part.
+/// </summary>
+/// <remarks>
+/// Without this attribute a complex object is added to a multipart request as one serialized part (for example a single
+/// <c>application/json</c> body named after the parameter), which server-side form model binding cannot bind field by
+/// field. With it, each property becomes its own named form field, so a server model bound from the form (such as an
+/// ASP.NET <c>[FromForm]</c> model) receives the individual values.
+/// <para>
+/// Field names are resolved per property in the same order as url-encoded body flattening: an explicit
+/// <see cref="AliasAsAttribute"/>, then <see cref="IHttpContentSerializer.GetFieldNameForProperty"/>, then
+/// <see cref="RefitSettings.UrlParameterKeyFormatter"/>. Values are rendered through
+/// <see cref="RefitSettings.FormUrlEncodedParameterFormatter"/>, collections honour
+/// <see cref="RefitSettings.CollectionFormat"/>, and a nested object composes its children under a
+/// <c>parent.child</c> field name (bounded by a nesting-depth cap and a reference-cycle guard).
+/// </para>
+/// <para>
+/// File-typed members (<see cref="System.IO.Stream"/>, <c>byte[]</c>, <see cref="System.IO.FileInfo"/> and the Refit
+/// part types) are not converted to file parts by this attribute; pass those as their own separate part parameters.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// interface IUploadApi
+/// {
+///   [Multipart]
+///   [Post("/setup")]
+///   Task SetupAsync([FormObject] SetupModel model, [AliasAs("recipe")] StreamPart recipe);
+/// }
+/// </code>
+/// Each public property of <c>SetupModel</c> is sent as its own form field alongside the <c>recipe</c> file part.
+/// </example>
+[AttributeUsage(AttributeTargets.Parameter)]
+public sealed class FormObjectAttribute : Attribute;

--- a/src/Refit/PublicAPI/net10.0/PublicAPI.Shipped.txt
+++ b/src/Refit/PublicAPI/net10.0/PublicAPI.Shipped.txt
@@ -502,3 +502,5 @@ static Refit.GeneratedRequestRunner.SetRequestTimeout(System.Net.Http.HttpReques
 static Refit.HttpRequestMessageOptions.MethodArguments.get -> string!
 Refit.RefitSettings.CaptureMethodArguments.get -> bool
 Refit.RefitSettings.CaptureMethodArguments.set -> void
+Refit.FormObjectAttribute
+Refit.FormObjectAttribute.FormObjectAttribute() -> void

--- a/src/Refit/PublicAPI/net11.0/PublicAPI.Shipped.txt
+++ b/src/Refit/PublicAPI/net11.0/PublicAPI.Shipped.txt
@@ -502,3 +502,5 @@ static Refit.GeneratedRequestRunner.SetRequestTimeout(System.Net.Http.HttpReques
 static Refit.HttpRequestMessageOptions.MethodArguments.get -> string!
 Refit.RefitSettings.CaptureMethodArguments.get -> bool
 Refit.RefitSettings.CaptureMethodArguments.set -> void
+Refit.FormObjectAttribute
+Refit.FormObjectAttribute.FormObjectAttribute() -> void

--- a/src/Refit/PublicAPI/net462/PublicAPI.Shipped.txt
+++ b/src/Refit/PublicAPI/net462/PublicAPI.Shipped.txt
@@ -498,3 +498,5 @@ static Refit.GeneratedRequestRunner.SetRequestTimeout(System.Net.Http.HttpReques
 static Refit.HttpRequestMessageOptions.MethodArguments.get -> string!
 Refit.RefitSettings.CaptureMethodArguments.get -> bool
 Refit.RefitSettings.CaptureMethodArguments.set -> void
+Refit.FormObjectAttribute
+Refit.FormObjectAttribute.FormObjectAttribute() -> void

--- a/src/Refit/PublicAPI/net470/PublicAPI.Shipped.txt
+++ b/src/Refit/PublicAPI/net470/PublicAPI.Shipped.txt
@@ -498,3 +498,5 @@ static Refit.GeneratedRequestRunner.SetRequestTimeout(System.Net.Http.HttpReques
 static Refit.HttpRequestMessageOptions.MethodArguments.get -> string!
 Refit.RefitSettings.CaptureMethodArguments.get -> bool
 Refit.RefitSettings.CaptureMethodArguments.set -> void
+Refit.FormObjectAttribute
+Refit.FormObjectAttribute.FormObjectAttribute() -> void

--- a/src/Refit/PublicAPI/net471/PublicAPI.Shipped.txt
+++ b/src/Refit/PublicAPI/net471/PublicAPI.Shipped.txt
@@ -498,3 +498,5 @@ static Refit.GeneratedRequestRunner.SetRequestTimeout(System.Net.Http.HttpReques
 static Refit.HttpRequestMessageOptions.MethodArguments.get -> string!
 Refit.RefitSettings.CaptureMethodArguments.get -> bool
 Refit.RefitSettings.CaptureMethodArguments.set -> void
+Refit.FormObjectAttribute
+Refit.FormObjectAttribute.FormObjectAttribute() -> void

--- a/src/Refit/PublicAPI/net472/PublicAPI.Shipped.txt
+++ b/src/Refit/PublicAPI/net472/PublicAPI.Shipped.txt
@@ -498,3 +498,5 @@ static Refit.GeneratedRequestRunner.SetRequestTimeout(System.Net.Http.HttpReques
 static Refit.HttpRequestMessageOptions.MethodArguments.get -> string!
 Refit.RefitSettings.CaptureMethodArguments.get -> bool
 Refit.RefitSettings.CaptureMethodArguments.set -> void
+Refit.FormObjectAttribute
+Refit.FormObjectAttribute.FormObjectAttribute() -> void

--- a/src/Refit/PublicAPI/net48/PublicAPI.Shipped.txt
+++ b/src/Refit/PublicAPI/net48/PublicAPI.Shipped.txt
@@ -498,3 +498,5 @@ static Refit.GeneratedRequestRunner.SetRequestTimeout(System.Net.Http.HttpReques
 static Refit.HttpRequestMessageOptions.MethodArguments.get -> string!
 Refit.RefitSettings.CaptureMethodArguments.get -> bool
 Refit.RefitSettings.CaptureMethodArguments.set -> void
+Refit.FormObjectAttribute
+Refit.FormObjectAttribute.FormObjectAttribute() -> void

--- a/src/Refit/PublicAPI/net481/PublicAPI.Shipped.txt
+++ b/src/Refit/PublicAPI/net481/PublicAPI.Shipped.txt
@@ -498,3 +498,5 @@ static Refit.GeneratedRequestRunner.SetRequestTimeout(System.Net.Http.HttpReques
 static Refit.HttpRequestMessageOptions.MethodArguments.get -> string!
 Refit.RefitSettings.CaptureMethodArguments.get -> bool
 Refit.RefitSettings.CaptureMethodArguments.set -> void
+Refit.FormObjectAttribute
+Refit.FormObjectAttribute.FormObjectAttribute() -> void

--- a/src/Refit/PublicAPI/net8.0/PublicAPI.Shipped.txt
+++ b/src/Refit/PublicAPI/net8.0/PublicAPI.Shipped.txt
@@ -502,3 +502,5 @@ static Refit.GeneratedRequestRunner.SetRequestTimeout(System.Net.Http.HttpReques
 static Refit.HttpRequestMessageOptions.MethodArguments.get -> string!
 Refit.RefitSettings.CaptureMethodArguments.get -> bool
 Refit.RefitSettings.CaptureMethodArguments.set -> void
+Refit.FormObjectAttribute
+Refit.FormObjectAttribute.FormObjectAttribute() -> void

--- a/src/Refit/PublicAPI/net9.0/PublicAPI.Shipped.txt
+++ b/src/Refit/PublicAPI/net9.0/PublicAPI.Shipped.txt
@@ -502,3 +502,5 @@ static Refit.GeneratedRequestRunner.SetRequestTimeout(System.Net.Http.HttpReques
 static Refit.HttpRequestMessageOptions.MethodArguments.get -> string!
 Refit.RefitSettings.CaptureMethodArguments.get -> bool
 Refit.RefitSettings.CaptureMethodArguments.set -> void
+Refit.FormObjectAttribute
+Refit.FormObjectAttribute.FormObjectAttribute() -> void

--- a/src/tests/Refit.GeneratorTests/MultipartRequestBuildingLiveTests.cs
+++ b/src/tests/Refit.GeneratorTests/MultipartRequestBuildingLiveTests.cs
@@ -19,6 +19,15 @@ public sealed class MultipartRequestBuildingLiveTests
     /// <summary>A stable score used by the serialized DTO part scenario.</summary>
     private const int ReportScore = 42;
 
+    /// <summary>The aliased name flattened by the <c>[FormObject]</c> scenario.</summary>
+    private const string ProfileName = "Ada Lovelace";
+
+    /// <summary>The age flattened by the <c>[FormObject]</c> scenario.</summary>
+    private const int ProfileAge = 36;
+
+    /// <summary>The expected plain-text rendering of <see cref="ProfileAge"/>.</summary>
+    private const string ProfileAgeText = "36";
+
     /// <summary>The bytes uploaded by the primary binary part scenarios.</summary>
     private static readonly byte[] SampleBytes = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
 
@@ -106,6 +115,40 @@ public sealed class MultipartRequestBuildingLiveTests
             () => [harness.CreateApiValue("Refit.LiveMultipart.Report", ("Title", "Q3"), ("Score", ReportScore))]);
     }
 
+    /// <summary>Verifies the compiled generated client flattens an opt-in <c>[FormObject]</c> parameter into one text
+    /// part per property, and stays in parity with the reflection request builder.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    [RequiresUnreferencedCode("Loads a generated assembly and reflects over generated types and members.")]
+    [RequiresDynamicCode("Compares generated request building against the reflection request builder.")]
+    public async Task FormObjectPartFlattensThroughGeneratedClient()
+    {
+        using var harness = LiveMultipartHarness.Create();
+
+        var snapshot = await harness.InvokeGeneratedAsync(
+            "UploadProfile",
+            () => [harness.CreateApiValue("Refit.LiveMultipart.Profile", ("Name", ProfileName), ("Age", ProfileAge))]);
+
+        // The generated client routes [FormObject] through the reflection request builder, which flattens the model into
+        // one text part per property instead of a single serialized part. Asserting the parts here (not just parity)
+        // proves the generated code path actually produces the flattened form-data.
+        const int expectedPartCount = 2;
+        await Assert.That(snapshot.Parts.Count).IsEqualTo(expectedPartCount);
+
+        var namePart = snapshot.Parts.Single(static part => part.Name == "full_name");
+        await Assert.That(namePart.FileName).IsNull();
+        await Assert.That(namePart.ContentType).Contains("text/plain");
+        await Assert.That(Encoding.UTF8.GetString(namePart.Body)).IsEqualTo(ProfileName);
+
+        var agePart = snapshot.Parts.Single(static part => part.Name == "Age");
+        await Assert.That(agePart.ContentType).Contains("text/plain");
+        await Assert.That(Encoding.UTF8.GetString(agePart.Body)).IsEqualTo(ProfileAgeText);
+
+        await harness.AssertParityAsync(
+            "UploadProfile",
+            () => [harness.CreateApiValue("Refit.LiveMultipart.Profile", ("Name", ProfileName), ("Age", ProfileAge))]);
+    }
+
     /// <summary>Verifies a header, request property and path parameter never become multipart parts.</summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Test]
@@ -159,8 +202,20 @@ public sealed class MultipartRequestBuildingLiveTests
                 public int Score { get; set; }
             }
 
+            public class Profile
+            {
+                [AliasAs("full_name")]
+                public string? Name { get; set; }
+
+                public int Age { get; set; }
+            }
+
             public interface ILiveMultipartApi
             {
+                [Multipart]
+                [Post("/upload")]
+                Task<string> UploadProfile([FormObject] Profile profile);
+
                 [Multipart]
                 [Post("/upload")]
                 Task<string> UploadFlag([AliasAs("flag")] bool flag);
@@ -277,6 +332,18 @@ public sealed class MultipartRequestBuildingLiveTests
             File.WriteAllBytes(path, bytes);
             _tempFiles.Add(path);
             return path;
+        }
+
+        /// <summary>Invokes a method through the compiled generated client only and snapshots the multipart it built.</summary>
+        /// <param name="methodName">The interface method name.</param>
+        /// <param name="argsFactory">Produces the argument set for the generated call.</param>
+        /// <returns>The multipart snapshot the generated client produced.</returns>
+        [RequiresUnreferencedCode("Reflects over generated types and members.")]
+        public async Task<MultipartSnapshot> InvokeGeneratedAsync(string methodName, Func<object[]> argsFactory)
+        {
+            var task = (Task)interfaceType.GetMethod(methodName)!.Invoke(generatedApi, argsFactory())!;
+            await task.ConfigureAwait(false);
+            return handler.TakeSnapshot();
         }
 
         /// <summary>Invokes a method through both request paths and asserts the multipart contents are identical.</summary>

--- a/src/tests/Refit.GeneratorTests/RequestGenerationCoverageTests.Multipart.cs
+++ b/src/tests/Refit.GeneratorTests/RequestGenerationCoverageTests.Multipart.cs
@@ -249,4 +249,105 @@ public sealed partial class RequestGenerationCoverageTests
 
         await Assert.That(generated).Contains(ReflectiveRequestBuilderCall);
     }
+
+    /// <summary>Verifies an opt-in <c>[FormObject]</c> multipart parameter routes the whole method to the reflection
+    /// request builder for every model shape of the parameter type (the attribute, not the type, triggers the
+    /// fallback), which flattens the object's properties into individual form-data parts.</summary>
+    /// <param name="typeDeclaration">The model type declaration inserted into the generated source, if any.</param>
+    /// <param name="parameterType">The <c>[FormObject]</c> parameter's declared type.</param>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    [Arguments("public sealed class FormModel { public string? Name { get; set; } }", "FormModel")]
+    [Arguments("public class FormModel { public string? Name { get; set; } }", "FormModel")]
+    [Arguments("public struct FormModel { public string? Name { get; set; } }", "FormModel")]
+    [Arguments("public interface IFormModel { string? Name { get; } }", "IFormModel")]
+    [Arguments("public record FormModel(string? Name);", "FormModel")]
+    [Arguments("", "object")]
+    [Arguments("", "System.Collections.Generic.Dictionary<string, string>")]
+    public async Task MultipartFormObjectPartFallsBackForAnyModelShape(string typeDeclaration, string parameterType)
+    {
+        var source =
+            $$"""
+              using System.Threading.Tasks;
+              using Refit;
+
+              namespace RefitGeneratorTest;
+
+              {{typeDeclaration}}
+
+              public interface IGeneratedClient
+              {
+                  [Multipart]
+                  [Post("/upload")]
+                  Task<string> Upload([FormObject] {{parameterType}} model);
+              }
+              """;
+
+        var result = Fixture.RunGenerator(source, generatedRequestBuilding: true);
+        var generated = result.GeneratedSources[GeneratedClientHintName];
+
+        await Assert.That(result.CompilesWithoutErrors).IsTrue();
+        await Assert.That(generated).Contains(ReflectiveRequestBuilderCall);
+    }
+
+    /// <summary>Verifies an opt-in <c>[FormObject]</c> parameter on an open generic method also falls back.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task MultipartFormObjectGenericParameterFallsBack()
+    {
+        const string Source =
+            """
+            using System.Threading.Tasks;
+            using Refit;
+
+            namespace RefitGeneratorTest;
+
+            public interface IGeneratedClient
+            {
+                [Multipart]
+                [Post("/upload")]
+                Task<string> Upload<TModel>([FormObject] TModel model);
+            }
+            """;
+
+        var result = Fixture.RunGenerator(Source, generatedRequestBuilding: true);
+        var generated = result.GeneratedSources[GeneratedClientHintName];
+
+        await Assert.That(result.CompilesWithoutErrors).IsTrue();
+        await Assert.That(generated).Contains(ReflectiveRequestBuilderCall);
+    }
+
+    /// <summary>Verifies the same concrete model part without <c>[FormObject]</c> is serialized inline, confirming the
+    /// attribute is the sole trigger for the reflection fallback.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task MultipartConcreteModelPartWithoutFormObjectGeneratesInline()
+    {
+        const string Source =
+            """
+            using System.Threading.Tasks;
+            using Refit;
+
+            namespace RefitGeneratorTest;
+
+            public sealed class FormModel
+            {
+                public string? Name { get; set; }
+            }
+
+            public interface IGeneratedClient
+            {
+                [Multipart]
+                [Post("/upload")]
+                Task<string> Upload(FormModel model);
+            }
+            """;
+
+        var result = Fixture.RunGenerator(Source, generatedRequestBuilding: true);
+        var generated = result.GeneratedSources[GeneratedClientHintName];
+
+        await Assert.That(result.CompilesWithoutErrors).IsTrue();
+        await Assert.That(generated).DoesNotContain(ReflectiveRequestBuilderCall);
+        await Assert.That(generated).Contains("MultipartFormDataContent");
+    }
 }

--- a/src/tests/Refit.Tests/FormObjectUploadModel.cs
+++ b/src/tests/Refit.Tests/FormObjectUploadModel.cs
@@ -1,0 +1,18 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+namespace Refit.Tests;
+
+/// <summary>A model flattened into individual multipart form fields by <see cref="FormObjectAttribute"/>.</summary>
+public class FormObjectUploadModel
+{
+    /// <summary>Gets or sets the display name, aliased to a snake-cased form field.</summary>
+    [AliasAs("full_name")]
+    public string? Name { get; set; }
+
+    /// <summary>Gets or sets the age, whose field name comes from the key formatter.</summary>
+    public int Age { get; set; }
+
+    /// <summary>Gets the roles rendered as a single delimited field per the collection format.</summary>
+    public string[]? Roles { get; init; }
+}

--- a/src/tests/Refit.Tests/IMultipartFormObjectApi.cs
+++ b/src/tests/Refit.Tests/IMultipartFormObjectApi.cs
@@ -1,0 +1,50 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace Refit.Tests;
+
+/// <summary>Refit API surface exercised by the multipart <see cref="FormObjectAttribute"/> flattening tests.</summary>
+public interface IMultipartFormObjectApi
+{
+    /// <summary>Uploads a model whose properties are flattened into individual form-data parts.</summary>
+    /// <param name="model">The model whose properties become form fields.</param>
+    /// <returns>The HTTP response message.</returns>
+    [Multipart]
+    [Post("/")]
+    Task<HttpResponseMessage> UploadFormObject([FormObject] FormObjectUploadModel model);
+
+    /// <summary>Uploads a flattened model alongside a separate file part.</summary>
+    /// <param name="model">The model whose properties become form fields.</param>
+    /// <param name="recipe">The file part uploaded next to the flattened fields.</param>
+    /// <returns>The HTTP response message.</returns>
+    [Multipart]
+    [Post("/")]
+    Task<HttpResponseMessage> UploadFormObjectWithFile(
+        [FormObject] FormObjectUploadModel model,
+        [AliasAs("recipe")] StreamPart recipe);
+
+    /// <summary>Uploads a model whose nested object is flattened into composed <c>parent.child</c> fields.</summary>
+    /// <param name="model">The nested model to flatten.</param>
+    /// <returns>The HTTP response message.</returns>
+    [Multipart]
+    [Post("/")]
+    Task<HttpResponseMessage> UploadNestedFormObject([FormObject] NestedFormObjectUploadModel model);
+
+    /// <summary>Uploads a model whose field names come from the content serializer.</summary>
+    /// <param name="model">The model whose serializer-named property becomes a form field.</param>
+    /// <returns>The HTTP response message.</returns>
+    [Multipart]
+    [Post("/")]
+    Task<HttpResponseMessage> UploadSerializerNamedFormObject([FormObject] SerializerNamedFormObjectModel model);
+
+    /// <summary>Uploads a dictionary flattened into individual form-data parts.</summary>
+    /// <param name="fields">The dictionary whose entries become form fields.</param>
+    /// <returns>The HTTP response message.</returns>
+    [Multipart]
+    [Post("/")]
+    Task<HttpResponseMessage> UploadFormDictionary([FormObject] Dictionary<string, string> fields);
+}

--- a/src/tests/Refit.Tests/MultipartTests.FormObjectFlattening.cs
+++ b/src/tests/Refit.Tests/MultipartTests.FormObjectFlattening.cs
@@ -1,0 +1,233 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace Refit.Tests;
+
+/// <summary>Tests covering opt-in <see cref="FormObjectAttribute"/> flattening of a complex object into form-data parts.</summary>
+public partial class MultipartTests
+{
+    /// <summary>Verifies an opt-in <see cref="FormObjectAttribute"/> model is flattened into one text form-data part per
+    /// property, named per property and independent of the content serializer used for other parts.</summary>
+    /// <param name="contentSerializerType">The serializer type configured on the request.</param>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    [Arguments(typeof(SystemTextJsonContentSerializer))]
+    [Arguments(typeof(XmlContentSerializer))]
+    public async Task MultipartFormObjectFlattensEachPropertyIntoOwnTextPart(Type contentSerializerType)
+    {
+        if (Activator.CreateInstance(contentSerializerType) is not IHttpContentSerializer serializer)
+        {
+            throw new ArgumentException(
+                $"{contentSerializerType.FullName} does not implement {nameof(IHttpContentSerializer)}");
+        }
+
+        var model = new FormObjectUploadModel
+        {
+            Name = FormObjectFullName,
+            Age = FormObjectAge,
+            Roles = [FormObjectAdminRole, "user"]
+        };
+
+        var handler = new MockHttpMessageHandler
+        {
+            Asserts = static async content =>
+            {
+                var parts = content.ToList();
+
+                const int expectedPartCount = 3;
+                await Assert.That(parts.Count).IsEqualTo(expectedPartCount);
+
+                await AssertTextPart(parts, "full_name", FormObjectFullName);
+                await AssertTextPart(parts, "Age", FormObjectAgeText);
+
+                // A collection property is joined by the settings collection format (comma by default), not repeated.
+                await AssertTextPart(parts, "Roles", "admin,user");
+            }
+        };
+
+        var settings = new RefitSettings
+        {
+            HttpMessageHandlerFactory = () => handler,
+            ContentSerializer = serializer
+        };
+
+        var fixture = RestService.For<IMultipartFormObjectApi>(BaseAddress, settings);
+        await fixture.UploadFormObject(model);
+    }
+
+    /// <summary>Verifies a nested object is flattened into composed <c>parent.child</c> form fields.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task MultipartFormObjectFlattensNestedObjectIntoComposedFields()
+    {
+        var model = new NestedFormObjectUploadModel
+        {
+            Title = "Notebook",
+            Author = new()
+            {
+                Name = FormObjectFullName,
+                Age = FormObjectAge,
+                Roles = [FormObjectAdminRole]
+            }
+        };
+
+        var handler = new MockHttpMessageHandler
+        {
+            Asserts = static async content =>
+            {
+                var parts = content.ToList();
+
+                const int expectedPartCount = 4;
+                await Assert.That(parts.Count).IsEqualTo(expectedPartCount);
+
+                await AssertTextPart(parts, "Title", "Notebook");
+                await AssertTextPart(parts, "Author.full_name", FormObjectFullName);
+                await AssertTextPart(parts, "Author.Age", FormObjectAgeText);
+                await AssertTextPart(parts, "Author.Roles", FormObjectAdminRole);
+            }
+        };
+
+        var settings = new RefitSettings { HttpMessageHandlerFactory = () => handler };
+
+        var fixture = RestService.For<IMultipartFormObjectApi>(BaseAddress, settings);
+        await fixture.UploadNestedFormObject(model);
+    }
+
+    /// <summary>Verifies a flattened property's field name is resolved by the content serializer.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task MultipartFormObjectResolvesFieldNameFromContentSerializer()
+    {
+        var handler = new MockHttpMessageHandler
+        {
+            Asserts = static async content =>
+            {
+                var parts = content.ToList();
+
+                await Assert.That(parts).HasSingleItem();
+                await AssertTextPart(parts, "user_id", "abc-123");
+            }
+        };
+
+        var settings = new RefitSettings
+        {
+            HttpMessageHandlerFactory = () => handler,
+            ContentSerializer = new SystemTextJsonContentSerializer()
+        };
+
+        var fixture = RestService.For<IMultipartFormObjectApi>(BaseAddress, settings);
+        await fixture.UploadSerializerNamedFormObject(new() { Id = "abc-123" });
+    }
+
+    /// <summary>Verifies a flattened model coexists with a separate file part, which stays a file part.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task MultipartFormObjectKeepsSeparateFilePartIntact()
+    {
+        var model = new FormObjectUploadModel { Name = FormObjectFullName, Age = FormObjectAge };
+
+        var handler = new MockHttpMessageHandler
+        {
+            Asserts = static async content =>
+            {
+                var parts = content.ToList();
+
+                const int expectedPartCount = 3;
+                await Assert.That(parts.Count).IsEqualTo(expectedPartCount);
+
+                await AssertTextPart(parts, "full_name", FormObjectFullName);
+                await AssertTextPart(parts, "Age", FormObjectAgeText);
+
+                var filePart = parts.Single(static p => p.Headers.ContentDisposition!.Name == "recipe");
+                await Assert.That(filePart.Headers.ContentDisposition!.FileName).IsEqualTo(StreamPartFileName);
+                await Assert.That(filePart.Headers.ContentType!.MediaType).IsEqualTo(PdfMediaType);
+            }
+        };
+
+        var settings = new RefitSettings { HttpMessageHandlerFactory = () => handler };
+
+        await using var stream = GetTestFileStream(TestFilePath);
+        var fixture = RestService.For<IMultipartFormObjectApi>(BaseAddress, settings);
+        await fixture.UploadFormObjectWithFile(model, new(stream, StreamPartFileName, PdfMediaType));
+    }
+
+    /// <summary>Verifies a flattened dictionary drops an entry whose field name is blank rather than throwing.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task MultipartFormObjectSkipsFieldWithBlankName()
+    {
+        var fields = new Dictionary<string, string>
+        {
+            ["   "] = "dropped",
+            ["kept"] = "value"
+        };
+
+        var handler = new MockHttpMessageHandler
+        {
+            Asserts = static async content =>
+            {
+                var parts = content.ToList();
+
+                await Assert.That(parts).HasSingleItem();
+                await AssertTextPart(parts, "kept", "value");
+            }
+        };
+
+        var settings = new RefitSettings { HttpMessageHandlerFactory = () => handler };
+
+        var fixture = RestService.For<IMultipartFormObjectApi>(BaseAddress, settings);
+        await fixture.UploadFormDictionary(fields);
+    }
+
+    /// <summary>Verifies a flattened field whose formatter returns null is sent as an empty part rather than throwing.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task MultipartFormObjectRendersNullFormattedValueAsEmptyPart()
+    {
+        var model = new FormObjectUploadModel { Name = "ignored", Age = 1 };
+
+        var handler = new MockHttpMessageHandler
+        {
+            Asserts = static async content =>
+            {
+                var parts = content.ToList();
+
+                await Assert.That(parts.Count).IsGreaterThan(0);
+                foreach (var part in parts)
+                {
+                    await Assert.That(await part.ReadAsStringAsync()).IsEqualTo(string.Empty);
+                }
+            }
+        };
+
+        var settings = new RefitSettings
+        {
+            HttpMessageHandlerFactory = () => handler,
+            FormUrlEncodedParameterFormatter = new NullReturningFormUrlEncodedParameterFormatter()
+        };
+
+        var fixture = RestService.For<IMultipartFormObjectApi>(BaseAddress, settings);
+        await fixture.UploadFormObject(model);
+    }
+
+    /// <summary>Asserts a flattened form field is a plain-text multipart part with the expected name and value.</summary>
+    /// <param name="parts">The multipart parts observed by the handler.</param>
+    /// <param name="name">The expected content-disposition field name.</param>
+    /// <param name="value">The expected plain-text value.</param>
+    /// <returns>A task representing the assertion work.</returns>
+    private static async Task AssertTextPart(List<HttpContent> parts, string name, string value)
+    {
+        var part = parts.Single(p => p.Headers.ContentDisposition!.Name == name);
+
+        await Assert.That(part.Headers.ContentDisposition!.FileName).IsNull();
+        await Assert.That(part.Headers.ContentType!.MediaType).IsEqualTo(PlainTextMediaType);
+        await Assert.That(part.Headers.ContentType!.CharSet).IsEqualTo(Utf8CharSet);
+        await Assert.That(await part.ReadAsStringAsync()).IsEqualTo(value);
+    }
+}

--- a/src/tests/Refit.Tests/MultipartTests.cs
+++ b/src/tests/Refit.Tests/MultipartTests.cs
@@ -58,6 +58,18 @@ public partial class MultipartTests
     /// <summary>The expected integer value uploaded in the mixed-types test.</summary>
     private const int ExpectedIntValue = 42;
 
+    /// <summary>The aliased name value uploaded in the form-object flattening tests.</summary>
+    private const string FormObjectFullName = "Ada Lovelace";
+
+    /// <summary>A role value uploaded in the form-object flattening tests.</summary>
+    private const string FormObjectAdminRole = "admin";
+
+    /// <summary>The age value uploaded in the form-object flattening tests.</summary>
+    private const int FormObjectAge = 36;
+
+    /// <summary>The expected plain-text rendering of <see cref="FormObjectAge"/>.</summary>
+    private const string FormObjectAgeText = "36";
+
     /// <summary>Verifies a raw stream is uploaded as a single multipart part.</summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Test]

--- a/src/tests/Refit.Tests/NestedFormObjectUploadModel.cs
+++ b/src/tests/Refit.Tests/NestedFormObjectUploadModel.cs
@@ -1,0 +1,14 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+namespace Refit.Tests;
+
+/// <summary>A model whose nested object is composed into <c>parent.child</c> form fields.</summary>
+public class NestedFormObjectUploadModel
+{
+    /// <summary>Gets or sets the top-level title field.</summary>
+    public string? Title { get; set; }
+
+    /// <summary>Gets or sets the nested author whose properties compose under <c>Author.*</c>.</summary>
+    public FormObjectUploadModel? Author { get; set; }
+}

--- a/src/tests/Refit.Tests/SerializerNamedFormObjectModel.cs
+++ b/src/tests/Refit.Tests/SerializerNamedFormObjectModel.cs
@@ -1,0 +1,14 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+using System.Text.Json.Serialization;
+
+namespace Refit.Tests;
+
+/// <summary>A model whose property field name is resolved by the content serializer.</summary>
+public class SerializerNamedFormObjectModel
+{
+    /// <summary>Gets or sets the identifier whose form field name comes from the JSON property name.</summary>
+    [JsonPropertyName("user_id")]
+    public string? Id { get; set; }
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature.

Opt-in flattening of a complex-object parameter into individual `multipart/form-data` fields in a `[Multipart]` method, via a new `[FormObject]` parameter attribute.

> Attribute name is OPEN TO MAINTAINER FEEDBACK. I chose `[FormObject]` (candidates were `[FormObject]`, `[Flatten]`, `[FormFields]`) because it reads as "treat this parameter as a form object whose properties are form fields". Happy to rename in review - it is a single symbol plus its PublicAPI/README/docs references.

## What is the new behavior?

- A new public `[FormObject]` attribute (`AttributeTargets.Parameter`). Applied to a complex-object parameter of a `[Multipart]` method, each of the object's public properties is sent as its own `multipart/form-data` text part (one part per property), so a server model bound from the form (for example an ASP.NET `[FromForm]` model) binds field by field.
- Field names resolve with the existing form-encoded precedence: `[AliasAs]`, then the content serializer's field name (for example `[JsonPropertyName]`), then the `UrlParameterKeyFormatter`. Values render as plain text through the `FormUrlEncodedParameterFormatter`; collections honor `CollectionFormat`; nested objects compose `parent.child` field names (bounded by a nesting-depth cap and a reference-cycle guard). This reuses `FormValueMultimap`, the same infrastructure as url-encoded body flattening.
- File-typed members (`byte[]`, `Stream`, `FileInfo`, and the `ByteArrayPart`/`StreamPart`/`FileInfoPart` wrappers) are not converted by `[FormObject]`; keep passing those as their own separate part parameters, which continue to work alongside a flattened model.
- Source-generator path (the primary path): the generator detects a `[FormObject]` parameter of ANY model shape (sealed/unsealed class, struct, record, interface, `object`, dictionary, open generic) and routes the whole method to the reflection request builder, which owns the one authoritative flattening implementation. The compiled generated client is exercised end-to-end in tests and asserted to produce the flattened parts, not just to compile.
- Documented in the README "Multipart uploads" section and a breaking-changes note.

## What is the current behavior?

Closes #930.

In a `[Multipart]` method a complex-object parameter is added as a single serialized part (for example one `application/json` body named after the parameter). That single part cannot be bound field by field by a server expecting form fields, which is exactly the `[FromForm]` model-binding gap reported in the issue. There was no way to flatten it. The default (no attribute) single-serialized-part behavior is unchanged by this PR.

## What might this PR break?

- None for existing code. `[FormObject]` is strictly opt-in; a method without it behaves exactly as before (a single serialized part).
- Design note for reviewers (the source generator is the primary path): per the authoritative-reflection design, a `[FormObject]` method routes to the reflection request builder, so it requires the `Refit.Reflection` package and is not available on a generated-only / Native AOT client (`AddRefitGeneratedClient` / `RestService.ForGenerated`) - the same trade-off as other reflection-fallback shapes (nested url-encoded bodies, `object`-typed multipart parts). If you would rather `[FormObject]` also generate inline for generated-only/AOT clients, that is a deliberate design change (an inline emitter flatten mirroring `FormValueMultimap`) - flagging it as a decision rather than shipping a second flatten implementation unprompted.

## Checklist
- [x] I have read the [Contribute guide](https://www.reactiveui.net/contribute/index.html)
- [x] Tests have been added or updated (for bug fixes / features)
- [x] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the `main` branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional information

- Reflection runtime: `RequestBuilderImplementation.Payload.cs` adds `AddFlattenedFormObject`, invoked when the parameter carries `[FormObject]`.
- Source generator: `Parser.Request.Multipart.cs` returns null from the multipart classifier for a `[FormObject]` parameter (the same shortcut used for nested url-encoded bodies), so the method uses the reflection builder with byte-identical output and no duplicated emit logic.
- Verification: full solution builds clean across all 10 target frameworks (0 warnings, analyzers enforced). Refit.Tests (1150) and Refit.GeneratorTests (445) pass on net8.0. Merged line coverage on every touched product file is 100% (`RequestBuilderImplementation.Payload.cs` 269/269, `Parser.Request.Multipart.cs` 182/182; `FormObjectAttribute.cs` is a marker attribute with no coverable lines, matching the shipped `UrlAttribute`).
- Tests: runtime flattening (per-property text parts named by alias/serializer/formatter, nested `parent.child`, collections, blank-name and null-value edges) in `MultipartTests.FormObjectFlattening.cs`; generator fallback decision across every model shape of T in `RequestGenerationCoverageTests.Multipart.cs`; and an end-to-end assertion that the compiled generated client flattens in `MultipartRequestBuildingLiveTests.cs`.
- PublicAPI: the new attribute is promoted into `PublicAPI.Shipped.txt` for all 10 target frameworks; the pending unshipped block from an earlier PR is left untouched.
