### PR TITLE
perf: check for `allowUnmatchedParameter` before calling `IndexOf`

### DIFF
--- a/src/Refit/GeneratedRequestRunner.cs
+++ b/src/Refit/GeneratedRequestRunner.cs
@@ -655,8 +655,13 @@ public static partial class GeneratedRequestRunner
     /// <returns>The validated path, returned unchanged.</returns>
     private static string ThrowIfUnmatchedParameter(string path, string relativePathTemplate, bool allowUnmatchedParameter)
     {
+        if (allowUnmatchedParameter)
+        {
+            return path;
+        }
+
         var i = path.IndexOf('{');
-        if (i < 0 || allowUnmatchedParameter)
+        if (i < 0)
         {
             return path;
         }


### PR DESCRIPTION
Early return for `allowUnmatchedParameter` before calling `IndexOf`. Extremely minor performance change 😆 

Possible area for slightly better code gen:
- Don't we already know at compile time if there is an unmatched parameter?
- Only pass `refitSettings.AllowUnmatchedRouteParameters` as a parameter when an unmatched value is found at compile time; otherwise we can just pass `true`
- If `false` is passed the method throws the error. I don't think we even need to run the logic at runtime, we already know at compile if a parameter is missing.
