### PR TITLE
fix: escape keyword identifiers in generated interface member names

### DIFF
--- a/src/InterfaceStubGenerator.Shared/Parser.Helpers.cs
+++ b/src/InterfaceStubGenerator.Shared/Parser.Helpers.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for full license information.
 using System.Text;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 
 namespace Refit.Generator;
 
@@ -27,6 +28,10 @@ internal static partial class Parser
         {
             declaredBaseName = declaredBaseName[(lastDot + 1)..];
         }
+
+        // A method named after a C# keyword (e.g. @class) must be emitted verbatim, otherwise the generated
+        // signature is invalid C#. Escape the name before any generic type-parameter list is appended.
+        declaredBaseName = EscapeIdentifier(declaredBaseName);
 
         if (methodSymbol.TypeParameters.IsEmpty)
         {
@@ -53,6 +58,14 @@ internal static partial class Parser
         _ = builder.Append('>');
         return builder.ToString();
     }
+
+    /// <summary>Prefixes an identifier with <c>@</c> when it is a reserved C# keyword, so it can be emitted verbatim
+    /// as a declaration name. Non-keyword identifiers (including contextual keywords, which are valid as identifiers)
+    /// are returned unchanged so the generated output for ordinary members is unaffected.</summary>
+    /// <param name="identifier">The simple identifier to escape.</param>
+    /// <returns>The identifier, prefixed with <c>@</c> when it is a reserved keyword; otherwise the identifier itself.</returns>
+    internal static string EscapeIdentifier(string identifier) =>
+        SyntaxFacts.GetKeywordKind(identifier) != SyntaxKind.None ? "@" + identifier : identifier;
 
     /// <summary>Determines whether a method is decorated with a Refit HTTP method attribute.</summary>
     /// <param name="methodSymbol">The method symbol to inspect.</param>

