### PR TITLE
fix: name generated helper types per assembly to avoid InternalsVisibleTo conflicts

### DIFF
--- a/src/InterfaceStubGenerator.Shared/Emitter.SharedCode.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.SharedCode.cs
@@ -61,11 +61,6 @@ internal static partial class Emitter
         string generatedFileHeader,
         Action<string, SourceText> addSource)
     {
-        const string dynamicDependencyLine =
-            "[System.Diagnostics.CodeAnalysis.DynamicDependency("
-            + "System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All, "
-            + "typeof(global::Refit.Implementation.Generated))]";
-
         var generatedCodeAttribute = GeneratedCodeAttribute;
         var generatedSource = $$"""
             {{generatedFileHeader}}
@@ -78,7 +73,7 @@ internal static partial class Emitter
                 [{{model.PreserveAttributeDisplayName}}]
                 [global::System.Reflection.Obfuscation(Exclude=true)]
                 [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-                internal static partial class Generated
+                internal static partial class {{model.GeneratedClassName}}
                 {
             #if NET5_0_OR_GREATER
                     /// <summary>Registers generated Refit factories when the assembly is loaded.</summary>
@@ -87,7 +82,9 @@ internal static partial class Emitter
                         "CA2255:The ModuleInitializer attribute should not be used in libraries",
                         Justification = "ModuleInitializer is used intentionally so generated Refit factories are registered when the assembly loads.")]
                     [System.Runtime.CompilerServices.ModuleInitializer]
-                    {{dynamicDependencyLine}}
+                    [System.Diagnostics.CodeAnalysis.DynamicDependency(
+                        System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All,
+                        typeof(global::Refit.Implementation.{{model.GeneratedClassName}}))]
                     internal static void Initialize()
                     {
             {{BuildGeneratedFactoryRegistrations(model.Interfaces)}}        }

--- a/src/InterfaceStubGenerator.Shared/Emitter.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.cs
@@ -102,7 +102,7 @@ internal static partial class Emitter
             namespace Refit.Implementation
             {
                 /// <summary>Contains generated Refit implementation types.</summary>
-                internal partial class Generated
+                internal partial class {{model.GeneratedClassName}}
                 {
                     /// <summary>Generated Refit implementation for {{ToXmlDocumentationText(model.InterfaceDisplayName)}}.</summary>
             {{typeParameterDocs}}        {{generatedCodeAttribute}}
@@ -341,13 +341,14 @@ internal static partial class Emitter
                 continue;
             }
 
-            var generatedType = $"global::Refit.Implementation.Generated.{interfaceModel.Ns}{interfaceModel.ClassSuffix}";
+            var generatedType = $"global::Refit.Implementation.{interfaceModel.GeneratedClassName}.{interfaceModel.Ns}{interfaceModel.ClassSuffix}";
 
             // The static modifier on a lambda is C# 9; older consumers must not see it.
             var lambdaModifier = interfaceModel.SupportsStaticLambdas ? "static " : string.Empty;
             registrations[count] = $$"""
                                     global::Refit.RestService.RegisterGeneratedFactory<{{interfaceModel.InterfaceDisplayName}}>(
-                                        {{lambdaModifier}}(client, requestBuilder) => new {{generatedType}}(client, requestBuilder));
+                                        {{lambdaModifier}}(client, requestBuilder) =>
+                                            new {{generatedType}}(client, requestBuilder));
 
                         """;
             count++;
@@ -356,7 +357,8 @@ internal static partial class Emitter
             {
                 registrations[count] = $$"""
                                         global::Refit.RestService.RegisterGeneratedSettingsFactory<{{interfaceModel.InterfaceDisplayName}}>(
-                                            {{lambdaModifier}}(client, settings) => new {{generatedType}}(client, settings));
+                                            {{lambdaModifier}}(client, settings) =>
+                                                new {{generatedType}}(client, settings));
 
                             """;
                 count++;

--- a/src/InterfaceStubGenerator.Shared/InterfaceStubGeneratorV2.cs
+++ b/src/InterfaceStubGenerator.Shared/InterfaceStubGeneratorV2.cs
@@ -381,6 +381,7 @@ public class InterfaceStubGeneratorV2 : IIncrementalGenerator
             new(
                 string.Empty,
                 string.Empty,
+                string.Empty,
                 false,
                 true,
                 ImmutableEquatableArrayFactory.Empty<InterfaceModel>()));

--- a/src/InterfaceStubGenerator.Shared/Models/ContextGenerationModel.cs
+++ b/src/InterfaceStubGenerator.Shared/Models/ContextGenerationModel.cs
@@ -6,12 +6,14 @@ namespace Refit.Generator;
 /// <summary>Model describing the shared generation context for a set of Refit interfaces.</summary>
 /// <param name="RefitInternalNamespace">The namespace used for Refit internal generated types.</param>
 /// <param name="PreserveAttributeDisplayName">The display name of the preserve attribute.</param>
+/// <param name="GeneratedClassName">The assembly-scoped name of the generated implementation container type.</param>
 /// <param name="GeneratedRequestBuilding">Whether generated request construction is enabled.</param>
 /// <param name="EmitGeneratedCodeMarkers">Whether generated files include generated-code analyzer skip markers.</param>
 /// <param name="Interfaces">The interfaces to generate implementations for.</param>
 internal sealed record ContextGenerationModel(
     string RefitInternalNamespace,
     string PreserveAttributeDisplayName,
+    string GeneratedClassName,
     bool GeneratedRequestBuilding,
     bool EmitGeneratedCodeMarkers,
     ImmutableEquatableArray<InterfaceModel> Interfaces);

--- a/src/InterfaceStubGenerator.Shared/Models/InterfaceGenerationContext.cs
+++ b/src/InterfaceStubGenerator.Shared/Models/InterfaceGenerationContext.cs
@@ -14,6 +14,7 @@ namespace Refit.Generator;
 /// models are the equatable, cache-safe values, never this.</remarks>
 /// <param name="Diagnostics">The list that collects diagnostics produced during processing.</param>
 /// <param name="PreserveAttributeDisplayName">The display name of the generated preserve attribute.</param>
+/// <param name="GeneratedClassName">The assembly-scoped name of the generated implementation container type.</param>
 /// <param name="DisposableInterfaceSymbol">The <c>IDisposable</c> symbol, if available.</param>
 /// <param name="HttpMethodBaseAttributeSymbol">The Refit HTTP method attribute symbol.</param>
 /// <param name="FormattableSymbol">The <c>System.IFormattable</c> symbol used to classify inline-eligible value types, if available.</param>
@@ -36,6 +37,7 @@ namespace Refit.Generator;
 internal sealed record InterfaceGenerationContext(
     List<Diagnostic> Diagnostics,
     string PreserveAttributeDisplayName,
+    string GeneratedClassName,
     ISymbol? DisposableInterfaceSymbol,
     INamedTypeSymbol HttpMethodBaseAttributeSymbol,
     INamedTypeSymbol? FormattableSymbol,

--- a/src/InterfaceStubGenerator.Shared/Models/InterfaceModel.cs
+++ b/src/InterfaceStubGenerator.Shared/Models/InterfaceModel.cs
@@ -5,6 +5,7 @@ namespace Refit.Generator;
 
 /// <summary>Describes a Refit interface and the data needed to generate its implementation.</summary>
 /// <param name="PreserveAttributeDisplayName">The display name of the Preserve attribute.</param>
+/// <param name="GeneratedClassName">The assembly-scoped name of the generated implementation container type.</param>
 /// <param name="FileName">The generated file name.</param>
 /// <param name="ClassName">The generated class name.</param>
 /// <param name="Ns">The namespace of the interface.</param>
@@ -28,6 +29,7 @@ namespace Refit.Generator;
 /// <param name="ExternAliases">The extern aliases the interface's types require, emitted as <c>extern alias</c> directives.</param>
 internal sealed record InterfaceModel(
     string PreserveAttributeDisplayName,
+    string GeneratedClassName,
     string FileName,
     string ClassName,
     string Ns,

--- a/src/InterfaceStubGenerator.Shared/Parser.GeneratedNaming.cs
+++ b/src/InterfaceStubGenerator.Shared/Parser.GeneratedNaming.cs
@@ -61,7 +61,7 @@ internal static partial class Parser
     private static string BuildGeneratedContainerName(string? assemblyName) =>
         GeneratedContainerBaseName + SanitizeAssemblyScope(assemblyName);
 
-    /// <summary>Reduces an assembly name to a Pascal-cased identifier fragment folded into generated names.</summary>
+    /// <summary>Reduces an assembly name to an identifier fragment folded into generated names.</summary>
     /// <param name="assemblyName">The compilation assembly name, or <see langword="null"/> when unavailable.</param>
     /// <returns>The fragment, or an empty string when the assembly name is null or blank. This must stay identical to
     /// the runtime <c>UniqueName.SanitizeAssemblyName</c> so the reflection lookup reconstructs the same container.</returns>
@@ -78,7 +78,6 @@ internal static partial class Parser
             _ = builder.Append(char.IsLetterOrDigit(character) ? character : '_');
         }
 
-        builder[0] = char.ToUpperInvariant(builder[0]);
         return builder.ToString();
     }
 

--- a/src/InterfaceStubGenerator.Shared/Parser.GeneratedNaming.cs
+++ b/src/InterfaceStubGenerator.Shared/Parser.GeneratedNaming.cs
@@ -1,0 +1,125 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+using System.Text;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace Refit.Generator;
+
+/// <summary>Parses candidate interfaces and methods into the models used to generate Refit stubs.</summary>
+/// <content>
+/// Builds the assembly-scoped names of the generated helpers. Folding the assembly name into the container type and
+/// the internal namespace gives each assembly distinctly named copies, so two assemblies linked by
+/// <c>[InternalsVisibleTo]</c> no longer emit identically named internal types that the second compilation sees twice.
+/// </content>
+internal static partial class Parser
+{
+    /// <summary>Builds the internal generated namespace from a consumer-provided namespace prefix and the assembly name.</summary>
+    /// <param name="refitInternalNamespace">The optional user or MSBuild-supplied namespace prefix.</param>
+    /// <param name="assemblyName">The compilation assembly name, folded in so each assembly gets a distinct namespace.</param>
+    /// <returns>A valid C# namespace for generated Refit internals.</returns>
+    private static string BuildRefitInternalNamespace(string? refitInternalNamespace, string? assemblyName)
+    {
+        var prefixedNamespace = string.IsNullOrWhiteSpace(refitInternalNamespace)
+            ? RefitInternalGeneratedSuffix
+            : refitInternalNamespace + RefitInternalGeneratedSuffix;
+
+        // Fold the assembly name in as a trailing segment so the PreserveAttribute this namespace houses no longer
+        // collides across assemblies linked by [InternalsVisibleTo]. Blank names (unnamed compilations) leave the
+        // namespace as-is, matching the historical single-assembly output.
+        var assemblyScope = SanitizeAssemblyScope(assemblyName);
+        var rawNamespace = assemblyScope.Length == 0
+            ? prefixedNamespace
+            : prefixedNamespace + "." + assemblyScope;
+        var parts = rawNamespace.Split('.');
+        var builder = new StringBuilder(rawNamespace.Length);
+
+        foreach (var part in parts)
+        {
+            var normalized = NormalizeNamespacePart(part);
+            if (normalized.Length == 0)
+            {
+                continue;
+            }
+
+            if (builder.Length > 0)
+            {
+                _ = builder.Append('.');
+            }
+
+            _ = builder.Append(normalized);
+        }
+
+        // The raw namespace always contains the non-empty RefitInternalGeneratedSuffix segment, so at least one
+        // normalized part is appended and the builder is never empty here.
+        return builder.ToString();
+    }
+
+    /// <summary>Builds the generated implementation container name for the compilation's assembly.</summary>
+    /// <param name="assemblyName">The compilation assembly name, or <see langword="null"/> when unavailable.</param>
+    /// <returns>The container name, scoped to the assembly so each assembly emits a distinct container.</returns>
+    private static string BuildGeneratedContainerName(string? assemblyName) =>
+        GeneratedContainerBaseName + SanitizeAssemblyScope(assemblyName);
+
+    /// <summary>Reduces an assembly name to a Pascal-cased identifier fragment folded into generated names.</summary>
+    /// <param name="assemblyName">The compilation assembly name, or <see langword="null"/> when unavailable.</param>
+    /// <returns>The fragment, or an empty string when the assembly name is null or blank. This must stay identical to
+    /// the runtime <c>UniqueName.SanitizeAssemblyName</c> so the reflection lookup reconstructs the same container.</returns>
+    private static string SanitizeAssemblyScope(string? assemblyName)
+    {
+        if (string.IsNullOrEmpty(assemblyName))
+        {
+            return string.Empty;
+        }
+
+        var builder = new StringBuilder(assemblyName!.Length);
+        foreach (var character in assemblyName)
+        {
+            _ = builder.Append(char.IsLetterOrDigit(character) ? character : '_');
+        }
+
+        builder[0] = char.ToUpperInvariant(builder[0]);
+        return builder.ToString();
+    }
+
+    /// <summary>Normalizes one namespace segment into a valid identifier.</summary>
+    /// <param name="part">The namespace segment.</param>
+    /// <returns>The normalized segment, or an empty string when the segment is blank.</returns>
+    private static string NormalizeNamespacePart(string part)
+    {
+        if (string.IsNullOrWhiteSpace(part))
+        {
+            return string.Empty;
+        }
+
+        var builder = new StringBuilder(part.Length + 1);
+        foreach (var character in part)
+        {
+            if (builder.Length == 0)
+            {
+                if (SyntaxFacts.IsIdentifierStartCharacter(character))
+                {
+                    _ = builder.Append(character);
+                }
+                else if (SyntaxFacts.IsIdentifierPartCharacter(character))
+                {
+                    _ = builder.Append('_').Append(character);
+                }
+                else
+                {
+                    _ = builder.Append('_');
+                }
+
+                continue;
+            }
+
+            _ = builder.Append(SyntaxFacts.IsIdentifierPartCharacter(character) ? character : '_');
+        }
+
+        var normalized = builder.ToString();
+        return SyntaxFacts.GetKeywordKind(normalized) != SyntaxKind.None
+            || SyntaxFacts.GetContextualKeywordKind(normalized) != SyntaxKind.None
+            ? "_" + normalized
+            : normalized;
+    }
+}

--- a/src/InterfaceStubGenerator.Shared/Parser.InlineEligibility.cs
+++ b/src/InterfaceStubGenerator.Shared/Parser.InlineEligibility.cs
@@ -52,6 +52,7 @@ internal static partial class Parser
         var context = new InterfaceGenerationContext(
             [],
             string.Empty,
+            string.Empty,
             null,
             httpMethodBaseAttributeSymbol,
             formattableSymbol,

--- a/src/InterfaceStubGenerator.Shared/Parser.cs
+++ b/src/InterfaceStubGenerator.Shared/Parser.cs
@@ -2,7 +2,6 @@
 // ReactiveUI and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 using System.Collections.Immutable;
-using System.Text;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -14,6 +13,9 @@ internal static partial class Parser
 {
     /// <summary>The suffix used for generator-private Refit helper types.</summary>
     private const string RefitInternalGeneratedSuffix = "RefitInternalGenerated";
+
+    /// <summary>The base name of the generated implementation container, before the assembly scope is folded in.</summary>
+    private const string GeneratedContainerBaseName = "Generated";
 
     /// <summary>Builds the generator model for the candidate Refit interfaces.</summary>
     /// <param name="compilation">The compilation.</param>
@@ -37,7 +39,12 @@ internal static partial class Parser
     {
         ArgumentExceptionHelper.ThrowIfNull(compilation);
 
-        refitInternalNamespace = BuildRefitInternalNamespace(refitInternalNamespace);
+        // The generated container and the internal-generated namespace both fold in the assembly name so that every
+        // assembly emits distinctly named copies. Two assemblies linked by [InternalsVisibleTo] would otherwise each
+        // emit identically named internal helpers, and the second compilation would see both and report a conflict.
+        var assemblyName = compilation.AssemblyName;
+        refitInternalNamespace = BuildRefitInternalNamespace(refitInternalNamespace, assemblyName);
+        var generatedClassName = BuildGeneratedContainerName(assemblyName);
 
         var httpMethodBaseAttributeSymbol = compilation.GetTypeByMetadataName("Refit.HttpMethodAttribute");
 
@@ -45,7 +52,7 @@ internal static partial class Parser
         if (httpMethodBaseAttributeSymbol is null)
         {
             diagnostics.Add(Diagnostic.Create(DiagnosticDescriptors.RefitNotReferenced, null));
-            return CreateEmptyResult(diagnostics, refitInternalNamespace, generatedRequestBuilding, emitGeneratedCodeMarkers);
+            return CreateEmptyResult(diagnostics, refitInternalNamespace, generatedClassName, generatedRequestBuilding, emitGeneratedCodeMarkers);
         }
 
         var interfaceToNullableEnabledMap = new Dictionary<INamedTypeSymbol, bool>(
@@ -63,7 +70,7 @@ internal static partial class Parser
         // Nothing needs to be generated in this pass.
         if (interfaces.Count == 0)
         {
-            return CreateEmptyResult(diagnostics, refitInternalNamespace, generatedRequestBuilding, emitGeneratedCodeMarkers);
+            return CreateEmptyResult(diagnostics, refitInternalNamespace, generatedClassName, generatedRequestBuilding, emitGeneratedCodeMarkers);
         }
 
         var context = CreateGenerationContext(
@@ -84,6 +91,7 @@ internal static partial class Parser
         var contextGenerationSpec = new ContextGenerationModel(
             refitInternalNamespace,
             context.PreserveAttributeDisplayName,
+            generatedClassName,
             generatedRequestBuilding,
             emitGeneratedCodeMarkers,
             interfaceModels);
@@ -93,12 +101,14 @@ internal static partial class Parser
     /// <summary>Builds the empty generation result returned when there is nothing to generate.</summary>
     /// <param name="diagnostics">The diagnostics collected so far.</param>
     /// <param name="refitInternalNamespace">The resolved internal generated namespace.</param>
+    /// <param name="generatedClassName">The assembly-scoped name of the generated implementation container type.</param>
     /// <param name="generatedRequestBuilding">Whether generated request construction is enabled.</param>
     /// <param name="emitGeneratedCodeMarkers">Whether generated files include generated-code analyzer skip markers.</param>
     /// <returns>The diagnostics paired with an empty context model.</returns>
     private static (List<Diagnostic> diagnostics, ContextGenerationModel contextGenerationSpec) CreateEmptyResult(
         List<Diagnostic> diagnostics,
         string refitInternalNamespace,
+        string generatedClassName,
         bool generatedRequestBuilding,
         bool emitGeneratedCodeMarkers) =>
         (
@@ -106,6 +116,7 @@ internal static partial class Parser
             new(
                 refitInternalNamespace,
                 string.Empty,
+                generatedClassName,
                 generatedRequestBuilding,
                 emitGeneratedCodeMarkers,
                 ImmutableEquatableArrayFactory.Empty<InterfaceModel>())
@@ -152,12 +163,17 @@ internal static partial class Parser
         // every generator pass, which mutated the compilation and forced an extra bind.
         var preserveAttributeDisplayName = $"global::{refitInternalNamespace}.PreserveAttribute";
 
+        // The generated implementation container folds in the assembly name so each assembly emits a distinctly named
+        // container; UniqueName reconstructs the identical name at runtime for reflection-based resolution.
+        var generatedClassName = BuildGeneratedContainerName(compilation.AssemblyName);
+
         var returnTypeAdapterInterface = ResolveReturnTypeAdapterInterface(compilation);
         var returnTypeAdapters = DiscoverReturnTypeAdapters(compilation, returnTypeAdapterInterface, cancellationToken);
 
         return new InterfaceGenerationContext(
             diagnostics,
             preserveAttributeDisplayName,
+            generatedClassName,
             disposableInterfaceSymbol,
             httpMethodBaseAttributeSymbol,
             formattableSymbol,
@@ -173,79 +189,6 @@ internal static partial class Parser
             returnTypeAdapters,
             [],
             new Dictionary<ISymbol, string?>(SymbolEqualityComparer.Default));
-    }
-
-    /// <summary>Builds the internal generated namespace from a consumer-provided namespace prefix.</summary>
-    /// <param name="refitInternalNamespace">The optional user or MSBuild-supplied namespace prefix.</param>
-    /// <returns>A valid C# namespace for generated Refit internals.</returns>
-    private static string BuildRefitInternalNamespace(string? refitInternalNamespace)
-    {
-        var rawNamespace = string.IsNullOrWhiteSpace(refitInternalNamespace)
-            ? RefitInternalGeneratedSuffix
-            : refitInternalNamespace + RefitInternalGeneratedSuffix;
-        var parts = rawNamespace.Split('.');
-        var builder = new StringBuilder(rawNamespace.Length);
-
-        foreach (var part in parts)
-        {
-            var normalized = NormalizeNamespacePart(part);
-            if (normalized.Length == 0)
-            {
-                continue;
-            }
-
-            if (builder.Length > 0)
-            {
-                _ = builder.Append('.');
-            }
-
-            _ = builder.Append(normalized);
-        }
-
-        // The raw namespace always contains the non-empty RefitInternalGeneratedSuffix segment, so at least one
-        // normalized part is appended and the builder is never empty here.
-        return builder.ToString();
-    }
-
-    /// <summary>Normalizes one namespace segment into a valid identifier.</summary>
-    /// <param name="part">The namespace segment.</param>
-    /// <returns>The normalized segment, or an empty string when the segment is blank.</returns>
-    private static string NormalizeNamespacePart(string part)
-    {
-        if (string.IsNullOrWhiteSpace(part))
-        {
-            return string.Empty;
-        }
-
-        var builder = new StringBuilder(part.Length + 1);
-        foreach (var character in part)
-        {
-            if (builder.Length == 0)
-            {
-                if (SyntaxFacts.IsIdentifierStartCharacter(character))
-                {
-                    _ = builder.Append(character);
-                }
-                else if (SyntaxFacts.IsIdentifierPartCharacter(character))
-                {
-                    _ = builder.Append('_').Append(character);
-                }
-                else
-                {
-                    _ = builder.Append('_');
-                }
-
-                continue;
-            }
-
-            _ = builder.Append(SyntaxFacts.IsIdentifierPartCharacter(character) ? character : '_');
-        }
-
-        var normalized = builder.ToString();
-        return SyntaxFacts.GetKeywordKind(normalized) != SyntaxKind.None
-            || SyntaxFacts.GetContextualKeywordKind(normalized) != SyntaxKind.None
-            ? "_" + normalized
-            : normalized;
     }
 
     /// <summary>Collects the interfaces with Refit methods, declared or inherited, into a single map.</summary>
@@ -424,6 +367,7 @@ internal static partial class Parser
         };
         return new(
             context.PreserveAttributeDisplayName,
+            context.GeneratedClassName,
             fileName,
             names.ClassName,
             names.Namespace,

--- a/src/Shared/UniqueName.cs
+++ b/src/Shared/UniqueName.cs
@@ -12,6 +12,9 @@ namespace Refit;
 /// </summary>
 public static class UniqueName
 {
+    /// <summary>The initial stack buffer size for sanitizing an assembly name; longer names grow onto pooled storage.</summary>
+    private const int AssemblyNameStackBufferLength = 128;
+
     /// <summary>Builds the unique name for the generated implementation of the given interface type.</summary>
     /// <typeparam name="T">The Refit interface type.</typeparam>
     /// <returns>The unique generated type name.</returns>
@@ -82,13 +85,39 @@ public static class UniqueName
         var ns = refitInterfaceType.Namespace?.Replace(".", string.Empty);
 #endif
 
-        // Refit types will be generated as private classes within a Generated type in namespace
-        // Refit.Implementation
-        // E.g., Refit.Implementation.Generated.NamespaceContainingTpeInterfaceType
+        // Refit types are generated as private classes within a container type in namespace Refit.Implementation.
+        // The container name folds in the interface's assembly name so each assembly emits a distinctly named
+        // container; the generator emits the same name for the same assembly, so this reconstruction matches it.
+        // E.g., Refit.Implementation.GeneratedMyApp.NamespaceContainingTheInterfaceType
+        var assemblyScope = SanitizeAssemblyName(refitInterfaceType.Assembly.GetName().Name);
         var refitTypeName =
-            $"Refit.Implementation.Generated+{ns}{interfaceTypeName}{genericArgs}";
+            $"Refit.Implementation.Generated{assemblyScope}+{ns}{interfaceTypeName}{genericArgs}";
 
         return $"{refitTypeName}, {refitInterfaceType.Assembly.FullName}";
+    }
+
+    /// <summary>Reduces an assembly name to a Pascal-cased identifier fragment folded into the generated container name.</summary>
+    /// <param name="assemblyName">The simple assembly name, or <see langword="null"/> when unavailable.</param>
+    /// <returns>The fragment, or an empty string when the assembly name is null or empty. This must stay identical to
+    /// the source generator's sanitization so the reconstructed container name matches the emitted one byte-for-byte.</returns>
+    internal static string SanitizeAssemblyName(string? assemblyName)
+    {
+        if (string.IsNullOrEmpty(assemblyName))
+        {
+            return string.Empty;
+        }
+
+        // Assembly names routinely contain dots and dashes, which are illegal inside an identifier, so every character
+        // that cannot appear in one is folded to an underscore and the first character is upper-cased to keep the
+        // container a well-formed Pascal-cased type name.
+        var builder = new ValueStringBuilder(stackalloc char[AssemblyNameStackBufferLength]);
+        foreach (var character in assemblyName!)
+        {
+            builder.Append(char.IsLetterOrDigit(character) ? character : '_');
+        }
+
+        builder[0] = char.ToUpperInvariant(builder[0]);
+        return builder.ToString();
     }
 
     /// <summary>Returns the suffix for the service key to be added to the unique name for a given type.</summary>

--- a/src/Shared/UniqueName.cs
+++ b/src/Shared/UniqueName.cs
@@ -96,7 +96,7 @@ public static class UniqueName
         return $"{refitTypeName}, {refitInterfaceType.Assembly.FullName}";
     }
 
-    /// <summary>Reduces an assembly name to a Pascal-cased identifier fragment folded into the generated container name.</summary>
+    /// <summary>Reduces an assembly name to an identifier fragment folded into the generated container name.</summary>
     /// <param name="assemblyName">The simple assembly name, or <see langword="null"/> when unavailable.</param>
     /// <returns>The fragment, or an empty string when the assembly name is null or empty. This must stay identical to
     /// the source generator's sanitization so the reconstructed container name matches the emitted one byte-for-byte.</returns>
@@ -108,15 +108,13 @@ public static class UniqueName
         }
 
         // Assembly names routinely contain dots and dashes, which are illegal inside an identifier, so every character
-        // that cannot appear in one is folded to an underscore and the first character is upper-cased to keep the
-        // container a well-formed Pascal-cased type name.
+        // that cannot appear in one is folded to an underscore.
         var builder = new ValueStringBuilder(stackalloc char[AssemblyNameStackBufferLength]);
         foreach (var character in assemblyName!)
         {
             builder.Append(char.IsLetterOrDigit(character) ? character : '_');
         }
 
-        builder[0] = char.ToUpperInvariant(builder[0]);
         return builder.ToString();
     }
 

--- a/src/tests/Refit.GeneratorTests/Fixture.cs
+++ b/src/tests/Refit.GeneratorTests/Fixture.cs
@@ -309,7 +309,15 @@ public static class Fixture
     /// <summary>Creates a compilation from the given syntax trees with the required references.</summary>
     /// <param name="source">The syntax trees to compile.</param>
     /// <returns>The created compilation.</returns>
-    public static CSharpCompilation CreateLibrary(params SyntaxTree[] source)
+    public static CSharpCompilation CreateLibrary(params SyntaxTree[] source) =>
+        CreateNamedLibrary("compilation", source);
+
+    /// <summary>Creates a named compilation from the given syntax trees with the required references.</summary>
+    /// <param name="assemblyName">The assembly name for the compilation, so distinct libraries get distinct identities;
+    /// <see langword="null"/> produces an unnamed compilation.</param>
+    /// <param name="source">The syntax trees to compile.</param>
+    /// <returns>The created compilation.</returns>
+    public static CSharpCompilation CreateNamedLibrary(string? assemblyName, params SyntaxTree[] source)
     {
         var referencePaths = new HashSet<string>(StringComparer.Ordinal);
         AddTrustedPlatformAssemblies(referencePaths);
@@ -330,7 +338,7 @@ public static class Fixture
 
         references.Add(_refitAssembly);
         return CSharpCompilation.Create(
-            "compilation",
+            assemblyName,
             source,
             references,
             new(OutputKind.DynamicallyLinkedLibrary));

--- a/src/tests/Refit.GeneratorTests/Fixture.cs
+++ b/src/tests/Refit.GeneratorTests/Fixture.cs
@@ -310,7 +310,7 @@ public static class Fixture
     /// <param name="source">The syntax trees to compile.</param>
     /// <returns>The created compilation.</returns>
     public static CSharpCompilation CreateLibrary(params SyntaxTree[] source) =>
-        CreateNamedLibrary("compilation", source);
+        CreateNamedLibrary(nameof(Compilation), source);
 
     /// <summary>Creates a named compilation from the given syntax trees with the required references.</summary>
     /// <param name="assemblyName">The assembly name for the compilation, so distinct libraries get distinct identities;

--- a/src/tests/Refit.GeneratorTests/GeneratorComponentTests.EmitterHelpers.cs
+++ b/src/tests/Refit.GeneratorTests/GeneratorComponentTests.EmitterHelpers.cs
@@ -411,6 +411,7 @@ public static partial class GeneratorComponentTests
             ImmutableEquatableArray<MethodModel> derivedRefitMethods) =>
             new(
                 "RefitInternalGenerated.PreserveAttribute",
+                "Generated",
                 "IGeneratedClient.g.cs",
                 "IGeneratedClient",
                 "RefitGeneratorTest",

--- a/src/tests/Refit.GeneratorTests/InternalsVisibleToGenerationTests.cs
+++ b/src/tests/Refit.GeneratorTests/InternalsVisibleToGenerationTests.cs
@@ -143,7 +143,10 @@ public sealed class InternalsVisibleToGenerationTests
 
         var compilation = Fixture.CreateNamedLibrary((string?)null, CSharpSyntaxTree.ParseText(source));
         var result = Fixture.RunGenerator(compilation, generatedRequestBuilding: true, false, null);
-        var generated = string.Join("\n", result.GeneratedSources.Values);
+
+        // Each generated source keeps its own line endings (CRLF on Windows), so normalize to LF before asserting
+        // against a newline-anchored needle; otherwise the "...Generated\n" match fails on Windows runners.
+        var generated = string.Join("\n", result.GeneratedSources.Values).Replace("\r\n", "\n");
 
         await Assert.That(generated).Contains("typeof(global::Refit.Implementation.Generated))");
         await Assert.That(generated).Contains("namespace RefitInternalGenerated\n");

--- a/src/tests/Refit.GeneratorTests/InternalsVisibleToGenerationTests.cs
+++ b/src/tests/Refit.GeneratorTests/InternalsVisibleToGenerationTests.cs
@@ -1,0 +1,151 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace Refit.GeneratorTests;
+
+/// <summary>Verifies the generated helper types are named per assembly, so two assemblies linked by
+/// <c>[InternalsVisibleTo]</c> no longer emit identically named internal types that the second compilation
+/// sees twice and reports as conflicting (issue #2254), while the runtime reflection resolution still matches
+/// the container name the generator emits.</summary>
+public sealed class InternalsVisibleToGenerationTests
+{
+    /// <summary>The compiler diagnostic raised when a source type conflicts with an imported type of the same name.</summary>
+    private const string ConflictingImportedTypeDiagnosticId = "CS0436";
+
+    /// <summary>Verifies a downstream assembly that can see an upstream assembly's Refit internals through
+    /// <c>[InternalsVisibleTo]</c> generates its own client without a type-conflict diagnostic.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task GeneratedHelperTypesDoNotConflictAcrossInternalsVisibleToBoundary()
+    {
+        const string upstream =
+            """
+            using System.Runtime.CompilerServices;
+            using System.Threading.Tasks;
+            using Refit;
+
+            [assembly: InternalsVisibleTo("Downstream")]
+
+            namespace Upstream;
+
+            public interface IUpstreamApi
+            {
+                [Get("/upstream")]
+                Task<string> GetUpstream();
+            }
+            """;
+
+        // The upstream assembly exposes its internal generated helpers to "Downstream", so the downstream compile
+        // imports them. Before the fix, both assemblies emitted Refit.Implementation.Generated and
+        // RefitInternalGenerated.PreserveAttribute, and the downstream compile saw its own copy plus the imported
+        // one, raising CS0436.
+        var upstreamCompilation = Fixture.CreateNamedLibrary("Upstream", CSharpSyntaxTree.ParseText(upstream));
+        var upstreamResult = Fixture.RunGenerator(upstreamCompilation, generatedRequestBuilding: true, false, null);
+        var upstreamReference = upstreamResult.OutputCompilation.ToMetadataReference();
+
+        const string downstream =
+            """
+            using System.Threading.Tasks;
+            using Refit;
+
+            namespace Downstream;
+
+            public interface IDownstreamApi
+            {
+                [Get("/downstream")]
+                Task<string> GetDownstream();
+            }
+            """;
+
+        var downstreamCompilation = Fixture
+            .CreateNamedLibrary("Downstream", CSharpSyntaxTree.ParseText(downstream))
+            .AddReferences(upstreamReference);
+        var downstreamResult = Fixture.RunGenerator(downstreamCompilation, generatedRequestBuilding: true, false, null);
+
+        var conflicts = downstreamResult.OutputCompilation
+            .GetDiagnostics()
+            .Where(static diagnostic => diagnostic.Id == ConflictingImportedTypeDiagnosticId)
+            .Select(static diagnostic => diagnostic.ToString())
+            .ToArray();
+
+        await Assert.That(conflicts).IsEmpty();
+    }
+
+    /// <summary>Verifies the runtime reconstructs the exact container name the generator emitted, so the reflection
+    /// resolution path for a generic interface still finds the generated type after the rename.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    [RequiresUnreferencedCode("Loads an emitted test assembly to resolve a generated type by reflection.")]
+    [RequiresDynamicCode("Closes a generic interface with MakeGenericType to reconstruct the generated container name.")]
+    public async Task ReflectionResolutionMatchesGeneratedContainerNameForGenericInterface()
+    {
+        const string source =
+            """
+            using System.Threading.Tasks;
+            using Refit;
+
+            namespace ReflectionProbe;
+
+            public interface IGenericProbeApi<T>
+            {
+                [Get("/probe")]
+                Task<T> Fetch();
+            }
+            """;
+
+        // The dotted assembly name also exercises the identifier sanitization: the dot becomes an underscore in the
+        // container name, and the runtime must apply the same mapping for the reflection lookup to line up.
+        var compilation = Fixture.CreateNamedLibrary("Reflection.Probe", CSharpSyntaxTree.ParseText(source));
+        var result = Fixture.RunGenerator(compilation, generatedRequestBuilding: true, false, null);
+        var (assembly, context) = Fixture.EmitAndLoad(result);
+        using (context)
+        {
+            var interfaceType = assembly.GetType("ReflectionProbe.IGenericProbeApi`1", throwOnError: true)!;
+            var closedInterface = interfaceType.MakeGenericType(typeof(string));
+
+            // UniqueName.ForType produces the exact assembly-qualified string the reflection path feeds to
+            // Type.GetType, so its container-definition portion must name a real type in the emitted assembly.
+            var uniqueName = UniqueName.ForType(closedInterface);
+            var containerDefinition = uniqueName.Substring(0, uniqueName.IndexOf('['));
+            var resolved = assembly.GetType(containerDefinition, throwOnError: false);
+
+            await Assert.That(resolved).IsNotNull();
+            await Assert.That(containerDefinition)
+                .Contains("Refit.Implementation.GeneratedReflection_Probe+");
+        }
+    }
+
+    /// <summary>Verifies an unnamed compilation falls back to the historical single-assembly container name, so
+    /// the generated output still compiles when no assembly name is available.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task UnnamedCompilationEmitsUnscopedContainerName()
+    {
+        const string source =
+            """
+            using System.Threading.Tasks;
+            using Refit;
+
+            namespace UnnamedProbe;
+
+            public interface IUnnamedApi
+            {
+                [Get("/unnamed")]
+                Task<string> GetUnnamed();
+            }
+            """;
+
+        var compilation = Fixture.CreateNamedLibrary((string?)null, CSharpSyntaxTree.ParseText(source));
+        var result = Fixture.RunGenerator(compilation, generatedRequestBuilding: true, false, null);
+        var generated = string.Join("\n", result.GeneratedSources.Values);
+
+        await Assert.That(generated).Contains("typeof(global::Refit.Implementation.Generated))");
+        await Assert.That(generated).Contains("namespace RefitInternalGenerated\n");
+    }
+}

--- a/src/tests/Refit.GeneratorTests/ParserCoverageTests.cs
+++ b/src/tests/Refit.GeneratorTests/ParserCoverageTests.cs
@@ -60,7 +60,7 @@ public sealed class ParserCoverageTests
             CancellationToken.None);
 
         await Assert.That(diagnostics.Count).IsEqualTo(1);
-        await Assert.That(model.RefitInternalNamespace).IsEqualTo("bad_name_thing_RefitInternalGenerated");
+        await Assert.That(model.RefitInternalNamespace).IsEqualTo("bad_name_thing_RefitInternalGenerated.No_refit");
         await Assert.That(model.Interfaces).IsEmpty();
     }
 
@@ -105,10 +105,12 @@ public sealed class ParserCoverageTests
             [],
             CancellationToken.None);
 
-        await Assert.That(leadingDotModel.RefitInternalNamespace).IsEqualTo("ApplicationRefitInternalGenerated");
-        await Assert.That(digitModel.RefitInternalNamespace).IsEqualTo("_123_AppRefitInternalGenerated");
-        await Assert.That(dottedModel.RefitInternalNamespace).IsEqualTo("One.TwoRefitInternalGenerated");
-        await Assert.That(invalidStartModel.RefitInternalNamespace).IsEqualTo("__.ApplicationRefitInternalGenerated");
+        // The compilation assembly name ("no-refit") is folded in as a trailing, identifier-sanitized segment so each
+        // assembly's PreserveAttribute namespace is distinct; the user-provided prefix normalization is unchanged.
+        await Assert.That(leadingDotModel.RefitInternalNamespace).IsEqualTo("ApplicationRefitInternalGenerated.No_refit");
+        await Assert.That(digitModel.RefitInternalNamespace).IsEqualTo("_123_AppRefitInternalGenerated.No_refit");
+        await Assert.That(dottedModel.RefitInternalNamespace).IsEqualTo("One.TwoRefitInternalGenerated.No_refit");
+        await Assert.That(invalidStartModel.RefitInternalNamespace).IsEqualTo("__.ApplicationRefitInternalGenerated.No_refit");
     }
 
     /// <summary>Verifies well-known type lookup caching and failure paths.</summary>

--- a/src/tests/Refit.GeneratorTests/ParserCoverageTests.cs
+++ b/src/tests/Refit.GeneratorTests/ParserCoverageTests.cs
@@ -60,7 +60,7 @@ public sealed class ParserCoverageTests
             CancellationToken.None);
 
         await Assert.That(diagnostics.Count).IsEqualTo(1);
-        await Assert.That(model.RefitInternalNamespace).IsEqualTo("bad_name_thing_RefitInternalGenerated.No_refit");
+        await Assert.That(model.RefitInternalNamespace).IsEqualTo("bad_name_thing_RefitInternalGenerated.no_refit");
         await Assert.That(model.Interfaces).IsEmpty();
     }
 
@@ -107,10 +107,10 @@ public sealed class ParserCoverageTests
 
         // The compilation assembly name ("no-refit") is folded in as a trailing, identifier-sanitized segment so each
         // assembly's PreserveAttribute namespace is distinct; the user-provided prefix normalization is unchanged.
-        await Assert.That(leadingDotModel.RefitInternalNamespace).IsEqualTo("ApplicationRefitInternalGenerated.No_refit");
-        await Assert.That(digitModel.RefitInternalNamespace).IsEqualTo("_123_AppRefitInternalGenerated.No_refit");
-        await Assert.That(dottedModel.RefitInternalNamespace).IsEqualTo("One.TwoRefitInternalGenerated.No_refit");
-        await Assert.That(invalidStartModel.RefitInternalNamespace).IsEqualTo("__.ApplicationRefitInternalGenerated.No_refit");
+        await Assert.That(leadingDotModel.RefitInternalNamespace).IsEqualTo("ApplicationRefitInternalGenerated.no_refit");
+        await Assert.That(digitModel.RefitInternalNamespace).IsEqualTo("_123_AppRefitInternalGenerated.no_refit");
+        await Assert.That(dottedModel.RefitInternalNamespace).IsEqualTo("One.TwoRefitInternalGenerated.no_refit");
+        await Assert.That(invalidStartModel.RefitInternalNamespace).IsEqualTo("__.ApplicationRefitInternalGenerated.no_refit");
     }
 
     /// <summary>Verifies well-known type lookup caching and failure paths.</summary>

--- a/src/tests/Refit.GeneratorTests/_snapshots/GeneratedTest.ShouldEmitAllFiles#Generated.g.verified.cs
+++ b/src/tests/Refit.GeneratorTests/_snapshots/GeneratedTest.ShouldEmitAllFiles#Generated.g.verified.cs
@@ -9,10 +9,10 @@ namespace Refit.Implementation
     /// <summary>Registers generated Refit factories for interfaces discovered at compile time.</summary>
     [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     [global::System.Diagnostics.DebuggerNonUserCode]
-    [global::RefitInternalGenerated.PreserveAttribute]
+    [global::RefitInternalGenerated.Compilation.PreserveAttribute]
     [global::System.Reflection.Obfuscation(Exclude=true)]
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    internal static partial class Generated
+    internal static partial class GeneratedCompilation
     {
 #if NET5_0_OR_GREATER
         /// <summary>Registers generated Refit factories when the assembly is loaded.</summary>
@@ -21,13 +21,17 @@ namespace Refit.Implementation
             "CA2255:The ModuleInitializer attribute should not be used in libraries",
             Justification = "ModuleInitializer is used intentionally so generated Refit factories are registered when the assembly loads.")]
         [System.Runtime.CompilerServices.ModuleInitializer]
-        [System.Diagnostics.CodeAnalysis.DynamicDependency(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All, typeof(global::Refit.Implementation.Generated))]
+        [System.Diagnostics.CodeAnalysis.DynamicDependency(
+            System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All,
+            typeof(global::Refit.Implementation.GeneratedCompilation))]
         internal static void Initialize()
         {
             global::Refit.RestService.RegisterGeneratedFactory<global::RefitGeneratorTest.IGeneratedClient>(
-                static (client, requestBuilder) => new global::Refit.Implementation.Generated.RefitGeneratorTestIGeneratedClient(client, requestBuilder));
+                static (client, requestBuilder) =>
+                    new global::Refit.Implementation.GeneratedCompilation.RefitGeneratorTestIGeneratedClient(client, requestBuilder));
             global::Refit.RestService.RegisterGeneratedSettingsFactory<global::RefitGeneratorTest.IGeneratedClient>(
-                static (client, settings) => new global::Refit.Implementation.Generated.RefitGeneratorTestIGeneratedClient(client, settings));
+                static (client, settings) =>
+                    new global::Refit.Implementation.GeneratedCompilation.RefitGeneratorTestIGeneratedClient(client, settings));
         }
 #endif
     }

--- a/src/tests/Refit.GeneratorTests/_snapshots/GeneratedTest.ShouldEmitAllFiles#IGeneratedClient.g.verified.cs
+++ b/src/tests/Refit.GeneratorTests/_snapshots/GeneratedTest.ShouldEmitAllFiles#IGeneratedClient.g.verified.cs
@@ -7,12 +7,12 @@
 namespace Refit.Implementation
 {
     /// <summary>Contains generated Refit implementation types.</summary>
-    internal partial class Generated
+    internal partial class GeneratedCompilation
     {
         /// <summary>Generated Refit implementation for global::RefitGeneratorTest.IGeneratedClient.</summary>
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [global::System.Diagnostics.DebuggerNonUserCode]
-        [global::RefitInternalGenerated.PreserveAttribute]
+        [global::RefitInternalGenerated.Compilation.PreserveAttribute]
         [global::System.Reflection.Obfuscation(Exclude=true)]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         private sealed class RefitGeneratorTestIGeneratedClient

--- a/src/tests/Refit.GeneratorTests/_snapshots/GeneratedTest.ShouldEmitAllFiles#PreserveAttribute.g.verified.cs
+++ b/src/tests/Refit.GeneratorTests/_snapshots/GeneratedTest.ShouldEmitAllFiles#PreserveAttribute.g.verified.cs
@@ -4,7 +4,7 @@
 #nullable enable annotations
 #nullable disable warnings
 
-namespace RefitInternalGenerated
+namespace RefitInternalGenerated.Compilation
 {
     /// <summary>Identifies generated members that should be preserved by tools that honor this attribute.</summary>
     [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]

--- a/src/tests/Refit.GeneratorTests/_snapshots/InterfaceStubGeneratorTests.FindInterfacesSmokeTest#Generated.g.verified.cs
+++ b/src/tests/Refit.GeneratorTests/_snapshots/InterfaceStubGeneratorTests.FindInterfacesSmokeTest#Generated.g.verified.cs
@@ -9,10 +9,10 @@ namespace Refit.Implementation
     /// <summary>Registers generated Refit factories for interfaces discovered at compile time.</summary>
     [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     [global::System.Diagnostics.DebuggerNonUserCode]
-    [global::RefitInternalGenerated.PreserveAttribute]
+    [global::RefitInternalGenerated.Compilation.PreserveAttribute]
     [global::System.Reflection.Obfuscation(Exclude=true)]
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    internal static partial class Generated
+    internal static partial class GeneratedCompilation
     {
 #if NET5_0_OR_GREATER
         /// <summary>Registers generated Refit factories when the assembly is loaded.</summary>
@@ -21,21 +21,29 @@ namespace Refit.Implementation
             "CA2255:The ModuleInitializer attribute should not be used in libraries",
             Justification = "ModuleInitializer is used intentionally so generated Refit factories are registered when the assembly loads.")]
         [System.Runtime.CompilerServices.ModuleInitializer]
-        [System.Diagnostics.CodeAnalysis.DynamicDependency(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All, typeof(global::Refit.Implementation.Generated))]
+        [System.Diagnostics.CodeAnalysis.DynamicDependency(
+            System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All,
+            typeof(global::Refit.Implementation.GeneratedCompilation))]
         internal static void Initialize()
         {
             global::Refit.RestService.RegisterGeneratedFactory<global::Refit.Tests.IGitHubApi>(
-                static (client, requestBuilder) => new global::Refit.Implementation.Generated.RefitTestsIGitHubApi(client, requestBuilder));
+                static (client, requestBuilder) =>
+                    new global::Refit.Implementation.GeneratedCompilation.RefitTestsIGitHubApi(client, requestBuilder));
             global::Refit.RestService.RegisterGeneratedSettingsFactory<global::Refit.Tests.IGitHubApi>(
-                static (client, settings) => new global::Refit.Implementation.Generated.RefitTestsIGitHubApi(client, settings));
+                static (client, settings) =>
+                    new global::Refit.Implementation.GeneratedCompilation.RefitTestsIGitHubApi(client, settings));
             global::Refit.RestService.RegisterGeneratedFactory<global::Refit.Tests.IGitHubApiDisposable>(
-                static (client, requestBuilder) => new global::Refit.Implementation.Generated.RefitTestsIGitHubApiDisposable(client, requestBuilder));
+                static (client, requestBuilder) =>
+                    new global::Refit.Implementation.GeneratedCompilation.RefitTestsIGitHubApiDisposable(client, requestBuilder));
             global::Refit.RestService.RegisterGeneratedSettingsFactory<global::Refit.Tests.IGitHubApiDisposable>(
-                static (client, settings) => new global::Refit.Implementation.Generated.RefitTestsIGitHubApiDisposable(client, settings));
+                static (client, settings) =>
+                    new global::Refit.Implementation.GeneratedCompilation.RefitTestsIGitHubApiDisposable(client, settings));
             global::Refit.RestService.RegisterGeneratedFactory<global::Refit.Tests.TestNested.INestedGitHubApi>(
-                static (client, requestBuilder) => new global::Refit.Implementation.Generated.RefitTestsTestNestedINestedGitHubApi(client, requestBuilder));
+                static (client, requestBuilder) =>
+                    new global::Refit.Implementation.GeneratedCompilation.RefitTestsTestNestedINestedGitHubApi(client, requestBuilder));
             global::Refit.RestService.RegisterGeneratedSettingsFactory<global::Refit.Tests.TestNested.INestedGitHubApi>(
-                static (client, settings) => new global::Refit.Implementation.Generated.RefitTestsTestNestedINestedGitHubApi(client, settings));
+                static (client, settings) =>
+                    new global::Refit.Implementation.GeneratedCompilation.RefitTestsTestNestedINestedGitHubApi(client, settings));
         }
 #endif
     }

--- a/src/tests/Refit.GeneratorTests/_snapshots/InterfaceStubGeneratorTests.FindInterfacesSmokeTest#IGitHubApi.g.verified.cs
+++ b/src/tests/Refit.GeneratorTests/_snapshots/InterfaceStubGeneratorTests.FindInterfacesSmokeTest#IGitHubApi.g.verified.cs
@@ -7,12 +7,12 @@
 namespace Refit.Implementation
 {
     /// <summary>Contains generated Refit implementation types.</summary>
-    internal partial class Generated
+    internal partial class GeneratedCompilation
     {
         /// <summary>Generated Refit implementation for global::Refit.Tests.IGitHubApi.</summary>
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [global::System.Diagnostics.DebuggerNonUserCode]
-        [global::RefitInternalGenerated.PreserveAttribute]
+        [global::RefitInternalGenerated.Compilation.PreserveAttribute]
         [global::System.Reflection.Obfuscation(Exclude=true)]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         private sealed class RefitTestsIGitHubApi

--- a/src/tests/Refit.GeneratorTests/_snapshots/InterfaceStubGeneratorTests.FindInterfacesSmokeTest#IGitHubApiDisposable.g.verified.cs
+++ b/src/tests/Refit.GeneratorTests/_snapshots/InterfaceStubGeneratorTests.FindInterfacesSmokeTest#IGitHubApiDisposable.g.verified.cs
@@ -7,12 +7,12 @@
 namespace Refit.Implementation
 {
     /// <summary>Contains generated Refit implementation types.</summary>
-    internal partial class Generated
+    internal partial class GeneratedCompilation
     {
         /// <summary>Generated Refit implementation for global::Refit.Tests.IGitHubApiDisposable.</summary>
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [global::System.Diagnostics.DebuggerNonUserCode]
-        [global::RefitInternalGenerated.PreserveAttribute]
+        [global::RefitInternalGenerated.Compilation.PreserveAttribute]
         [global::System.Reflection.Obfuscation(Exclude=true)]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         private sealed class RefitTestsIGitHubApiDisposable

--- a/src/tests/Refit.GeneratorTests/_snapshots/InterfaceStubGeneratorTests.FindInterfacesSmokeTest#INestedGitHubApi.g.verified.cs
+++ b/src/tests/Refit.GeneratorTests/_snapshots/InterfaceStubGeneratorTests.FindInterfacesSmokeTest#INestedGitHubApi.g.verified.cs
@@ -7,12 +7,12 @@
 namespace Refit.Implementation
 {
     /// <summary>Contains generated Refit implementation types.</summary>
-    internal partial class Generated
+    internal partial class GeneratedCompilation
     {
         /// <summary>Generated Refit implementation for global::Refit.Tests.TestNested.INestedGitHubApi.</summary>
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [global::System.Diagnostics.DebuggerNonUserCode]
-        [global::RefitInternalGenerated.PreserveAttribute]
+        [global::RefitInternalGenerated.Compilation.PreserveAttribute]
         [global::System.Reflection.Obfuscation(Exclude=true)]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         private sealed class RefitTestsTestNestedINestedGitHubApi

--- a/src/tests/Refit.GeneratorTests/_snapshots/InterfaceStubGeneratorTests.FindInterfacesSmokeTest#PreserveAttribute.g.verified.cs
+++ b/src/tests/Refit.GeneratorTests/_snapshots/InterfaceStubGeneratorTests.FindInterfacesSmokeTest#PreserveAttribute.g.verified.cs
@@ -4,7 +4,7 @@
 #nullable enable annotations
 #nullable disable warnings
 
-namespace RefitInternalGenerated
+namespace RefitInternalGenerated.Compilation
 {
     /// <summary>Identifies generated members that should be preserved by tools that honor this attribute.</summary>
     [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]

--- a/src/tests/Refit.GeneratorTests/_snapshots/InterfaceStubGeneratorTests.GenerateInterfaceStubsWithoutNamespaceSmokeTest#Generated.g.verified.cs
+++ b/src/tests/Refit.GeneratorTests/_snapshots/InterfaceStubGeneratorTests.GenerateInterfaceStubsWithoutNamespaceSmokeTest#Generated.g.verified.cs
@@ -9,10 +9,10 @@ namespace Refit.Implementation
     /// <summary>Registers generated Refit factories for interfaces discovered at compile time.</summary>
     [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     [global::System.Diagnostics.DebuggerNonUserCode]
-    [global::RefitInternalGenerated.PreserveAttribute]
+    [global::RefitInternalGenerated.Compilation.PreserveAttribute]
     [global::System.Reflection.Obfuscation(Exclude=true)]
     [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    internal static partial class Generated
+    internal static partial class GeneratedCompilation
     {
 #if NET5_0_OR_GREATER
         /// <summary>Registers generated Refit factories when the assembly is loaded.</summary>
@@ -21,13 +21,17 @@ namespace Refit.Implementation
             "CA2255:The ModuleInitializer attribute should not be used in libraries",
             Justification = "ModuleInitializer is used intentionally so generated Refit factories are registered when the assembly loads.")]
         [System.Runtime.CompilerServices.ModuleInitializer]
-        [System.Diagnostics.CodeAnalysis.DynamicDependency(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All, typeof(global::Refit.Implementation.Generated))]
+        [System.Diagnostics.CodeAnalysis.DynamicDependency(
+            System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All,
+            typeof(global::Refit.Implementation.GeneratedCompilation))]
         internal static void Initialize()
         {
             global::Refit.RestService.RegisterGeneratedFactory<global::IServiceWithoutNamespace>(
-                static (client, requestBuilder) => new global::Refit.Implementation.Generated.IServiceWithoutNamespace(client, requestBuilder));
+                static (client, requestBuilder) =>
+                    new global::Refit.Implementation.GeneratedCompilation.IServiceWithoutNamespace(client, requestBuilder));
             global::Refit.RestService.RegisterGeneratedSettingsFactory<global::IServiceWithoutNamespace>(
-                static (client, settings) => new global::Refit.Implementation.Generated.IServiceWithoutNamespace(client, settings));
+                static (client, settings) =>
+                    new global::Refit.Implementation.GeneratedCompilation.IServiceWithoutNamespace(client, settings));
         }
 #endif
     }

--- a/src/tests/Refit.GeneratorTests/_snapshots/InterfaceStubGeneratorTests.GenerateInterfaceStubsWithoutNamespaceSmokeTest#IServiceWithoutNamespace.g.verified.cs
+++ b/src/tests/Refit.GeneratorTests/_snapshots/InterfaceStubGeneratorTests.GenerateInterfaceStubsWithoutNamespaceSmokeTest#IServiceWithoutNamespace.g.verified.cs
@@ -7,12 +7,12 @@
 namespace Refit.Implementation
 {
     /// <summary>Contains generated Refit implementation types.</summary>
-    internal partial class Generated
+    internal partial class GeneratedCompilation
     {
         /// <summary>Generated Refit implementation for global::IServiceWithoutNamespace.</summary>
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [global::System.Diagnostics.DebuggerNonUserCode]
-        [global::RefitInternalGenerated.PreserveAttribute]
+        [global::RefitInternalGenerated.Compilation.PreserveAttribute]
         [global::System.Reflection.Obfuscation(Exclude=true)]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         private sealed class IServiceWithoutNamespace

--- a/src/tests/Refit.GeneratorTests/_snapshots/InterfaceStubGeneratorTests.GenerateInterfaceStubsWithoutNamespaceSmokeTest#PreserveAttribute.g.verified.cs
+++ b/src/tests/Refit.GeneratorTests/_snapshots/InterfaceStubGeneratorTests.GenerateInterfaceStubsWithoutNamespaceSmokeTest#PreserveAttribute.g.verified.cs
@@ -4,7 +4,7 @@
 #nullable enable annotations
 #nullable disable warnings
 
-namespace RefitInternalGenerated
+namespace RefitInternalGenerated.Compilation
 {
     /// <summary>Identifies generated members that should be preserved by tools that honor this attribute.</summary>
     [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]

--- a/src/tests/Refit.GeneratorTests/_snapshots/InterfaceTests.ContainedInterfaceTest#IContainedInterface.g.verified.cs
+++ b/src/tests/Refit.GeneratorTests/_snapshots/InterfaceTests.ContainedInterfaceTest#IContainedInterface.g.verified.cs
@@ -7,12 +7,12 @@
 namespace Refit.Implementation
 {
     /// <summary>Contains generated Refit implementation types.</summary>
-    internal partial class Generated
+    internal partial class GeneratedCompilation
     {
         /// <summary>Generated Refit implementation for global::RefitGeneratorTest.ContainerType.IContainedInterface.</summary>
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [global::System.Diagnostics.DebuggerNonUserCode]
-        [global::RefitInternalGenerated.PreserveAttribute]
+        [global::RefitInternalGenerated.Compilation.PreserveAttribute]
         [global::System.Reflection.Obfuscation(Exclude=true)]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         private sealed class RefitGeneratorTestContainerTypeIContainedInterface

--- a/src/tests/Refit.GeneratorTests/_snapshots/InterfaceTests.DefaultInterfaceMethod#IGeneratedInterface.g.verified.cs
+++ b/src/tests/Refit.GeneratorTests/_snapshots/InterfaceTests.DefaultInterfaceMethod#IGeneratedInterface.g.verified.cs
@@ -7,12 +7,12 @@
 namespace Refit.Implementation
 {
     /// <summary>Contains generated Refit implementation types.</summary>
-    internal partial class Generated
+    internal partial class GeneratedCompilation
     {
         /// <summary>Generated Refit implementation for global::RefitGeneratorTest.IGeneratedInterface.</summary>
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [global::System.Diagnostics.DebuggerNonUserCode]
-        [global::RefitInternalGenerated.PreserveAttribute]
+        [global::RefitInternalGenerated.Compilation.PreserveAttribute]
         [global::System.Reflection.Obfuscation(Exclude=true)]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         private sealed class RefitGeneratorTestIGeneratedInterface

--- a/src/tests/Refit.GeneratorTests/_snapshots/InterfaceTests.DerivedDefaultInterfaceMethod#IBaseInterface.g.verified.cs
+++ b/src/tests/Refit.GeneratorTests/_snapshots/InterfaceTests.DerivedDefaultInterfaceMethod#IBaseInterface.g.verified.cs
@@ -7,12 +7,12 @@
 namespace Refit.Implementation
 {
     /// <summary>Contains generated Refit implementation types.</summary>
-    internal partial class Generated
+    internal partial class GeneratedCompilation
     {
         /// <summary>Generated Refit implementation for global::RefitGeneratorTest.IBaseInterface.</summary>
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [global::System.Diagnostics.DebuggerNonUserCode]
-        [global::RefitInternalGenerated.PreserveAttribute]
+        [global::RefitInternalGenerated.Compilation.PreserveAttribute]
         [global::System.Reflection.Obfuscation(Exclude=true)]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         private sealed class RefitGeneratorTestIBaseInterface

--- a/src/tests/Refit.GeneratorTests/_snapshots/InterfaceTests.DerivedDefaultInterfaceMethod#IGeneratedInterface.g.verified.cs
+++ b/src/tests/Refit.GeneratorTests/_snapshots/InterfaceTests.DerivedDefaultInterfaceMethod#IGeneratedInterface.g.verified.cs
@@ -7,12 +7,12 @@
 namespace Refit.Implementation
 {
     /// <summary>Contains generated Refit implementation types.</summary>
-    internal partial class Generated
+    internal partial class GeneratedCompilation
     {
         /// <summary>Generated Refit implementation for global::RefitGeneratorTest.IGeneratedInterface.</summary>
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [global::System.Diagnostics.DebuggerNonUserCode]
-        [global::RefitInternalGenerated.PreserveAttribute]
+        [global::RefitInternalGenerated.Compilation.PreserveAttribute]
         [global::System.Reflection.Obfuscation(Exclude=true)]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         private sealed class RefitGeneratorTestIGeneratedInterface

--- a/src/tests/Refit.GeneratorTests/_snapshots/InterfaceTests.DisposableTest#IGeneratedInterface.g.verified.cs
+++ b/src/tests/Refit.GeneratorTests/_snapshots/InterfaceTests.DisposableTest#IGeneratedInterface.g.verified.cs
@@ -7,12 +7,12 @@
 namespace Refit.Implementation
 {
     /// <summary>Contains generated Refit implementation types.</summary>
-    internal partial class Generated
+    internal partial class GeneratedCompilation
     {
         /// <summary>Generated Refit implementation for global::IGeneratedInterface.</summary>
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [global::System.Diagnostics.DebuggerNonUserCode]
-        [global::RefitInternalGenerated.PreserveAttribute]
+        [global::RefitInternalGenerated.Compilation.PreserveAttribute]
         [global::System.Reflection.Obfuscation(Exclude=true)]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         private sealed class IGeneratedInterface

--- a/src/tests/Refit.GeneratorTests/_snapshots/InterfaceTests.GlobalNamespaceTest#IGeneratedInterface.g.verified.cs
+++ b/src/tests/Refit.GeneratorTests/_snapshots/InterfaceTests.GlobalNamespaceTest#IGeneratedInterface.g.verified.cs
@@ -7,12 +7,12 @@
 namespace Refit.Implementation
 {
     /// <summary>Contains generated Refit implementation types.</summary>
-    internal partial class Generated
+    internal partial class GeneratedCompilation
     {
         /// <summary>Generated Refit implementation for global::IGeneratedInterface.</summary>
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [global::System.Diagnostics.DebuggerNonUserCode]
-        [global::RefitInternalGenerated.PreserveAttribute]
+        [global::RefitInternalGenerated.Compilation.PreserveAttribute]
         [global::System.Reflection.Obfuscation(Exclude=true)]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         private sealed class IGeneratedInterface

--- a/src/tests/Refit.GeneratorTests/_snapshots/InterfaceTests.InterfaceDerivedFromRefitBaseTest#IBaseInterface.g.verified.cs
+++ b/src/tests/Refit.GeneratorTests/_snapshots/InterfaceTests.InterfaceDerivedFromRefitBaseTest#IBaseInterface.g.verified.cs
@@ -7,12 +7,12 @@
 namespace Refit.Implementation
 {
     /// <summary>Contains generated Refit implementation types.</summary>
-    internal partial class Generated
+    internal partial class GeneratedCompilation
     {
         /// <summary>Generated Refit implementation for global::RefitGeneratorTest.IBaseInterface.</summary>
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [global::System.Diagnostics.DebuggerNonUserCode]
-        [global::RefitInternalGenerated.PreserveAttribute]
+        [global::RefitInternalGenerated.Compilation.PreserveAttribute]
         [global::System.Reflection.Obfuscation(Exclude=true)]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         private sealed class RefitGeneratorTestIBaseInterface

--- a/src/tests/Refit.GeneratorTests/_snapshots/InterfaceTests.InterfaceDerivedFromRefitBaseTest#IDerivedInterface.g.verified.cs
+++ b/src/tests/Refit.GeneratorTests/_snapshots/InterfaceTests.InterfaceDerivedFromRefitBaseTest#IDerivedInterface.g.verified.cs
@@ -7,12 +7,12 @@
 namespace Refit.Implementation
 {
     /// <summary>Contains generated Refit implementation types.</summary>
-    internal partial class Generated
+    internal partial class GeneratedCompilation
     {
         /// <summary>Generated Refit implementation for global::RefitGeneratorTest.IDerivedInterface.</summary>
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [global::System.Diagnostics.DebuggerNonUserCode]
-        [global::RefitInternalGenerated.PreserveAttribute]
+        [global::RefitInternalGenerated.Compilation.PreserveAttribute]
         [global::System.Reflection.Obfuscation(Exclude=true)]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         private sealed class RefitGeneratorTestIDerivedInterface

--- a/src/tests/Refit.GeneratorTests/_snapshots/InterfaceTests.InterfaceWithGenericConstraint#IGeneratedInterface.g.verified.cs
+++ b/src/tests/Refit.GeneratorTests/_snapshots/InterfaceTests.InterfaceWithGenericConstraint#IGeneratedInterface.g.verified.cs
@@ -7,7 +7,7 @@
 namespace Refit.Implementation
 {
     /// <summary>Contains generated Refit implementation types.</summary>
-    internal partial class Generated
+    internal partial class GeneratedCompilation
     {
         /// <summary>Generated Refit implementation for global::IGeneratedInterface&lt;T1, T2, T3, T4, T5&gt;.</summary>
         /// <typeparam name="T1">The generated interface type parameter.</typeparam>
@@ -17,7 +17,7 @@ namespace Refit.Implementation
         /// <typeparam name="T5">The generated interface type parameter.</typeparam>
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [global::System.Diagnostics.DebuggerNonUserCode]
-        [global::RefitInternalGenerated.PreserveAttribute]
+        [global::RefitInternalGenerated.Compilation.PreserveAttribute]
         [global::System.Reflection.Obfuscation(Exclude=true)]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         private sealed class IGeneratedInterface<T1, T2, T3, T4, T5>

--- a/src/tests/Refit.GeneratorTests/_snapshots/InterfaceTests.InterfacesWithDifferentCasing#IApi.g.verified.cs
+++ b/src/tests/Refit.GeneratorTests/_snapshots/InterfaceTests.InterfacesWithDifferentCasing#IApi.g.verified.cs
@@ -7,12 +7,12 @@
 namespace Refit.Implementation
 {
     /// <summary>Contains generated Refit implementation types.</summary>
-    internal partial class Generated
+    internal partial class GeneratedCompilation
     {
         /// <summary>Generated Refit implementation for global::RefitGeneratorTest.IApi.</summary>
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [global::System.Diagnostics.DebuggerNonUserCode]
-        [global::RefitInternalGenerated.PreserveAttribute]
+        [global::RefitInternalGenerated.Compilation.PreserveAttribute]
         [global::System.Reflection.Obfuscation(Exclude=true)]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         private sealed class RefitGeneratorTestIApi

--- a/src/tests/Refit.GeneratorTests/_snapshots/InterfaceTests.InterfacesWithDifferentCasing#Iapi1.g.verified.cs
+++ b/src/tests/Refit.GeneratorTests/_snapshots/InterfaceTests.InterfacesWithDifferentCasing#Iapi1.g.verified.cs
@@ -7,12 +7,12 @@
 namespace Refit.Implementation
 {
     /// <summary>Contains generated Refit implementation types.</summary>
-    internal partial class Generated
+    internal partial class GeneratedCompilation
     {
         /// <summary>Generated Refit implementation for global::RefitGeneratorTest.Iapi.</summary>
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [global::System.Diagnostics.DebuggerNonUserCode]
-        [global::RefitInternalGenerated.PreserveAttribute]
+        [global::RefitInternalGenerated.Compilation.PreserveAttribute]
         [global::System.Reflection.Obfuscation(Exclude=true)]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         private sealed class RefitGeneratorTestIapi

--- a/src/tests/Refit.GeneratorTests/_snapshots/InterfaceTests.InterfacesWithDifferentSignature#IApi.g.verified.cs
+++ b/src/tests/Refit.GeneratorTests/_snapshots/InterfaceTests.InterfacesWithDifferentSignature#IApi.g.verified.cs
@@ -7,12 +7,12 @@
 namespace Refit.Implementation
 {
     /// <summary>Contains generated Refit implementation types.</summary>
-    internal partial class Generated
+    internal partial class GeneratedCompilation
     {
         /// <summary>Generated Refit implementation for global::RefitGeneratorTest.IApi.</summary>
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [global::System.Diagnostics.DebuggerNonUserCode]
-        [global::RefitInternalGenerated.PreserveAttribute]
+        [global::RefitInternalGenerated.Compilation.PreserveAttribute]
         [global::System.Reflection.Obfuscation(Exclude=true)]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         private sealed class RefitGeneratorTestIApi

--- a/src/tests/Refit.GeneratorTests/_snapshots/InterfaceTests.InterfacesWithDifferentSignature#IApi1.g.verified.cs
+++ b/src/tests/Refit.GeneratorTests/_snapshots/InterfaceTests.InterfacesWithDifferentSignature#IApi1.g.verified.cs
@@ -7,13 +7,13 @@
 namespace Refit.Implementation
 {
     /// <summary>Contains generated Refit implementation types.</summary>
-    internal partial class Generated
+    internal partial class GeneratedCompilation
     {
         /// <summary>Generated Refit implementation for global::RefitGeneratorTest.IApi&lt;T&gt;.</summary>
         /// <typeparam name="T">The generated interface type parameter.</typeparam>
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [global::System.Diagnostics.DebuggerNonUserCode]
-        [global::RefitInternalGenerated.PreserveAttribute]
+        [global::RefitInternalGenerated.Compilation.PreserveAttribute]
         [global::System.Reflection.Obfuscation(Exclude=true)]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         private sealed class RefitGeneratorTestIApi<T>

--- a/src/tests/Refit.GeneratorTests/_snapshots/InterfaceTests.NestedNamespaceTest#IGeneratedInterface.g.verified.cs
+++ b/src/tests/Refit.GeneratorTests/_snapshots/InterfaceTests.NestedNamespaceTest#IGeneratedInterface.g.verified.cs
@@ -7,12 +7,12 @@
 namespace Refit.Implementation
 {
     /// <summary>Contains generated Refit implementation types.</summary>
-    internal partial class Generated
+    internal partial class GeneratedCompilation
     {
         /// <summary>Generated Refit implementation for global::Nested.RefitGeneratorTest.IGeneratedInterface.</summary>
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [global::System.Diagnostics.DebuggerNonUserCode]
-        [global::RefitInternalGenerated.PreserveAttribute]
+        [global::RefitInternalGenerated.Compilation.PreserveAttribute]
         [global::System.Reflection.Obfuscation(Exclude=true)]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         private sealed class NestedRefitGeneratorTestIGeneratedInterface

--- a/src/tests/Refit.GeneratorTests/_snapshots/InterfaceTests.NonRefitMethodShouldRaiseDiagnostic#IGeneratedClient.g.verified.cs
+++ b/src/tests/Refit.GeneratorTests/_snapshots/InterfaceTests.NonRefitMethodShouldRaiseDiagnostic#IGeneratedClient.g.verified.cs
@@ -7,12 +7,12 @@
 namespace Refit.Implementation
 {
     /// <summary>Contains generated Refit implementation types.</summary>
-    internal partial class Generated
+    internal partial class GeneratedCompilation
     {
         /// <summary>Generated Refit implementation for global::RefitGeneratorTest.IGeneratedClient.</summary>
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [global::System.Diagnostics.DebuggerNonUserCode]
-        [global::RefitInternalGenerated.PreserveAttribute]
+        [global::RefitInternalGenerated.Compilation.PreserveAttribute]
         [global::System.Reflection.Obfuscation(Exclude=true)]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         private sealed class RefitGeneratorTestIGeneratedClient

--- a/src/tests/Refit.GeneratorTests/_snapshots/InterfaceTests.RefitInterfaceDerivedFromBaseTest#IGeneratedInterface.g.verified.cs
+++ b/src/tests/Refit.GeneratorTests/_snapshots/InterfaceTests.RefitInterfaceDerivedFromBaseTest#IGeneratedInterface.g.verified.cs
@@ -7,12 +7,12 @@
 namespace Refit.Implementation
 {
     /// <summary>Contains generated Refit implementation types.</summary>
-    internal partial class Generated
+    internal partial class GeneratedCompilation
     {
         /// <summary>Generated Refit implementation for global::RefitGeneratorTest.IGeneratedInterface.</summary>
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [global::System.Diagnostics.DebuggerNonUserCode]
-        [global::RefitInternalGenerated.PreserveAttribute]
+        [global::RefitInternalGenerated.Compilation.PreserveAttribute]
         [global::System.Reflection.Obfuscation(Exclude=true)]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         private sealed class RefitGeneratorTestIGeneratedInterface

--- a/src/tests/Refit.GeneratorTests/_snapshots/InterfaceTests.RefitInterfaceDerivedFromRefitBaseTest#IBaseInterface.g.verified.cs
+++ b/src/tests/Refit.GeneratorTests/_snapshots/InterfaceTests.RefitInterfaceDerivedFromRefitBaseTest#IBaseInterface.g.verified.cs
@@ -7,12 +7,12 @@
 namespace Refit.Implementation
 {
     /// <summary>Contains generated Refit implementation types.</summary>
-    internal partial class Generated
+    internal partial class GeneratedCompilation
     {
         /// <summary>Generated Refit implementation for global::RefitGeneratorTest.IBaseInterface.</summary>
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [global::System.Diagnostics.DebuggerNonUserCode]
-        [global::RefitInternalGenerated.PreserveAttribute]
+        [global::RefitInternalGenerated.Compilation.PreserveAttribute]
         [global::System.Reflection.Obfuscation(Exclude=true)]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         private sealed class RefitGeneratorTestIBaseInterface

--- a/src/tests/Refit.GeneratorTests/_snapshots/InterfaceTests.RefitInterfaceDerivedFromRefitBaseTest#IGeneratedInterface.g.verified.cs
+++ b/src/tests/Refit.GeneratorTests/_snapshots/InterfaceTests.RefitInterfaceDerivedFromRefitBaseTest#IGeneratedInterface.g.verified.cs
@@ -7,12 +7,12 @@
 namespace Refit.Implementation
 {
     /// <summary>Contains generated Refit implementation types.</summary>
-    internal partial class Generated
+    internal partial class GeneratedCompilation
     {
         /// <summary>Generated Refit implementation for global::RefitGeneratorTest.IGeneratedInterface.</summary>
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [global::System.Diagnostics.DebuggerNonUserCode]
-        [global::RefitInternalGenerated.PreserveAttribute]
+        [global::RefitInternalGenerated.Compilation.PreserveAttribute]
         [global::System.Reflection.Obfuscation(Exclude=true)]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         private sealed class RefitGeneratorTestIGeneratedInterface

--- a/src/tests/Refit.GeneratorTests/_snapshots/MethodTests.MethodsWithGenericConstraints#IGeneratedClient.g.verified.cs
+++ b/src/tests/Refit.GeneratorTests/_snapshots/MethodTests.MethodsWithGenericConstraints#IGeneratedClient.g.verified.cs
@@ -7,12 +7,12 @@
 namespace Refit.Implementation
 {
     /// <summary>Contains generated Refit implementation types.</summary>
-    internal partial class Generated
+    internal partial class GeneratedCompilation
     {
         /// <summary>Generated Refit implementation for global::RefitGeneratorTest.IGeneratedClient.</summary>
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [global::System.Diagnostics.DebuggerNonUserCode]
-        [global::RefitInternalGenerated.PreserveAttribute]
+        [global::RefitInternalGenerated.Compilation.PreserveAttribute]
         [global::System.Reflection.Obfuscation(Exclude=true)]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         private sealed class RefitGeneratorTestIGeneratedClient

--- a/src/tests/Refit.GeneratorTests/_snapshots/ParameterTests.NullableRouteParameter#IGeneratedClient.g.verified.cs
+++ b/src/tests/Refit.GeneratorTests/_snapshots/ParameterTests.NullableRouteParameter#IGeneratedClient.g.verified.cs
@@ -7,12 +7,12 @@
 namespace Refit.Implementation
 {
     /// <summary>Contains generated Refit implementation types.</summary>
-    internal partial class Generated
+    internal partial class GeneratedCompilation
     {
         /// <summary>Generated Refit implementation for global::RefitGeneratorTest.IGeneratedClient.</summary>
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [global::System.Diagnostics.DebuggerNonUserCode]
-        [global::RefitInternalGenerated.PreserveAttribute]
+        [global::RefitInternalGenerated.Compilation.PreserveAttribute]
         [global::System.Reflection.Obfuscation(Exclude=true)]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         private sealed class RefitGeneratorTestIGeneratedClient

--- a/src/tests/Refit.GeneratorTests/_snapshots/ParameterTests.NullableValueTypeRouteParameter#IGeneratedClient.g.verified.cs
+++ b/src/tests/Refit.GeneratorTests/_snapshots/ParameterTests.NullableValueTypeRouteParameter#IGeneratedClient.g.verified.cs
@@ -7,12 +7,12 @@
 namespace Refit.Implementation
 {
     /// <summary>Contains generated Refit implementation types.</summary>
-    internal partial class Generated
+    internal partial class GeneratedCompilation
     {
         /// <summary>Generated Refit implementation for global::RefitGeneratorTest.IGeneratedClient.</summary>
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [global::System.Diagnostics.DebuggerNonUserCode]
-        [global::RefitInternalGenerated.PreserveAttribute]
+        [global::RefitInternalGenerated.Compilation.PreserveAttribute]
         [global::System.Reflection.Obfuscation(Exclude=true)]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         private sealed class RefitGeneratorTestIGeneratedClient

--- a/src/tests/Refit.GeneratorTests/_snapshots/ParameterTests.RouteParameter#IGeneratedClient.g.verified.cs
+++ b/src/tests/Refit.GeneratorTests/_snapshots/ParameterTests.RouteParameter#IGeneratedClient.g.verified.cs
@@ -7,12 +7,12 @@
 namespace Refit.Implementation
 {
     /// <summary>Contains generated Refit implementation types.</summary>
-    internal partial class Generated
+    internal partial class GeneratedCompilation
     {
         /// <summary>Generated Refit implementation for global::RefitGeneratorTest.IGeneratedClient.</summary>
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [global::System.Diagnostics.DebuggerNonUserCode]
-        [global::RefitInternalGenerated.PreserveAttribute]
+        [global::RefitInternalGenerated.Compilation.PreserveAttribute]
         [global::System.Reflection.Obfuscation(Exclude=true)]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         private sealed class RefitGeneratorTestIGeneratedClient

--- a/src/tests/Refit.GeneratorTests/_snapshots/ParameterTests.ValueTypeRouteParameter#IGeneratedClient.g.verified.cs
+++ b/src/tests/Refit.GeneratorTests/_snapshots/ParameterTests.ValueTypeRouteParameter#IGeneratedClient.g.verified.cs
@@ -7,12 +7,12 @@
 namespace Refit.Implementation
 {
     /// <summary>Contains generated Refit implementation types.</summary>
-    internal partial class Generated
+    internal partial class GeneratedCompilation
     {
         /// <summary>Generated Refit implementation for global::RefitGeneratorTest.IGeneratedClient.</summary>
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [global::System.Diagnostics.DebuggerNonUserCode]
-        [global::RefitInternalGenerated.PreserveAttribute]
+        [global::RefitInternalGenerated.Compilation.PreserveAttribute]
         [global::System.Reflection.Obfuscation(Exclude=true)]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         private sealed class RefitGeneratorTestIGeneratedClient

--- a/src/tests/Refit.GeneratorTests/_snapshots/ParameterTests.ValueTypeRouteParameterInQueryWithAttribute#IGeneratedClient.g.verified.cs
+++ b/src/tests/Refit.GeneratorTests/_snapshots/ParameterTests.ValueTypeRouteParameterInQueryWithAttribute#IGeneratedClient.g.verified.cs
@@ -7,12 +7,12 @@
 namespace Refit.Implementation
 {
     /// <summary>Contains generated Refit implementation types.</summary>
-    internal partial class Generated
+    internal partial class GeneratedCompilation
     {
         /// <summary>Generated Refit implementation for global::RefitGeneratorTest.IGeneratedClient.</summary>
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [global::System.Diagnostics.DebuggerNonUserCode]
-        [global::RefitInternalGenerated.PreserveAttribute]
+        [global::RefitInternalGenerated.Compilation.PreserveAttribute]
         [global::System.Reflection.Obfuscation(Exclude=true)]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         private sealed class RefitGeneratorTestIGeneratedClient

--- a/src/tests/Refit.GeneratorTests/_snapshots/ParameterTests.ValueTypeRouteParameterInQueryWithoutAttribute#IGeneratedClient.g.verified.cs
+++ b/src/tests/Refit.GeneratorTests/_snapshots/ParameterTests.ValueTypeRouteParameterInQueryWithoutAttribute#IGeneratedClient.g.verified.cs
@@ -7,12 +7,12 @@
 namespace Refit.Implementation
 {
     /// <summary>Contains generated Refit implementation types.</summary>
-    internal partial class Generated
+    internal partial class GeneratedCompilation
     {
         /// <summary>Generated Refit implementation for global::RefitGeneratorTest.IGeneratedClient.</summary>
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [global::System.Diagnostics.DebuggerNonUserCode]
-        [global::RefitInternalGenerated.PreserveAttribute]
+        [global::RefitInternalGenerated.Compilation.PreserveAttribute]
         [global::System.Reflection.Obfuscation(Exclude=true)]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         private sealed class RefitGeneratorTestIGeneratedClient

--- a/src/tests/Refit.GeneratorTests/_snapshots/ParameterTests.ValueTypeRouteParameterWithAttribute#IGeneratedClient.g.verified.cs
+++ b/src/tests/Refit.GeneratorTests/_snapshots/ParameterTests.ValueTypeRouteParameterWithAttribute#IGeneratedClient.g.verified.cs
@@ -7,12 +7,12 @@
 namespace Refit.Implementation
 {
     /// <summary>Contains generated Refit implementation types.</summary>
-    internal partial class Generated
+    internal partial class GeneratedCompilation
     {
         /// <summary>Generated Refit implementation for global::RefitGeneratorTest.IGeneratedClient.</summary>
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [global::System.Diagnostics.DebuggerNonUserCode]
-        [global::RefitInternalGenerated.PreserveAttribute]
+        [global::RefitInternalGenerated.Compilation.PreserveAttribute]
         [global::System.Reflection.Obfuscation(Exclude=true)]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         private sealed class RefitGeneratorTestIGeneratedClient

--- a/src/tests/Refit.GeneratorTests/_snapshots/ReturnTypeTests.GenericConstraintReturnTask#IGeneratedClient.g.verified.cs
+++ b/src/tests/Refit.GeneratorTests/_snapshots/ReturnTypeTests.GenericConstraintReturnTask#IGeneratedClient.g.verified.cs
@@ -7,12 +7,12 @@
 namespace Refit.Implementation
 {
     /// <summary>Contains generated Refit implementation types.</summary>
-    internal partial class Generated
+    internal partial class GeneratedCompilation
     {
         /// <summary>Generated Refit implementation for global::RefitGeneratorTest.IGeneratedClient.</summary>
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [global::System.Diagnostics.DebuggerNonUserCode]
-        [global::RefitInternalGenerated.PreserveAttribute]
+        [global::RefitInternalGenerated.Compilation.PreserveAttribute]
         [global::System.Reflection.Obfuscation(Exclude=true)]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         private sealed class RefitGeneratorTestIGeneratedClient

--- a/src/tests/Refit.GeneratorTests/_snapshots/ReturnTypeTests.GenericStructConstraintReturnTask#IGeneratedClient.g.verified.cs
+++ b/src/tests/Refit.GeneratorTests/_snapshots/ReturnTypeTests.GenericStructConstraintReturnTask#IGeneratedClient.g.verified.cs
@@ -7,12 +7,12 @@
 namespace Refit.Implementation
 {
     /// <summary>Contains generated Refit implementation types.</summary>
-    internal partial class Generated
+    internal partial class GeneratedCompilation
     {
         /// <summary>Generated Refit implementation for global::RefitGeneratorTest.IGeneratedClient.</summary>
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [global::System.Diagnostics.DebuggerNonUserCode]
-        [global::RefitInternalGenerated.PreserveAttribute]
+        [global::RefitInternalGenerated.Compilation.PreserveAttribute]
         [global::System.Reflection.Obfuscation(Exclude=true)]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         private sealed class RefitGeneratorTestIGeneratedClient

--- a/src/tests/Refit.GeneratorTests/_snapshots/ReturnTypeTests.GenericTaskShouldWork#IGeneratedClient.g.verified.cs
+++ b/src/tests/Refit.GeneratorTests/_snapshots/ReturnTypeTests.GenericTaskShouldWork#IGeneratedClient.g.verified.cs
@@ -7,12 +7,12 @@
 namespace Refit.Implementation
 {
     /// <summary>Contains generated Refit implementation types.</summary>
-    internal partial class Generated
+    internal partial class GeneratedCompilation
     {
         /// <summary>Generated Refit implementation for global::RefitGeneratorTest.IGeneratedClient.</summary>
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [global::System.Diagnostics.DebuggerNonUserCode]
-        [global::RefitInternalGenerated.PreserveAttribute]
+        [global::RefitInternalGenerated.Compilation.PreserveAttribute]
         [global::System.Reflection.Obfuscation(Exclude=true)]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         private sealed class RefitGeneratorTestIGeneratedClient

--- a/src/tests/Refit.GeneratorTests/_snapshots/ReturnTypeTests.GenericUnmanagedConstraintReturnTask#IGeneratedClient.g.verified.cs
+++ b/src/tests/Refit.GeneratorTests/_snapshots/ReturnTypeTests.GenericUnmanagedConstraintReturnTask#IGeneratedClient.g.verified.cs
@@ -7,12 +7,12 @@
 namespace Refit.Implementation
 {
     /// <summary>Contains generated Refit implementation types.</summary>
-    internal partial class Generated
+    internal partial class GeneratedCompilation
     {
         /// <summary>Generated Refit implementation for global::RefitGeneratorTest.IGeneratedClient.</summary>
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [global::System.Diagnostics.DebuggerNonUserCode]
-        [global::RefitInternalGenerated.PreserveAttribute]
+        [global::RefitInternalGenerated.Compilation.PreserveAttribute]
         [global::System.Reflection.Obfuscation(Exclude=true)]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         private sealed class RefitGeneratorTestIGeneratedClient

--- a/src/tests/Refit.GeneratorTests/_snapshots/ReturnTypeTests.GenericValueTaskShouldWork#IGeneratedClient.g.verified.cs
+++ b/src/tests/Refit.GeneratorTests/_snapshots/ReturnTypeTests.GenericValueTaskShouldWork#IGeneratedClient.g.verified.cs
@@ -7,12 +7,12 @@
 namespace Refit.Implementation
 {
     /// <summary>Contains generated Refit implementation types.</summary>
-    internal partial class Generated
+    internal partial class GeneratedCompilation
     {
         /// <summary>Generated Refit implementation for global::RefitGeneratorTest.IGeneratedClient.</summary>
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [global::System.Diagnostics.DebuggerNonUserCode]
-        [global::RefitInternalGenerated.PreserveAttribute]
+        [global::RefitInternalGenerated.Compilation.PreserveAttribute]
         [global::System.Reflection.Obfuscation(Exclude=true)]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         private sealed class RefitGeneratorTestIGeneratedClient

--- a/src/tests/Refit.GeneratorTests/_snapshots/ReturnTypeTests.ReturnIObservable#IGeneratedClient.g.verified.cs
+++ b/src/tests/Refit.GeneratorTests/_snapshots/ReturnTypeTests.ReturnIObservable#IGeneratedClient.g.verified.cs
@@ -7,12 +7,12 @@
 namespace Refit.Implementation
 {
     /// <summary>Contains generated Refit implementation types.</summary>
-    internal partial class Generated
+    internal partial class GeneratedCompilation
     {
         /// <summary>Generated Refit implementation for global::RefitGeneratorTest.IGeneratedClient.</summary>
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [global::System.Diagnostics.DebuggerNonUserCode]
-        [global::RefitInternalGenerated.PreserveAttribute]
+        [global::RefitInternalGenerated.Compilation.PreserveAttribute]
         [global::System.Reflection.Obfuscation(Exclude=true)]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         private sealed class RefitGeneratorTestIGeneratedClient

--- a/src/tests/Refit.GeneratorTests/_snapshots/ReturnTypeTests.ReturnNullableObject#IGeneratedClient.g.verified.cs
+++ b/src/tests/Refit.GeneratorTests/_snapshots/ReturnTypeTests.ReturnNullableObject#IGeneratedClient.g.verified.cs
@@ -7,12 +7,12 @@
 namespace Refit.Implementation
 {
     /// <summary>Contains generated Refit implementation types.</summary>
-    internal partial class Generated
+    internal partial class GeneratedCompilation
     {
         /// <summary>Generated Refit implementation for global::RefitGeneratorTest.IGeneratedClient.</summary>
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [global::System.Diagnostics.DebuggerNonUserCode]
-        [global::RefitInternalGenerated.PreserveAttribute]
+        [global::RefitInternalGenerated.Compilation.PreserveAttribute]
         [global::System.Reflection.Obfuscation(Exclude=true)]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         private sealed class RefitGeneratorTestIGeneratedClient

--- a/src/tests/Refit.GeneratorTests/_snapshots/ReturnTypeTests.ReturnNullableValueType#IGeneratedClient.g.verified.cs
+++ b/src/tests/Refit.GeneratorTests/_snapshots/ReturnTypeTests.ReturnNullableValueType#IGeneratedClient.g.verified.cs
@@ -7,12 +7,12 @@
 namespace Refit.Implementation
 {
     /// <summary>Contains generated Refit implementation types.</summary>
-    internal partial class Generated
+    internal partial class GeneratedCompilation
     {
         /// <summary>Generated Refit implementation for global::RefitGeneratorTest.IGeneratedClient.</summary>
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [global::System.Diagnostics.DebuggerNonUserCode]
-        [global::RefitInternalGenerated.PreserveAttribute]
+        [global::RefitInternalGenerated.Compilation.PreserveAttribute]
         [global::System.Reflection.Obfuscation(Exclude=true)]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         private sealed class RefitGeneratorTestIGeneratedClient

--- a/src/tests/Refit.GeneratorTests/_snapshots/ReturnTypeTests.ReturnUnsupportedType#IGeneratedClient.g.verified.cs
+++ b/src/tests/Refit.GeneratorTests/_snapshots/ReturnTypeTests.ReturnUnsupportedType#IGeneratedClient.g.verified.cs
@@ -7,12 +7,12 @@
 namespace Refit.Implementation
 {
     /// <summary>Contains generated Refit implementation types.</summary>
-    internal partial class Generated
+    internal partial class GeneratedCompilation
     {
         /// <summary>Generated Refit implementation for global::RefitGeneratorTest.IGeneratedClient.</summary>
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [global::System.Diagnostics.DebuggerNonUserCode]
-        [global::RefitInternalGenerated.PreserveAttribute]
+        [global::RefitInternalGenerated.Compilation.PreserveAttribute]
         [global::System.Reflection.Obfuscation(Exclude=true)]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         private sealed class RefitGeneratorTestIGeneratedClient

--- a/src/tests/Refit.GeneratorTests/_snapshots/ReturnTypeTests.ValueTaskApiResponseShouldWork#IGeneratedClient.g.verified.cs
+++ b/src/tests/Refit.GeneratorTests/_snapshots/ReturnTypeTests.ValueTaskApiResponseShouldWork#IGeneratedClient.g.verified.cs
@@ -7,12 +7,12 @@
 namespace Refit.Implementation
 {
     /// <summary>Contains generated Refit implementation types.</summary>
-    internal partial class Generated
+    internal partial class GeneratedCompilation
     {
         /// <summary>Generated Refit implementation for global::RefitGeneratorTest.IGeneratedClient.</summary>
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [global::System.Diagnostics.DebuggerNonUserCode]
-        [global::RefitInternalGenerated.PreserveAttribute]
+        [global::RefitInternalGenerated.Compilation.PreserveAttribute]
         [global::System.Reflection.Obfuscation(Exclude=true)]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         private sealed class RefitGeneratorTestIGeneratedClient

--- a/src/tests/Refit.GeneratorTests/_snapshots/ReturnTypeTests.VoidTaskShouldWork#IGeneratedClient.g.verified.cs
+++ b/src/tests/Refit.GeneratorTests/_snapshots/ReturnTypeTests.VoidTaskShouldWork#IGeneratedClient.g.verified.cs
@@ -7,12 +7,12 @@
 namespace Refit.Implementation
 {
     /// <summary>Contains generated Refit implementation types.</summary>
-    internal partial class Generated
+    internal partial class GeneratedCompilation
     {
         /// <summary>Generated Refit implementation for global::RefitGeneratorTest.IGeneratedClient.</summary>
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [global::System.Diagnostics.DebuggerNonUserCode]
-        [global::RefitInternalGenerated.PreserveAttribute]
+        [global::RefitInternalGenerated.Compilation.PreserveAttribute]
         [global::System.Reflection.Obfuscation(Exclude=true)]
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         private sealed class RefitGeneratorTestIGeneratedClient

--- a/src/tests/Refit.Tests/UniqueNameTests.cs
+++ b/src/tests/Refit.Tests/UniqueNameTests.cs
@@ -90,4 +90,37 @@ public class UniqueNameTests
 
         await Assert.That(name).Contains(nameof(IGlobalNamespaceRefitApi));
     }
+
+    /// <summary>Verifies a null or empty assembly name yields no scope, keeping the historical container name.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task MissingAssemblyNameProducesNoScope()
+    {
+        await Assert.That(UniqueName.SanitizeAssemblyName(null)).IsEqualTo(string.Empty);
+        await Assert.That(UniqueName.SanitizeAssemblyName(string.Empty)).IsEqualTo(string.Empty);
+    }
+
+    /// <summary>Verifies a lowercase assembly name is folded in Pascal-cased.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task LowercaseAssemblyNameIsPascalCased()
+    {
+        await Assert.That(UniqueName.SanitizeAssemblyName("myapp")).IsEqualTo("Myapp");
+    }
+
+    /// <summary>Verifies characters that cannot appear in an identifier, such as dots and dashes, become underscores.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task NonIdentifierCharactersBecomeUnderscores()
+    {
+        await Assert.That(UniqueName.SanitizeAssemblyName("Refit.Tests-1")).IsEqualTo("Refit_Tests_1");
+    }
+
+    /// <summary>Verifies a leading digit is preserved (it cannot be upper-cased) since the container base prefixes it.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Test]
+    public async Task LeadingDigitAssemblyNameIsPreserved()
+    {
+        await Assert.That(UniqueName.SanitizeAssemblyName("7zip")).IsEqualTo("7zip");
+    }
 }

--- a/src/tests/Refit.Tests/UniqueNameTests.cs
+++ b/src/tests/Refit.Tests/UniqueNameTests.cs
@@ -100,12 +100,12 @@ public class UniqueNameTests
         await Assert.That(UniqueName.SanitizeAssemblyName(string.Empty)).IsEqualTo(string.Empty);
     }
 
-    /// <summary>Verifies a lowercase assembly name is folded in Pascal-cased.</summary>
+    /// <summary>Verifies a lowercase assembly name is folded in with its case preserved (no forced Pascal-casing).</summary>
     /// <returns>A task that represents the asynchronous test operation.</returns>
     [Test]
-    public async Task LowercaseAssemblyNameIsPascalCased()
+    public async Task LowercaseAssemblyNameIsPreserved()
     {
-        await Assert.That(UniqueName.SanitizeAssemblyName("myapp")).IsEqualTo("Myapp");
+        await Assert.That(UniqueName.SanitizeAssemblyName("myapp")).IsEqualTo("myapp");
     }
 
     /// <summary>Verifies characters that cannot appear in an identifier, such as dots and dashes, become underscores.</summary>
@@ -116,7 +116,7 @@ public class UniqueNameTests
         await Assert.That(UniqueName.SanitizeAssemblyName("Refit.Tests-1")).IsEqualTo("Refit_Tests_1");
     }
 
-    /// <summary>Verifies a leading digit is preserved (it cannot be upper-cased) since the container base prefixes it.</summary>
+    /// <summary>Verifies a leading digit is preserved; the container base name prefixes it, so the result stays valid.</summary>
     /// <returns>A task that represents the asynchronous test operation.</returns>
     [Test]
     public async Task LeadingDigitAssemblyNameIsPreserved()


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (source generator + runtime).

## What is the new behavior?

- The generator folds the (identifier-sanitized, Pascal-cased) assembly name into the generated implementation container type and the internal `PreserveAttribute` namespace, so each assembly emits distinctly named copies (e.g. `Refit.Implementation.GeneratedMyApp`).
- Two assemblies linked by `[InternalsVisibleTo]` that both use Refit now compile cleanly.
- `UniqueName.ForType` reconstructs the identical container name at runtime (its own sanitizer, mirroring the generator), so reflection-based resolution and the derived `IHttpClientFactory` client key stay in sync with the emitted code.

## What is the current behavior?

Every assembly emitted the same `Refit.Implementation.Generated` container and `RefitInternalGenerated.PreserveAttribute`. Under `[InternalsVisibleTo]` the second compilation imported those alongside the ones it generated, producing `CS0436` duplicate-type warnings that fail a `TreatWarningsAsErrors` build.

Closes #2254

## What might this PR break?

- `UniqueName.ForType<T>()` (and the `IHttpClientFactory` client key derived from it) returns a different string - it now includes the interface's assembly name. The value is computed at runtime, never hardcoded, so no consumer code change is needed. v14 is still beta.

## Checklist
- [x] I have read the [Contribute guide](https://www.reactiveui.net/contribute/index.html)
- [x] Tests have been added or updated (for bug fixes / features)
- [x] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the `main` branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional information

The scope segment maps every non-identifier character to `_` and upper-cases the first character; a null/blank assembly name yields no segment (unnamed compilations keep the historic `Generated` name). The generator builds it and the runtime `UniqueName` reconstructs it independently - a mirrored pair guarded by a parity test that resolves a generic interface against the real emitted assembly. `dotnet test -c Release` from `./src`: 7065 passed, 0 failed (net8-net11); `UniqueName.cs` is 100 percent line and branch.
