### PR TITLE
feat: refactor `AppendFormattedValue` in `GeneratedQueryStringBuilder`

### DIFF
--- a/src/Refit/GeneratedQueryStringBuilder.cs
+++ b/src/Refit/GeneratedQueryStringBuilder.cs
@@ -255,34 +255,6 @@ public ref struct GeneratedQueryStringBuilder
         return _text.ToString();
     }
 
-#if NET6_0_OR_GREATER
-    /// <summary>Formats a span-formattable value into <paramref name="buffer"/>, growing a rented buffer until the value fits.</summary>
-    /// <typeparam name="T">The span-formattable value type.</typeparam>
-    /// <param name="value">The value to render.</param>
-    /// <param name="buffer">The target buffer, replaced with a larger rented buffer when the value overflows it.</param>
-    /// <param name="rented">The rented buffer to grow and return to the pool, or null while the stack buffer is in use.</param>
-    /// <param name="format">The compile-time format, or null for the default rendering.</param>
-    /// <returns>The number of characters written into <paramref name="buffer"/>.</returns>
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage] // The grow back-edge only fires for a value larger than the stack buffer; the compiler's loop second-jump stays unreachable in practice.
-    private static int FormatWithGrowth<T>(T value, ref Span<char> buffer, ref char[]? rented, string? format)
-        where T : ISpanFormattable
-    {
-        int written;
-        while (!value.TryFormat(buffer, out written, format.AsSpan(), System.Globalization.CultureInfo.InvariantCulture))
-        {
-            if (rented is not null)
-            {
-                System.Buffers.ArrayPool<char>.Shared.Return(rented);
-            }
-
-            rented = System.Buffers.ArrayPool<char>.Shared.Rent(buffer.Length * BufferGrowthFactor);
-            buffer = rented;
-        }
-
-        return written;
-    }
-#endif
-
     /// <summary>Appends the <c>?</c> or <c>&amp;</c> separator, materializing the text buffer on first use.</summary>
     private void AppendSeparator()
     {
@@ -337,33 +309,26 @@ public ref struct GeneratedQueryStringBuilder
     private readonly void AppendFormattedValue<T>(ref ValueStringBuilder target, T value, string? format, bool escape)
         where T : ISpanFormattable
     {
-        Span<char> buffer = stackalloc char[FormatBufferLength];
-        char[]? rented = null;
-        try
+        var buffer = new ValueStringBuilder(stackalloc char[FormatBufferLength]);
+        var written = 0;
+        while (!value.TryFormat(buffer.RawChars, out written, format.AsSpan(), System.Globalization.CultureInfo.InvariantCulture))
         {
-            var written = FormatWithGrowth(value, ref buffer, ref rented, format);
-
-            var formatted = (ReadOnlySpan<char>)buffer[..written];
-            if (escape)
-            {
-                // Percent-encode straight into the builder with no intermediate escaped string, on every target
-                // framework (the span overload of Uri.EscapeDataString only exists on net9+).
-                StringHelpers.AppendUriDataEscaped(ref target, formatted);
-                return;
-            }
-
-            // Copy into a reserved slice so the stack buffer is never captured by the builder (ref-safety), matching a
-            // verbatim span append with no intermediate string.
-            formatted.CopyTo(target.AppendSpan(written));
+            buffer.EnsureCapacity(buffer.Capacity * BufferGrowthFactor);
         }
-        finally
+
+        buffer.Length = written;
+
+        if (escape)
         {
-            if (rented is not null)
-            {
-                System.Buffers.ArrayPool<char>.Shared.Return(rented);
-            }
+            // Percent-encode straight into the builder with no intermediate escaped string, on every target
+            // framework (the span overload of Uri.EscapeDataString only exists on net9+).
+            StringHelpers.AppendUriDataEscaped(ref target, buffer.AsSpan());
+            return;
         }
+
+        // Copy into a reserved slice so the stack buffer is never captured by the builder (ref-safety), matching a
+        // verbatim span append with no intermediate string.
+        target.Append(buffer.AsSpan());
     }
-
 #endif
 }

--- a/src/Refit/ValueStringBuilder.cs
+++ b/src/Refit/ValueStringBuilder.cs
@@ -277,7 +277,7 @@ internal ref struct ValueStringBuilder
 
     /// <summary>Appends the characters of a span to the builder.</summary>
     /// <param name="value">The characters to append.</param>
-    public void Append(ReadOnlySpan<char> value)
+    public void Append(scoped ReadOnlySpan<char> value)
     {
         var pos = _pos;
         if (pos > _chars.Length - value.Length)


### PR DESCRIPTION
Refactor `AppendFormattedValue` to use `ValiueStringBuilder` and inline `FormatWithGrowth`