--- a/src/InterfaceStubGenerator.Shared/Parser.Members.cs
+++ b/src/InterfaceStubGenerator.Shared/Parser.Members.cs
@@ -62,7 +62,7 @@ internal static partial class Parser
             isDerived || (HasGeneratedMemberNameCollision(property) && !isSatisfiedByGeneratedMember);
 
         return new(
-            property.MetadataName,
+            EscapeIdentifier(property.MetadataName),
             propertyType,
             annotation,
             containingType,

--- a/src/tests/Refit.GeneratorTests/EscapedIdentifierBindingTests.cs
+++ b/src/tests/Refit.GeneratorTests/EscapedIdentifierBindingTests.cs
@@ -1,0 +1,168 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Net;
+using System.Text;
+
+namespace Refit.GeneratorTests;
+
+/// <summary>
+/// Compiles, loads and invokes a generated client whose members use escaped (@-prefixed) keyword identifiers, asserting
+/// each escaped value binds into the request under its unescaped name - proving the generated code is not merely valid
+/// C# but semantically correct.
+/// </summary>
+public sealed class EscapedIdentifierBindingTests
+{
+    /// <summary>Verifies a keyword path parameter's value is substituted into the request path.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    [RequiresUnreferencedCode("Loads a generated assembly and reflects over generated types and members.")]
+    public async Task KeywordPathParameterFlowsIntoRequestPath()
+    {
+        using var harness = LiveHarness.Create();
+
+        var request = await harness.InvokeAsync("ByNamespace", ["system"]);
+
+        await Assert.That(request.RequestUri!.PathAndQuery).IsEqualTo("/lookup/system");
+    }
+
+    /// <summary>Verifies keyword query parameters bind under their unescaped names.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    [RequiresUnreferencedCode("Loads a generated assembly and reflects over generated types and members.")]
+    public async Task KeywordQueryParametersFlowIntoQueryString()
+    {
+        using var harness = LiveHarness.Create();
+
+        var request = await harness.InvokeAsync("Query", ["alpha", "beta"]);
+
+        await Assert.That(request.RequestUri!.PathAndQuery).IsEqualTo("/query?class=alpha&event=beta");
+    }
+
+    /// <summary>Verifies a keyword header parameter sets its header value.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    [RequiresUnreferencedCode("Loads a generated assembly and reflects over generated types and members.")]
+    public async Task KeywordHeaderParameterSetsHeaderValue()
+    {
+        using var harness = LiveHarness.Create();
+
+        var request = await harness.InvokeAsync("WithHeader", ["secret"]);
+
+        await Assert.That(request.Headers.GetValues("X-Value").Single()).IsEqualTo("secret");
+    }
+
+    /// <summary>Builds, loads and invokes the escaped-identifier interface through the generated request path.</summary>
+    /// <param name="context">The load context owning the compiled assembly.</param>
+    /// <param name="handler">The capturing handler that records each outgoing request.</param>
+    /// <param name="client">The HTTP client the generated stub sends through.</param>
+    /// <param name="interfaceType">The compiled escaped-identifier interface type.</param>
+    /// <param name="generatedApi">The generated stub instance.</param>
+    private sealed class LiveHarness(
+        CollectibleAssemblyLoadContext context,
+        CapturingHandler handler,
+        HttpClient client,
+        Type interfaceType,
+        object generatedApi) : IDisposable
+    {
+        /// <summary>The base address the generated client sends through.</summary>
+        private const string BaseAddress = "https://api.example.com";
+
+        /// <summary>The interface source exercised by the harness.</summary>
+        private const string Source =
+            """
+            using System.Threading.Tasks;
+            using Refit;
+
+            namespace Refit.EscapedIdentifierLive;
+
+            public interface IEscapedIdentifierLiveApi
+            {
+                [Get("/lookup/{namespace}")]
+                Task<string> ByNamespace(string @namespace);
+
+                [Get("/query")]
+                Task<string> Query(string @class, string @event);
+
+                [Get("/header")]
+                Task<string> WithHeader([Header("X-Value")] string @internal);
+            }
+            """;
+
+        /// <summary>Compiles the interface, loads the generated client, and wires it to a capturing handler.</summary>
+        /// <returns>The live harness.</returns>
+        [RequiresUnreferencedCode("Loads a generated assembly and reflects over generated types and members.")]
+        public static LiveHarness Create()
+        {
+            var result = Fixture.RunGenerator(Source, generatedRequestBuilding: true);
+            if (!result.CompilesWithoutErrors)
+            {
+                throw new InvalidOperationException(
+                    "Generated compilation failed: " + string.Join(Environment.NewLine, result.CompilationErrors));
+            }
+
+            var (assembly, loadContext) = Fixture.EmitAndLoad(result);
+            var interfaceType = assembly.GetType("Refit.EscapedIdentifierLive.IEscapedIdentifierLiveApi", throwOnError: true)!;
+            var generatedType = assembly
+                .GetTypes()
+                .Single(type => type.IsClass && interfaceType.IsAssignableFrom(type));
+
+            var capturingHandler = new CapturingHandler();
+            var httpClient = new HttpClient(capturingHandler) { BaseAddress = new(BaseAddress) };
+            var requestBuilder = RequestBuilder.ForType(interfaceType, new RefitSettings());
+            var generatedApi = Activator.CreateInstance(generatedType, [httpClient, requestBuilder])!;
+            return new(loadContext, capturingHandler, httpClient, interfaceType, generatedApi);
+        }
+
+        /// <summary>Invokes a generated method and returns the request it produced.</summary>
+        /// <param name="methodName">The interface method name.</param>
+        /// <param name="args">The argument values.</param>
+        /// <returns>The captured request.</returns>
+        [RequiresUnreferencedCode("Reflects over generated types and members.")]
+        public async Task<HttpRequestMessage> InvokeAsync(string methodName, object?[] args)
+        {
+            var task = (Task)interfaceType.GetMethod(methodName)!.Invoke(generatedApi, args)!;
+            await task.ConfigureAwait(false);
+            return handler.TakeLastRequest();
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            client.Dispose();
+            handler.Dispose();
+            context.Dispose();
+        }
+    }
+
+    /// <summary>Captures each outgoing request and returns a fixed JSON response.</summary>
+    private sealed class CapturingHandler : HttpMessageHandler
+    {
+        /// <summary>The last request sent through the handler.</summary>
+        private HttpRequestMessage? _lastRequest;
+
+        /// <summary>Takes the last captured request, clearing the slot.</summary>
+        /// <returns>The captured request.</returns>
+        public HttpRequestMessage TakeLastRequest()
+        {
+            var request = _lastRequest ?? throw new InvalidOperationException("No request was captured.");
+            _lastRequest = null;
+            return request;
+        }
+
+        /// <inheritdoc/>
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            _lastRequest = request;
+            return Task.FromResult(
+                new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("\"done\"", Encoding.UTF8, "application/json")
+                });
+        }
+    }
+}

--- a/src/tests/Refit.GeneratorTests/EscapedIdentifierGenerationTests.cs
+++ b/src/tests/Refit.GeneratorTests/EscapedIdentifierGenerationTests.cs
@@ -1,0 +1,199 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+using System.Linq;
+
+namespace Refit.GeneratorTests;
+
+/// <summary>
+/// Compile-safety tests for interface members whose names are escaped (@-prefixed) C# keyword identifiers, in every
+/// position the source generator emits an identifier. Guards the regression where a keyword parameter was emitted as a
+/// bare identifier, producing source that does not compile.
+/// </summary>
+public sealed class EscapedIdentifierGenerationTests
+{
+    /// <summary>Verifies a path parameter named after a keyword, bound to a matching route placeholder, compiles.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public Task PathParameter() =>
+        AssertCompilesAsync(
+            """
+                [Get("/lookup/{namespace}")]
+                Task<string> ByNamespace(string @namespace);
+            """);
+
+    /// <summary>Verifies an optional path segment bound to a nullable keyword parameter compiles.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public Task OptionalPathParameter() =>
+        AssertCompilesAsync(
+            """
+                [Get("/lookup/{namespace?}")]
+                Task<string> ByOptionalNamespace(string? @namespace);
+            """);
+
+    /// <summary>Verifies keyword parameters bound implicitly to the query string compile.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public Task QueryParameters() =>
+        AssertCompilesAsync(
+            """
+                [Get("/query")]
+                Task<string> QueryKeywords(string @class, string @event);
+            """);
+
+    /// <summary>Verifies an aliased keyword query parameter compiles.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public Task AliasedQueryParameter() =>
+        AssertCompilesAsync(
+            """
+                [Get("/query")]
+                Task<string> AliasedQuery([AliasAs("key")] string @object);
+            """);
+
+    /// <summary>Verifies a keyword body parameter compiles.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public Task BodyParameter() =>
+        AssertCompilesAsync(
+            """
+                [Post("/body")]
+                Task<string> BodyKeyword([Body] string @object);
+            """);
+
+    /// <summary>Verifies a keyword header parameter compiles.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public Task HeaderParameter() =>
+        AssertCompilesAsync(
+            """
+                [Get("/header")]
+                Task<string> HeaderKeyword([Header("X-Value")] string @internal);
+            """);
+
+    /// <summary>Verifies a keyword header-collection parameter compiles.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public Task HeaderCollectionParameter() =>
+        AssertCompilesAsync(
+            """
+                [Get("/headers")]
+                Task<string> HeaderCollectionKeyword([HeaderCollection] IDictionary<string, string> @params);
+            """);
+
+    /// <summary>Verifies a keyword property parameter compiles.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public Task PropertyParameter() =>
+        AssertCompilesAsync(
+            """
+                [Get("/property")]
+                Task<string> PropertyKeyword([Property("tenant")] int @int);
+            """);
+
+    /// <summary>Verifies a keyword interface property member compiles.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public Task PropertyMember() =>
+        AssertCompilesAsync(
+            """
+                [Property("tenant")]
+                int @int { get; set; }
+
+                [Get("/property")]
+                Task<string> WithProperty();
+            """);
+
+    /// <summary>Verifies keyword multipart part parameters compile.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public Task MultipartParameters() =>
+        AssertCompilesAsync(
+            """
+                [Multipart]
+                [Post("/upload")]
+                Task<string> MultipartKeyword(StreamPart @stream, [AliasAs("file")] ByteArrayPart @byte);
+            """);
+
+    /// <summary>Verifies a keyword round-tripping <c>[Encoded]</c> path parameter compiles.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public Task EncodedRoundTripParameter() =>
+        AssertCompilesAsync(
+            """
+                [Get("/encoded/{string}")]
+                Task<string> EncodedKeyword([Encoded] string @string);
+            """);
+
+    /// <summary>Verifies a keyword parameter on a build-the-request (<c>Task&lt;HttpRequestMessage&gt;</c>) method compiles.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public Task BuildRequestReturnShape() =>
+        AssertCompilesAsync(
+            """
+                [Get("/request/{namespace}")]
+                Task<HttpRequestMessage> BuildKeyword(string @namespace);
+            """);
+
+    /// <summary>Verifies a keyword-named cancellation-token parameter alongside a keyword path parameter compiles.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public Task CancellationTokenKeywordName() =>
+        AssertCompilesAsync(
+            """
+                [Get("/cancel/{namespace}")]
+                Task<string> CancellationKeyword(string @namespace, CancellationToken @default);
+            """);
+
+    /// <summary>Verifies an interface method whose own name is an escaped keyword compiles.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public Task KeywordMethodName() =>
+        AssertCompilesAsync(
+            """
+                [Get("/keyword")]
+                Task<string> @class();
+            """);
+
+    /// <summary>Verifies a single method combining keyword parameters across path, query, header and body compiles.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public Task MixedKeywordPositions() =>
+        AssertCompilesAsync(
+            """
+                [Post("/mixed/{namespace}")]
+                Task<string> Mixed(
+                    string @namespace,
+                    string @class,
+                    [Header("X-Op")] string @operator,
+                    [Body] string @object);
+            """);
+
+    /// <summary>Runs the source generator over an interface built from the given members and asserts the generated
+    /// output compiles with no errors, surfacing any compilation errors in the assertion message.</summary>
+    /// <param name="members">The interface member declarations to place inside the test interface.</param>
+    /// <returns>A task representing the asynchronous assertion.</returns>
+    private static async Task AssertCompilesAsync(string members)
+    {
+        const string header =
+            "using System.Collections.Generic;\n" +
+            "using System.Net.Http;\n" +
+            "using System.Threading;\n" +
+            "using System.Threading.Tasks;\n" +
+            "using Refit;\n\n" +
+            "namespace Refit.EscapedIdentifierScenarios;\n\n" +
+            "public interface IEscapedIdentifierApi\n{\n";
+        const string footer = "\n}\n";
+
+        var result = Fixture.RunGenerator(header + members + footer, generatedRequestBuilding: true);
+
+        var report = result.CompilesWithoutErrors
+            ? "OK"
+            : string.Join(
+                Environment.NewLine,
+                result.CompilationErrors.Select(static diagnostic => diagnostic.ToString()));
+
+        await Assert.That(report).IsEqualTo("OK");
+    }
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (source generator).

## What is the new behavior?

- The source generator now escapes an interface member name with a leading `@` when that name is a reserved C# keyword, so keyword-named members generate valid, compiling code:
  - a method named after a keyword, e.g. `[Get("/keyword")] Task<string> @class();`
  - an interface property whose name is a keyword, e.g. `[Property("tenant")] int @int { get; set; }`
- Ordinary member names, and contextual keywords (which are valid as identifiers), are emitted unchanged - existing generated output is unaffected.
- Adds an escaped-identifier test suite:
  - compile-safety across every position an escaped keyword identifier can appear: path, optional path, query, aliased query, body, header, header collection, property parameter, property member, multipart, encoded round-trip, build-request return shape, keyword cancellation-token name, keyword method name, and a mixed method
  - behavioral tests asserting escaped path/query/header values bind into the request under their unescaped names

## What is the current behavior?

A keyword-named method or property was emitted as the bare keyword (e.g. `class`, `int`), so the generated stub did not compile.

Related: #2247 reported the escaped-parameter case (e.g. `@namespace`), which the reflection-free request-building rewrite already fixed in 14.x. This PR fixes the remaining keyword method-name and property-name cases and adds the regression suite covering all of them.

## What might this PR break?

None. Escaping is applied only to reserved-keyword names; ordinary names produce byte-identical output, verified against the existing generator snapshots.

## Checklist
- [x] I have read the Contribute guide
- [x] Tests have been added or updated (for bug fixes / features)
- [ ] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the `main` branch
- [x] PR title follows Conventional Commits

## Additional information

- Keyword detection uses `SyntaxFacts.GetKeywordKind`, applied at the two model builders (`Parser.Helpers.cs` `BuildDeclaredBaseName` for the method name, `Parser.Members.cs` for the property member name), so the escaped identifier flows consistently to every emission site.
- Both touched product files are at 100% line and branch coverage; the full generator suite (463 tests, including the existing snapshot tests) passes, and the generator and analyzer projects build clean.
