### PR TITLE
perf: cut Roslyn source generator allocations on the emit and parse paths

### DIFF
--- a/src/InterfaceStubGenerator.Roslyn48/InterfaceStubGenerator.Roslyn48.csproj
+++ b/src/InterfaceStubGenerator.Roslyn48/InterfaceStubGenerator.Roslyn48.csproj
@@ -24,6 +24,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- The generator deliberately avoids LINQ on its per-keystroke hot paths (iterator/closure allocations).
+         ImplicitUsings would otherwise import System.Linq, so remove it to make accidental LINQ a compile error. -->
+    <Using Remove="System.Linq"/>
+  </ItemGroup>
+
+  <ItemGroup>
     <Compile Include="..\InterfaceStubGenerator.Shared\**\*.cs" LinkBase="InterfaceStubGenerator.Shared"/>
   </ItemGroup>
 

--- a/src/InterfaceStubGenerator.Roslyn48/InterfaceStubGenerator.Roslyn48.csproj
+++ b/src/InterfaceStubGenerator.Roslyn48/InterfaceStubGenerator.Roslyn48.csproj
@@ -20,6 +20,7 @@
   <ItemGroup>
     <InternalsVisibleTo Include="Refit.Tests"/>
     <InternalsVisibleTo Include="Refit.GeneratorTests"/>
+    <InternalsVisibleTo Include="Refit.Generator.Benchmarks"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/InterfaceStubGenerator.Roslyn50/InterfaceStubGenerator.Roslyn50.csproj
+++ b/src/InterfaceStubGenerator.Roslyn50/InterfaceStubGenerator.Roslyn50.csproj
@@ -19,6 +19,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="Refit.GeneratorTests"/>
+    <InternalsVisibleTo Include="Refit.Generator.Benchmarks"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/InterfaceStubGenerator.Roslyn50/InterfaceStubGenerator.Roslyn50.csproj
+++ b/src/InterfaceStubGenerator.Roslyn50/InterfaceStubGenerator.Roslyn50.csproj
@@ -23,6 +23,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- The generator deliberately avoids LINQ on its per-keystroke hot paths (iterator/closure allocations).
+         ImplicitUsings would otherwise import System.Linq, so remove it to make accidental LINQ a compile error. -->
+    <Using Remove="System.Linq"/>
+  </ItemGroup>
+
+  <ItemGroup>
     <Compile Include="..\InterfaceStubGenerator.Shared\**\*.cs" LinkBase="InterfaceStubGenerator.Shared"/>
   </ItemGroup>
 

--- a/src/InterfaceStubGenerator.Shared/Emitter.Buffers.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.Buffers.cs
@@ -30,7 +30,7 @@ internal static partial class Emitter
     /// <param name="parts">The source fragments.</param>
     /// <param name="count">The populated fragment count.</param>
     /// <returns>The concatenated source.</returns>
-    private static string ConcatParts(string[] parts, int count)
+    internal static string ConcatParts(string[] parts, int count)
     {
         var length = 0;
         for (var i = 0; i < count; i++)
@@ -56,7 +56,7 @@ internal static partial class Emitter
     /// <param name="count">The populated fragment count.</param>
     /// <param name="separator">The separator text.</param>
     /// <returns>The joined source.</returns>
-    private static string JoinParts(string[] parts, int count, string separator)
+    internal static string JoinParts(string[] parts, int count, string separator)
     {
         if (count == 0)
         {
@@ -94,14 +94,14 @@ internal static partial class Emitter
     /// instead of allocating an identical fresh string at every per-method and per-parameter call site. Levels beyond
     /// the cache allocate a fresh string, a fallback reached only by nesting deeper than the shared test fixtures.</remarks>
     [ExcludeFromCodeCoverage]
-    private static string Indent(int level) =>
+    internal static string Indent(int level) =>
         (uint)level < (uint)IndentCache.Length
             ? IndentCache[level]
             : new string(' ', level * CharsPerIndentation);
 
     /// <summary>Precomputes the shared indentation strings for levels 0 through <see cref="MaxCachedIndentLevel"/>.</summary>
     /// <returns>The cached indentation strings, indexed by level.</returns>
-    private static string[] BuildIndentCache()
+    internal static string[] BuildIndentCache()
     {
         var cache = new string[MaxCachedIndentLevel + 1];
         for (var level = 0; level <= MaxCachedIndentLevel; level++)
@@ -168,7 +168,7 @@ internal static partial class Emitter
     /// <param name="destination">The target character span.</param>
     /// <param name="value">The value to quote, or <see langword="null"/>.</param>
     /// <param name="position">The current write position.</param>
-    private static void AppendLiteralOrNull(Span<char> destination, string? value, ref int position)
+    internal static void AppendLiteralOrNull(Span<char> destination, string? value, ref int position)
     {
         if (value is null)
         {
@@ -200,7 +200,7 @@ internal static partial class Emitter
     /// <param name="destination">The target character span.</param>
     /// <param name="value">The non-negative value to render (callers only pass <c>CollectionFormat</c> values).</param>
     /// <param name="position">The current write position.</param>
-    private static void AppendInt32(Span<char> destination, int value, ref int position)
+    internal static void AppendInt32(Span<char> destination, int value, ref int position)
     {
         var end = position + Int32Length(value);
         var write = end;
@@ -249,7 +249,7 @@ internal static partial class Emitter
     /// <param name="state">The caller supplied state.</param>
     /// <param name="action">The buffer fill callback.</param>
     /// <returns>The generated string.</returns>
-    private static string CreateGeneratedString<TState>(
+    internal static string CreateGeneratedString<TState>(
         int length,
         TState state,
         GeneratedStringAction<TState> action) =>
@@ -262,7 +262,7 @@ internal static partial class Emitter
     /// <param name="destination">The target character buffer.</param>
     /// <param name="text">The text to append.</param>
     /// <param name="position">The current write position.</param>
-    private static void AppendText(Span<char> destination, string text, ref int position)
+    internal static void AppendText(Span<char> destination, string text, ref int position)
     {
         text.AsSpan().CopyTo(destination[position..]);
         position += text.Length;

--- a/src/InterfaceStubGenerator.Shared/Emitter.Constraints.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.Constraints.cs
@@ -18,7 +18,7 @@ internal static partial class Emitter
     /// <param name="isOverrideOrExplicitImplementation">True if emitting for an override or explicit implementation.</param>
     /// <param name="indentationLevel">The generated indentation level.</param>
     /// <returns>The generated type constraint clauses.</returns>
-    private static string BuildConstraints(
+    internal static string BuildConstraints(
         ImmutableEquatableArray<TypeConstraint> typeParameters,
         bool isOverrideOrExplicitImplementation,
         int indentationLevel)
@@ -52,7 +52,7 @@ internal static partial class Emitter
     /// <param name="isOverrideOrExplicitImplementation">True if emitting for an override or explicit implementation.</param>
     /// <param name="indentationLevel">The generated indentation level.</param>
     /// <returns>The generated type constraint clause, or an empty string.</returns>
-    private static string BuildConstraintsForTypeParameter(
+    internal static string BuildConstraintsForTypeParameter(
         in TypeConstraint typeParameter,
         bool isOverrideOrExplicitImplementation,
         int indentationLevel) =>
@@ -69,7 +69,7 @@ internal static partial class Emitter
     /// <param name="typeParameter">The type parameter constraint to inspect.</param>
     /// <param name="isOverrideOrExplicitImplementation">True if emitting for an override or explicit implementation.</param>
     /// <returns><see langword="true"/> when at least one constraint should be emitted.</returns>
-    private static bool HasConstraintKeywords(
+    internal static bool HasConstraintKeywords(
         in TypeConstraint typeParameter,
         bool isOverrideOrExplicitImplementation)
     {
@@ -86,7 +86,7 @@ internal static partial class Emitter
     /// <param name="typeParameter">The type parameter constraint to inspect.</param>
     /// <param name="isOverrideOrExplicitImplementation">True if emitting for an override or explicit implementation.</param>
     /// <returns>The generated constraint list.</returns>
-    private static string BuildConstraintList(
+    internal static string BuildConstraintList(
         in TypeConstraint typeParameter,
         bool isOverrideOrExplicitImplementation)
     {
@@ -127,7 +127,7 @@ internal static partial class Emitter
     /// <param name="keyword">The constraint keyword.</param>
     /// <param name="condition">Whether the keyword should be emitted.</param>
     /// <param name="count">The populated part count.</param>
-    private static void AddConstraint(
+    internal static void AddConstraint(
         string[] parts,
         string keyword,
         bool condition,

--- a/src/InterfaceStubGenerator.Shared/Emitter.Helpers.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.Helpers.cs
@@ -295,7 +295,7 @@ internal static partial class Emitter
     /// <param name="methodModel">The method model being emitted.</param>
     /// <param name="isExplicitInterface">Whether the method is emitted explicitly.</param>
     /// <returns>The explicit interface prefix, or an empty string.</returns>
-    private static string BuildExplicitInterfacePrefix(MethodModel methodModel, bool isExplicitInterface)
+    internal static string BuildExplicitInterfacePrefix(MethodModel methodModel, bool isExplicitInterface)
     {
         if (!isExplicitInterface)
         {
@@ -312,7 +312,7 @@ internal static partial class Emitter
     /// <param name="parameters">The parameter models.</param>
     /// <param name="supportsNullable">Whether the consumer compilation supports nullable reference type syntax.</param>
     /// <returns>The generated method parameter list.</returns>
-    private static string BuildParameterList(
+    internal static string BuildParameterList(
         ImmutableEquatableArray<ParameterModel> parameters,
         bool supportsNullable)
     {

--- a/src/InterfaceStubGenerator.Shared/Emitter.Inline.Content.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.Inline.Content.cs
@@ -16,7 +16,7 @@ internal static partial class Emitter
     /// <param name="emission">The shared emission locals and helper state.</param>
     /// <param name="locals">The method-scope unique local name builder.</param>
     /// <returns>The generated content assignment.</returns>
-    private static string BuildInlineContent(
+    internal static string BuildInlineContent(
         RequestParameterModel bodyParameter,
         string requestLocal,
         string settingsLocal,
@@ -80,7 +80,7 @@ internal static partial class Emitter
     /// <param name="emission">The shared emission locals and helper state.</param>
     /// <param name="locals">The method-scope unique local name builder.</param>
     /// <returns>The generated content assignment.</returns>
-    private static string BuildInlineFormUnroll(
+    internal static string BuildInlineFormUnroll(
         RequestParameterModel bodyParameter,
         string requestLocal,
         bool supportsNullable,
@@ -129,7 +129,7 @@ internal static partial class Emitter
     /// <param name="field">The form field descriptor.</param>
     /// <param name="site">The shared locals and rendered fragments for the enclosing body.</param>
     /// <param name="emission">The shared emission locals and helper state.</param>
-    private static void AppendFormFieldUnroll(
+    internal static void AppendFormFieldUnroll(
         PooledStringBuilder sb,
         FormFieldModel field,
         in FormUnrollSite site,
@@ -179,7 +179,7 @@ internal static partial class Emitter
     /// <param name="indent">The statement indentation.</param>
     /// <param name="keyExpr">The field key expression.</param>
     /// <param name="valueExpr">The field value expression.</param>
-    private static void AppendFormEntryAdd(PooledStringBuilder sb, in FormUnrollSite site, string indent, string keyExpr, string valueExpr) =>
+    internal static void AppendFormEntryAdd(PooledStringBuilder sb, in FormUnrollSite site, string indent, string keyExpr, string valueExpr) =>
         _ = sb.Append(indent).Append(site.EntriesLocal).Append(".Add(").Append(site.KvpNew)
             .Append('(').Append(keyExpr).Append(", ").Append(valueExpr).AppendLine("));");
 
@@ -188,7 +188,7 @@ internal static partial class Emitter
     /// <param name="valueLocal">The non-null value local name.</param>
     /// <param name="emission">The shared emission locals and helper state.</param>
     /// <returns>The rendering expression, branching to the formatter when it is customized.</returns>
-    private static string BuildFormFieldValueExpression(
+    internal static string BuildFormFieldValueExpression(
         FormFieldModel field,
         string valueLocal,
         in InlineValueEmission emission)
@@ -208,7 +208,7 @@ internal static partial class Emitter
     /// <param name="bodyParameter">The body parameter model, or null when the method has no body.</param>
     /// <returns><see langword="true"/> when every field is a simple scalar carrying a compile-time rendering strategy,
     /// so the body needs neither the descriptor array nor reflection on the common System.Text.Json path.</returns>
-    private static bool IsUnrollableFormBody(RequestParameterModel? bodyParameter)
+    internal static bool IsUnrollableFormBody(RequestParameterModel? bodyParameter)
     {
         if (bodyParameter is not { BodySerializationMethod: "UrlEncoded", FormFields: { Count: > 0 } formFields })
         {
@@ -232,7 +232,7 @@ internal static partial class Emitter
     /// <param name="bodyParameter">The body parameter model, or null when the method has no body.</param>
     /// <returns><see langword="true"/> when a field renders through the default-form-formatting branch, so the generated
     /// method must declare that branch local.</returns>
-    private static bool FormBodyHasFastPath(RequestParameterModel? bodyParameter)
+    internal static bool FormBodyHasFastPath(RequestParameterModel? bodyParameter)
     {
         if (!IsUnrollableFormBody(bodyParameter))
         {

--- a/src/InterfaceStubGenerator.Shared/Emitter.Inline.FormFields.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.Inline.FormFields.cs
@@ -14,7 +14,7 @@ internal static partial class Emitter
     /// <remarks>A known verb resolves to a framework-cached <see cref="System.Net.Http.HttpMethod"/> singleton. A custom
     /// verb otherwise constructs a new instance on every call; caching it in a static field matches the reflection
     /// builder, which reads the verb from the attribute once per method.</remarks>
-    private static (string Source, string Expression) BuildHttpMethodField(RequestModel request, UniqueNameBuilder uniqueNames)
+    internal static (string Source, string Expression) BuildHttpMethodField(RequestModel request, UniqueNameBuilder uniqueNames)
     {
         var expression = ToHttpMethodExpression(request.HttpMethod);
         if (!expression.StartsWith("new ", StringComparison.Ordinal))
@@ -39,7 +39,7 @@ internal static partial class Emitter
     /// <param name="supportsNullable">Whether the consumer compilation supports nullable reference type syntax.</param>
     /// <param name="supportsStaticLambdas">Whether the consumer compilation supports static lambda syntax.</param>
     /// <returns>The generated field declaration and its name, or empty values when the reflection path is used.</returns>
-    private static (string Source, string? FieldName) BuildFormFieldsField(
+    internal static (string Source, string? FieldName) BuildFormFieldsField(
         RequestParameterModel? bodyParameter,
         UniqueNameBuilder uniqueNames,
         bool supportsNullable,
@@ -86,7 +86,7 @@ internal static partial class Emitter
     /// <param name="elementIndent">The element indentation.</param>
     /// <param name="getterOpen">The language-version-specific getter lambda opening.</param>
     /// <returns>The rendered descriptor array element source.</returns>
-    private static string BuildFormFieldElements(FormFieldModel[] fields, string bodyType, string elementIndent, string getterOpen)
+    internal static string BuildFormFieldElements(FormFieldModel[] fields, string bodyType, string elementIndent, string getterOpen)
     {
         var elementsLength = 0;
         for (var i = 0; i < fields.Length; i++)
@@ -141,7 +141,7 @@ internal static partial class Emitter
     /// <param name="getterOpenLength">The length of the language-version-specific getter lambda opening.</param>
     /// <param name="indentLength">The element indentation length.</param>
     /// <returns>The number of characters the rendered element occupies.</returns>
-    private static int MeasureFormFieldElement(FormFieldModel field, string bodyType, int getterOpenLength, int indentLength) =>
+    internal static int MeasureFormFieldElement(FormFieldModel field, string bodyType, int getterOpenLength, int indentLength) =>
         indentLength
         + FormFieldNew.Length
         + bodyType.Length

--- a/src/InterfaceStubGenerator.Shared/Emitter.Inline.Method.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.Inline.Method.cs
@@ -146,11 +146,11 @@ internal static partial class Emitter
             .Append(formFieldsSource)
             .Append(httpMethodFieldSource)
             .Append(opening)
-            .Append(bodyIndent).Append("var ").Append(settingsLocal).Append(" = ").Append(settingsFieldName).Append(";\n")
+            .Append(bodyIndent).Append("var ").Append(settingsLocal).Append(" = ").Append(settingsFieldName).AppendLine(";")
             .Append(prologue)
             .Append(bodyIndent).Append("var ").Append(requestLocal)
             .Append(" = new global::System.Net.Http.HttpRequestMessage(").Append(httpMethodExpression)
-            .Append(", ").Append(requestUriExpression).Append(");\n")
+            .Append(", ").Append(requestUriExpression).AppendLine(");")
             .Append(contentSource)
             .Append(headerSource);
         AppendInlineRequestProperties(builder, request, interfaceModel, methodModel, requestLocal, settingsLocal);
@@ -159,7 +159,7 @@ internal static partial class Emitter
         // dispatching on the return shape), then the method's closing brace.
         _ = builder.Append(timeoutSource);
         AppendInlineReturn(builder, methodModel, request, plan);
-        _ = builder.Append(methodIndent).Append("}\n");
+        _ = builder.Append(methodIndent).AppendLine("}");
     }
 
     /// <summary>Appends a cold-observable inline generated Refit method: a per-subscription request factory and its send.</summary>

--- a/src/InterfaceStubGenerator.Shared/Emitter.Inline.Method.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.Inline.Method.cs
@@ -104,7 +104,7 @@ internal static partial class Emitter
         // (prologue locals, the message, content, headers, request properties, and an optional per-call timeout), then
         // the return statement and closing brace. Appended fragment-by-fragment so no intermediate block string forms.
         _ = builder
-            .Append(plan.ParamInfoBuilder.ToString())
+            .Append(plan.ParamInfoBuilder)
             .Append(fragments.FormFieldsSource)
             .Append(fragments.HttpMethodFieldSource)
             .Append(fragments.Opening)

--- a/src/InterfaceStubGenerator.Shared/Emitter.Inline.Method.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.Inline.Method.cs
@@ -136,13 +136,6 @@ internal static partial class Emitter
             : string.Empty;
         var opening = BuildMethodOpening(methodModel, isExplicit, isExplicit, interfaceModel.SupportsNullable);
 
-        // A Task<HttpRequestMessage> method hands the fully built request back to the caller without dispatching it. The
-        // caller owns the returned request and its content, so it is neither sent nor disposed here; every other shape
-        // emits its normal send-and-deserialize return.
-        var returnSource = methodModel.ReturnTypeMetadata == ReturnTypeInfo.RequestMessage
-            ? BuildInlineRequestMessageReturn(requestLocal)
-            : BuildInlineReturn(methodModel, request, plan.BufferBodyExpression, plan.CancellationTokenExpression, requestLocal, settingsLocal, plan.AdapterTokenLocal);
-
         // The method prefix (fields, opening, settings local), then the request construction shared by every shape
         // (prologue locals, the message, content, headers, request properties, and an optional per-call timeout), then
         // the return statement and closing brace. Appended fragment-by-fragment so no intermediate block string forms.
@@ -161,10 +154,12 @@ internal static partial class Emitter
             .Append(contentSource)
             .Append(headerSource);
         AppendInlineRequestProperties(builder, request, interfaceModel, methodModel, requestLocal, settingsLocal);
-        _ = builder
-            .Append(timeoutSource)
-            .Append(returnSource)
-            .Append(methodIndent).Append("}\n");
+
+        // The optional per-call timeout, then the send-and-deserialize statement (appended straight into the buffer,
+        // dispatching on the return shape), then the method's closing brace.
+        _ = builder.Append(timeoutSource);
+        AppendInlineReturn(builder, methodModel, request, plan);
+        _ = builder.Append(methodIndent).Append("}\n");
     }
 
     /// <summary>Appends a cold-observable inline generated Refit method: a per-subscription request factory and its send.</summary>

--- a/src/InterfaceStubGenerator.Shared/Emitter.Inline.Method.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.Inline.Method.cs
@@ -77,21 +77,65 @@ internal static partial class Emitter
     /// <summary>Appends a standard inline generated Refit method: prefix, request construction, and return statement.</summary>
     /// <param name="builder">The buffer accumulating the interface's generated method source.</param>
     /// <param name="methodModel">The method model being emitted.</param>
+    /// <param name="interfaceModel">The interface model being emitted.</param>
+    /// <param name="isExplicit">Whether the method is emitted as an explicit interface implementation.</param>
     /// <param name="settingsFieldName">The unique generated field name that stores Refit settings.</param>
+    /// <param name="uniqueNames">Contains the unique member names in the interface scope.</param>
     /// <param name="plan">The method-scope locals and pre-built request fragments.</param>
-    /// <param name="fragments">The computed request-construction fragments.</param>
+    /// <remarks>Fragments are computed in the same order the observable-path fragment builder uses so the sequence of
+    /// unique member/local name allocations (and therefore the generated names) stays byte-for-byte identical. Building a
+    /// query- or converter-bound fragment appends helper member declarations into <c>plan.ParamInfoBuilder</c>, so every
+    /// fragment is computed before that buffer is drained into <paramref name="builder"/>. The request prologue is the
+    /// one block accumulated into a scratch buffer and buffer-copied in below rather than materialized as a string.</remarks>
     internal static void AppendInlineStandardRefitMethod(
         PooledStringBuilder builder,
         MethodModel methodModel,
+        InterfaceModel interfaceModel,
+        bool isExplicit,
         string settingsFieldName,
-        in InlineMethodPlan plan,
-        in InlineMethodFragments fragments)
+        UniqueNameBuilder uniqueNames,
+        in InlineMethodPlan plan)
     {
         var request = methodModel.Request;
         var settingsLocal = plan.SettingsLocal;
         var requestLocal = plan.RequestLocal;
         var bodyIndent = Indent(MethodBodyIndentation);
         var methodIndent = Indent(MethodMemberIndentation);
+
+        var prologue = new PooledStringBuilder();
+        var requestPathExpression = AppendInlineRequestPrologue(prologue, request, plan, bodyIndent);
+        var (httpMethodFieldSource, httpMethodExpression) = BuildHttpMethodField(request, uniqueNames);
+
+        // A [Url] method dispatches to an absolute URI (the validated [Url] value with any query appended), bypassing
+        // the base-address merge; every other method builds a relative URI merged onto the base address.
+        var requestUriExpression = HasUrlParameter(request)
+            ? $"new global::System.Uri({requestPathExpression}, global::System.UriKind.Absolute)"
+            : BuildRelativeUriExpression(request, requestPathExpression, settingsLocal);
+        var (formFieldsSource, formFieldsFieldName) = BuildFormFieldsField(
+            plan.BodyParameter,
+            uniqueNames,
+            interfaceModel.SupportsNullable,
+            interfaceModel.SupportsStaticLambdas);
+
+        // A multipart method builds a MultipartFormDataContent from its parts; every other method has at most one body
+        // parameter (a multipart method never carries one), so the two paths never both apply.
+        var contentSource = plan.BodyParameter is null
+            ? string.Empty
+            : BuildInlineContent(plan.BodyParameter, requestLocal, settingsLocal, formFieldsFieldName, interfaceModel.SupportsNullable, plan.Emission, plan.Locals);
+        if (request.IsMultipart)
+        {
+            contentSource = BuildInlineMultipartContent(request, requestLocal, settingsLocal, plan.Locals);
+        }
+
+        var headerSource = BuildInlineHeaders(request, requestLocal, settingsLocal);
+        var requestPropertySource = BuildInlineRequestProperties(request, interfaceModel, methodModel, requestLocal, settingsLocal);
+
+        // A method that declares a positive [Timeout] stashes it on the request so the send helpers apply it; every
+        // other method emits nothing here and pays no per-call timeout cost.
+        var timeoutSource = request.TimeoutMilliseconds > 0
+            ? $"{bodyIndent}global::Refit.GeneratedRequestRunner.SetRequestTimeout({requestLocal}, {request.TimeoutMilliseconds});\n"
+            : string.Empty;
+        var opening = BuildMethodOpening(methodModel, isExplicit, isExplicit, interfaceModel.SupportsNullable);
 
         // A Task<HttpRequestMessage> method hands the fully built request back to the caller without dispatching it. The
         // caller owns the returned request and its content, so it is neither sent nor disposed here; every other shape
@@ -105,18 +149,18 @@ internal static partial class Emitter
         // the return statement and closing brace. Appended fragment-by-fragment so no intermediate block string forms.
         _ = builder
             .Append(plan.ParamInfoBuilder)
-            .Append(fragments.FormFieldsSource)
-            .Append(fragments.HttpMethodFieldSource)
-            .Append(fragments.Opening)
+            .Append(formFieldsSource)
+            .Append(httpMethodFieldSource)
+            .Append(opening)
             .Append(bodyIndent).Append("var ").Append(settingsLocal).Append(" = ").Append(settingsFieldName).Append(";\n")
-            .Append(fragments.RequestPrologueSource)
+            .Append(prologue)
             .Append(bodyIndent).Append("var ").Append(requestLocal)
-            .Append(" = new global::System.Net.Http.HttpRequestMessage(").Append(fragments.HttpMethodExpression)
-            .Append(", ").Append(fragments.RequestUriExpression).Append(");\n")
-            .Append(fragments.ContentSource)
-            .Append(fragments.HeaderSource)
-            .Append(fragments.RequestPropertySource)
-            .Append(fragments.TimeoutSource)
+            .Append(" = new global::System.Net.Http.HttpRequestMessage(").Append(httpMethodExpression)
+            .Append(", ").Append(requestUriExpression).Append(");\n")
+            .Append(contentSource)
+            .Append(headerSource)
+            .Append(requestPropertySource)
+            .Append(timeoutSource)
             .Append(returnSource)
             .Append(methodIndent).Append("}\n");
     }

--- a/src/InterfaceStubGenerator.Shared/Emitter.Inline.Method.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.Inline.Method.cs
@@ -1,0 +1,155 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Refit.Generator;
+
+/// <summary>Assembles an inline generated Refit method body from its computed request-construction fragments.</summary>
+internal static partial class Emitter
+{
+    /// <summary>Computes the per-method source fragments shared by every inline generated Refit method shape.</summary>
+    /// <param name="methodModel">The method model being emitted.</param>
+    /// <param name="interfaceModel">The interface model being emitted.</param>
+    /// <param name="isExplicit">Whether the method is emitted as an explicit interface implementation.</param>
+    /// <param name="uniqueNames">Contains the unique member names in the interface scope.</param>
+    /// <param name="plan">The method-scope locals and pre-built request fragments.</param>
+    /// <returns>The computed request-construction fragments.</returns>
+    internal static InlineMethodFragments BuildInlineMethodFragments(
+        MethodModel methodModel,
+        InterfaceModel interfaceModel,
+        bool isExplicit,
+        UniqueNameBuilder uniqueNames,
+        in InlineMethodPlan plan)
+    {
+        var request = methodModel.Request;
+        var settingsLocal = plan.SettingsLocal;
+        var requestLocal = plan.RequestLocal;
+        var emission = plan.Emission;
+        var bodyIndent = Indent(MethodBodyIndentation);
+
+        var requestPrologueSource = BuildInlineRequestPrologue(request, plan, bodyIndent, out var requestPathExpression);
+        var (httpMethodFieldSource, httpMethodExpression) = BuildHttpMethodField(request, uniqueNames);
+
+        // A [Url] method dispatches to an absolute URI (the validated [Url] value with any query appended), bypassing
+        // the base-address merge; every other method builds a relative URI merged onto the base address.
+        var requestUriExpression = HasUrlParameter(request)
+            ? $"new global::System.Uri({requestPathExpression}, global::System.UriKind.Absolute)"
+            : BuildRelativeUriExpression(request, requestPathExpression, settingsLocal);
+        var (formFieldsSource, formFieldsFieldName) = BuildFormFieldsField(
+            plan.BodyParameter,
+            uniqueNames,
+            interfaceModel.SupportsNullable,
+            interfaceModel.SupportsStaticLambdas);
+
+        // A multipart method builds a MultipartFormDataContent from its parts; every other method has at most one body
+        // parameter (a multipart method never carries one), so the two paths never both apply.
+        var contentSource = plan.BodyParameter is null
+            ? string.Empty
+            : BuildInlineContent(plan.BodyParameter, requestLocal, settingsLocal, formFieldsFieldName, interfaceModel.SupportsNullable, emission, plan.Locals);
+        if (request.IsMultipart)
+        {
+            contentSource = BuildInlineMultipartContent(request, requestLocal, settingsLocal, plan.Locals);
+        }
+
+        var headerSource = BuildInlineHeaders(request, requestLocal, settingsLocal);
+        var requestPropertySource = BuildInlineRequestProperties(request, interfaceModel, methodModel, requestLocal, settingsLocal);
+
+        // A method that declares a positive [Timeout] stashes it on the request so the send helpers apply it; every
+        // other method emits nothing here and pays no per-call timeout cost.
+        var timeoutSource = request.TimeoutMilliseconds > 0
+            ? $"{bodyIndent}global::Refit.GeneratedRequestRunner.SetRequestTimeout({requestLocal}, {request.TimeoutMilliseconds});\n"
+            : string.Empty;
+        var opening = BuildMethodOpening(methodModel, isExplicit, isExplicit, interfaceModel.SupportsNullable);
+
+        return new InlineMethodFragments(
+            requestPrologueSource,
+            httpMethodFieldSource,
+            httpMethodExpression,
+            requestUriExpression,
+            formFieldsSource,
+            contentSource,
+            headerSource,
+            requestPropertySource,
+            timeoutSource,
+            opening);
+    }
+
+    /// <summary>Appends a standard inline generated Refit method: prefix, request construction, and return statement.</summary>
+    /// <param name="builder">The buffer accumulating the interface's generated method source.</param>
+    /// <param name="methodModel">The method model being emitted.</param>
+    /// <param name="settingsFieldName">The unique generated field name that stores Refit settings.</param>
+    /// <param name="plan">The method-scope locals and pre-built request fragments.</param>
+    /// <param name="fragments">The computed request-construction fragments.</param>
+    internal static void AppendInlineStandardRefitMethod(
+        PooledStringBuilder builder,
+        MethodModel methodModel,
+        string settingsFieldName,
+        in InlineMethodPlan plan,
+        in InlineMethodFragments fragments)
+    {
+        var request = methodModel.Request;
+        var settingsLocal = plan.SettingsLocal;
+        var requestLocal = plan.RequestLocal;
+        var bodyIndent = Indent(MethodBodyIndentation);
+        var methodIndent = Indent(MethodMemberIndentation);
+
+        // A Task<HttpRequestMessage> method hands the fully built request back to the caller without dispatching it. The
+        // caller owns the returned request and its content, so it is neither sent nor disposed here; every other shape
+        // emits its normal send-and-deserialize return.
+        var returnSource = methodModel.ReturnTypeMetadata == ReturnTypeInfo.RequestMessage
+            ? BuildInlineRequestMessageReturn(requestLocal)
+            : BuildInlineReturn(methodModel, request, plan.BufferBodyExpression, plan.CancellationTokenExpression, requestLocal, settingsLocal, plan.AdapterTokenLocal);
+
+        // The method prefix (fields, opening, settings local), then the request construction shared by every shape
+        // (prologue locals, the message, content, headers, request properties, and an optional per-call timeout), then
+        // the return statement and closing brace. Appended fragment-by-fragment so no intermediate block string forms.
+        _ = builder
+            .Append(plan.ParamInfoBuilder.ToString())
+            .Append(fragments.FormFieldsSource)
+            .Append(fragments.HttpMethodFieldSource)
+            .Append(fragments.Opening)
+            .Append(bodyIndent).Append("var ").Append(settingsLocal).Append(" = ").Append(settingsFieldName).Append(";\n")
+            .Append(fragments.RequestPrologueSource)
+            .Append(bodyIndent).Append("var ").Append(requestLocal)
+            .Append(" = new global::System.Net.Http.HttpRequestMessage(").Append(fragments.HttpMethodExpression)
+            .Append(", ").Append(fragments.RequestUriExpression).Append(");\n")
+            .Append(fragments.ContentSource)
+            .Append(fragments.HeaderSource)
+            .Append(fragments.RequestPropertySource)
+            .Append(fragments.TimeoutSource)
+            .Append(returnSource)
+            .Append(methodIndent).Append("}\n");
+    }
+
+    /// <summary>Appends a cold-observable inline generated Refit method: a per-subscription request factory and its send.</summary>
+    /// <param name="builder">The buffer accumulating the interface's generated method source.</param>
+    /// <param name="methodModel">The method model being emitted.</param>
+    /// <param name="settingsFieldName">The unique generated field name that stores Refit settings.</param>
+    /// <param name="plan">The method-scope locals and pre-built request fragments.</param>
+    /// <param name="fragments">The computed request-construction fragments.</param>
+    internal static void AppendInlineObservableRefitMethod(
+        PooledStringBuilder builder,
+        MethodModel methodModel,
+        string settingsFieldName,
+        in InlineMethodPlan plan,
+        in InlineMethodFragments fragments)
+    {
+        var request = methodModel.Request;
+        var settingsLocal = plan.SettingsLocal;
+        var requestLocal = plan.RequestLocal;
+        var bodyIndent = Indent(MethodBodyIndentation);
+        var methodIndent = Indent(MethodMemberIndentation);
+        var prologue = fragments.RequestPrologueSource;
+        var httpMethod = fragments.HttpMethodExpression;
+        var uri = fragments.RequestUriExpression;
+
+        var methodPrefix = $"{plan.ParamInfoBuilder}{fragments.FormFieldsSource}{fragments.HttpMethodFieldSource}{fragments.Opening}{bodyIndent}var {settingsLocal} = {settingsFieldName};\n";
+        var requestConstruction = $$"""
+            {{prologue}}{{bodyIndent}}var {{requestLocal}} = new global::System.Net.Http.HttpRequestMessage({{httpMethod}}, {{uri}});
+            {{fragments.ContentSource}}{{fragments.HeaderSource}}{{fragments.RequestPropertySource}}{{fragments.TimeoutSource}}
+            """;
+        var buildRequestLocal = plan.Locals.New("BuildRefitRequest");
+        var observableReturn = BuildInlineObservableReturn(request, plan.BufferBodyExpression, plan.CancellationTokenExpression, buildRequestLocal, settingsLocal);
+        _ = builder.Append(BuildInlineObservableMethodSource(methodPrefix, requestConstruction, buildRequestLocal, requestLocal, observableReturn, bodyIndent, methodIndent));
+    }
+}

--- a/src/InterfaceStubGenerator.Shared/Emitter.Inline.Method.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.Inline.Method.cs
@@ -128,7 +128,6 @@ internal static partial class Emitter
         }
 
         var headerSource = BuildInlineHeaders(request, requestLocal, settingsLocal);
-        var requestPropertySource = BuildInlineRequestProperties(request, interfaceModel, methodModel, requestLocal, settingsLocal);
 
         // A method that declares a positive [Timeout] stashes it on the request so the send helpers apply it; every
         // other method emits nothing here and pays no per-call timeout cost.
@@ -147,6 +146,8 @@ internal static partial class Emitter
         // The method prefix (fields, opening, settings local), then the request construction shared by every shape
         // (prologue locals, the message, content, headers, request properties, and an optional per-call timeout), then
         // the return statement and closing brace. Appended fragment-by-fragment so no intermediate block string forms.
+        // Request properties bind no query/converter helpers, so they are appended straight in after the attribute-
+        // provider buffer has already been drained above.
         _ = builder
             .Append(plan.ParamInfoBuilder)
             .Append(formFieldsSource)
@@ -158,8 +159,9 @@ internal static partial class Emitter
             .Append(" = new global::System.Net.Http.HttpRequestMessage(").Append(httpMethodExpression)
             .Append(", ").Append(requestUriExpression).Append(");\n")
             .Append(contentSource)
-            .Append(headerSource)
-            .Append(requestPropertySource)
+            .Append(headerSource);
+        AppendInlineRequestProperties(builder, request, interfaceModel, methodModel, requestLocal, settingsLocal);
+        _ = builder
             .Append(timeoutSource)
             .Append(returnSource)
             .Append(methodIndent).Append("}\n");

--- a/src/InterfaceStubGenerator.Shared/Emitter.Inline.Multipart.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.Inline.Multipart.cs
@@ -35,7 +35,7 @@ internal static partial class Emitter
     /// <param name="settingsLocal">The generated settings local name.</param>
     /// <param name="locals">The method-scope unique local name builder.</param>
     /// <returns>The generated multipart content statements, ending with the request-content assignment.</returns>
-    private static string BuildInlineMultipartContent(
+    internal static string BuildInlineMultipartContent(
         RequestModel request,
         string requestLocal,
         string settingsLocal,
@@ -69,7 +69,7 @@ internal static partial class Emitter
     /// <param name="settingsLocal">The generated settings local name.</param>
     /// <param name="contentLocal">The generated multipart content local name.</param>
     /// <param name="locals">The method-scope unique local name builder.</param>
-    private static void AppendMultipartPart(
+    internal static void AppendMultipartPart(
         PooledStringBuilder sb,
         RequestParameterModel parameter,
         MultipartPartModel part,
@@ -115,7 +115,7 @@ internal static partial class Emitter
     /// <param name="contentLocal">The generated multipart content local name.</param>
     /// <param name="value">The value expression (a parameter accessor or a foreach element local).</param>
     /// <param name="indent">The statement indentation.</param>
-    private static void AppendMultipartAdd(
+    internal static void AppendMultipartAdd(
         PooledStringBuilder sb,
         MultipartPartModel part,
         string settingsLocal,
@@ -139,7 +139,7 @@ internal static partial class Emitter
     /// <remarks>The <see cref="MultipartPartKind"/> arms are exhaustive over statically-dispatchable part kinds; the
     /// compiler-required default arm handling the formattable kind cannot be selected for every kind by tests.</remarks>
     [ExcludeFromCodeCoverage]
-    private static void AppendMultipartAddArguments(
+    internal static void AppendMultipartAddArguments(
         PooledStringBuilder sb,
         MultipartPartModel part,
         string settingsLocal,
@@ -214,7 +214,7 @@ internal static partial class Emitter
     /// <param name="settingsLocal">The generated settings local name.</param>
     /// <param name="value">The value expression (a parameter accessor or a foreach element local).</param>
     /// <param name="fieldName">The C# string literal for the part's field name.</param>
-    private static void AppendSerializedMultipartArgument(PooledStringBuilder sb, string settingsLocal, string value, string fieldName)
+    internal static void AppendSerializedMultipartArgument(PooledStringBuilder sb, string settingsLocal, string value, string fieldName)
     {
         // A sealed/value part is JSON-serialized under its field name, matching AddSerializedMultipartItem's
         // serializer fallback. The declared type drives ToHttpContent<T>, so the serialized form matches; a

--- a/src/InterfaceStubGenerator.Shared/Emitter.Inline.ParameterInfo.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.Inline.ParameterInfo.cs
@@ -11,7 +11,7 @@ internal static partial class Emitter
     /// <param name="parameterName">The source parameter name.</param>
     /// <param name="uniqueNames">The unique member name builder for the interface scope.</param>
     /// <returns>The unique generated field name.</returns>
-    private static string GetParameterInfoFieldName(string parameterName, UniqueNameBuilder uniqueNames) =>
+    internal static string GetParameterInfoFieldName(string parameterName, UniqueNameBuilder uniqueNames) =>
         uniqueNames.New($"______{parameterName}AttributeProvider");
 
     /// <summary>Appends a separator before all but the first element.</summary>
@@ -19,7 +19,7 @@ internal static partial class Emitter
     /// <param name="sb">The target builder.</param>
     /// <param name="separator">The separator to append.</param>
     /// <returns>The same builder for chaining.</returns>
-    private static PooledStringBuilder AppendSeparator(int i, PooledStringBuilder sb, string separator = ", ")
+    internal static PooledStringBuilder AppendSeparator(int i, PooledStringBuilder sb, string separator = ", ")
     {
         return i <= 0 ? sb : sb.Append(separator);
     }
@@ -30,7 +30,7 @@ internal static partial class Emitter
     /// <param name="sb">The target builder.</param>
     /// <param name="separator">The separator to append before the value.</param>
     /// <returns>The same builder for chaining.</returns>
-    private static PooledStringBuilder AppendJoining(string value, int i, PooledStringBuilder sb, string separator = ", ")
+    internal static PooledStringBuilder AppendJoining(string value, int i, PooledStringBuilder sb, string separator = ", ")
     {
         return AppendSeparator(i, sb, separator).Append(value);
     }
@@ -38,7 +38,7 @@ internal static partial class Emitter
     /// <summary>Appends a C# attribute construction expression to the builder.</summary>
     /// <param name="attribute">The attribute model to render.</param>
     /// <param name="sb0">The target builder.</param>
-    private static void AppendAttributeValue(ParameterAttributeModel attribute, PooledStringBuilder sb0)
+    internal static void AppendAttributeValue(ParameterAttributeModel attribute, PooledStringBuilder sb0)
     {
         _ = sb0.Append("new ").Append(attribute.TypeExpression).Append('(');
         var i = 0;
@@ -72,7 +72,7 @@ internal static partial class Emitter
     /// <param name="method">The declaring method name, used for the generated documentation.</param>
     /// <param name="paramInfoFieldName">The unique generated field name.</param>
     /// <param name="sb">The target builder.</param>
-    private static void BuildParameterInfoField(RequestParameterModel parameter, string method, string paramInfoFieldName, PooledStringBuilder sb)
+    internal static void BuildParameterInfoField(RequestParameterModel parameter, string method, string paramInfoFieldName, PooledStringBuilder sb)
     {
         // Build the initializer.
         var memberIndent = Indent(MethodMemberIndentation);
@@ -130,7 +130,7 @@ internal static partial class Emitter
     /// <param name="declaredMethod">The declared method name the emitted fields are scoped to.</param>
     /// <param name="paramInfoSb">The builder receiving the emitted attribute-provider fields.</param>
     /// <returns>A map of parameter name to its cached attribute-provider field name.</returns>
-    private static Dictionary<string, string> BuildParameterInfoFields(
+    internal static Dictionary<string, string> BuildParameterInfoFields(
         RequestModel request,
         UniqueNameBuilder uniqueNames,
         string declaredMethod,
@@ -157,7 +157,7 @@ internal static partial class Emitter
     /// <param name="uniqueNameLookup">The map of parameter name to cached attribute-provider field name.</param>
     /// <param name="emission">The shared emission locals and helper state.</param>
     /// <returns>The generated argument list fragment.</returns>
-    private static string GetParametersArg(
+    internal static string GetParametersArg(
         RequestModel request,
         Dictionary<string, string> uniqueNameLookup,
         in InlineValueEmission emission)
@@ -204,7 +204,7 @@ internal static partial class Emitter
     /// <param name="uniqueNameLookup">The map of parameter name to cached attribute-provider field name.</param>
     /// <param name="emission">The shared emission locals and helper state.</param>
     /// <returns>The unordered path-template replacements.</returns>
-    private static List<PathReplacement> CollectPathReplacements(
+    internal static List<PathReplacement> CollectPathReplacements(
         RequestModel request,
         Dictionary<string, string> uniqueNameLookup,
         in InlineValueEmission emission)

--- a/src/InterfaceStubGenerator.Shared/Emitter.Inline.Path.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.Inline.Path.cs
@@ -15,13 +15,13 @@ internal static partial class Emitter
     /// stack (net8.0+ inline arrays) so no array is allocated; an older consumer receives an inferred array that the same
     /// <c>ReadOnlySpan</c> overload accepts via the array-to-span conversion. The array element type is inferred from the
     /// tuple values rather than stated, so no nullable reference annotation is emitted into a pre-C# 8 consumer.</remarks>
-    private static string WrapPathReplacements(string tuples, bool supportsCollectionExpressions) =>
+    internal static string WrapPathReplacements(string tuples, bool supportsCollectionExpressions) =>
         supportsCollectionExpressions ? ", [" + tuples + "]" : ", new[] { " + tuples + " }";
 
     /// <summary>Determines whether any path parameter passes its value through pre-encoded.</summary>
     /// <param name="request">The parsed request model.</param>
     /// <returns><see langword="true"/> when a path parameter carries <c>[Encoded]</c>.</returns>
-    private static bool HasPreEncodedPathParameter(RequestModel request)
+    internal static bool HasPreEncodedPathParameter(RequestModel request)
     {
         foreach (var parameter in request.Parameters)
         {
@@ -41,7 +41,7 @@ internal static partial class Emitter
     /// <param name="valueExpression">The replacement value expression.</param>
     /// <param name="includePreEncoded">Whether the tuple carries the per-value pre-encoded flag.</param>
     /// <param name="preEncoded">The pre-encoded flag value, emitted only when <paramref name="includePreEncoded"/> is set.</param>
-    private static void AppendPathTuple(
+    internal static void AppendPathTuple(
         PooledStringBuilder sb,
         int start,
         int end,
@@ -65,7 +65,7 @@ internal static partial class Emitter
     /// <param name="settingsLocal">The generated settings local name.</param>
     /// <param name="parameters">The default path builder argument fragment.</param>
     /// <returns>The generated path expression.</returns>
-    private static string BuildInlinePathExpression(
+    internal static string BuildInlinePathExpression(
         RequestModel request,
         Dictionary<string, string> parameterInfoNames,
         in InlineValueEmission emission,
@@ -87,7 +87,7 @@ internal static partial class Emitter
     /// <returns>The path expression using the span-formattable fast overload, or null to use the default path building.</returns>
     /// <remarks>The default-formatting branch formats the value straight into the path buffer (net6+ integers with no
     /// escaping, net10+ span-escaped values); a customized <c>IUrlParameterFormatter</c> falls back to the string overload.</remarks>
-    private static string? TryBuildInlinePathFastExpression(
+    internal static string? TryBuildInlinePathFastExpression(
         RequestModel request,
         Dictionary<string, string> parameterInfoNames,
         in InlineValueEmission emission)

--- a/src/InterfaceStubGenerator.Shared/Emitter.Inline.Query.Dictionary.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.Inline.Query.Dictionary.cs
@@ -20,7 +20,7 @@ internal static partial class Emitter
     /// attribute provider and the declared type, a blank key drops the pair, and the value is rendered using the
     /// enclosing parameter's attributes and declared type.
     /// </remarks>
-    private static void AppendDictionaryQueryStatements(
+    internal static void AppendDictionaryQueryStatements(
         PooledStringBuilder sb,
         RequestParameterModel parameter,
         QueryParameterModel query,
@@ -81,7 +81,7 @@ internal static partial class Emitter
     /// <param name="providerField">The cached attribute-provider field name.</param>
     /// <param name="emission">The shared emission locals and helper state.</param>
     /// <param name="entry">The generated locals and indentation for the current entry.</param>
-    private static void AppendDictionaryEntryStatements(
+    internal static void AppendDictionaryEntryStatements(
         PooledStringBuilder sb,
         RequestParameterModel parameter,
         QueryParameterModel query,
@@ -135,7 +135,7 @@ internal static partial class Emitter
     /// <param name="valueProperties">The flattened property descriptors of the value type.</param>
     /// <remarks>Reuses the query-object flattening walk with the entry key as the runtime parent key, so each value
     /// property emits an <c>entryKey.property=value</c> pair, matching the reflection builder's nested <c>BuildQueryMap</c>.</remarks>
-    private static void AppendDictionaryValueFlatten(
+    internal static void AppendDictionaryValueFlatten(
         PooledStringBuilder sb,
         RequestParameterModel parameter,
         QueryParameterModel query,

--- a/src/InterfaceStubGenerator.Shared/Emitter.Inline.Query.Formatters.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.Inline.Query.Formatters.cs
@@ -12,7 +12,7 @@ internal static partial class Emitter
     /// <param name="valueFormat">The enum rendering strategy.</param>
     /// <param name="emission">The shared emission locals and helper state.</param>
     /// <returns>The helper method name.</returns>
-    private static string GetOrAddEnumFormatter(
+    internal static string GetOrAddEnumFormatter(
         InlineValueFormatModel valueFormat,
         in InlineValueEmission emission)
     {
@@ -33,7 +33,7 @@ internal static partial class Emitter
     /// <param name="valueFormat">The enum rendering strategy.</param>
     /// <param name="helperName">The unique helper method name.</param>
     /// <param name="memberSb">The builder receiving emitted helper members.</param>
-    private static void AppendEnumFormatterSource(
+    internal static void AppendEnumFormatterSource(
         InlineValueFormatModel valueFormat,
         string helperName,
         PooledStringBuilder memberSb)
@@ -81,7 +81,7 @@ internal static partial class Emitter
     /// <param name="converterTypeName">The fully-qualified converter type.</param>
     /// <param name="emission">The shared emission locals and helper state.</param>
     /// <returns>The cached field name.</returns>
-    private static string GetOrAddConverterField(string converterTypeName, in InlineValueEmission emission)
+    internal static string GetOrAddConverterField(string converterTypeName, in InlineValueEmission emission)
     {
         var scope = emission.Scope;
         if (scope.Converters.TryGetValue(converterTypeName, out var existing))
@@ -99,7 +99,7 @@ internal static partial class Emitter
     /// <param name="converterTypeName">The fully-qualified converter type.</param>
     /// <param name="fieldName">The unique field name.</param>
     /// <param name="memberSb">The builder receiving emitted helper members.</param>
-    private static void AppendConverterFieldSource(
+    internal static void AppendConverterFieldSource(
         string converterTypeName,
         string fieldName,
         PooledStringBuilder memberSb)

--- a/src/InterfaceStubGenerator.Shared/Emitter.Inline.Query.Object.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.Inline.Query.Object.cs
@@ -20,7 +20,7 @@ internal static partial class Emitter
     /// form-url-encoded formatter first and omits the pair when it yields null; and the surviving value is rendered by
     /// the URL parameter formatter, which receives the enclosing <em>parameter's</em> attributes and declared type.
     /// </remarks>
-    private static void AppendObjectQueryStatements(
+    internal static void AppendObjectQueryStatements(
         PooledStringBuilder sb,
         RequestParameterModel parameter,
         QueryParameterModel query,
@@ -59,7 +59,7 @@ internal static partial class Emitter
     /// <param name="properties">The flattened property descriptors at this nesting level.</param>
     /// <param name="scope">The access expression, parent key, delimiter, local suffix and indentation.</param>
     /// <param name="emission">The shared emission locals and helper state.</param>
-    private static void AppendObjectPropertyList(
+    internal static void AppendObjectPropertyList(
         PooledStringBuilder sb,
         in QueryObjectContext context,
         ImmutableEquatableArray<QueryObjectPropertyModel> properties,
@@ -92,7 +92,7 @@ internal static partial class Emitter
     /// <param name="site">The generated locals and indentation for this property.</param>
     /// <param name="scope">The access expression and indentation for this nesting level.</param>
     /// <param name="emission">The shared emission locals and helper state.</param>
-    private static void AppendObjectLeafProperty(
+    internal static void AppendObjectLeafProperty(
         PooledStringBuilder sb,
         in QueryObjectContext context,
         QueryObjectPropertyModel property,
@@ -132,7 +132,7 @@ internal static partial class Emitter
     /// <param name="site">The generated value local, composed key expression, and indentation for this property.</param>
     /// <param name="scope">The nesting scope, supplying the key delimiter.</param>
     /// <param name="emission">The shared emission locals and helper state.</param>
-    private static void AppendObjectDictionaryProperty(
+    internal static void AppendObjectDictionaryProperty(
         PooledStringBuilder sb,
         in QueryObjectContext context,
         QueryObjectPropertyModel property,
@@ -204,7 +204,7 @@ internal static partial class Emitter
     /// <param name="context">The enclosing parameter and provider-field context.</param>
     /// <param name="emission">The shared emission locals and helper state.</param>
     /// <returns>The generated entry-key and value formatting expressions.</returns>
-    private static (string EntryKeyExpression, string ValueExpression) BuildDictionaryEntryExpressions(
+    internal static (string EntryKeyExpression, string ValueExpression) BuildDictionaryEntryExpressions(
         string entryLocal,
         string entryValueLocal,
         QueryDictionaryModel dictionary,
@@ -235,7 +235,7 @@ internal static partial class Emitter
     /// <param name="site">The generated value local and composed key expression for this property.</param>
     /// <param name="scope">The access expression, delimiter, local suffix and indentation for this level.</param>
     /// <param name="emission">The shared emission locals and helper state.</param>
-    private static void AppendNestedObjectProperty(
+    internal static void AppendNestedObjectProperty(
         PooledStringBuilder sb,
         in QueryObjectContext context,
         QueryObjectPropertyModel property,
@@ -292,7 +292,7 @@ internal static partial class Emitter
     /// <param name="delimiter">The nesting delimiter.</param>
     /// <param name="emission">The shared emission locals and helper state.</param>
     /// <returns>The composed key expression: parent key, delimiter, this property's own prefix, then its name.</returns>
-    private static string BuildNestedKeyExpression(
+    internal static string BuildNestedKeyExpression(
         QueryObjectPropertyModel property,
         string parentKeyExpr,
         string delimiter,
@@ -328,7 +328,7 @@ internal static partial class Emitter
     /// which reproduces both passes. A null collection is omitted unless <c>[Query(SerializeNull = true)]</c> emits a
     /// bare <c>key=</c>, matching the reflection builder.
     /// </remarks>
-    private static void AppendObjectQueryCollectionProperty(
+    internal static void AppendObjectQueryCollectionProperty(
         PooledStringBuilder sb,
         in QueryObjectContext context,
         QueryObjectPropertyModel property,
@@ -375,7 +375,7 @@ internal static partial class Emitter
     /// <param name="site">The generated locals and indentation, with <c>KeyExpression</c> set to the key local and
     /// <c>Indentation</c> set to the body indentation.</param>
     /// <param name="emission">The shared emission locals and helper state.</param>
-    private static void AppendCollectionPropertyBody(
+    internal static void AppendCollectionPropertyBody(
         PooledStringBuilder sb,
         in QueryObjectContext context,
         QueryObjectPropertyModel property,
@@ -414,7 +414,7 @@ internal static partial class Emitter
     /// <param name="parameterCollectionFormat">The enclosing parameter's <c>[Query(CollectionFormat)]</c>, or null.</param>
     /// <param name="emission">The shared emission locals and helper state.</param>
     /// <returns>A compile-time cast literal, or the runtime settings default.</returns>
-    private static string BuildCollectionFormatExpression(
+    internal static string BuildCollectionFormatExpression(
         int? propertyCollectionFormat,
         int? parameterCollectionFormat,
         in InlineValueEmission emission) =>
@@ -428,7 +428,7 @@ internal static partial class Emitter
     /// <param name="collection">The collection descriptor.</param>
     /// <param name="emission">The shared emission locals and helper state.</param>
     /// <returns>The reflection-free element expression, or a formatter call for an element with no inline rendering.</returns>
-    private static string BuildFastCollectionElementExpression(
+    internal static string BuildFastCollectionElementExpression(
         string elementLocal,
         InlineValueFormatModel elementFormat,
         QueryObjectCollectionModel collection,
@@ -456,7 +456,7 @@ internal static partial class Emitter
     /// <param name="site">The generated locals and indentation for this property.</param>
     /// <param name="providerField">The cached attribute-provider field name.</param>
     /// <param name="emission">The shared emission locals and helper state.</param>
-    private static void AppendNullableObjectQueryProperty(
+    internal static void AppendNullableObjectQueryProperty(
         PooledStringBuilder sb,
         RequestParameterModel parameter,
         QueryObjectPropertyModel property,
@@ -497,7 +497,7 @@ internal static partial class Emitter
     /// <param name="site">The generated locals and indentation for this property.</param>
     /// <param name="providerField">The cached attribute-provider field name.</param>
     /// <param name="emission">The shared emission locals and helper state.</param>
-    private static void AppendObjectQueryPropertyValue(
+    internal static void AppendObjectQueryPropertyValue(
         PooledStringBuilder sb,
         RequestParameterModel parameter,
         QueryObjectPropertyModel property,
@@ -522,7 +522,7 @@ internal static partial class Emitter
     /// <param name="providerField">The cached attribute-provider field name.</param>
     /// <param name="emission">The shared emission locals and helper state.</param>
     /// <param name="fastExpression">The reflection-free expression, or null when the formatter must always run.</param>
-    private static void AppendUnformattedObjectQueryProperty(
+    internal static void AppendUnformattedObjectQueryProperty(
         PooledStringBuilder sb,
         RequestParameterModel parameter,
         in QueryPropertySite site,
@@ -548,7 +548,7 @@ internal static partial class Emitter
     /// <param name="providerField">The cached attribute-provider field name.</param>
     /// <param name="emission">The shared emission locals and helper state.</param>
     /// <param name="fastExpression">The reflection-free expression, or null when the formatter must always run.</param>
-    private static void AppendFormattedObjectQueryProperty(
+    internal static void AppendFormattedObjectQueryProperty(
         PooledStringBuilder sb,
         RequestParameterModel parameter,
         QueryObjectPropertyModel property,
@@ -586,7 +586,7 @@ internal static partial class Emitter
     /// <param name="providerField">The cached attribute-provider field name.</param>
     /// <param name="emission">The shared emission locals and helper state.</param>
     /// <returns>The formatter call expression.</returns>
-    private static string BuildUrlFormatterCall(
+    internal static string BuildUrlFormatterCall(
         string valueExpression,
         string parameterTypeName,
         string providerField,
@@ -600,7 +600,7 @@ internal static partial class Emitter
     /// <param name="typeExpression">The declared-type expression passed to the formatter.</param>
     /// <param name="emission">The shared emission locals and helper state.</param>
     /// <returns>The formatter call expression, keeping the reflection and generated paths in parity.</returns>
-    private static string EmitFormatUrlParameter(
+    internal static string EmitFormatUrlParameter(
         string valueExpression,
         string providerExpression,
         string typeExpression,
@@ -611,7 +611,7 @@ internal static partial class Emitter
     /// <param name="property">The flattened property descriptor.</param>
     /// <param name="emission">The shared emission locals and helper state.</param>
     /// <returns>A constant literal when the key is fully known, otherwise a helper call or a settings-gated choice.</returns>
-    private static string BuildQueryObjectKeyExpression(QueryObjectPropertyModel property, in InlineValueEmission emission)
+    internal static string BuildQueryObjectKeyExpression(QueryObjectPropertyModel property, in InlineValueEmission emission)
     {
         // An [AliasAs] name always wins and bypasses the key formatter, so prefix + alias is fully known at compile time.
         if (property.ExplicitName is { } explicitName)
@@ -634,7 +634,7 @@ internal static partial class Emitter
     /// <param name="property">The flattened property descriptor.</param>
     /// <param name="emission">The shared emission locals and helper state.</param>
     /// <returns>The <c>BuildQueryKey</c> call expression.</returns>
-    private static string BuildQueryKeyHelperCall(QueryObjectPropertyModel property, in InlineValueEmission emission)
+    internal static string BuildQueryKeyHelperCall(QueryObjectPropertyModel property, in InlineValueEmission emission)
     {
         var clrName = ToCSharpStringLiteral(property.ClrName);
         var prefix = ToNullableCSharpStringLiteral(property.PrefixSegment);

--- a/src/InterfaceStubGenerator.Shared/Emitter.Inline.Query.Values.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.Inline.Query.Values.cs
@@ -20,7 +20,7 @@ internal static partial class Emitter
     /// <param name="providerField">The cached attribute-provider field name.</param>
     /// <param name="emission">The shared emission locals and helper state.</param>
     /// <returns>The generated formatting expression.</returns>
-    private static string BuildFormattedValueExpression(
+    internal static string BuildFormattedValueExpression(
         string valueExpression,
         bool canBeNullAtEvaluation,
         string parameterTypeName,
@@ -55,7 +55,7 @@ internal static partial class Emitter
     /// <param name="providerField">The cached attribute-provider field name.</param>
     /// <param name="emission">The shared emission locals and helper state.</param>
     /// <returns>The generated formatting expression.</returns>
-    private static string BuildPathValueExpression(
+    internal static string BuildPathValueExpression(
         RequestParameterModel parameter,
         string providerField,
         in InlineValueEmission emission)
@@ -84,7 +84,7 @@ internal static partial class Emitter
     /// <param name="providerField">The cached attribute-provider field name.</param>
     /// <param name="emission">The shared emission locals and helper state.</param>
     /// <returns>The path value expression.</returns>
-    private static string BuildPathValueExpressionCore(
+    internal static string BuildPathValueExpressionCore(
         string valueAccessor,
         string typeName,
         InlineValueFormatModel? valueFormat,
@@ -117,7 +117,7 @@ internal static partial class Emitter
     /// <remarks>Path bindings always carry a rendering strategy, so the absent-format arm is only reachable for a path
     /// parameter without one, which the shared fixtures never present.</remarks>
     [ExcludeFromCodeCoverage]
-    private static string? ComputeFastPathExpression(
+    internal static string? ComputeFastPathExpression(
         string valueAccessor,
         InlineValueFormatModel? valueFormat,
         in InlineValueEmission emission) =>
@@ -130,7 +130,7 @@ internal static partial class Emitter
     /// <returns><see langword="true"/> when the value has a span-formattable fast write on the consumer target.</returns>
     /// <remarks>Reuses the shared span-formattable tiers computed by the parser: an unformatted URL-safe integer (net6+)
     /// or any span-escapable value (net9+). A <c>TreatAsString</c> value stringifies first and stays on the string path.</remarks>
-    private static bool IsSpanFormattableFast(QueryParameterModel query, out string? format)
+    internal static bool IsSpanFormattableFast(QueryParameterModel query, out string? format)
     {
         var valueFormat = query.ValueFormat;
         format = valueFormat.Format;
@@ -145,7 +145,7 @@ internal static partial class Emitter
     /// <returns><see langword="true"/> when each element has an unformatted span-formattable fast write on the target.</returns>
     /// <remarks><c>AddCollectionValueFormatted</c> takes no format, so a per-element <c>[Query(Format)]</c> keeps the
     /// string-formatted path; only unformatted span-formattable elements qualify.</remarks>
-    private static bool IsCollectionSpanFormattableFast(QueryParameterModel query)
+    internal static bool IsCollectionSpanFormattableFast(QueryParameterModel query)
     {
         var valueFormat = query.ValueFormat;
         return !query.TreatAsString
@@ -160,7 +160,7 @@ internal static partial class Emitter
     /// <param name="valueFormat">The rendering strategy.</param>
     /// <param name="emission">The shared emission locals and helper state.</param>
     /// <returns>The fast-path expression, or <see langword="null"/> when the formatter must always run.</returns>
-    private static string? BuildFastFormatExpression(
+    internal static string? BuildFastFormatExpression(
         string valueExpression,
         InlineValueFormatModel valueFormat,
         in InlineValueEmission emission)

--- a/src/InterfaceStubGenerator.Shared/Emitter.Inline.Query.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.Inline.Query.cs
@@ -52,7 +52,7 @@ internal static partial class Emitter
     /// <summary>Determines whether any parameter binds to the query string.</summary>
     /// <param name="request">The parsed request model.</param>
     /// <returns><see langword="true"/> when query emission is required.</returns>
-    private static bool HasQueryBindings(RequestModel request)
+    internal static bool HasQueryBindings(RequestModel request)
     {
         foreach (var parameter in request.Parameters)
         {
@@ -68,7 +68,7 @@ internal static partial class Emitter
     /// <summary>Determines whether the generated method needs the default-formatting branch local.</summary>
     /// <param name="request">The parsed request model.</param>
     /// <returns><see langword="true"/> when at least one bound value has a reflection-free fast path.</returns>
-    private static bool NeedsFormattingLocal(RequestModel request)
+    internal static bool NeedsFormattingLocal(RequestModel request)
     {
         foreach (var parameter in request.Parameters)
         {
@@ -105,7 +105,7 @@ internal static partial class Emitter
     /// <summary>Determines whether any flattened property branches on the default-formatting local.</summary>
     /// <param name="properties">The flattened property descriptors.</param>
     /// <returns><see langword="true"/> when at least one property has a reflection-free fast path or a format.</returns>
-    private static bool ObjectPropertiesNeedFormattingLocal(ImmutableEquatableArray<QueryObjectPropertyModel> properties)
+    internal static bool ObjectPropertiesNeedFormattingLocal(ImmutableEquatableArray<QueryObjectPropertyModel> properties)
     {
         foreach (var property in properties)
         {
@@ -136,7 +136,7 @@ internal static partial class Emitter
     /// <summary>Determines whether a path parameter's value or any of its object bindings uses the fast-format branch.</summary>
     /// <param name="parameter">The path parameter model.</param>
     /// <returns><see langword="true"/> when the default-formatting local is referenced when formatting the value.</returns>
-    private static bool PathParameterNeedsFormattingLocal(RequestParameterModel parameter)
+    internal static bool PathParameterNeedsFormattingLocal(RequestParameterModel parameter)
     {
         if (parameter.ValueFormat is { Kind: not InlineFormatKind.FormatterOnly })
         {
@@ -162,14 +162,14 @@ internal static partial class Emitter
     /// <summary>Determines whether a parameter needs a generated attribute-provider field.</summary>
     /// <param name="parameter">The parameter model.</param>
     /// <returns><see langword="true"/> when formatting may consult the parameter's attributes at runtime.</returns>
-    private static bool NeedsAttributeProvider(RequestParameterModel parameter) =>
+    internal static bool NeedsAttributeProvider(RequestParameterModel parameter) =>
         parameter.Kind == RequestParameterKind.Path
         || parameter.Query is { Shape: not QueryParameterShape.Converter };
 
     /// <summary>Determines whether the generated method needs the default-form-formatting branch local.</summary>
     /// <param name="request">The parsed request model.</param>
     /// <returns><see langword="true"/> when a flattened query-object property carries a compile-time format.</returns>
-    private static bool NeedsFormFormattingLocal(RequestModel request)
+    internal static bool NeedsFormFormattingLocal(RequestModel request)
     {
         foreach (var parameter in request.Parameters)
         {
@@ -191,7 +191,7 @@ internal static partial class Emitter
     /// <summary>Determines whether any flattened property (recursing into nested objects) carries a compile-time format.</summary>
     /// <param name="properties">The flattened property descriptors.</param>
     /// <returns><see langword="true"/> when at least one property carries a <c>[Query(Format)]</c>.</returns>
-    private static bool ObjectPropertiesHaveFormat(ImmutableEquatableArray<QueryObjectPropertyModel> properties)
+    internal static bool ObjectPropertiesHaveFormat(ImmutableEquatableArray<QueryObjectPropertyModel> properties)
     {
         foreach (var property in properties)
         {
@@ -219,7 +219,7 @@ internal static partial class Emitter
     /// <param name="parameterInfoNames">The map of parameter name to cached attribute-provider field name.</param>
     /// <param name="emission">The shared emission locals and helper state.</param>
     /// <returns>The generated query statements.</returns>
-    private static string BuildInlineQueryStatements(
+    internal static string BuildInlineQueryStatements(
         RequestModel request,
         Dictionary<string, string> parameterInfoNames,
         in InlineValueEmission emission)
@@ -249,7 +249,7 @@ internal static partial class Emitter
     /// <remarks>The <see cref="QueryParameterShape"/> arms are exhaustive over the shapes the parser produces; the
     /// compiler-required collection default arm cannot be reached for every shape value by tests.</remarks>
     [ExcludeFromCodeCoverage]
-    private static void AppendInlineQueryStatement(
+    internal static void AppendInlineQueryStatement(
         PooledStringBuilder sb,
         RequestParameterModel parameter,
         QueryParameterModel query,
@@ -296,7 +296,7 @@ internal static partial class Emitter
     /// <param name="query">The query-binding metadata.</param>
     /// <param name="providerField">The cached attribute-provider field name.</param>
     /// <param name="emission">The shared emission locals and helper state.</param>
-    private static void AppendScalarQueryStatement(
+    internal static void AppendScalarQueryStatement(
         PooledStringBuilder sb,
         RequestParameterModel parameter,
         QueryParameterModel query,
@@ -325,7 +325,7 @@ internal static partial class Emitter
     /// <param name="providerField">The cached attribute-provider field name.</param>
     /// <param name="indent">The indentation of the emitted statement.</param>
     /// <param name="emission">The shared emission locals and helper state.</param>
-    private static void AppendScalarAddCall(
+    internal static void AppendScalarAddCall(
         PooledStringBuilder sb,
         RequestParameterModel parameter,
         QueryParameterModel query,
@@ -382,7 +382,7 @@ internal static partial class Emitter
     /// <returns>The C# string literal, URI-data-escaped unless <paramref name="preEncoded"/>.</returns>
     /// <remarks>Escaping here rather than on every request matches the reflection builder's output because
     /// <c>Uri.EscapeDataString</c> follows RFC 3986 consistently across the supported target frameworks.</remarks>
-    private static string BuildPreEscapedQueryKeyLiteral(string key, bool preEncoded) =>
+    internal static string BuildPreEscapedQueryKeyLiteral(string key, bool preEncoded) =>
         ToCSharpStringLiteral(preEncoded ? key : System.Uri.EscapeDataString(key));
 
     /// <summary>Appends the statements emitting one collection-valued query parameter or flag set.</summary>
@@ -391,7 +391,7 @@ internal static partial class Emitter
     /// <param name="query">The query-binding metadata.</param>
     /// <param name="providerField">The cached attribute-provider field name.</param>
     /// <param name="emission">The shared emission locals and helper state.</param>
-    private static void AppendCollectionQueryStatement(
+    internal static void AppendCollectionQueryStatement(
         PooledStringBuilder sb,
         RequestParameterModel parameter,
         QueryParameterModel query,
@@ -468,7 +468,7 @@ internal static partial class Emitter
     /// <param name="emission">The shared emission locals and helper state.</param>
     /// <param name="preEncoded">The rendered <c>preEncoded</c> boolean literal.</param>
     /// <param name="loopIndent">The indentation of the emitted call.</param>
-    private static void AppendBeginCollection(
+    internal static void AppendBeginCollection(
         PooledStringBuilder sb,
         QueryParameterModel query,
         in InlineValueEmission emission,
@@ -496,7 +496,7 @@ internal static partial class Emitter
     /// <param name="providerField">The cached attribute-provider field name.</param>
     /// <param name="emission">The shared emission locals and helper state.</param>
     /// <param name="itemIndent">The indentation of the emitted element statements.</param>
-    private static void AppendFastCollectionElement(
+    internal static void AppendFastCollectionElement(
         PooledStringBuilder sb,
         RequestParameterModel parameter,
         string providerField,
@@ -520,7 +520,7 @@ internal static partial class Emitter
     /// <param name="parameter">The parameter model.</param>
     /// <param name="query">The query-binding metadata.</param>
     /// <param name="emission">The shared emission locals and helper state.</param>
-    private static void AppendConverterQueryStatements(
+    internal static void AppendConverterQueryStatements(
         PooledStringBuilder sb,
         RequestParameterModel parameter,
         QueryParameterModel query,
@@ -561,7 +561,7 @@ internal static partial class Emitter
     /// <param name="MemberSource">The builder receiving emitted helper members.</param>
     /// <param name="SupportsCollectionExpressions">Whether the consumer supports C# 12 collection expressions, so path
     /// replacements are emitted as a stack-allocatable <c>[...]</c> span instead of an explicitly-typed array.</param>
-    private readonly record struct InlineValueEmission(
+    internal readonly record struct InlineValueEmission(
         string QueryBuilderLocal,
         string QueryValueLocal,
         string SettingsLocal,
@@ -576,7 +576,7 @@ internal static partial class Emitter
     /// <param name="KeyExpression">The query key expression, constant or key-formatter call.</param>
     /// <param name="PreEncoded">The rendered <c>preEncoded</c> boolean literal.</param>
     /// <param name="Indentation">The indentation of the statements emitting this property.</param>
-    private readonly record struct QueryPropertySite(
+    internal readonly record struct QueryPropertySite(
         string ValueLocal,
         string KeyExpression,
         string PreEncoded,
@@ -587,7 +587,7 @@ internal static partial class Emitter
     /// <param name="ProviderField">The cached attribute-provider field name for the parameter.</param>
     /// <param name="ParameterCollectionFormat">The parameter's <c>[Query(CollectionFormat)]</c>, or null.</param>
     /// <param name="PreEncoded">The rendered <c>preEncoded</c> boolean literal for the parameter.</param>
-    private readonly record struct QueryObjectContext(
+    internal readonly record struct QueryObjectContext(
         RequestParameterModel Parameter,
         string ProviderField,
         int? ParameterCollectionFormat,
@@ -599,7 +599,7 @@ internal static partial class Emitter
     /// <param name="Delimiter">The delimiter joining nested keys.</param>
     /// <param name="LocalSuffix">The suffix appended to generated local names to keep nested locals unique.</param>
     /// <param name="Indentation">The indentation of the statements emitted at this level.</param>
-    private readonly record struct ObjectFlattenScope(
+    internal readonly record struct ObjectFlattenScope(
         string AccessExpr,
         string? ParentKeyExpr,
         string Delimiter,
@@ -611,7 +611,7 @@ internal static partial class Emitter
     /// <param name="KeyLocal">The local receiving the formatted key.</param>
     /// <param name="ValueLocal">The local holding the entry value.</param>
     /// <param name="Indentation">The indentation of the statements emitting this entry.</param>
-    private readonly record struct DictionaryEntrySite(
+    internal readonly record struct DictionaryEntrySite(
         string EntryLocal,
         string KeyLocal,
         string ValueLocal,
@@ -619,7 +619,7 @@ internal static partial class Emitter
 
     /// <summary>Tracks the enum formatting helpers emitted for one generated interface implementation.</summary>
     /// <param name="uniqueNames">The unique member name builder for the interface scope.</param>
-    private sealed class EnumFormatterScope(UniqueNameBuilder uniqueNames)
+    internal sealed class EnumFormatterScope(UniqueNameBuilder uniqueNames)
     {
         /// <summary>Gets the emitted helper names keyed by enum type and compile-time format.</summary>
         public Dictionary<(string TypeName, string? Format), string> Formatters { get; } = new();

--- a/src/InterfaceStubGenerator.Shared/Emitter.Inline.Query.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.Inline.Query.cs
@@ -214,17 +214,17 @@ internal static partial class Emitter
         return false;
     }
 
-    /// <summary>Builds the query-appending statements for an inline generated method.</summary>
+    /// <summary>Appends the query-appending statements for an inline generated method straight into the prologue buffer.</summary>
+    /// <param name="sb">The buffer accumulating the request-prologue source.</param>
     /// <param name="request">The parsed request model.</param>
     /// <param name="parameterInfoNames">The map of parameter name to cached attribute-provider field name.</param>
     /// <param name="emission">The shared emission locals and helper state.</param>
-    /// <returns>The generated query statements.</returns>
-    internal static string BuildInlineQueryStatements(
+    internal static void AppendInlineQueryStatements(
+        PooledStringBuilder sb,
         RequestModel request,
         Dictionary<string, string> parameterInfoNames,
         in InlineValueEmission emission)
     {
-        var sb = new PooledStringBuilder();
         foreach (var parameter in request.Parameters)
         {
             if (parameter.Query is not { } query)
@@ -236,8 +236,6 @@ internal static partial class Emitter
             _ = parameterInfoNames.TryGetValue(parameter.Name, out var providerField);
             AppendInlineQueryStatement(sb, parameter, query, providerField, emission);
         }
-
-        return sb.ToString();
     }
 
     /// <summary>Appends the query-building statements for one parameter, dispatched on its query shape.</summary>

--- a/src/InterfaceStubGenerator.Shared/Emitter.Inline.RequestProperties.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.Inline.RequestProperties.cs
@@ -1,0 +1,103 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Refit.Generator;
+
+/// <summary>Emits inline request-construction source for generated Refit method implementations.</summary>
+/// <content>Emits the request-property/option application statements for an inline generated method.</content>
+internal static partial class Emitter
+{
+    /// <summary>The opening of a generated <c>GeneratedRequestRunner.AddRequestProperty</c> call up to the type argument.</summary>
+    private const string RunnerAddRequestProperty = "global::Refit.GeneratedRequestRunner.AddRequestProperty<";
+
+    /// <summary>The request-property key for the reflection-parity method name.</summary>
+    private const string MethodNameOption = "global::Refit.HttpRequestMessageOptions.MethodName";
+
+    /// <summary>The request-property key for the raw relative route template.</summary>
+    private const string RelativePathTemplateOption = "global::Refit.HttpRequestMessageOptions.RelativePathTemplate";
+
+    /// <summary>The request-property key for the captured method arguments array.</summary>
+    private const string MethodArgumentsOption = "global::Refit.HttpRequestMessageOptions.MethodArguments";
+
+    /// <summary>Builds request-option/property application for an inline generated method.</summary>
+    /// <param name="request">The parsed request model.</param>
+    /// <param name="interfaceModel">The interface model being emitted.</param>
+    /// <param name="methodModel">The method model being emitted.</param>
+    /// <param name="requestLocal">The generated request message local name.</param>
+    /// <param name="settingsLocal">The generated settings local name.</param>
+    /// <returns>The generated request option/property statements.</returns>
+    internal static string BuildInlineRequestProperties(
+        RequestModel request,
+        InterfaceModel interfaceModel,
+        MethodModel methodModel,
+        string requestLocal,
+        string settingsLocal)
+    {
+        // Append every statement into one pooled buffer. The previous string[] + ConcatParts shape allocated a
+        // throwaway interpolated string per statement; the emitted text is identical, appended with no intermediates.
+        var bodyIndent = Indent(MethodBodyIndentation);
+        var sb = new PooledStringBuilder();
+        _ = sb.Append(bodyIndent)
+            .Append("global::Refit.GeneratedRequestRunner.AddConfiguredRequestOptions(")
+            .Append(requestLocal).Append(ArgumentSeparator).Append(settingsLocal)
+            .Append(", typeof(").Append(interfaceModel.InterfaceDisplayName).Append("));\n");
+
+        // The method name (stripped of any explicit-interface prefix, matching reflection's MethodInfo.Name) and the
+        // raw route template are compile-time literals a source-gen handler reads without any runtime reflection.
+        var methodName = ToCSharpStringLiteral(StripExplicitInterfacePrefix(methodModel.Name));
+        AppendRequestProperty(sb, bodyIndent, requestLocal, "string", MethodNameOption, methodName);
+        var pathLiteral = ToCSharpStringLiteral(request.Path);
+        AppendRequestProperty(sb, bodyIndent, requestLocal, "string", RelativePathTemplateOption, pathLiteral);
+
+        // Capture the declared-order argument values only when RefitSettings.CaptureMethodArguments opts in, so the
+        // object[] allocation is paid per call solely when a handler needs them. The annotation is gated on the target
+        // language version so the C# 7.3 baseline still compiles.
+        var argumentsArrayType = interfaceModel.SupportsNullable ? "object?[]" : "object[]";
+        _ = sb.Append(bodyIndent).Append("if (").Append(settingsLocal)
+            .Append(".CaptureMethodArguments) { ").Append(RunnerAddRequestProperty)
+            .Append(argumentsArrayType).Append(">(").Append(requestLocal).Append(", ").Append(MethodArgumentsOption)
+            .Append(ArgumentSeparator)
+            .Append(BuildMethodArgumentsCaptureLiteral(methodModel, interfaceModel.SupportsNullable))
+            .Append("); }\n");
+
+        foreach (var property in interfaceModel.Properties)
+        {
+            if (property.RequestPropertyKey.Length != 0 && property.HasGetter)
+            {
+                var key = ToCSharpStringLiteral(property.RequestPropertyKey);
+                AppendRequestProperty(sb, bodyIndent, requestLocal, property.Type, key, BuildPropertyAccessExpression(property));
+            }
+        }
+
+        foreach (var parameter in request.Parameters)
+        {
+            if (parameter.Kind == RequestParameterKind.Property)
+            {
+                var key = ToCSharpStringLiteral(parameter.PropertyKey);
+                AppendRequestProperty(sb, bodyIndent, requestLocal, parameter.Type, key, "@" + parameter.Name);
+            }
+        }
+
+        return sb.ToString();
+    }
+
+    /// <summary>Appends one <c>AddRequestProperty&lt;T&gt;</c> statement directly into the request-property buffer.</summary>
+    /// <param name="sb">The pooled statement buffer.</param>
+    /// <param name="bodyIndent">The method-body indentation.</param>
+    /// <param name="requestLocal">The generated request message local name.</param>
+    /// <param name="typeArgument">The request-property value type argument.</param>
+    /// <param name="keyExpression">The property-key expression.</param>
+    /// <param name="valueExpression">The property-value expression.</param>
+    internal static void AppendRequestProperty(
+        PooledStringBuilder sb,
+        string bodyIndent,
+        string requestLocal,
+        string typeArgument,
+        string keyExpression,
+        string valueExpression) =>
+        sb.Append(bodyIndent).Append(RunnerAddRequestProperty).Append(typeArgument)
+            .Append(">(").Append(requestLocal).Append(ArgumentSeparator)
+            .Append(keyExpression).Append(ArgumentSeparator).Append(valueExpression)
+            .Append(");\n");
+}

--- a/src/InterfaceStubGenerator.Shared/Emitter.Inline.RequestProperties.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.Inline.RequestProperties.cs
@@ -60,7 +60,7 @@ internal static partial class Emitter
         _ = sb.Append(bodyIndent)
             .Append("global::Refit.GeneratedRequestRunner.AddConfiguredRequestOptions(")
             .Append(requestLocal).Append(ArgumentSeparator).Append(settingsLocal)
-            .Append(", typeof(").Append(interfaceModel.InterfaceDisplayName).Append("));\n");
+            .Append(", typeof(").Append(interfaceModel.InterfaceDisplayName).AppendLine("));");
 
         // The method name (stripped of any explicit-interface prefix, matching reflection's MethodInfo.Name) and the
         // raw route template are compile-time literals a source-gen handler reads without any runtime reflection.
@@ -78,7 +78,7 @@ internal static partial class Emitter
             .Append(argumentsArrayType).Append(">(").Append(requestLocal).Append(", ").Append(MethodArgumentsOption)
             .Append(ArgumentSeparator)
             .Append(BuildMethodArgumentsCaptureLiteral(methodModel, interfaceModel.SupportsNullable))
-            .Append("); }\n");
+            .AppendLine("); }");
 
         foreach (var property in interfaceModel.Properties)
         {
@@ -116,5 +116,5 @@ internal static partial class Emitter
         sb.Append(bodyIndent).Append(RunnerAddRequestProperty).Append(typeArgument)
             .Append(">(").Append(requestLocal).Append(ArgumentSeparator)
             .Append(keyExpression).Append(ArgumentSeparator).Append(valueExpression)
-            .Append(");\n");
+            .AppendLine(");");
 }

--- a/src/InterfaceStubGenerator.Shared/Emitter.Inline.RequestProperties.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.Inline.RequestProperties.cs
@@ -27,6 +27,8 @@ internal static partial class Emitter
     /// <param name="requestLocal">The generated request message local name.</param>
     /// <param name="settingsLocal">The generated settings local name.</param>
     /// <returns>The generated request option/property statements.</returns>
+    /// <remarks>The cold-observable shape reuses this block inside a string-interpolated construction block, so it
+    /// materializes it here; the standard shape appends it straight into the interface buffer.</remarks>
     internal static string BuildInlineRequestProperties(
         RequestModel request,
         InterfaceModel interfaceModel,
@@ -34,10 +36,27 @@ internal static partial class Emitter
         string requestLocal,
         string settingsLocal)
     {
-        // Append every statement into one pooled buffer. The previous string[] + ConcatParts shape allocated a
-        // throwaway interpolated string per statement; the emitted text is identical, appended with no intermediates.
-        var bodyIndent = Indent(MethodBodyIndentation);
         var sb = new PooledStringBuilder();
+        AppendInlineRequestProperties(sb, request, interfaceModel, methodModel, requestLocal, settingsLocal);
+        return sb.ToString();
+    }
+
+    /// <summary>Appends request-option/property application for an inline generated method straight into the buffer.</summary>
+    /// <param name="sb">The buffer accumulating the interface's generated method source.</param>
+    /// <param name="request">The parsed request model.</param>
+    /// <param name="interfaceModel">The interface model being emitted.</param>
+    /// <param name="methodModel">The method model being emitted.</param>
+    /// <param name="requestLocal">The generated request message local name.</param>
+    /// <param name="settingsLocal">The generated settings local name.</param>
+    internal static void AppendInlineRequestProperties(
+        PooledStringBuilder sb,
+        RequestModel request,
+        InterfaceModel interfaceModel,
+        MethodModel methodModel,
+        string requestLocal,
+        string settingsLocal)
+    {
+        var bodyIndent = Indent(MethodBodyIndentation);
         _ = sb.Append(bodyIndent)
             .Append("global::Refit.GeneratedRequestRunner.AddConfiguredRequestOptions(")
             .Append(requestLocal).Append(ArgumentSeparator).Append(settingsLocal)
@@ -78,8 +97,6 @@ internal static partial class Emitter
                 AppendRequestProperty(sb, bodyIndent, requestLocal, parameter.Type, key, "@" + parameter.Name);
             }
         }
-
-        return sb.ToString();
     }
 
     /// <summary>Appends one <c>AddRequestProperty&lt;T&gt;</c> statement directly into the request-property buffer.</summary>

--- a/src/InterfaceStubGenerator.Shared/Emitter.Inline.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.Inline.cs
@@ -34,8 +34,9 @@ internal static partial class Emitter
     /// <summary>The settings member read for the header validation flag, plus the call terminator that follows it.</summary>
     private const string ValidateHeadersMember = ".ValidateHeaders";
 
-    /// <summary>The indented <c>this.Client</c> argument line shared by every generated send-helper return statement.</summary>
-    private const string ClientArgumentLine = "    this.Client,\n";
+    /// <summary>The indented <c>this.Client</c> argument shared by every generated send-helper return statement; the
+    /// caller terminates it with <see cref="PooledStringBuilder.AppendLine(string)"/>.</summary>
+    private const string ClientArgument = "    this.Client,";
 
     /// <summary>Builds the body of the Refit method, appending it to the interface's method buffer.</summary>
     /// <param name="builder">The buffer accumulating the interface's generated method source.</param>
@@ -352,7 +353,7 @@ internal static partial class Emitter
     /// <param name="requestLocal">The generated request message local name.</param>
     internal static void AppendInlineRequestMessageReturn(PooledStringBuilder builder, string requestLocal) =>
         builder.Append(Indent(MethodBodyIndentation))
-            .Append("return global::System.Threading.Tasks.Task.FromResult(").Append(requestLocal).Append(");\n");
+            .Append("return global::System.Threading.Tasks.Task.FromResult(").Append(requestLocal).AppendLine(");");
 
     /// <summary>Appends the return statement for an inline generated Refit method straight into the method buffer.</summary>
     /// <param name="builder">The buffer accumulating the interface's generated method source.</param>
@@ -383,23 +384,23 @@ internal static partial class Emitter
         if (methodModel.ReturnTypeMetadata == ReturnTypeInfo.AsyncVoid)
         {
             _ = builder
-                .Append(bodyIndent).Append("return global::Refit.GeneratedRequestRunner.SendVoidAsync(\n")
-                .Append(bodyIndent).Append(ClientArgumentLine)
-                .Append(bodyIndent).Append("    ").Append(plan.RequestLocal).Append(",\n")
-                .Append(bodyIndent).Append("    ").Append(plan.SettingsLocal).Append(",\n")
-                .Append(bodyIndent).Append("    ").Append(plan.BufferBodyExpression).Append(",\n")
-                .Append(bodyIndent).Append("    ").Append(plan.CancellationTokenExpression).Append(");\n");
+                .Append(bodyIndent).AppendLine("return global::Refit.GeneratedRequestRunner.SendVoidAsync(")
+                .Append(bodyIndent).AppendLine(ClientArgument)
+                .Append(bodyIndent).Append("    ").Append(plan.RequestLocal).AppendLine(",")
+                .Append(bodyIndent).Append("    ").Append(plan.SettingsLocal).AppendLine(",")
+                .Append(bodyIndent).Append("    ").Append(plan.BufferBodyExpression).AppendLine(",")
+                .Append(bodyIndent).Append("    ").Append(plan.CancellationTokenExpression).AppendLine(");");
             return;
         }
 
         if (methodModel.ReturnTypeMetadata == ReturnTypeInfo.AsyncEnumerable)
         {
             _ = builder
-                .Append(bodyIndent).Append("return global::Refit.GeneratedRequestRunner.StreamAsync<").Append(request.ResultType).Append(">(\n")
-                .Append(bodyIndent).Append(ClientArgumentLine)
-                .Append(bodyIndent).Append("    ").Append(plan.RequestLocal).Append(",\n")
-                .Append(bodyIndent).Append("    ").Append(plan.SettingsLocal).Append(",\n")
-                .Append(bodyIndent).Append("    ").Append(plan.CancellationTokenExpression).Append(");\n");
+                .Append(bodyIndent).Append("return global::Refit.GeneratedRequestRunner.StreamAsync<").Append(request.ResultType).AppendLine(">(")
+                .Append(bodyIndent).AppendLine(ClientArgument)
+                .Append(bodyIndent).Append("    ").Append(plan.RequestLocal).AppendLine(",")
+                .Append(bodyIndent).Append("    ").Append(plan.SettingsLocal).AppendLine(",")
+                .Append(bodyIndent).Append("    ").Append(plan.CancellationTokenExpression).AppendLine(");");
             return;
         }
 
@@ -423,14 +424,14 @@ internal static partial class Emitter
         builder
             .Append(bodyIndent).Append("return new ").Append(adapterType).Append("().Adapt((").Append(plan.AdapterTokenLocal)
             .Append(") => global::Refit.GeneratedRequestRunner.SendAsync<").Append(request.ResultType).Append(", ")
-            .Append(request.DeserializedResultType).Append(">(\n")
-            .Append(bodyIndent).Append(ClientArgumentLine)
-            .Append(bodyIndent).Append("    ").Append(plan.RequestLocal).Append(",\n")
-            .Append(bodyIndent).Append("    ").Append(plan.SettingsLocal).Append(",\n")
-            .Append(bodyIndent).Append("    ").Append(ToLowerInvariantString(request.IsApiResponse)).Append(",\n")
-            .Append(bodyIndent).Append("    ").Append(ToLowerInvariantString(request.ShouldDisposeResponse)).Append(",\n")
-            .Append(bodyIndent).Append("    ").Append(plan.BufferBodyExpression).Append(",\n")
-            .Append(bodyIndent).Append("    ").Append(plan.AdapterTokenLocal).Append("));\n");
+            .Append(request.DeserializedResultType).AppendLine(">(")
+            .Append(bodyIndent).AppendLine(ClientArgument)
+            .Append(bodyIndent).Append("    ").Append(plan.RequestLocal).AppendLine(",")
+            .Append(bodyIndent).Append("    ").Append(plan.SettingsLocal).AppendLine(",")
+            .Append(bodyIndent).Append("    ").Append(ToLowerInvariantString(request.IsApiResponse)).AppendLine(",")
+            .Append(bodyIndent).Append("    ").Append(ToLowerInvariantString(request.ShouldDisposeResponse)).AppendLine(",")
+            .Append(bodyIndent).Append("    ").Append(plan.BufferBodyExpression).AppendLine(",")
+            .Append(bodyIndent).Append("    ").Append(plan.AdapterTokenLocal).AppendLine("));");
 
     /// <summary>Appends the awaited <c>SendAsync</c> return statement for the standard async-result inline path.</summary>
     /// <param name="builder">The buffer accumulating the interface's generated method source.</param>
@@ -459,14 +460,14 @@ internal static partial class Emitter
         }
 
         _ = builder
-            .Append(request.ResultType).Append(", ").Append(request.DeserializedResultType).Append(">(\n")
-            .Append(bodyIndent).Append(ClientArgumentLine)
-            .Append(bodyIndent).Append("    ").Append(plan.RequestLocal).Append(",\n")
-            .Append(bodyIndent).Append("    ").Append(plan.SettingsLocal).Append(",\n")
-            .Append(bodyIndent).Append("    ").Append(ToLowerInvariantString(request.IsApiResponse)).Append(",\n")
-            .Append(bodyIndent).Append("    ").Append(ToLowerInvariantString(request.ShouldDisposeResponse)).Append(",\n")
-            .Append(bodyIndent).Append("    ").Append(plan.BufferBodyExpression).Append(",\n")
-            .Append(bodyIndent).Append("    ").Append(plan.CancellationTokenExpression).Append(isValueTask ? "));\n" : ");\n");
+            .Append(request.ResultType).Append(", ").Append(request.DeserializedResultType).AppendLine(">(")
+            .Append(bodyIndent).AppendLine(ClientArgument)
+            .Append(bodyIndent).Append("    ").Append(plan.RequestLocal).AppendLine(",")
+            .Append(bodyIndent).Append("    ").Append(plan.SettingsLocal).AppendLine(",")
+            .Append(bodyIndent).Append("    ").Append(ToLowerInvariantString(request.IsApiResponse)).AppendLine(",")
+            .Append(bodyIndent).Append("    ").Append(ToLowerInvariantString(request.ShouldDisposeResponse)).AppendLine(",")
+            .Append(bodyIndent).Append("    ").Append(plan.BufferBodyExpression).AppendLine(",")
+            .Append(bodyIndent).Append("    ").Append(plan.CancellationTokenExpression).AppendLine(isValueTask ? "));" : ");");
     }
 
     /// <summary>Builds static and dynamic header application for an inline generated method.</summary>
@@ -510,7 +511,7 @@ internal static partial class Emitter
                         sb ??= new PooledStringBuilder();
                         _ = sb.Append(bodyIndent).Append("global::Refit.GeneratedRequestRunner.AddHeaderCollection(")
                             .Append(requestLocal).Append(ArgumentSeparator).Append("@").Append(parameter.Name)
-                            .Append(ArgumentSeparator).Append(settingsLocal).Append(ValidateHeadersMember).Append(");\n");
+                            .Append(ArgumentSeparator).Append(settingsLocal).Append(ValidateHeadersMember).AppendLine(");");
                         break;
                     }
 
@@ -542,7 +543,7 @@ internal static partial class Emitter
         string settingsLocal) =>
         sb.Append(bodyIndent).Append(RunnerSetHeader).Append(requestLocal).Append(ArgumentSeparator)
             .Append(nameExpression).Append(ArgumentSeparator).Append(valueExpression).Append(ArgumentSeparator)
-            .Append(settingsLocal).Append(ValidateHeadersMember).Append(");\n");
+            .Append(settingsLocal).Append(ValidateHeadersMember).AppendLine(");");
 
     /// <summary>Builds a header value expression without null-conditionals on non-nullable value types.</summary>
     /// <param name="parameter">The header parameter to format.</param>

--- a/src/InterfaceStubGenerator.Shared/Emitter.Inline.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.Inline.cs
@@ -34,6 +34,9 @@ internal static partial class Emitter
     /// <summary>The settings member read for the header validation flag, plus the call terminator that follows it.</summary>
     private const string ValidateHeadersMember = ".ValidateHeaders";
 
+    /// <summary>The indented <c>this.Client</c> argument line shared by every generated send-helper return statement.</summary>
+    private const string ClientArgumentLine = "    this.Client,\n";
+
     /// <summary>Builds the body of the Refit method, appending it to the interface's method buffer.</summary>
     /// <param name="builder">The buffer accumulating the interface's generated method source.</param>
     /// <param name="methodModel">The method model being emitted.</param>
@@ -344,119 +347,127 @@ internal static partial class Emitter
             """;
     }
 
-    /// <summary>Builds the return statement for a <c>Task&lt;HttpRequestMessage&gt;</c> method that returns the built request.</summary>
+    /// <summary>Appends the return statement for a <c>Task&lt;HttpRequestMessage&gt;</c> method that returns the built request.</summary>
+    /// <param name="builder">The buffer accumulating the interface's generated method source.</param>
     /// <param name="requestLocal">The generated request message local name.</param>
-    /// <returns>The generated return statement handing the built request back without sending it.</returns>
-    internal static string BuildInlineRequestMessageReturn(string requestLocal)
-    {
-        var bodyIndent = Indent(MethodBodyIndentation);
-        return $$"""
-            {{bodyIndent}}return global::System.Threading.Tasks.Task.FromResult({{requestLocal}});
+    internal static void AppendInlineRequestMessageReturn(PooledStringBuilder builder, string requestLocal) =>
+        builder.Append(Indent(MethodBodyIndentation))
+            .Append("return global::System.Threading.Tasks.Task.FromResult(").Append(requestLocal).Append(");\n");
 
-            """;
-    }
-
-    /// <summary>Builds the return statement for an inline generated Refit method.</summary>
+    /// <summary>Appends the return statement for an inline generated Refit method straight into the method buffer.</summary>
+    /// <param name="builder">The buffer accumulating the interface's generated method source.</param>
     /// <param name="methodModel">The method model being emitted.</param>
     /// <param name="request">The parsed request model.</param>
-    /// <param name="bufferBodyExpression">The expression indicating whether request content should be buffered.</param>
-    /// <param name="cancellationTokenExpression">The cancellation token expression.</param>
-    /// <param name="requestLocal">The generated request message local name.</param>
-    /// <param name="settingsLocal">The generated settings local name.</param>
-    /// <param name="adapterTokenLocal">The lambda parameter name for the return-type adapter's cancellation token.</param>
-    /// <returns>The generated return statement.</returns>
-    internal static string BuildInlineReturn(
+    /// <param name="plan">The method-scope locals and pre-built request fragments.</param>
+    internal static void AppendInlineReturn(
+        PooledStringBuilder builder,
         MethodModel methodModel,
         RequestModel request,
-        string bufferBodyExpression,
-        string cancellationTokenExpression,
-        string requestLocal,
-        string settingsLocal,
-        string adapterTokenLocal)
+        in InlineMethodPlan plan)
     {
+        // A Task<HttpRequestMessage> method hands the fully built request back to the caller without dispatching it. The
+        // caller owns the returned request and its content, so it is neither sent nor disposed here.
+        if (methodModel.ReturnTypeMetadata == ReturnTypeInfo.RequestMessage)
+        {
+            AppendInlineRequestMessageReturn(builder, plan.RequestLocal);
+            return;
+        }
+
         var bodyIndent = Indent(MethodBodyIndentation);
         if (request.AdapterTypeExpression is { } adapterType)
         {
-            // The adapter surfaces the call synchronously and receives a deferred send. The request is built eagerly
-            // and captured, so the deferred call is single-use (a second invocation sends a disposed request).
-            return $$"""
-                {{bodyIndent}}return new {{adapterType}}().Adapt(({{adapterTokenLocal}}) => global::Refit.GeneratedRequestRunner.SendAsync<{{request.ResultType}}, {{request.DeserializedResultType}}>(
-                {{bodyIndent}}    this.Client,
-                {{bodyIndent}}    {{requestLocal}},
-                {{bodyIndent}}    {{settingsLocal}},
-                {{bodyIndent}}    {{ToLowerInvariantString(request.IsApiResponse)}},
-                {{bodyIndent}}    {{ToLowerInvariantString(request.ShouldDisposeResponse)}},
-                {{bodyIndent}}    {{bufferBodyExpression}},
-                {{bodyIndent}}    {{adapterTokenLocal}}));
-
-                """;
+            AppendInlineAdapterReturn(builder, request, adapterType, plan, bodyIndent);
+            return;
         }
 
         if (methodModel.ReturnTypeMetadata == ReturnTypeInfo.AsyncVoid)
         {
-            return $$"""
-                {{bodyIndent}}return global::Refit.GeneratedRequestRunner.SendVoidAsync(
-                {{bodyIndent}}    this.Client,
-                {{bodyIndent}}    {{requestLocal}},
-                {{bodyIndent}}    {{settingsLocal}},
-                {{bodyIndent}}    {{bufferBodyExpression}},
-                {{bodyIndent}}    {{cancellationTokenExpression}});
-
-                """;
+            _ = builder
+                .Append(bodyIndent).Append("return global::Refit.GeneratedRequestRunner.SendVoidAsync(\n")
+                .Append(bodyIndent).Append(ClientArgumentLine)
+                .Append(bodyIndent).Append("    ").Append(plan.RequestLocal).Append(",\n")
+                .Append(bodyIndent).Append("    ").Append(plan.SettingsLocal).Append(",\n")
+                .Append(bodyIndent).Append("    ").Append(plan.BufferBodyExpression).Append(",\n")
+                .Append(bodyIndent).Append("    ").Append(plan.CancellationTokenExpression).Append(");\n");
+            return;
         }
 
-        return methodModel.ReturnTypeMetadata == ReturnTypeInfo.AsyncEnumerable
-            ? $$"""
-                {{bodyIndent}}return global::Refit.GeneratedRequestRunner.StreamAsync<{{request.ResultType}}>(
-                {{bodyIndent}}    this.Client,
-                {{bodyIndent}}    {{requestLocal}},
-                {{bodyIndent}}    {{settingsLocal}},
-                {{bodyIndent}}    {{cancellationTokenExpression}});
+        if (methodModel.ReturnTypeMetadata == ReturnTypeInfo.AsyncEnumerable)
+        {
+            _ = builder
+                .Append(bodyIndent).Append("return global::Refit.GeneratedRequestRunner.StreamAsync<").Append(request.ResultType).Append(">(\n")
+                .Append(bodyIndent).Append(ClientArgumentLine)
+                .Append(bodyIndent).Append("    ").Append(plan.RequestLocal).Append(",\n")
+                .Append(bodyIndent).Append("    ").Append(plan.SettingsLocal).Append(",\n")
+                .Append(bodyIndent).Append("    ").Append(plan.CancellationTokenExpression).Append(");\n");
+            return;
+        }
 
-                """
-            : BuildInlineSendAsyncReturn(methodModel, request, bufferBodyExpression, cancellationTokenExpression, requestLocal, settingsLocal, bodyIndent);
+        AppendInlineSendAsyncReturn(builder, methodModel, request, plan, bodyIndent);
     }
 
-    /// <summary>Builds the awaited <c>SendAsync</c> return statement for the standard async-result inline path.</summary>
+    /// <summary>Appends the deferred-send return statement for a return-type adapter into the method buffer.</summary>
+    /// <param name="builder">The buffer accumulating the interface's generated method source.</param>
+    /// <param name="request">The parsed request model.</param>
+    /// <param name="adapterType">The adapter type expression that surfaces the call synchronously.</param>
+    /// <param name="plan">The method-scope locals and pre-built request fragments.</param>
+    /// <param name="bodyIndent">The method-body indentation.</param>
+    /// <remarks>The adapter receives a deferred send: the request is built eagerly and captured, so the deferred call is
+    /// single-use (a second invocation would send a disposed request).</remarks>
+    internal static void AppendInlineAdapterReturn(
+        PooledStringBuilder builder,
+        RequestModel request,
+        string adapterType,
+        in InlineMethodPlan plan,
+        string bodyIndent) =>
+        builder
+            .Append(bodyIndent).Append("return new ").Append(adapterType).Append("().Adapt((").Append(plan.AdapterTokenLocal)
+            .Append(") => global::Refit.GeneratedRequestRunner.SendAsync<").Append(request.ResultType).Append(", ")
+            .Append(request.DeserializedResultType).Append(">(\n")
+            .Append(bodyIndent).Append(ClientArgumentLine)
+            .Append(bodyIndent).Append("    ").Append(plan.RequestLocal).Append(",\n")
+            .Append(bodyIndent).Append("    ").Append(plan.SettingsLocal).Append(",\n")
+            .Append(bodyIndent).Append("    ").Append(ToLowerInvariantString(request.IsApiResponse)).Append(",\n")
+            .Append(bodyIndent).Append("    ").Append(ToLowerInvariantString(request.ShouldDisposeResponse)).Append(",\n")
+            .Append(bodyIndent).Append("    ").Append(plan.BufferBodyExpression).Append(",\n")
+            .Append(bodyIndent).Append("    ").Append(plan.AdapterTokenLocal).Append("));\n");
+
+    /// <summary>Appends the awaited <c>SendAsync</c> return statement for the standard async-result inline path.</summary>
+    /// <param name="builder">The buffer accumulating the interface's generated method source.</param>
     /// <param name="methodModel">The method model being emitted.</param>
     /// <param name="request">The parsed request model.</param>
-    /// <param name="bufferBodyExpression">The request-body buffering expression.</param>
-    /// <param name="cancellationTokenExpression">The cancellation token expression.</param>
-    /// <param name="requestLocal">The generated request message local name.</param>
-    /// <param name="settingsLocal">The generated settings local name.</param>
+    /// <param name="plan">The method-scope locals and pre-built request fragments.</param>
     /// <param name="bodyIndent">The method-body indentation.</param>
-    /// <returns>The generated return statement.</returns>
-    internal static string BuildInlineSendAsyncReturn(
+    /// <remarks>A <c>ValueTask</c> result wraps the send in a <c>new ValueTask&lt;T&gt;(...)</c> and closes an extra
+    /// parenthesis; the two shapes are otherwise byte-identical, so they share one append sequence.</remarks>
+    internal static void AppendInlineSendAsyncReturn(
+        PooledStringBuilder builder,
         MethodModel methodModel,
         RequestModel request,
-        string bufferBodyExpression,
-        string cancellationTokenExpression,
-        string requestLocal,
-        string settingsLocal,
-        string bodyIndent) =>
-        methodModel.ReturnType.StartsWith("global::System.Threading.Tasks.ValueTask<", StringComparison.Ordinal)
-            ? $$"""
-                {{bodyIndent}}return new {{methodModel.ReturnType}}(global::Refit.GeneratedRequestRunner.SendAsync<{{request.ResultType}}, {{request.DeserializedResultType}}>(
-                {{bodyIndent}}    this.Client,
-                {{bodyIndent}}    {{requestLocal}},
-                {{bodyIndent}}    {{settingsLocal}},
-                {{bodyIndent}}    {{ToLowerInvariantString(request.IsApiResponse)}},
-                {{bodyIndent}}    {{ToLowerInvariantString(request.ShouldDisposeResponse)}},
-                {{bodyIndent}}    {{bufferBodyExpression}},
-                {{bodyIndent}}    {{cancellationTokenExpression}}));
+        in InlineMethodPlan plan,
+        string bodyIndent)
+    {
+        var isValueTask = methodModel.ReturnType.StartsWith("global::System.Threading.Tasks.ValueTask<", StringComparison.Ordinal);
+        _ = builder.Append(bodyIndent).Append(isValueTask ? "return new " : "return ");
+        if (isValueTask)
+        {
+            _ = builder.Append(methodModel.ReturnType).Append("(global::Refit.GeneratedRequestRunner.SendAsync<");
+        }
+        else
+        {
+            _ = builder.Append("global::Refit.GeneratedRequestRunner.SendAsync<");
+        }
 
-                """
-            : $$"""
-                {{bodyIndent}}return global::Refit.GeneratedRequestRunner.SendAsync<{{request.ResultType}}, {{request.DeserializedResultType}}>(
-                {{bodyIndent}}    this.Client,
-                {{bodyIndent}}    {{requestLocal}},
-                {{bodyIndent}}    {{settingsLocal}},
-                {{bodyIndent}}    {{ToLowerInvariantString(request.IsApiResponse)}},
-                {{bodyIndent}}    {{ToLowerInvariantString(request.ShouldDisposeResponse)}},
-                {{bodyIndent}}    {{bufferBodyExpression}},
-                {{bodyIndent}}    {{cancellationTokenExpression}});
-
-                """;
+        _ = builder
+            .Append(request.ResultType).Append(", ").Append(request.DeserializedResultType).Append(">(\n")
+            .Append(bodyIndent).Append(ClientArgumentLine)
+            .Append(bodyIndent).Append("    ").Append(plan.RequestLocal).Append(",\n")
+            .Append(bodyIndent).Append("    ").Append(plan.SettingsLocal).Append(",\n")
+            .Append(bodyIndent).Append("    ").Append(ToLowerInvariantString(request.IsApiResponse)).Append(",\n")
+            .Append(bodyIndent).Append("    ").Append(ToLowerInvariantString(request.ShouldDisposeResponse)).Append(",\n")
+            .Append(bodyIndent).Append("    ").Append(plan.BufferBodyExpression).Append(",\n")
+            .Append(bodyIndent).Append("    ").Append(plan.CancellationTokenExpression).Append(isValueTask ? "));\n" : ");\n");
+    }
 
     /// <summary>Builds static and dynamic header application for an inline generated method.</summary>
     /// <param name="request">The parsed request model.</param>

--- a/src/InterfaceStubGenerator.Shared/Emitter.Inline.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.Inline.cs
@@ -41,7 +41,7 @@ internal static partial class Emitter
     /// <param name="settingsFieldName">The unique generated field name that stores Refit settings.</param>
     /// <param name="enumFormatterScope">The enum formatter scope for the interface.</param>
     /// <returns>The generated method implementation.</returns>
-    private static string BuildRefitMethod(
+    internal static string BuildRefitMethod(
         MethodModel methodModel,
         bool isTopLevel,
         InterfaceModel interfaceModel,
@@ -103,7 +103,7 @@ internal static partial class Emitter
     /// <param name="uniqueNames">Contains the unique member names in the interface scope.</param>
     /// <param name="enumFormatterScope">The enum formatter scope for the interface.</param>
     /// <returns>The generated inline method implementation.</returns>
-    private static string BuildInlineRefitMethod(
+    internal static string BuildInlineRefitMethod(
         MethodModel methodModel,
         InterfaceModel interfaceModel,
         bool isTopLevel,
@@ -159,7 +159,7 @@ internal static partial class Emitter
     /// <param name="uniqueNames">Contains the unique member names in the interface scope.</param>
     /// <param name="plan">The method-scope locals and pre-built request fragments.</param>
     /// <returns>The generated inline method implementation.</returns>
-    private static string BuildInlineRefitMethodBody(
+    internal static string BuildInlineRefitMethodBody(
         MethodModel methodModel,
         InterfaceModel interfaceModel,
         bool isExplicit,
@@ -245,7 +245,7 @@ internal static partial class Emitter
     /// <param name="bodyIndent">The method-body indentation.</param>
     /// <param name="requestPathExpression">The request-path expression: the query builder's <c>Build()</c> call, or the path when no query binds.</param>
     /// <returns>The generated request-prologue source.</returns>
-    private static string BuildInlineRequestPrologue(
+    internal static string BuildInlineRequestPrologue(
         RequestModel request,
         in InlineMethodPlan plan,
         string bodyIndent,
@@ -297,7 +297,7 @@ internal static partial class Emitter
     /// <param name="pathExpression">The generated relative-path expression.</param>
     /// <param name="bodyIndent">The method-body indentation.</param>
     /// <returns>The request-path expression: the query builder's <c>Build()</c> call, or the path when no query binds.</returns>
-    private static string AppendInlineQueryPrologue(
+    internal static string AppendInlineQueryPrologue(
         PooledStringBuilder prologue,
         RequestModel request,
         Dictionary<string, string> parameterInfoNames,
@@ -336,7 +336,7 @@ internal static partial class Emitter
     /// <param name="bodyIndent">The method-body indentation.</param>
     /// <param name="methodIndent">The method-member indentation.</param>
     /// <returns>The generated method source.</returns>
-    private static string BuildInlineObservableMethodSource(
+    internal static string BuildInlineObservableMethodSource(
         string methodPrefix,
         string requestConstruction,
         string buildRequestLocal,
@@ -360,7 +360,7 @@ internal static partial class Emitter
     /// <param name="buildRequestLocal">The per-subscription request-building local function name.</param>
     /// <param name="settingsLocal">The generated settings local name.</param>
     /// <returns>The generated <c>return SendObservable(...)</c> statement.</returns>
-    private static string BuildInlineObservableReturn(
+    internal static string BuildInlineObservableReturn(
         RequestModel request,
         string bufferBodyExpression,
         string cancellationTokenExpression,
@@ -384,7 +384,7 @@ internal static partial class Emitter
     /// <summary>Builds the return statement for a <c>Task&lt;HttpRequestMessage&gt;</c> method that returns the built request.</summary>
     /// <param name="requestLocal">The generated request message local name.</param>
     /// <returns>The generated return statement handing the built request back without sending it.</returns>
-    private static string BuildInlineRequestMessageReturn(string requestLocal)
+    internal static string BuildInlineRequestMessageReturn(string requestLocal)
     {
         var bodyIndent = Indent(MethodBodyIndentation);
         return $$"""
@@ -402,7 +402,7 @@ internal static partial class Emitter
     /// <param name="settingsLocal">The generated settings local name.</param>
     /// <param name="adapterTokenLocal">The lambda parameter name for the return-type adapter's cancellation token.</param>
     /// <returns>The generated return statement.</returns>
-    private static string BuildInlineReturn(
+    internal static string BuildInlineReturn(
         MethodModel methodModel,
         RequestModel request,
         string bufferBodyExpression,
@@ -463,7 +463,7 @@ internal static partial class Emitter
     /// <param name="settingsLocal">The generated settings local name.</param>
     /// <param name="bodyIndent">The method-body indentation.</param>
     /// <returns>The generated return statement.</returns>
-    private static string BuildInlineSendAsyncReturn(
+    internal static string BuildInlineSendAsyncReturn(
         MethodModel methodModel,
         RequestModel request,
         string bufferBodyExpression,
@@ -500,7 +500,7 @@ internal static partial class Emitter
     /// <param name="requestLocal">The generated request message local name.</param>
     /// <param name="settingsLocal">The generated settings local name, read for the header validation flag.</param>
     /// <returns>The generated header statements.</returns>
-    private static string BuildInlineHeaders(RequestModel request, string requestLocal, string settingsLocal)
+    internal static string BuildInlineHeaders(RequestModel request, string requestLocal, string settingsLocal)
     {
         var parts = new string[request.StaticHeaders.Count + request.Parameters.Count];
         var count = 0;
@@ -554,7 +554,7 @@ internal static partial class Emitter
     /// <summary>Builds a header value expression without null-conditionals on non-nullable value types.</summary>
     /// <param name="parameter">The header parameter to format.</param>
     /// <returns>The generated header value expression.</returns>
-    private static string BuildHeaderValueExpression(RequestParameterModel parameter)
+    internal static string BuildHeaderValueExpression(RequestParameterModel parameter)
     {
         var parameterExpression = $"@{parameter.Name}";
         return parameter.CanBeNull
@@ -569,7 +569,7 @@ internal static partial class Emitter
     /// <param name="requestLocal">The generated request message local name.</param>
     /// <param name="settingsLocal">The generated settings local name.</param>
     /// <returns>The generated request option/property statements.</returns>
-    private static string BuildInlineRequestProperties(
+    internal static string BuildInlineRequestProperties(
         RequestModel request,
         InterfaceModel interfaceModel,
         MethodModel methodModel,
@@ -634,7 +634,7 @@ internal static partial class Emitter
     /// <summary>Creates a name builder reserved with a method's parameter names so generated locals never collide with them.</summary>
     /// <param name="parameters">The method parameters whose names must be avoided.</param>
     /// <returns>A <see cref="UniqueNameBuilder"/> seeded with the parameter names.</returns>
-    private static UniqueNameBuilder CreateMethodLocalNameBuilder(ImmutableEquatableArray<ParameterModel> parameters)
+    internal static UniqueNameBuilder CreateMethodLocalNameBuilder(ImmutableEquatableArray<ParameterModel> parameters)
     {
         var builder = new UniqueNameBuilder();
         foreach (var parameter in parameters)
@@ -648,7 +648,7 @@ internal static partial class Emitter
     /// <summary>Determines whether the request dispatches to an absolute URI supplied by a <c>[Url]</c> parameter.</summary>
     /// <param name="request">The request model to inspect.</param>
     /// <returns><see langword="true"/> when a <c>[Url]</c> parameter is present.</returns>
-    private static bool HasUrlParameter(RequestModel request) =>
+    internal static bool HasUrlParameter(RequestModel request) =>
         FindRequestParameter(request, RequestParameterKind.Url) is not null;
 
     /// <summary>Builds the relative-URI expression that merges the built path and query onto the client base address.</summary>
@@ -658,7 +658,7 @@ internal static partial class Emitter
     /// <returns>The generated <c>BuildRelativeUri</c> call.</returns>
     /// <remarks>A <c>[QueryUriFormat]</c> method re-encodes the whole path and query with the attribute's UriFormat,
     /// matching the reflection builder's final GetComponents pass; every other method uses the direct relative URI.</remarks>
-    private static string BuildRelativeUriExpression(RequestModel request, string requestPathExpression, string settingsLocal) =>
+    internal static string BuildRelativeUriExpression(RequestModel request, string requestPathExpression, string settingsLocal) =>
         request.QueryUriFormat is { } queryUriFormat
             ? $"global::Refit.GeneratedRequestRunner.BuildRelativeUri(this.Client, {requestPathExpression}, {settingsLocal}.UrlResolution, (global::System.UriFormat){queryUriFormat})"
             : $"global::Refit.GeneratedRequestRunner.BuildRelativeUri(this.Client, {requestPathExpression}, {settingsLocal}.UrlResolution)";
@@ -667,7 +667,7 @@ internal static partial class Emitter
     /// <param name="request">The request model to inspect.</param>
     /// <param name="kind">The parameter kind to find.</param>
     /// <returns>The parameter model, if present.</returns>
-    private static RequestParameterModel? FindRequestParameter(RequestModel request, RequestParameterKind kind)
+    internal static RequestParameterModel? FindRequestParameter(RequestModel request, RequestParameterKind kind)
     {
         foreach (var parameter in request.Parameters)
         {
@@ -683,7 +683,7 @@ internal static partial class Emitter
     /// <summary>Builds the cancellation token expression for an inline generated method.</summary>
     /// <param name="request">The request model to inspect.</param>
     /// <returns>The cancellation token expression.</returns>
-    private static string BuildCancellationTokenExpression(RequestModel request)
+    internal static string BuildCancellationTokenExpression(RequestModel request)
     {
         var cancellationToken = FindRequestParameter(request, RequestParameterKind.CancellationToken);
         if (cancellationToken is null)
@@ -699,7 +699,7 @@ internal static partial class Emitter
     /// <summary>Builds the body serialization enum expression for an inline generated method.</summary>
     /// <param name="bodyParameter">The parsed body parameter.</param>
     /// <returns>The serialization method expression.</returns>
-    private static string BuildBodySerializationMethodExpression(RequestParameterModel bodyParameter)
+    internal static string BuildBodySerializationMethodExpression(RequestParameterModel bodyParameter)
     {
         var serializationMethod = bodyParameter.BodySerializationMethod == "Json"
             ? "Serialized"
@@ -713,7 +713,7 @@ internal static partial class Emitter
     /// <param name="Indentation">The statement indentation.</param>
     /// <param name="KvpNew">The <c>new KeyValuePair&lt;...&gt;</c> constructor prefix, nullable-annotated per language version.</param>
     /// <param name="Locals">The method-scope unique local name builder.</param>
-    private readonly record struct FormUnrollSite(
+    internal readonly record struct FormUnrollSite(
         string BodyExpr,
         string EntriesLocal,
         string Indentation,
@@ -725,7 +725,7 @@ internal static partial class Emitter
     /// <param name="End">The placeholder end offset in the template.</param>
     /// <param name="Value">The generated replacement value expression.</param>
     /// <param name="PreEncoded">Whether the value passes through pre-encoded.</param>
-    private readonly record struct PathReplacement(int Start, int End, string Value, bool PreEncoded);
+    internal readonly record struct PathReplacement(int Start, int End, string Value, bool PreEncoded);
 
     /// <summary>The method-scope locals and pre-built request fragments threaded through inline method assembly.</summary>
     /// <param name="BodyParameter">The request body parameter, or null.</param>
@@ -739,7 +739,7 @@ internal static partial class Emitter
     /// <param name="ParamInfoBuilder">The builder holding the emitted attribute-provider fields.</param>
     /// <param name="Emission">The inline value-emission context.</param>
     /// <param name="Locals">The method-scope unique local name builder.</param>
-    private readonly record struct InlineMethodPlan(
+    internal readonly record struct InlineMethodPlan(
         RequestParameterModel? BodyParameter,
         string SettingsLocal,
         string RequestLocal,

--- a/src/InterfaceStubGenerator.Shared/Emitter.Inline.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.Inline.cs
@@ -28,10 +28,6 @@ internal static partial class Emitter
     /// <summary>The cast prefix for an explicit collection format value.</summary>
     private const string CollectionFormatCast = "(global::Refit.CollectionFormat)";
 
-    /// <summary>The count of request-property statements every inline method emits unconditionally: the configured-options
-    /// call, the method name, the raw route template, and the method-argument capture block.</summary>
-    private const int UnconditionalRequestPropertyCount = 4;
-
     /// <summary>Builds the body of the Refit method.</summary>
     /// <param name="methodModel">The method model being emitted.</param>
     /// <param name="isTopLevel">True if directly from the type we're generating for, false for methods found on base interfaces.</param>
@@ -560,75 +556,6 @@ internal static partial class Emitter
         return parameter.CanBeNull
             ? $"{parameterExpression}?.ToString()"
             : $"{parameterExpression}.ToString()";
-    }
-
-    /// <summary>Builds request-option/property application for an inline generated method.</summary>
-    /// <param name="request">The parsed request model.</param>
-    /// <param name="interfaceModel">The interface model being emitted.</param>
-    /// <param name="methodModel">The method model being emitted.</param>
-    /// <param name="requestLocal">The generated request message local name.</param>
-    /// <param name="settingsLocal">The generated settings local name.</param>
-    /// <returns>The generated request option/property statements.</returns>
-    internal static string BuildInlineRequestProperties(
-        RequestModel request,
-        InterfaceModel interfaceModel,
-        MethodModel methodModel,
-        string requestLocal,
-        string settingsLocal)
-    {
-        var parts = new string[UnconditionalRequestPropertyCount + interfaceModel.Properties.Count + request.Parameters.Count];
-        var count = 0;
-        var bodyIndent = Indent(MethodBodyIndentation);
-        parts[count] =
-            $"{bodyIndent}global::Refit.GeneratedRequestRunner.AddConfiguredRequestOptions({requestLocal}, {settingsLocal}, typeof({interfaceModel.InterfaceDisplayName}));\n";
-        count++;
-
-        // The method name (stripped of any explicit-interface prefix, matching reflection's MethodInfo.Name) and the
-        // raw route template are compile-time literals, so a source-gen handler can read the same low-cardinality
-        // metadata the reflection path publishes without any runtime reflection.
-        parts[count] =
-            $"{bodyIndent}global::Refit.GeneratedRequestRunner.AddRequestProperty<string>({requestLocal}, "
-            + $"global::Refit.HttpRequestMessageOptions.MethodName, {ToCSharpStringLiteral(StripExplicitInterfacePrefix(methodModel.Name))});\n";
-        count++;
-        parts[count] =
-            $"{bodyIndent}global::Refit.GeneratedRequestRunner.AddRequestProperty<string>({requestLocal}, "
-            + $"global::Refit.HttpRequestMessageOptions.RelativePathTemplate, {ToCSharpStringLiteral(request.Path)});\n";
-        count++;
-
-        // Capture the declared-order argument values only when RefitSettings.CaptureMethodArguments opts in, so the
-        // object[] allocation is paid per call solely when a handler needs the values. The nullable annotation is
-        // gated on the target language version so the C# 7.3 baseline still compiles.
-        var argumentsArrayType = interfaceModel.SupportsNullable ? "object?[]" : "object[]";
-        parts[count] =
-            $"{bodyIndent}if ({settingsLocal}.CaptureMethodArguments) {{ global::Refit.GeneratedRequestRunner.AddRequestProperty<{argumentsArrayType}>"
-            + $"({requestLocal}, global::Refit.HttpRequestMessageOptions.MethodArguments, {BuildMethodArgumentsCaptureLiteral(methodModel, interfaceModel.SupportsNullable)}); }}\n";
-        count++;
-
-        foreach (var property in interfaceModel.Properties)
-        {
-            if (property.RequestPropertyKey.Length == 0 || !property.HasGetter)
-            {
-                continue;
-            }
-
-            parts[count] =
-                $"{bodyIndent}global::Refit.GeneratedRequestRunner.AddRequestProperty<{property.Type}>"
-                + $"({requestLocal}, {ToCSharpStringLiteral(property.RequestPropertyKey)}, "
-                + $"{BuildPropertyAccessExpression(property)});\n";
-            count++;
-        }
-
-        foreach (var parameter in request.Parameters)
-        {
-            if (parameter.Kind == RequestParameterKind.Property)
-            {
-                parts[count] =
-                    $"{bodyIndent}global::Refit.GeneratedRequestRunner.AddRequestProperty<{parameter.Type}>({requestLocal}, {ToCSharpStringLiteral(parameter.PropertyKey)}, @{parameter.Name});\n";
-                count++;
-            }
-        }
-
-        return ConcatParts(parts, count);
     }
 
     /// <summary>Creates a name builder reserved with a method's parameter names so generated locals never collide with them.</summary>

--- a/src/InterfaceStubGenerator.Shared/Emitter.Inline.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.Inline.cs
@@ -34,27 +34,27 @@ internal static partial class Emitter
     /// <summary>The settings member read for the header validation flag, plus the call terminator that follows it.</summary>
     private const string ValidateHeadersMember = ".ValidateHeaders";
 
-    /// <summary>Builds the body of the Refit method.</summary>
+    /// <summary>Builds the body of the Refit method, appending it to the interface's method buffer.</summary>
+    /// <param name="builder">The buffer accumulating the interface's generated method source.</param>
     /// <param name="methodModel">The method model being emitted.</param>
     /// <param name="isTopLevel">True if directly from the type we're generating for, false for methods found on base interfaces.</param>
     /// <param name="interfaceModel">The interface model being emitted.</param>
     /// <param name="uniqueNames">Contains the unique member names in the interface scope.</param>
-    /// <param name="requestBuilderFieldName">The unique generated field name that stores the request builder.</param>
-    /// <param name="settingsFieldName">The unique generated field name that stores Refit settings.</param>
+    /// <param name="fieldNames">The generated request-builder and settings backing-field names.</param>
     /// <param name="enumFormatterScope">The enum formatter scope for the interface.</param>
-    /// <returns>The generated method implementation.</returns>
-    internal static string BuildRefitMethod(
+    internal static void BuildRefitMethod(
+        PooledStringBuilder builder,
         MethodModel methodModel,
         bool isTopLevel,
         InterfaceModel interfaceModel,
         UniqueNameBuilder uniqueNames,
-        string requestBuilderFieldName,
-        string settingsFieldName,
+        GeneratedFieldNames fieldNames,
         EnumFormatterScope enumFormatterScope)
     {
         if (interfaceModel.GeneratedRequestBuilding && methodModel.Request.CanGenerateInline)
         {
-            return BuildInlineRefitMethod(methodModel, interfaceModel, isTopLevel, settingsFieldName, uniqueNames, enumFormatterScope);
+            BuildInlineRefitMethod(builder, methodModel, interfaceModel, isTopLevel, fieldNames.Settings, uniqueNames, enumFormatterScope);
+            return;
         }
 
         var locals = CreateMethodLocalNameBuilder(methodModel.Parameters);
@@ -75,10 +75,11 @@ internal static partial class Emitter
         var methodIndent = Indent(MethodMemberIndentation);
         var bodyIndent = Indent(MethodBodyIndentation);
         var requestBuilderInit =
-            $"{requestBuilderFieldName} ?? throw new global::System.InvalidOperationException(\"This generated Refit method requires a request builder.\")";
+            $"{fieldNames.RequestBuilder} ?? throw new global::System.InvalidOperationException(\"This generated Refit method requires a request builder.\")";
 
-        return typeParameterFieldSource
-            + BuildMethodOpening(
+        _ = builder
+            .Append(typeParameterFieldSource)
+            .Append(BuildMethodOpening(
                 methodModel,
                 isExplicit,
                 isExplicit,
@@ -86,26 +87,27 @@ internal static partial class Emitter
                 isAsync,
                 BuildReflectionFallbackSuppressions(
                     methodModel.RequiresUnreferencedCode,
-                    methodModel.RequiresDynamicCode))
-            + $$"""
+                    methodModel.RequiresDynamicCode)))
+            .Append($$"""
                 {{bodyIndent}}var {{argumentsLocal}} = {{BuildArgumentsArrayLiteral(methodModel)}};
                 {{bodyIndent}}var {{requestBuilderLocal}} = {{requestBuilderInit}};
                 {{bodyIndent}}var {{funcLocal}} = {{requestBuilderLocal}}.BuildRestResultFuncForMethod("{{lookupName}}", {{typeParameterExpression}}{{genericTypesArgument}} );
 
                 {{returnStatement}}{{methodIndent}}}
 
-                """;
+                """);
     }
 
     /// <summary>Builds a Refit method that constructs the request directly in generated code.</summary>
+    /// <param name="builder">The buffer accumulating the interface's generated method source.</param>
     /// <param name="methodModel">The method model being emitted.</param>
     /// <param name="interfaceModel">The interface model being emitted.</param>
     /// <param name="isTopLevel">True if directly from the type we're generating for, false for methods found on base interfaces.</param>
     /// <param name="settingsFieldName">The unique generated field name that stores Refit settings.</param>
     /// <param name="uniqueNames">Contains the unique member names in the interface scope.</param>
     /// <param name="enumFormatterScope">The enum formatter scope for the interface.</param>
-    /// <returns>The generated inline method implementation.</returns>
-    internal static string BuildInlineRefitMethod(
+    internal static void BuildInlineRefitMethod(
+        PooledStringBuilder builder,
         MethodModel methodModel,
         InterfaceModel interfaceModel,
         bool isTopLevel,
@@ -150,18 +152,20 @@ internal static partial class Emitter
             paramInfoSb,
             emission,
             locals);
-        return BuildInlineRefitMethodBody(methodModel, interfaceModel, isExplicit, settingsFieldName, uniqueNames, plan);
+        BuildInlineRefitMethodBody(builder, methodModel, interfaceModel, isExplicit, settingsFieldName, uniqueNames, plan);
     }
 
-    /// <summary>Assembles the generated inline method from its request-message construction and return statement.</summary>
+    /// <summary>Assembles the generated inline method from its request-message construction and return statement,
+    /// appending it to the interface's method buffer.</summary>
+    /// <param name="builder">The buffer accumulating the interface's generated method source.</param>
     /// <param name="methodModel">The method model being emitted.</param>
     /// <param name="interfaceModel">The interface model being emitted.</param>
     /// <param name="isExplicit">Whether the method is emitted as an explicit interface implementation.</param>
     /// <param name="settingsFieldName">The unique generated field name that stores Refit settings.</param>
     /// <param name="uniqueNames">Contains the unique member names in the interface scope.</param>
     /// <param name="plan">The method-scope locals and pre-built request fragments.</param>
-    /// <returns>The generated inline method implementation.</returns>
-    internal static string BuildInlineRefitMethodBody(
+    internal static void BuildInlineRefitMethodBody(
+        PooledStringBuilder builder,
         MethodModel methodModel,
         InterfaceModel interfaceModel,
         bool isExplicit,
@@ -169,76 +173,19 @@ internal static partial class Emitter
         UniqueNameBuilder uniqueNames,
         in InlineMethodPlan plan)
     {
-        var request = methodModel.Request;
-        var settingsLocal = plan.SettingsLocal;
-        var requestLocal = plan.RequestLocal;
-        var emission = plan.Emission;
-        var bodyIndent = Indent(MethodBodyIndentation);
+        var fragments = BuildInlineMethodFragments(methodModel, interfaceModel, isExplicit, uniqueNames, plan);
 
-        var requestPrologueSource = BuildInlineRequestPrologue(request, plan, bodyIndent, out var requestPathExpression);
-
-        var (httpMethodFieldSource, httpMethodExpression) = BuildHttpMethodField(request, uniqueNames);
-
-        // A [Url] method dispatches to an absolute URI (the validated [Url] value with any query appended), bypassing
-        // the base-address merge; every other method builds a relative URI merged onto the base address.
-        var requestUriExpression = HasUrlParameter(request)
-            ? $"new global::System.Uri({requestPathExpression}, global::System.UriKind.Absolute)"
-            : BuildRelativeUriExpression(request, requestPathExpression, settingsLocal);
-        var (formFieldsSource, formFieldsFieldName) = BuildFormFieldsField(
-            plan.BodyParameter,
-            uniqueNames,
-            interfaceModel.SupportsNullable,
-            interfaceModel.SupportsStaticLambdas);
-
-        // A multipart method builds a MultipartFormDataContent from its parts; every other method has at most one body
-        // parameter (a multipart method never carries one), so the two paths never both apply.
-        var contentSource = plan.BodyParameter is null
-            ? string.Empty
-            : BuildInlineContent(plan.BodyParameter, requestLocal, settingsLocal, formFieldsFieldName, interfaceModel.SupportsNullable, emission, plan.Locals);
-        if (request.IsMultipart)
-        {
-            contentSource = BuildInlineMultipartContent(request, requestLocal, settingsLocal, plan.Locals);
-        }
-
-        var headerSource = BuildInlineHeaders(request, requestLocal, settingsLocal);
-        var requestPropertySource = BuildInlineRequestProperties(request, interfaceModel, methodModel, requestLocal, settingsLocal);
-
-        // A method that declares a positive [Timeout] stashes it on the request so the send helpers apply it; every
-        // other method emits nothing here and pays no per-call timeout cost. Emitted inside the shared construction so
-        // the cold IObservable's per-subscription request is annotated too.
-        var timeoutSource = request.TimeoutMilliseconds > 0
-            ? $"{bodyIndent}global::Refit.GeneratedRequestRunner.SetRequestTimeout({requestLocal}, {request.TimeoutMilliseconds});\n"
-            : string.Empty;
-        var methodIndent = Indent(MethodMemberIndentation);
-        var opening = BuildMethodOpening(methodModel, isExplicit, isExplicit, interfaceModel.SupportsNullable);
-        var methodPrefix = $"{plan.ParamInfoBuilder}{formFieldsSource}{httpMethodFieldSource}{opening}{bodyIndent}var {settingsLocal} = {settingsFieldName};\n";
-
-        // The request construction shared by every shape: prologue locals, the message, content, headers, request
-        // properties, and an optional per-call timeout. The configured HTTP version and version policy are applied by
-        // AddConfiguredRequestOptions in the request-property source. A cold IObservable wraps this in a per-subscription
-        // local function so a second subscription rebuilds and re-sends instead of reusing a disposed request.
-        var requestConstruction = $$"""
-            {{requestPrologueSource}}{{bodyIndent}}var {{requestLocal}} = new global::System.Net.Http.HttpRequestMessage({{httpMethodExpression}}, {{requestUriExpression}});
-            {{contentSource}}{{headerSource}}{{requestPropertySource}}{{timeoutSource}}
-            """;
-
+        // A cold IObservable wraps the shared request construction in a per-subscription local function so a second
+        // subscription rebuilds and re-sends instead of reusing a disposed request. That shape reuses both the method
+        // prefix and the construction block, so it materializes them as strings; every other shape appends its fragments
+        // straight into the buffer, so the prefix and construction strings never allocate.
         if (methodModel.ReturnTypeMetadata == ReturnTypeInfo.Observable)
         {
-            var buildRequestLocal = plan.Locals.New("BuildRefitRequest");
-            var observableReturn = BuildInlineObservableReturn(request, plan.BufferBodyExpression, plan.CancellationTokenExpression, buildRequestLocal, settingsLocal);
-            return BuildInlineObservableMethodSource(methodPrefix, requestConstruction, buildRequestLocal, requestLocal, observableReturn, bodyIndent, methodIndent);
+            AppendInlineObservableRefitMethod(builder, methodModel, settingsFieldName, plan, fragments);
+            return;
         }
 
-        // A Task<HttpRequestMessage> method hands the fully built request back to the caller without dispatching it. The
-        // caller owns the returned request and its content, so it is neither sent nor disposed here; every other shape
-        // emits its normal send-and-deserialize return.
-        var returnSource = methodModel.ReturnTypeMetadata == ReturnTypeInfo.RequestMessage
-            ? BuildInlineRequestMessageReturn(requestLocal)
-            : BuildInlineReturn(methodModel, request, plan.BufferBodyExpression, plan.CancellationTokenExpression, requestLocal, settingsLocal, plan.AdapterTokenLocal);
-        return $$"""
-            {{methodPrefix}}{{requestConstruction}}{{returnSource}}{{methodIndent}}}
-
-            """;
+        AppendInlineStandardRefitMethod(builder, methodModel, settingsFieldName, plan, fragments);
     }
 
     /// <summary>Emits the request-prologue formatting locals and resolves the request-path expression to use.</summary>

--- a/src/InterfaceStubGenerator.Shared/Emitter.Inline.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.Inline.cs
@@ -285,8 +285,8 @@ internal static partial class Emitter
             _ = prologue.Append(", ").Append(ToLowerInvariantString(request.Path.IndexOf('?') >= 0));
         }
 
-        _ = prologue.AppendLine(");")
-            .Append(BuildInlineQueryStatements(request, parameterInfoNames, emission));
+        _ = prologue.AppendLine(");");
+        AppendInlineQueryStatements(prologue, request, parameterInfoNames, emission);
         return emission.QueryBuilderLocal + ".Build()";
     }
 

--- a/src/InterfaceStubGenerator.Shared/Emitter.Inline.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.Inline.cs
@@ -28,6 +28,12 @@ internal static partial class Emitter
     /// <summary>The cast prefix for an explicit collection format value.</summary>
     private const string CollectionFormatCast = "(global::Refit.CollectionFormat)";
 
+    /// <summary>The opening of a generated <c>GeneratedRequestRunner.SetHeader</c> call.</summary>
+    private const string RunnerSetHeader = "global::Refit.GeneratedRequestRunner.SetHeader(";
+
+    /// <summary>The settings member read for the header validation flag, plus the call terminator that follows it.</summary>
+    private const string ValidateHeadersMember = ".ValidateHeaders";
+
     /// <summary>Builds the body of the Refit method.</summary>
     /// <param name="methodModel">The method model being emitted.</param>
     /// <param name="isTopLevel">True if directly from the type we're generating for, false for methods found on base interfaces.</param>
@@ -498,17 +504,17 @@ internal static partial class Emitter
     /// <returns>The generated header statements.</returns>
     internal static string BuildInlineHeaders(RequestModel request, string requestLocal, string settingsLocal)
     {
-        var parts = new string[request.StaticHeaders.Count + request.Parameters.Count];
-        var count = 0;
+        // Append directly into a pooled buffer allocated only once a header is actually emitted; the previous
+        // string[] + interpolated-fragment + ConcatParts shape allocated the array (and a validate-flag string) even
+        // for the common header-less method. The emitted text is identical.
         var bodyIndent = Indent(MethodBodyIndentation);
-        var validateHeaders = $"{settingsLocal}.ValidateHeaders";
+        PooledStringBuilder? sb = null;
         foreach (var header in request.StaticHeaders)
         {
-            var headerName = ToCSharpStringLiteral(header.Name);
-            var headerValue = ToNullableCSharpStringLiteral(header.Value);
-            parts[count] =
-                $"{bodyIndent}global::Refit.GeneratedRequestRunner.SetHeader({requestLocal}, {headerName}, {headerValue}, {validateHeaders});\n";
-            count++;
+            sb ??= new PooledStringBuilder();
+            var name = ToCSharpStringLiteral(header.Name);
+            var value = ToNullableCSharpStringLiteral(header.Value);
+            AppendSetHeader(sb, bodyIndent, requestLocal, name, value, settingsLocal);
         }
 
         foreach (var parameter in request.Parameters)
@@ -519,19 +525,20 @@ internal static partial class Emitter
                     {
                         // An [Authorize] parameter carries a "{scheme} " prefix; a plain [Header] has none.
                         var headerValueExpression = parameter.HeaderValuePrefix is { } valuePrefix
-                            ? $"{ToCSharpStringLiteral(valuePrefix)} + {BuildHeaderValueExpression(parameter)}"
+                            ? ToCSharpStringLiteral(valuePrefix) + " + " + BuildHeaderValueExpression(parameter)
                             : BuildHeaderValueExpression(parameter);
-                        parts[count] =
-                            $"{bodyIndent}global::Refit.GeneratedRequestRunner.SetHeader({requestLocal}, {ToCSharpStringLiteral(parameter.HeaderName)}, {headerValueExpression}, {validateHeaders});\n";
-                        count++;
-                        continue;
+                        sb ??= new PooledStringBuilder();
+                        var headerName = ToCSharpStringLiteral(parameter.HeaderName);
+                        AppendSetHeader(sb, bodyIndent, requestLocal, headerName, headerValueExpression, settingsLocal);
+                        break;
                     }
 
                 case RequestParameterKind.HeaderCollection:
                     {
-                        parts[count] =
-                            $"{bodyIndent}global::Refit.GeneratedRequestRunner.AddHeaderCollection({requestLocal}, @{parameter.Name}, {validateHeaders});\n";
-                        count++;
+                        sb ??= new PooledStringBuilder();
+                        _ = sb.Append(bodyIndent).Append("global::Refit.GeneratedRequestRunner.AddHeaderCollection(")
+                            .Append(requestLocal).Append(ArgumentSeparator).Append("@").Append(parameter.Name)
+                            .Append(ArgumentSeparator).Append(settingsLocal).Append(ValidateHeadersMember).Append(");\n");
                         break;
                     }
 
@@ -544,8 +551,26 @@ internal static partial class Emitter
             }
         }
 
-        return count == 0 ? string.Empty : ConcatParts(parts, count);
+        return sb?.ToString() ?? string.Empty;
     }
+
+    /// <summary>Appends one <c>SetHeader</c> statement directly into the header buffer.</summary>
+    /// <param name="sb">The pooled statement buffer.</param>
+    /// <param name="bodyIndent">The method-body indentation.</param>
+    /// <param name="requestLocal">The generated request message local name.</param>
+    /// <param name="nameExpression">The header-name expression.</param>
+    /// <param name="valueExpression">The header-value expression.</param>
+    /// <param name="settingsLocal">The generated settings local name, read for the header validation flag.</param>
+    internal static void AppendSetHeader(
+        PooledStringBuilder sb,
+        string bodyIndent,
+        string requestLocal,
+        string nameExpression,
+        string valueExpression,
+        string settingsLocal) =>
+        sb.Append(bodyIndent).Append(RunnerSetHeader).Append(requestLocal).Append(ArgumentSeparator)
+            .Append(nameExpression).Append(ArgumentSeparator).Append(valueExpression).Append(ArgumentSeparator)
+            .Append(settingsLocal).Append(ValidateHeadersMember).Append(");\n");
 
     /// <summary>Builds a header value expression without null-conditionals on non-nullable value types.</summary>
     /// <param name="parameter">The header parameter to format.</param>

--- a/src/InterfaceStubGenerator.Shared/Emitter.Inline.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.Inline.cs
@@ -173,19 +173,18 @@ internal static partial class Emitter
         UniqueNameBuilder uniqueNames,
         in InlineMethodPlan plan)
     {
-        var fragments = BuildInlineMethodFragments(methodModel, interfaceModel, isExplicit, uniqueNames, plan);
-
         // A cold IObservable wraps the shared request construction in a per-subscription local function so a second
         // subscription rebuilds and re-sends instead of reusing a disposed request. That shape reuses both the method
-        // prefix and the construction block, so it materializes them as strings; every other shape appends its fragments
-        // straight into the buffer, so the prefix and construction strings never allocate.
+        // prefix and the construction block, so it materializes them as strings; every other shape appends its
+        // request-construction fragments straight into the interface buffer, so none of those fragment strings allocate.
         if (methodModel.ReturnTypeMetadata == ReturnTypeInfo.Observable)
         {
+            var fragments = BuildInlineMethodFragments(methodModel, interfaceModel, isExplicit, uniqueNames, plan);
             AppendInlineObservableRefitMethod(builder, methodModel, settingsFieldName, plan, fragments);
             return;
         }
 
-        AppendInlineStandardRefitMethod(builder, methodModel, settingsFieldName, plan, fragments);
+        AppendInlineStandardRefitMethod(builder, methodModel, interfaceModel, isExplicit, settingsFieldName, uniqueNames, plan);
     }
 
     /// <summary>Emits the request-prologue formatting locals and resolves the request-path expression to use.</summary>
@@ -200,12 +199,28 @@ internal static partial class Emitter
         string bodyIndent,
         out string requestPathExpression)
     {
+        // The cold-observable shape reuses the prologue inside a string-interpolated construction block, so it
+        // materializes it through a scratch buffer; the standard shape appends straight into the interface buffer.
+        var prologue = new PooledStringBuilder();
+        requestPathExpression = AppendInlineRequestPrologue(prologue, request, plan, bodyIndent);
+        return prologue.ToString();
+    }
+
+    /// <summary>Appends the request-prologue formatting locals into the interface buffer and resolves the request-path
+    /// expression to use, without materializing the prologue as an intermediate string.</summary>
+    /// <param name="prologue">The buffer accumulating the interface's generated method source.</param>
+    /// <param name="request">The parsed request model.</param>
+    /// <param name="plan">The method-scope locals and pre-built request fragments.</param>
+    /// <param name="bodyIndent">The method-body indentation.</param>
+    /// <returns>The request-path expression: the query builder's <c>Build()</c> call, or the path when no query binds.</returns>
+    internal static string AppendInlineRequestPrologue(
+        PooledStringBuilder prologue,
+        RequestModel request,
+        in InlineMethodPlan plan,
+        string bodyIndent)
+    {
         var emission = plan.Emission;
         var settingsLocal = plan.SettingsLocal;
-
-        // Accumulate the request prologue through a pooled buffer rather than reallocating the whole string on each
-        // '+=' branch below.
-        var prologue = new PooledStringBuilder();
 
         // A [Url] method dispatches to the absolute URI its [Url] parameter supplies, bypassing the base address:
         // validate the value and use it as the base the query string is appended to, instead of the (empty) template.
@@ -234,8 +249,7 @@ internal static partial class Emitter
                 .Append(settingsLocal).AppendLine(");");
         }
 
-        requestPathExpression = AppendInlineQueryPrologue(prologue, request, plan.ParameterInfoNames, emission, basePathExpression, bodyIndent);
-        return prologue.ToString();
+        return AppendInlineQueryPrologue(prologue, request, plan.ParameterInfoNames, emission, basePathExpression, bodyIndent);
     }
 
     /// <summary>Appends the query-string-builder prologue and returns the request-path expression to use.</summary>

--- a/src/InterfaceStubGenerator.Shared/Emitter.ReflectionArguments.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.ReflectionArguments.cs
@@ -10,7 +10,7 @@ internal static partial class Emitter
     /// <summary>Builds the <c>object[]</c> literal that holds the method's argument values.</summary>
     /// <param name="methodModel">The method model being emitted.</param>
     /// <returns>The generated argument array literal.</returns>
-    private static string BuildArgumentsArrayLiteral(MethodModel methodModel)
+    internal static string BuildArgumentsArrayLiteral(MethodModel methodModel)
     {
         var parameters = methodModel.Parameters.AsArray();
         if (parameters.Length == 0)
@@ -53,7 +53,7 @@ internal static partial class Emitter
     /// <param name="methodModel">The method model being emitted.</param>
     /// <param name="supportsNullable">Whether the target language version supports nullable reference type annotations.</param>
     /// <returns>The generated argument-capture array literal, including any cancellation token parameter.</returns>
-    private static string BuildMethodArgumentsCaptureLiteral(MethodModel methodModel, bool supportsNullable)
+    internal static string BuildMethodArgumentsCaptureLiteral(MethodModel methodModel, bool supportsNullable)
     {
         var parameters = methodModel.Parameters.AsArray();
         var prefix = supportsNullable ? "new object?[] { " : "new object[] { ";
@@ -96,7 +96,7 @@ internal static partial class Emitter
     /// <summary>Builds the optional generic <c>Type[]</c> argument for the request builder call.</summary>
     /// <param name="methodModel">The method model being emitted.</param>
     /// <returns>The generated generic type argument, or an empty string.</returns>
-    private static string BuildGenericTypesArgument(MethodModel methodModel)
+    internal static string BuildGenericTypesArgument(MethodModel methodModel)
     {
         var constraints = methodModel.Constraints.AsArray();
         if (constraints.Length == 0)
@@ -140,7 +140,7 @@ internal static partial class Emitter
     /// <param name="methodModel">The method model being emitted.</param>
     /// <param name="uniqueNames">Contains the unique member names in the interface scope.</param>
     /// <returns>The generated field source and field name, if one was generated.</returns>
-    private static (string Source, string? FieldName) BuildTypeParameterField(
+    internal static (string Source, string? FieldName) BuildTypeParameterField(
         MethodModel methodModel,
         UniqueNameBuilder uniqueNames)
     {
@@ -164,7 +164,7 @@ internal static partial class Emitter
     /// <summary>Determines whether any parameter type depends on a method type parameter.</summary>
     /// <param name="parameters">The parameter models to inspect.</param>
     /// <returns>True when at least one parameter is generic.</returns>
-    private static bool ContainsGenericParameter(ImmutableEquatableArray<ParameterModel> parameters)
+    internal static bool ContainsGenericParameter(ImmutableEquatableArray<ParameterModel> parameters)
     {
         for (var i = 0; i < parameters.Count; i++)
         {
@@ -181,7 +181,7 @@ internal static partial class Emitter
     /// <param name="parameters">The parameter models to emit.</param>
     /// <param name="cachedTypeParameterFieldName">The cached field name, if one was generated.</param>
     /// <returns>The generated type parameter expression.</returns>
-    private static string BuildTypeParameterExpression(
+    internal static string BuildTypeParameterExpression(
         ImmutableEquatableArray<ParameterModel> parameters,
         string? cachedTypeParameterFieldName) =>
         parameters.Count == 0
@@ -191,7 +191,7 @@ internal static partial class Emitter
     /// <summary>Builds the generated <c>typeof(...)</c> argument list for method parameters.</summary>
     /// <param name="parameters">The parameter models to emit.</param>
     /// <returns>The generated parameter type list.</returns>
-    private static string BuildParameterTypeList(ImmutableEquatableArray<ParameterModel> parameters)
+    internal static string BuildParameterTypeList(ImmutableEquatableArray<ParameterModel> parameters)
     {
         if (parameters.Count == 0)
         {
@@ -233,7 +233,7 @@ internal static partial class Emitter
     /// <param name="funcLocal">The generated request-func local name.</param>
     /// <param name="argumentsLocal">The generated arguments-array local name.</param>
     /// <returns>The generated return statement.</returns>
-    private static string BuildRefitReturnStatement(
+    internal static string BuildRefitReturnStatement(
         MethodModel methodModel,
         string returnPrefix,
         string returnType,

--- a/src/InterfaceStubGenerator.Shared/Emitter.SharedCode.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.SharedCode.cs
@@ -13,7 +13,7 @@ internal static partial class Emitter
     /// <param name="model">The context generation model describing the interfaces.</param>
     /// <param name="generatedFileHeader">The shared generated file header.</param>
     /// <param name="addSource">Callback used to add generated source files.</param>
-    private static void EmitPreserveAttribute(
+    internal static void EmitPreserveAttribute(
         ContextGenerationModel model,
         string generatedFileHeader,
         Action<string, SourceText> addSource)
@@ -56,7 +56,7 @@ internal static partial class Emitter
     /// <param name="model">The context generation model describing the interfaces.</param>
     /// <param name="generatedFileHeader">The shared generated file header.</param>
     /// <param name="addSource">Callback used to add generated source files.</param>
-    private static void EmitGeneratedFactoryModule(
+    internal static void EmitGeneratedFactoryModule(
         ContextGenerationModel model,
         string generatedFileHeader,
         Action<string, SourceText> addSource)

--- a/src/InterfaceStubGenerator.Shared/Emitter.Testing.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.Testing.cs
@@ -60,13 +60,17 @@ internal static partial class Emitter
         InterfaceModel interfaceModel,
         UniqueNameBuilder uniqueNames,
         string requestBuilderFieldName,
-        string settingsFieldName) =>
+        string settingsFieldName)
+    {
+        var builder = new PooledStringBuilder();
         BuildRefitMethod(
+            builder,
             methodModel,
             isTopLevel,
             interfaceModel,
             uniqueNames,
-            requestBuilderFieldName,
-            settingsFieldName,
+            new GeneratedFieldNames(requestBuilderFieldName, settingsFieldName),
             new(uniqueNames));
+        return builder.ToString();
+    }
 }

--- a/src/InterfaceStubGenerator.Shared/Emitter.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.cs
@@ -153,37 +153,17 @@ internal static partial class Emitter
         string settingsFieldName)
     {
         var enumFormatterScope = new EnumFormatterScope(uniqueNames);
-        var propertySource = BuildInterfaceProperties(model.Properties, model.SupportsNullable);
-        var refitMethodSource = BuildRefitMethods(
-            model.RefitMethods,
-            true,
-            model,
-            uniqueNames,
-            requestBuilderFieldName,
-            settingsFieldName,
-            enumFormatterScope);
-        var derivedRefitMethodSource = BuildRefitMethods(
-            model.DerivedRefitMethods,
-            false,
-            model,
-            uniqueNames,
-            requestBuilderFieldName,
-            settingsFieldName,
-            enumFormatterScope);
-        var nonRefitMethodSource = BuildNonRefitMethods(model.NonRefitMethods, model.SupportsNullable);
-        var disposableSource = BuildDisposableMethod(model.DisposeMethod);
+        var fieldNames = new GeneratedFieldNames(requestBuilderFieldName, settingsFieldName);
 
-        // Concatenate the five member blocks through a pooled buffer instead of a five-operand '+', which would
-        // allocate a params string[] for the String.Concat overload.
-        return new PooledStringBuilder(
-                propertySource.Length + refitMethodSource.Length + derivedRefitMethodSource.Length
-                + nonRefitMethodSource.Length + disposableSource.Length)
-            .Append(propertySource)
-            .Append(refitMethodSource)
-            .Append(derivedRefitMethodSource)
-            .Append(nonRefitMethodSource)
-            .Append(disposableSource)
-            .ToString();
+        // Append the five member blocks (properties, top-level and derived Refit methods, non-Refit stubs, and dispose)
+        // straight into one pooled buffer so none of the block strings materialize before the interface source is built.
+        var builder = new PooledStringBuilder();
+        AppendInterfaceProperties(builder, model.Properties, model.SupportsNullable);
+        AppendRefitMethods(builder, model.RefitMethods, true, model, uniqueNames, fieldNames, enumFormatterScope);
+        AppendRefitMethods(builder, model.DerivedRefitMethods, false, model, uniqueNames, fieldNames, enumFormatterScope);
+        AppendNonRefitMethods(builder, model.NonRefitMethods, model.SupportsNullable);
+        AppendDisposableMethod(builder, model.DisposeMethod);
+        return builder.ToString();
     }
 
     /// <summary>Creates source text from generated source.</summary>
@@ -432,56 +412,39 @@ internal static partial class Emitter
         return ConcatParts(parts, parts.Length);
     }
 
-    /// <summary>Builds generated interface property implementations.</summary>
+    /// <summary>Appends the generated interface property implementations into the member buffer.</summary>
+    /// <param name="builder">The buffer accumulating the interface's generated member source.</param>
     /// <param name="properties">The property models to emit.</param>
     /// <param name="supportsNullable">Whether the consumer compilation supports nullable reference type syntax.</param>
-    /// <returns>The generated property implementations.</returns>
-    internal static string BuildInterfaceProperties(
+    internal static void AppendInterfaceProperties(
+        PooledStringBuilder builder,
         ImmutableEquatableArray<InterfacePropertyModel> properties,
         bool supportsNullable)
     {
-        var parts = new string[properties.Count];
-        var count = 0;
         for (var i = 0; i < properties.Count; i++)
         {
-            var source = BuildInterfaceProperty(properties[i], supportsNullable);
-            if (source.Length != 0)
-            {
-                parts[count] = source;
-                count++;
-            }
+            // A satisfied member emits an empty string, which appends as a no-op.
+            _ = builder.Append(BuildInterfaceProperty(properties[i], supportsNullable));
         }
-
-        return count == 0 ? string.Empty : ConcatParts(parts, count);
     }
 
-    /// <summary>Builds generated Refit method implementations.</summary>
+    /// <summary>Appends the generated Refit method implementations into the member buffer.</summary>
+    /// <param name="builder">The buffer accumulating the interface's generated member source.</param>
     /// <param name="methods">The method models to emit.</param>
     /// <param name="isTopLevel">True if directly from the type we're generating for, false for methods found on base interfaces.</param>
     /// <param name="interfaceModel">The interface model being emitted.</param>
     /// <param name="uniqueNames">Contains the unique member names in the interface scope.</param>
-    /// <param name="requestBuilderFieldName">The unique generated field name that stores the request builder.</param>
-    /// <param name="settingsFieldName">The unique generated field name that stores Refit settings.</param>
+    /// <param name="fieldNames">The generated request-builder and settings backing-field names.</param>
     /// <param name="enumFormatterScope">The enum formatter scope for the interface.</param>
-    /// <returns>The generated method implementations.</returns>
-    internal static string BuildRefitMethods(
+    internal static void AppendRefitMethods(
+        PooledStringBuilder builder,
         ImmutableEquatableArray<MethodModel> methods,
         bool isTopLevel,
         InterfaceModel interfaceModel,
         UniqueNameBuilder uniqueNames,
-        string requestBuilderFieldName,
-        string settingsFieldName,
+        GeneratedFieldNames fieldNames,
         EnumFormatterScope enumFormatterScope)
     {
-        if (methods.Count == 0)
-        {
-            return string.Empty;
-        }
-
-        // Append every method body into one pooled buffer rather than building a per-method string and a parts array
-        // for ConcatParts: the individual method strings and the trimmed array never materialize.
-        var fieldNames = new GeneratedFieldNames(requestBuilderFieldName, settingsFieldName);
-        var builder = new PooledStringBuilder();
         for (var i = 0; i < methods.Count; i++)
         {
             BuildRefitMethod(
@@ -493,30 +456,21 @@ internal static partial class Emitter
                 fieldNames,
                 enumFormatterScope);
         }
-
-        return builder.ToString();
     }
 
-    /// <summary>Builds generated non-Refit method stubs.</summary>
+    /// <summary>Appends the generated non-Refit method stubs into the member buffer.</summary>
+    /// <param name="builder">The buffer accumulating the interface's generated member source.</param>
     /// <param name="methods">The non-Refit method models to emit.</param>
     /// <param name="supportsNullable">Whether the consumer compilation supports nullable reference type syntax.</param>
-    /// <returns>The generated method stubs.</returns>
-    internal static string BuildNonRefitMethods(
+    internal static void AppendNonRefitMethods(
+        PooledStringBuilder builder,
         ImmutableEquatableArray<MethodModel> methods,
         bool supportsNullable)
     {
-        if (methods.Count == 0)
-        {
-            return string.Empty;
-        }
-
-        var parts = new string[methods.Count];
         for (var i = 0; i < methods.Count; i++)
         {
-            parts[i] = BuildNonRefitMethod(methods[i], supportsNullable);
+            _ = builder.Append(BuildNonRefitMethod(methods[i], supportsNullable));
         }
-
-        return ConcatParts(parts, parts.Length);
     }
 
     /// <summary>Converts a bool to a lowercase C# literal.</summary>
@@ -611,19 +565,19 @@ internal static partial class Emitter
             """;
     }
 
-    /// <summary>Builds the explicit IDisposable.Dispose implementation.</summary>
+    /// <summary>Appends the explicit IDisposable.Dispose implementation into the member buffer.</summary>
+    /// <param name="builder">The buffer accumulating the interface's generated member source.</param>
     /// <param name="shouldEmit">True when the dispose method should be emitted.</param>
-    /// <returns>The generated dispose method, or an empty string.</returns>
-    internal static string BuildDisposableMethod(bool shouldEmit)
+    internal static void AppendDisposableMethod(PooledStringBuilder builder, bool shouldEmit)
     {
         if (!shouldEmit)
         {
-            return string.Empty;
+            return;
         }
 
         var methodIndent = Indent(MethodMemberIndentation);
         var bodyIndent = Indent(MethodBodyIndentation);
-        return $$"""
+        _ = builder.Append($$"""
 
             {{methodIndent}}/// <inheritdoc />
             {{methodIndent}}void global::System.IDisposable.Dispose()
@@ -631,6 +585,6 @@ internal static partial class Emitter
             {{bodyIndent}}Client?.Dispose();
             {{methodIndent}}}
 
-            """;
+            """);
     }
 }

--- a/src/InterfaceStubGenerator.Shared/Emitter.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.cs
@@ -44,6 +44,9 @@ internal static partial class Emitter
     /// <c>Generated</c> partial class, and the <c>Refit.Implementation</c> namespace.</summary>
     private const string InterfaceSourceClosingBraces = "        }\n    }\n}\n";
 
+    /// <summary>The fully qualified prefix of a generated implementation type, before its namespace mangling and suffix.</summary>
+    private const string GeneratedTypePrefix = "global::Refit.Implementation.Generated.";
+
     /// <summary>The number of spaces in one generated indentation level.</summary>
     private const int CharsPerIndentation = 4;
 
@@ -339,23 +342,19 @@ internal static partial class Emitter
                 continue;
             }
 
-            var generatedType = $"global::Refit.Implementation.Generated.{interfaceModel.Ns}{interfaceModel.ClassSuffix}";
-
             // The static modifier on a lambda is C# 9; older consumers must not see it.
             var lambdaModifier = interfaceModel.SupportsStaticLambdas ? "static " : string.Empty;
-            _ = builder.Append($$"""
-                                    global::Refit.RestService.RegisterGeneratedFactory<{{interfaceModel.InterfaceDisplayName}}>(
-                                        {{lambdaModifier}}(client, requestBuilder) => new {{generatedType}}(client, requestBuilder));
-
-                        """);
+            _ = builder
+                .Append("            global::Refit.RestService.RegisterGeneratedFactory<").Append(interfaceModel.InterfaceDisplayName).Append(">(\n")
+                .Append("                ").Append(lambdaModifier).Append("(client, requestBuilder) => new ").Append(GeneratedTypePrefix)
+                .Append(interfaceModel.Ns).Append(interfaceModel.ClassSuffix).Append("(client, requestBuilder));\n");
 
             if (CanUseGeneratedSettingsFactory(interfaceModel))
             {
-                _ = builder.Append($$"""
-                                        global::Refit.RestService.RegisterGeneratedSettingsFactory<{{interfaceModel.InterfaceDisplayName}}>(
-                                            {{lambdaModifier}}(client, settings) => new {{generatedType}}(client, settings));
-
-                            """);
+                _ = builder
+                    .Append("            global::Refit.RestService.RegisterGeneratedSettingsFactory<").Append(interfaceModel.InterfaceDisplayName).Append(">(\n")
+                    .Append("                ").Append(lambdaModifier).Append("(client, settings) => new ").Append(GeneratedTypePrefix)
+                    .Append(interfaceModel.Ns).Append(interfaceModel.ClassSuffix).Append("(client, settings));\n");
             }
         }
 

--- a/src/InterfaceStubGenerator.Shared/Emitter.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.cs
@@ -146,7 +146,7 @@ internal static partial class Emitter
     /// <param name="requestBuilderFieldName">The unique generated field name that stores the request builder.</param>
     /// <param name="settingsFieldName">The unique generated field name that stores Refit settings.</param>
     /// <returns>The concatenated member source.</returns>
-    private static string BuildInterfaceMemberSource(
+    internal static string BuildInterfaceMemberSource(
         InterfaceModel model,
         UniqueNameBuilder uniqueNames,
         string requestBuilderFieldName,
@@ -189,11 +189,11 @@ internal static partial class Emitter
     /// <summary>Creates source text from generated source.</summary>
     /// <param name="source">The generated source.</param>
     /// <returns>The generated source text.</returns>
-    private static SourceText ToSourceText(string source) => SourceText.From(source, Encoding.UTF8);
+    internal static SourceText ToSourceText(string source) => SourceText.From(source, Encoding.UTF8);
 
     /// <summary>Builds the generated code attribute using this generator assembly identity.</summary>
     /// <returns>The generated attribute source.</returns>
-    private static string BuildGeneratedCodeAttribute()
+    internal static string BuildGeneratedCodeAttribute()
     {
         // This generator assembly always carries a name and version, so no placeholder fallback is reachable.
         var assemblyName = typeof(Emitter).Assembly.GetName();
@@ -208,7 +208,7 @@ internal static partial class Emitter
     /// <summary>Escapes text for generated XML documentation comments.</summary>
     /// <param name="value">The text to escape.</param>
     /// <returns>The escaped XML documentation text.</returns>
-    private static string ToXmlDocumentationText(string value)
+    internal static string ToXmlDocumentationText(string value)
     {
         // Most identifiers and type names contain none of the XML metacharacters, so return them untouched
         // instead of allocating a builder and copying character by character.
@@ -254,7 +254,7 @@ internal static partial class Emitter
     /// <summary>Builds the <c>extern alias</c> directives an interface's types require, if any.</summary>
     /// <param name="aliases">The extern aliases the interface's types reference.</param>
     /// <returns>The directives, or an empty string when none are needed.</returns>
-    private static string BuildExternAliasDirectives(ImmutableEquatableArray<string> aliases)
+    internal static string BuildExternAliasDirectives(ImmutableEquatableArray<string> aliases)
     {
         if (aliases.Count == 0)
         {
@@ -274,7 +274,7 @@ internal static partial class Emitter
     /// <param name="nullability">The nullable context for the generated source.</param>
     /// <param name="emitGeneratedCodeMarkers">Whether generated-code markers should be emitted.</param>
     /// <returns>The generated file header.</returns>
-    private static string BuildGeneratedFileHeader(Nullability nullability, bool emitGeneratedCodeMarkers)
+    internal static string BuildGeneratedFileHeader(Nullability nullability, bool emitGeneratedCodeMarkers)
     {
         if (!emitGeneratedCodeMarkers)
         {
@@ -311,7 +311,7 @@ internal static partial class Emitter
     /// <param name="interfaces">The parsed interface models.</param>
     /// <param name="emitGeneratedCodeMarkers">Whether generated-code markers should be emitted.</param>
     /// <returns>The generated file header.</returns>
-    private static string BuildSharedGeneratedFileHeader(
+    internal static string BuildSharedGeneratedFileHeader(
         ImmutableEquatableArray<InterfaceModel> interfaces,
         bool emitGeneratedCodeMarkers)
     {
@@ -329,7 +329,7 @@ internal static partial class Emitter
     /// <summary>Builds the generated factory registrations for non-generic interfaces.</summary>
     /// <param name="interfaces">The parsed interface models.</param>
     /// <returns>The generated factory registrations.</returns>
-    private static string BuildGeneratedFactoryRegistrations(ImmutableEquatableArray<InterfaceModel> interfaces)
+    internal static string BuildGeneratedFactoryRegistrations(ImmutableEquatableArray<InterfaceModel> interfaces)
     {
         var registrations = new string[interfaces.Count * RegistrationsPerInterface];
         var count = 0;
@@ -370,7 +370,7 @@ internal static partial class Emitter
     /// <param name="model">The interface model being emitted.</param>
     /// <param name="settingsFieldName">The unique generated field name that stores Refit settings.</param>
     /// <returns>The generated constructor source, or an empty string.</returns>
-    private static string BuildSettingsConstructor(InterfaceModel model, string settingsFieldName) =>
+    internal static string BuildSettingsConstructor(InterfaceModel model, string settingsFieldName) =>
         !CanUseGeneratedSettingsFactory(model)
             ? string.Empty
             : $$"""
@@ -388,7 +388,7 @@ internal static partial class Emitter
     /// <summary>Determines whether an interface can be constructed without a reflection request builder.</summary>
     /// <param name="model">The interface model being emitted.</param>
     /// <returns><see langword="true"/> when all Refit methods use generated request construction.</returns>
-    private static bool CanUseGeneratedSettingsFactory(InterfaceModel model) =>
+    internal static bool CanUseGeneratedSettingsFactory(InterfaceModel model) =>
         (model.RefitMethods.Count != 0 || model.DerivedRefitMethods.Count != 0)
         && AllRequestsCanGenerateInline(model.RefitMethods)
         && AllRequestsCanGenerateInline(model.DerivedRefitMethods);
@@ -396,7 +396,7 @@ internal static partial class Emitter
     /// <summary>Determines whether all methods in a collection use generated request construction.</summary>
     /// <param name="methods">The methods to inspect.</param>
     /// <returns><see langword="true"/> when each method can be emitted inline.</returns>
-    private static bool AllRequestsCanGenerateInline(ImmutableEquatableArray<MethodModel> methods)
+    internal static bool AllRequestsCanGenerateInline(ImmutableEquatableArray<MethodModel> methods)
     {
         for (var i = 0; i < methods.Count; i++)
         {
@@ -413,7 +413,7 @@ internal static partial class Emitter
     /// <param name="typeParameters">The parsed type parameter constraints.</param>
     /// <param name="indentationLevel">The generated indentation level.</param>
     /// <returns>The generated type parameter documentation.</returns>
-    private static string BuildTypeParameterDocumentation(
+    internal static string BuildTypeParameterDocumentation(
         ImmutableEquatableArray<TypeConstraint> typeParameters,
         int indentationLevel)
     {
@@ -436,7 +436,7 @@ internal static partial class Emitter
     /// <param name="properties">The property models to emit.</param>
     /// <param name="supportsNullable">Whether the consumer compilation supports nullable reference type syntax.</param>
     /// <returns>The generated property implementations.</returns>
-    private static string BuildInterfaceProperties(
+    internal static string BuildInterfaceProperties(
         ImmutableEquatableArray<InterfacePropertyModel> properties,
         bool supportsNullable)
     {
@@ -464,7 +464,7 @@ internal static partial class Emitter
     /// <param name="settingsFieldName">The unique generated field name that stores Refit settings.</param>
     /// <param name="enumFormatterScope">The enum formatter scope for the interface.</param>
     /// <returns>The generated method implementations.</returns>
-    private static string BuildRefitMethods(
+    internal static string BuildRefitMethods(
         ImmutableEquatableArray<MethodModel> methods,
         bool isTopLevel,
         InterfaceModel interfaceModel,
@@ -498,7 +498,7 @@ internal static partial class Emitter
     /// <param name="methods">The non-Refit method models to emit.</param>
     /// <param name="supportsNullable">Whether the consumer compilation supports nullable reference type syntax.</param>
     /// <returns>The generated method stubs.</returns>
-    private static string BuildNonRefitMethods(
+    internal static string BuildNonRefitMethods(
         ImmutableEquatableArray<MethodModel> methods,
         bool supportsNullable)
     {
@@ -519,12 +519,12 @@ internal static partial class Emitter
     /// <summary>Converts a bool to a lowercase C# literal.</summary>
     /// <param name="value">The value to convert.</param>
     /// <returns>The lowercase bool literal.</returns>
-    private static string ToLowerInvariantString(bool value) => value ? TrueLiteral : FalseLiteral;
+    internal static string ToLowerInvariantString(bool value) => value ? TrueLiteral : FalseLiteral;
 
     /// <summary>Converts a string into a C# string literal.</summary>
     /// <param name="value">The value to quote.</param>
     /// <returns>The escaped C# string literal.</returns>
-    private static string ToCSharpStringLiteral(string value)
+    internal static string ToCSharpStringLiteral(string value)
     {
         // The vast majority of emitted literals (query keys, header names, paths) need no escaping, so wrap them in
         // quotes with a single concat instead of allocating a builder and appending each character.
@@ -547,7 +547,7 @@ internal static partial class Emitter
     /// <summary>Determines whether any character in a value requires C# string-literal escaping.</summary>
     /// <param name="value">The value to inspect.</param>
     /// <returns><see langword="true"/> when at least one character needs an escape sequence.</returns>
-    private static bool NeedsCSharpEscaping(string value)
+    internal static bool NeedsCSharpEscaping(string value)
     {
         foreach (var c in value)
         {
@@ -564,7 +564,7 @@ internal static partial class Emitter
     /// <param name="methodModel">The method model being emitted.</param>
     /// <param name="supportsNullable">Whether the consumer compilation supports nullable reference type syntax.</param>
     /// <returns>The generated method stub.</returns>
-    private static string BuildNonRefitMethod(MethodModel methodModel, bool supportsNullable)
+    internal static string BuildNonRefitMethod(MethodModel methodModel, bool supportsNullable)
     {
         var isExplicit = methodModel.IsExplicitInterface;
         var messageLiteral = ToCSharpStringLiteral(NonRefitMethodExceptionMessage);
@@ -582,7 +582,7 @@ internal static partial class Emitter
     /// <param name="property">The property model being emitted.</param>
     /// <param name="supportsNullable">Whether the consumer compilation supports nullable reference type syntax.</param>
     /// <returns>The generated property implementation, or an empty string.</returns>
-    private static string BuildInterfaceProperty(
+    internal static string BuildInterfaceProperty(
         InterfacePropertyModel property,
         bool supportsNullable)
     {
@@ -611,7 +611,7 @@ internal static partial class Emitter
     /// <summary>Builds the explicit IDisposable.Dispose implementation.</summary>
     /// <param name="shouldEmit">True when the dispose method should be emitted.</param>
     /// <returns>The generated dispose method, or an empty string.</returns>
-    private static string BuildDisposableMethod(bool shouldEmit)
+    internal static string BuildDisposableMethod(bool shouldEmit)
     {
         if (!shouldEmit)
         {

--- a/src/InterfaceStubGenerator.Shared/Emitter.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.cs
@@ -478,20 +478,23 @@ internal static partial class Emitter
             return string.Empty;
         }
 
-        var parts = new string[methods.Count];
+        // Append every method body into one pooled buffer rather than building a per-method string and a parts array
+        // for ConcatParts: the individual method strings and the trimmed array never materialize.
+        var fieldNames = new GeneratedFieldNames(requestBuilderFieldName, settingsFieldName);
+        var builder = new PooledStringBuilder();
         for (var i = 0; i < methods.Count; i++)
         {
-            parts[i] = BuildRefitMethod(
+            BuildRefitMethod(
+                builder,
                 methods[i],
                 isTopLevel,
                 interfaceModel,
                 uniqueNames,
-                requestBuilderFieldName,
-                settingsFieldName,
+                fieldNames,
                 enumFormatterScope);
         }
 
-        return ConcatParts(parts, parts.Length);
+        return builder.ToString();
     }
 
     /// <summary>Builds generated non-Refit method stubs.</summary>

--- a/src/InterfaceStubGenerator.Shared/Emitter.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.cs
@@ -91,58 +91,71 @@ internal static partial class Emitter
         uniqueNames.Reserve(model.MemberNames);
         var requestBuilderFieldName = uniqueNames.New("_requestBuilder");
         var settingsFieldName = uniqueNames.New("_settings");
-        var typeParameterDocs = BuildTypeParameterDocumentation(model.Constraints, ClassMemberIndentation);
-        var generatedCodeAttribute = GeneratedCodeAttribute;
-        var settingsConstructorSource = BuildSettingsConstructor(model, settingsFieldName);
-        var requestBuilderFieldType = model.SupportsNullable
-            ? "global::Refit.IRequestBuilder?"
-            : "global::Refit.IRequestBuilder";
 
         // Assemble the interface source in one pooled buffer: the fixed wrapper (header, type declaration, fields, and
         // constructors up to the settings constructor), then the member blocks appended straight in, then the closing
-        // braces. The member-block string never materializes before the interface source is assembled.
-        var prefix = $$"""
-            {{BuildGeneratedFileHeader(model.Nullability, model.EmitGeneratedCodeMarkers)}}{{BuildExternAliasDirectives(model.ExternAliases)}}
-            namespace Refit.Implementation
-            {
-                /// <summary>Contains generated Refit implementation types.</summary>
-                internal partial class Generated
-                {
-                    /// <summary>Generated Refit implementation for {{ToXmlDocumentationText(model.InterfaceDisplayName)}}.</summary>
-            {{typeParameterDocs}}        {{generatedCodeAttribute}}
-                    [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-                    [global::System.Diagnostics.DebuggerNonUserCode]
-                    [{{model.PreserveAttributeDisplayName}}]
-                    [global::System.Reflection.Obfuscation(Exclude=true)]
-                    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-                    private sealed class {{model.Ns}}{{model.ClassDeclaration}}
-                        : {{model.InterfaceDisplayName}}
-            {{BuildConstraints(model.Constraints, false, ClassMemberIndentation)}}        {
-                        /// <summary>The request builder used to create Refit method delegates.</summary>
-                        private readonly {{requestBuilderFieldType}} {{requestBuilderFieldName}};
-
-                        /// <summary>The settings used by this generated Refit implementation.</summary>
-                        private readonly global::Refit.RefitSettings {{settingsFieldName}};
-
-                        /// <summary>Gets the HTTP client used by this generated Refit implementation.</summary>
-                        public global::System.Net.Http.HttpClient Client { get; }
-
-                        /// <summary>Initializes a new instance of the {{model.Ns}}{{model.ClassSuffix}} class.</summary>
-                        /// <param name="client">The HTTP client used by the generated implementation.</param>
-                        /// <param name="requestBuilder">The request builder used to create Refit method delegates.</param>
-                        public {{model.Ns}}{{model.ClassSuffix}}(global::System.Net.Http.HttpClient client, global::Refit.IRequestBuilder requestBuilder)
-                        {
-                            Client = client;
-                            {{requestBuilderFieldName}} = requestBuilder;
-                            {{settingsFieldName}} = requestBuilder.Settings;
-                        }
-            {{settingsConstructorSource}}
-            """;
+        // braces. Neither the wrapper nor the member blocks materialize as their own string before the source is built.
         var builder = new PooledStringBuilder();
-        _ = builder.Append(prefix);
+        AppendInterfacePrefix(builder, model, requestBuilderFieldName, settingsFieldName);
         AppendInterfaceMemberSource(builder, model, uniqueNames, requestBuilderFieldName, settingsFieldName);
         _ = builder.Append(InterfaceSourceClosingBraces);
         return ToSourceText(builder.ToString());
+    }
+
+    /// <summary>Appends the fixed class wrapper up to the settings constructor straight into the interface buffer.</summary>
+    /// <param name="builder">The buffer accumulating the interface source.</param>
+    /// <param name="model">The interface model being emitted.</param>
+    /// <param name="requestBuilderFieldName">The unique generated field name that stores the request builder.</param>
+    /// <param name="settingsFieldName">The unique generated field name that stores Refit settings.</param>
+    internal static void AppendInterfacePrefix(
+        PooledStringBuilder builder,
+        InterfaceModel model,
+        string requestBuilderFieldName,
+        string settingsFieldName)
+    {
+        var typeParameterDocs = BuildTypeParameterDocumentation(model.Constraints, ClassMemberIndentation);
+        var requestBuilderFieldType = model.SupportsNullable
+            ? "global::Refit.IRequestBuilder?"
+            : "global::Refit.IRequestBuilder";
+        var settingsConstructorSource = BuildSettingsConstructor(model, settingsFieldName);
+
+        _ = builder
+            .Append(BuildGeneratedFileHeader(model.Nullability, model.EmitGeneratedCodeMarkers))
+            .Append(BuildExternAliasDirectives(model.ExternAliases)).Append("\n")
+            .Append("namespace Refit.Implementation\n")
+            .Append("{\n")
+            .Append("    /// <summary>Contains generated Refit implementation types.</summary>\n")
+            .Append("    internal partial class Generated\n")
+            .Append("    {\n")
+            .Append("        /// <summary>Generated Refit implementation for ").Append(ToXmlDocumentationText(model.InterfaceDisplayName)).Append(".</summary>\n")
+            .Append(typeParameterDocs).Append("        ").Append(GeneratedCodeAttribute).Append("\n")
+            .Append("        [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]\n")
+            .Append("        [global::System.Diagnostics.DebuggerNonUserCode]\n")
+            .Append("        [").Append(model.PreserveAttributeDisplayName).Append("]\n")
+            .Append("        [global::System.Reflection.Obfuscation(Exclude=true)]\n")
+            .Append("        [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]\n")
+            .Append("        private sealed class ").Append(model.Ns).Append(model.ClassDeclaration).Append("\n")
+            .Append("            : ").Append(model.InterfaceDisplayName).Append("\n")
+            .Append(BuildConstraints(model.Constraints, false, ClassMemberIndentation)).Append("        {\n")
+            .Append("            /// <summary>The request builder used to create Refit method delegates.</summary>\n")
+            .Append("            private readonly ").Append(requestBuilderFieldType).Append(" ").Append(requestBuilderFieldName).Append(";\n")
+            .Append("\n")
+            .Append("            /// <summary>The settings used by this generated Refit implementation.</summary>\n")
+            .Append("            private readonly global::Refit.RefitSettings ").Append(settingsFieldName).Append(";\n")
+            .Append("\n")
+            .Append("            /// <summary>Gets the HTTP client used by this generated Refit implementation.</summary>\n")
+            .Append("            public global::System.Net.Http.HttpClient Client { get; }\n")
+            .Append("\n")
+            .Append("            /// <summary>Initializes a new instance of the ").Append(model.Ns).Append(model.ClassSuffix).Append(" class.</summary>\n")
+            .Append("            /// <param name=\"client\">The HTTP client used by the generated implementation.</param>\n")
+            .Append("            /// <param name=\"requestBuilder\">The request builder used to create Refit method delegates.</param>\n")
+            .Append("            public ").Append(model.Ns).Append(model.ClassSuffix).Append("(global::System.Net.Http.HttpClient client, global::Refit.IRequestBuilder requestBuilder)\n")
+            .Append("            {\n")
+            .Append("                Client = client;\n")
+            .Append("                ").Append(requestBuilderFieldName).Append(" = requestBuilder;\n")
+            .Append("                ").Append(settingsFieldName).Append(" = requestBuilder.Settings;\n")
+            .Append("            }\n")
+            .Append(settingsConstructorSource);
     }
 
     /// <summary>Appends the generated property, method, and dispose member blocks for an interface into the buffer.</summary>

--- a/src/InterfaceStubGenerator.Shared/Emitter.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.cs
@@ -40,10 +40,6 @@ internal static partial class Emitter
     /// <summary>The generated prefix for type expressions.</summary>
     private const string TypeOfPrefix = "typeof(";
 
-    /// <summary>The closing braces that terminate a generated interface source: the implementation class, the
-    /// <c>Generated</c> partial class, and the <c>Refit.Implementation</c> namespace.</summary>
-    private const string InterfaceSourceClosingBraces = "        }\n    }\n}\n";
-
     /// <summary>The fully qualified prefix of a generated implementation type, before its namespace mangling and suffix.</summary>
     private const string GeneratedTypePrefix = "global::Refit.Implementation.Generated.";
 
@@ -101,7 +97,9 @@ internal static partial class Emitter
         var builder = new PooledStringBuilder();
         AppendInterfacePrefix(builder, model, requestBuilderFieldName, settingsFieldName);
         AppendInterfaceMemberSource(builder, model, uniqueNames, requestBuilderFieldName, settingsFieldName);
-        _ = builder.Append(InterfaceSourceClosingBraces);
+
+        // Close the implementation class, the Generated partial class, and the Refit.Implementation namespace.
+        _ = builder.AppendLine("        }").AppendLine("    }").AppendLine("}");
         return ToSourceText(builder.ToString());
     }
 
@@ -124,40 +122,40 @@ internal static partial class Emitter
 
         _ = builder
             .Append(BuildGeneratedFileHeader(model.Nullability, model.EmitGeneratedCodeMarkers))
-            .Append(BuildExternAliasDirectives(model.ExternAliases)).Append("\n")
-            .Append("namespace Refit.Implementation\n")
-            .Append("{\n")
-            .Append("    /// <summary>Contains generated Refit implementation types.</summary>\n")
-            .Append("    internal partial class Generated\n")
-            .Append("    {\n")
-            .Append("        /// <summary>Generated Refit implementation for ").Append(ToXmlDocumentationText(model.InterfaceDisplayName)).Append(".</summary>\n")
-            .Append(typeParameterDocs).Append("        ").Append(GeneratedCodeAttribute).Append("\n")
-            .Append("        [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]\n")
-            .Append("        [global::System.Diagnostics.DebuggerNonUserCode]\n")
-            .Append("        [").Append(model.PreserveAttributeDisplayName).Append("]\n")
-            .Append("        [global::System.Reflection.Obfuscation(Exclude=true)]\n")
-            .Append("        [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]\n")
-            .Append("        private sealed class ").Append(model.Ns).Append(model.ClassDeclaration).Append("\n")
-            .Append("            : ").Append(model.InterfaceDisplayName).Append("\n")
-            .Append(BuildConstraints(model.Constraints, false, ClassMemberIndentation)).Append("        {\n")
-            .Append("            /// <summary>The request builder used to create Refit method delegates.</summary>\n")
-            .Append("            private readonly ").Append(requestBuilderFieldType).Append(" ").Append(requestBuilderFieldName).Append(";\n")
-            .Append("\n")
-            .Append("            /// <summary>The settings used by this generated Refit implementation.</summary>\n")
-            .Append("            private readonly global::Refit.RefitSettings ").Append(settingsFieldName).Append(";\n")
-            .Append("\n")
-            .Append("            /// <summary>Gets the HTTP client used by this generated Refit implementation.</summary>\n")
-            .Append("            public global::System.Net.Http.HttpClient Client { get; }\n")
-            .Append("\n")
-            .Append("            /// <summary>Initializes a new instance of the ").Append(model.Ns).Append(model.ClassSuffix).Append(" class.</summary>\n")
-            .Append("            /// <param name=\"client\">The HTTP client used by the generated implementation.</param>\n")
-            .Append("            /// <param name=\"requestBuilder\">The request builder used to create Refit method delegates.</param>\n")
-            .Append("            public ").Append(model.Ns).Append(model.ClassSuffix).Append("(global::System.Net.Http.HttpClient client, global::Refit.IRequestBuilder requestBuilder)\n")
-            .Append("            {\n")
-            .Append("                Client = client;\n")
-            .Append("                ").Append(requestBuilderFieldName).Append(" = requestBuilder;\n")
-            .Append("                ").Append(settingsFieldName).Append(" = requestBuilder.Settings;\n")
-            .Append("            }\n")
+            .Append(BuildExternAliasDirectives(model.ExternAliases)).AppendLine()
+            .AppendLine("namespace Refit.Implementation")
+            .AppendLine("{")
+            .AppendLine("    /// <summary>Contains generated Refit implementation types.</summary>")
+            .AppendLine("    internal partial class Generated")
+            .AppendLine("    {")
+            .Append("        /// <summary>Generated Refit implementation for ").Append(ToXmlDocumentationText(model.InterfaceDisplayName)).AppendLine(".</summary>")
+            .Append(typeParameterDocs).Append("        ").Append(GeneratedCodeAttribute).AppendLine()
+            .AppendLine("        [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]")
+            .AppendLine("        [global::System.Diagnostics.DebuggerNonUserCode]")
+            .Append("        [").Append(model.PreserveAttributeDisplayName).AppendLine("]")
+            .AppendLine("        [global::System.Reflection.Obfuscation(Exclude=true)]")
+            .AppendLine("        [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]")
+            .Append("        private sealed class ").Append(model.Ns).Append(model.ClassDeclaration).AppendLine()
+            .Append("            : ").Append(model.InterfaceDisplayName).AppendLine()
+            .Append(BuildConstraints(model.Constraints, false, ClassMemberIndentation)).AppendLine("        {")
+            .AppendLine("            /// <summary>The request builder used to create Refit method delegates.</summary>")
+            .Append("            private readonly ").Append(requestBuilderFieldType).Append(" ").Append(requestBuilderFieldName).AppendLine(";")
+            .AppendLine()
+            .AppendLine("            /// <summary>The settings used by this generated Refit implementation.</summary>")
+            .Append("            private readonly global::Refit.RefitSettings ").Append(settingsFieldName).AppendLine(";")
+            .AppendLine()
+            .AppendLine("            /// <summary>Gets the HTTP client used by this generated Refit implementation.</summary>")
+            .AppendLine("            public global::System.Net.Http.HttpClient Client { get; }")
+            .AppendLine()
+            .Append("            /// <summary>Initializes a new instance of the ").Append(model.Ns).Append(model.ClassSuffix).AppendLine(" class.</summary>")
+            .AppendLine("            /// <param name=\"client\">The HTTP client used by the generated implementation.</param>")
+            .AppendLine("            /// <param name=\"requestBuilder\">The request builder used to create Refit method delegates.</param>")
+            .Append("            public ").Append(model.Ns).Append(model.ClassSuffix).AppendLine("(global::System.Net.Http.HttpClient client, global::Refit.IRequestBuilder requestBuilder)")
+            .AppendLine("            {")
+            .AppendLine("                Client = client;")
+            .Append("                ").Append(requestBuilderFieldName).AppendLine(" = requestBuilder;")
+            .Append("                ").Append(settingsFieldName).AppendLine(" = requestBuilder.Settings;")
+            .AppendLine("            }")
             .Append(settingsConstructorSource);
     }
 
@@ -345,16 +343,16 @@ internal static partial class Emitter
             // The static modifier on a lambda is C# 9; older consumers must not see it.
             var lambdaModifier = interfaceModel.SupportsStaticLambdas ? "static " : string.Empty;
             _ = builder
-                .Append("            global::Refit.RestService.RegisterGeneratedFactory<").Append(interfaceModel.InterfaceDisplayName).Append(">(\n")
+                .Append("            global::Refit.RestService.RegisterGeneratedFactory<").Append(interfaceModel.InterfaceDisplayName).AppendLine(">(")
                 .Append("                ").Append(lambdaModifier).Append("(client, requestBuilder) => new ").Append(GeneratedTypePrefix)
-                .Append(interfaceModel.Ns).Append(interfaceModel.ClassSuffix).Append("(client, requestBuilder));\n");
+                .Append(interfaceModel.Ns).Append(interfaceModel.ClassSuffix).AppendLine("(client, requestBuilder));");
 
             if (CanUseGeneratedSettingsFactory(interfaceModel))
             {
                 _ = builder
-                    .Append("            global::Refit.RestService.RegisterGeneratedSettingsFactory<").Append(interfaceModel.InterfaceDisplayName).Append(">(\n")
+                    .Append("            global::Refit.RestService.RegisterGeneratedSettingsFactory<").Append(interfaceModel.InterfaceDisplayName).AppendLine(">(")
                     .Append("                ").Append(lambdaModifier).Append("(client, settings) => new ").Append(GeneratedTypePrefix)
-                    .Append(interfaceModel.Ns).Append(interfaceModel.ClassSuffix).Append("(client, settings));\n");
+                    .Append(interfaceModel.Ns).Append(interfaceModel.ClassSuffix).AppendLine("(client, settings));");
             }
         }
 

--- a/src/InterfaceStubGenerator.Shared/Emitter.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.cs
@@ -21,9 +21,6 @@ internal static partial class Emitter
     /// <summary>The rendered length of the <c>", "</c> separator emitted between joined items.</summary>
     private const int ListSeparatorLength = 2;
 
-    /// <summary>The number of generated factory registrations emitted per non-generic interface.</summary>
-    private const int RegistrationsPerInterface = 2;
-
     /// <summary>The radix used when rendering decimal integers.</summary>
     private const int DecimalRadix = 10;
 
@@ -318,8 +315,9 @@ internal static partial class Emitter
     /// <returns>The generated factory registrations.</returns>
     internal static string BuildGeneratedFactoryRegistrations(ImmutableEquatableArray<InterfaceModel> interfaces)
     {
-        var registrations = new string[interfaces.Count * RegistrationsPerInterface];
-        var count = 0;
+        // Append each registration straight into one pooled buffer instead of a per-registration string array joined by
+        // ConcatParts, so the array and the trimmed join result never materialize.
+        var builder = new PooledStringBuilder();
         for (var i = 0; i < interfaces.Count; i++)
         {
             var interfaceModel = interfaces[i];
@@ -332,25 +330,23 @@ internal static partial class Emitter
 
             // The static modifier on a lambda is C# 9; older consumers must not see it.
             var lambdaModifier = interfaceModel.SupportsStaticLambdas ? "static " : string.Empty;
-            registrations[count] = $$"""
+            _ = builder.Append($$"""
                                     global::Refit.RestService.RegisterGeneratedFactory<{{interfaceModel.InterfaceDisplayName}}>(
                                         {{lambdaModifier}}(client, requestBuilder) => new {{generatedType}}(client, requestBuilder));
 
-                        """;
-            count++;
+                        """);
 
             if (CanUseGeneratedSettingsFactory(interfaceModel))
             {
-                registrations[count] = $$"""
+                _ = builder.Append($$"""
                                         global::Refit.RestService.RegisterGeneratedSettingsFactory<{{interfaceModel.InterfaceDisplayName}}>(
                                             {{lambdaModifier}}(client, settings) => new {{generatedType}}(client, settings));
 
-                            """;
-                count++;
+                            """);
             }
         }
 
-        return count == 0 ? string.Empty : ConcatParts(registrations, count);
+        return builder.ToString();
     }
 
     /// <summary>Builds the settings-only constructor when the generated implementation can avoid request-builder reflection.</summary>

--- a/src/InterfaceStubGenerator.Shared/Emitter.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.cs
@@ -43,6 +43,10 @@ internal static partial class Emitter
     /// <summary>The generated prefix for type expressions.</summary>
     private const string TypeOfPrefix = "typeof(";
 
+    /// <summary>The closing braces that terminate a generated interface source: the implementation class, the
+    /// <c>Generated</c> partial class, and the <c>Refit.Implementation</c> namespace.</summary>
+    private const string InterfaceSourceClosingBraces = "        }\n    }\n}\n";
+
     /// <summary>The number of spaces in one generated indentation level.</summary>
     private const int CharsPerIndentation = 4;
 
@@ -90,14 +94,17 @@ internal static partial class Emitter
         uniqueNames.Reserve(model.MemberNames);
         var requestBuilderFieldName = uniqueNames.New("_requestBuilder");
         var settingsFieldName = uniqueNames.New("_settings");
-        var memberSource = BuildInterfaceMemberSource(model, uniqueNames, requestBuilderFieldName, settingsFieldName);
         var typeParameterDocs = BuildTypeParameterDocumentation(model.Constraints, ClassMemberIndentation);
         var generatedCodeAttribute = GeneratedCodeAttribute;
         var settingsConstructorSource = BuildSettingsConstructor(model, settingsFieldName);
         var requestBuilderFieldType = model.SupportsNullable
             ? "global::Refit.IRequestBuilder?"
             : "global::Refit.IRequestBuilder";
-        var source = $$"""
+
+        // Assemble the interface source in one pooled buffer: the fixed wrapper (header, type declaration, fields, and
+        // constructors up to the settings constructor), then the member blocks appended straight in, then the closing
+        // braces. The member-block string never materializes before the interface source is assembled.
+        var prefix = $$"""
             {{BuildGeneratedFileHeader(model.Nullability, model.EmitGeneratedCodeMarkers)}}{{BuildExternAliasDirectives(model.ExternAliases)}}
             namespace Refit.Implementation
             {
@@ -132,21 +139,23 @@ internal static partial class Emitter
                             {{requestBuilderFieldName}} = requestBuilder;
                             {{settingsFieldName}} = requestBuilder.Settings;
                         }
-            {{settingsConstructorSource}}{{memberSource}}        }
-                }
-            }
-
+            {{settingsConstructorSource}}
             """;
-        return ToSourceText(source);
+        var builder = new PooledStringBuilder();
+        _ = builder.Append(prefix);
+        AppendInterfaceMemberSource(builder, model, uniqueNames, requestBuilderFieldName, settingsFieldName);
+        _ = builder.Append(InterfaceSourceClosingBraces);
+        return ToSourceText(builder.ToString());
     }
 
-    /// <summary>Concatenates the generated property, method, and dispose member blocks for an interface.</summary>
+    /// <summary>Appends the generated property, method, and dispose member blocks for an interface into the buffer.</summary>
+    /// <param name="builder">The buffer accumulating the interface source.</param>
     /// <param name="model">The interface model being emitted.</param>
     /// <param name="uniqueNames">Contains the unique member names in the interface scope.</param>
     /// <param name="requestBuilderFieldName">The unique generated field name that stores the request builder.</param>
     /// <param name="settingsFieldName">The unique generated field name that stores Refit settings.</param>
-    /// <returns>The concatenated member source.</returns>
-    internal static string BuildInterfaceMemberSource(
+    internal static void AppendInterfaceMemberSource(
+        PooledStringBuilder builder,
         InterfaceModel model,
         UniqueNameBuilder uniqueNames,
         string requestBuilderFieldName,
@@ -156,14 +165,12 @@ internal static partial class Emitter
         var fieldNames = new GeneratedFieldNames(requestBuilderFieldName, settingsFieldName);
 
         // Append the five member blocks (properties, top-level and derived Refit methods, non-Refit stubs, and dispose)
-        // straight into one pooled buffer so none of the block strings materialize before the interface source is built.
-        var builder = new PooledStringBuilder();
+        // straight into the interface buffer so none of the block strings materialize before the source is built.
         AppendInterfaceProperties(builder, model.Properties, model.SupportsNullable);
         AppendRefitMethods(builder, model.RefitMethods, true, model, uniqueNames, fieldNames, enumFormatterScope);
         AppendRefitMethods(builder, model.DerivedRefitMethods, false, model, uniqueNames, fieldNames, enumFormatterScope);
         AppendNonRefitMethods(builder, model.NonRefitMethods, model.SupportsNullable);
         AppendDisposableMethod(builder, model.DisposeMethod);
-        return builder.ToString();
     }
 
     /// <summary>Creates source text from generated source.</summary>

--- a/src/InterfaceStubGenerator.Shared/InterfaceStubGeneratorV2.cs
+++ b/src/InterfaceStubGenerator.Shared/InterfaceStubGeneratorV2.cs
@@ -157,7 +157,7 @@ public class InterfaceStubGeneratorV2 : IIncrementalGenerator
     /// <summary>Creates the provider for methods decorated with Refit's built-in HTTP method attributes.</summary>
     /// <param name="context">The generator initialization context.</param>
     /// <returns>The collected candidate methods.</returns>
-    private static IncrementalValueProvider<ImmutableArray<MethodDeclarationSyntax>>
+    internal static IncrementalValueProvider<ImmutableArray<MethodDeclarationSyntax>>
         CreateStandardHttpMethodCandidateProvider(in IncrementalGeneratorInitializationContext context)
     {
         var deleteMethods = CreateHttpMethodCandidateProvider(context, DeleteAttributeMetadataName).Collect();
@@ -194,7 +194,7 @@ public class InterfaceStubGeneratorV2 : IIncrementalGenerator
     /// <param name="context">The generator initialization context.</param>
     /// <param name="metadataName">The fully qualified metadata name.</param>
     /// <returns>The matching method declarations.</returns>
-    private static IncrementalValuesProvider<MethodDeclarationSyntax> CreateHttpMethodCandidateProvider(
+    internal static IncrementalValuesProvider<MethodDeclarationSyntax> CreateHttpMethodCandidateProvider(
         in IncrementalGeneratorInitializationContext context,
         string metadataName) =>
         context.SyntaxProvider.ForAttributeWithMetadataName(
@@ -206,13 +206,13 @@ public class InterfaceStubGeneratorV2 : IIncrementalGenerator
     /// <param name="syntax">The candidate syntax node carrying a Refit HTTP method attribute.</param>
     /// <returns><see langword="true"/> when the node is an interface method declaration.</returns>
     [ExcludeFromCodeCoverage]
-    private static bool IsInterfaceMethodDeclaration(SyntaxNode syntax) =>
+    internal static bool IsInterfaceMethodDeclaration(SyntaxNode syntax) =>
         syntax is MethodDeclarationSyntax { Parent: InterfaceDeclarationSyntax };
 
     /// <summary>Combines standard HTTP method candidate arrays into one array.</summary>
     /// <param name="candidates">The candidate arrays.</param>
     /// <returns>The combined candidates.</returns>
-    private static ImmutableArray<MethodDeclarationSyntax> CombineStandardHttpMethodCandidates(
+    internal static ImmutableArray<MethodDeclarationSyntax> CombineStandardHttpMethodCandidates(
         in StandardHttpMethodCandidates candidates)
     {
 #if ROSLYN_5
@@ -250,7 +250,7 @@ public class InterfaceStubGeneratorV2 : IIncrementalGenerator
     /// <summary>Combines built-in and potential custom HTTP method candidates.</summary>
     /// <param name="combined">The built-in and custom candidate arrays.</param>
     /// <returns>The combined candidates.</returns>
-    private static ImmutableArray<MethodDeclarationSyntax> CombineCandidateMethods(
+    internal static ImmutableArray<MethodDeclarationSyntax> CombineCandidateMethods(
         (ImmutableArray<MethodDeclarationSyntax> StandardMethods,
         ImmutableArray<MethodDeclarationSyntax> CustomMethods) combined)
     {
@@ -278,7 +278,7 @@ public class InterfaceStubGeneratorV2 : IIncrementalGenerator
     /// <summary>Determines whether syntax might be a method using a custom Refit HTTP method attribute.</summary>
     /// <param name="syntax">The syntax node to inspect.</param>
     /// <returns><see langword="true"/> when the method should go through the compatibility fallback.</returns>
-    private static bool IsPotentialCustomHttpMethodSyntax(SyntaxNode syntax)
+    internal static bool IsPotentialCustomHttpMethodSyntax(SyntaxNode syntax)
     {
         if (syntax is not MethodDeclarationSyntax
             {
@@ -306,7 +306,7 @@ public class InterfaceStubGeneratorV2 : IIncrementalGenerator
     /// <summary>Determines whether an attribute syntax name is a built-in Refit HTTP method attribute name.</summary>
     /// <param name="name">The attribute name syntax.</param>
     /// <returns><see langword="true"/> when the name is one of Refit's built-in HTTP method attributes.</returns>
-    private static bool IsStandardHttpMethodAttributeName(NameSyntax name)
+    internal static bool IsStandardHttpMethodAttributeName(NameSyntax name)
     {
         var identifier = GetRightmostIdentifier(name);
         const string attributeSuffix = "Attribute";
@@ -321,7 +321,7 @@ public class InterfaceStubGeneratorV2 : IIncrementalGenerator
     /// <summary>Gets the rightmost identifier text from an attribute name.</summary>
     /// <param name="name">The attribute name syntax.</param>
     /// <returns>The rightmost identifier text.</returns>
-    private static string GetRightmostIdentifier(NameSyntax name) =>
+    internal static string GetRightmostIdentifier(NameSyntax name) =>
         name switch
         {
             IdentifierNameSyntax identifierName => identifierName.Identifier.ValueText,
@@ -333,14 +333,14 @@ public class InterfaceStubGeneratorV2 : IIncrementalGenerator
     /// <summary>Creates the collected candidate syntax input.</summary>
     /// <param name="combined">The combined method and interface candidate collections.</param>
     /// <returns>The named candidate syntax input.</returns>
-    private static CandidateSyntax CreateCandidateSyntax(
+    internal static CandidateSyntax CreateCandidateSyntax(
         (ImmutableArray<MethodDeclarationSyntax> Methods, ImmutableArray<InterfaceDeclarationSyntax> Interfaces) combined) =>
         new(combined.Methods, combined.Interfaces);
 
     /// <summary>Creates the generator options input.</summary>
     /// <param name="options">The global analyzer-config options.</param>
     /// <returns>The named generator options input.</returns>
-    private static GeneratorOptions CreateGeneratorOptions(AnalyzerConfigOptions options)
+    internal static GeneratorOptions CreateGeneratorOptions(AnalyzerConfigOptions options)
     {
         _ = TryGetGlobalOption(options, RefitInternalNamespaceOption, out var refitInternalNamespace);
 
@@ -354,14 +354,14 @@ public class InterfaceStubGeneratorV2 : IIncrementalGenerator
     /// <summary>Creates the combined syntax and options input.</summary>
     /// <param name="combined">The combined candidate syntax and generator options.</param>
     /// <returns>The named syntax-and-options input.</returns>
-    private static SyntaxAndOptions CreateSyntaxAndOptions(
+    internal static SyntaxAndOptions CreateSyntaxAndOptions(
         (CandidateSyntax CandidateSyntax, GeneratorOptions Options) combined) =>
         new(combined.CandidateSyntax, combined.Options);
 
     /// <summary>Creates the final parser input.</summary>
     /// <param name="combined">The combined syntax/options input and compilation.</param>
     /// <returns>The named parser input.</returns>
-    private static GeneratorInputs CreateGeneratorInputs(
+    internal static GeneratorInputs CreateGeneratorInputs(
         (SyntaxAndOptions SyntaxAndOptions, Compilation Compilation) combined) =>
         new(
             combined.SyntaxAndOptions.CandidateSyntax.CandidateMethods,
@@ -374,7 +374,7 @@ public class InterfaceStubGeneratorV2 : IIncrementalGenerator
 
     /// <summary>Creates an empty result when generation is explicitly disabled.</summary>
     /// <returns>The disabled generation result.</returns>
-    private static (List<Diagnostic> diagnostics, ContextGenerationModel contextGenerationSpec)
+    internal static (List<Diagnostic> diagnostics, ContextGenerationModel contextGenerationSpec)
         CreateDisabledGenerationResult() =>
         new(
             [],
@@ -390,7 +390,7 @@ public class InterfaceStubGeneratorV2 : IIncrementalGenerator
     /// <param name="name">The option name without the build-property prefix.</param>
     /// <param name="defaultValue">The value to use when the option is not present or cannot be parsed.</param>
     /// <returns>The parsed option value.</returns>
-    private static bool GetBooleanOption(
+    internal static bool GetBooleanOption(
         AnalyzerConfigOptions options,
         string name,
         bool defaultValue) =>
@@ -401,12 +401,12 @@ public class InterfaceStubGeneratorV2 : IIncrementalGenerator
     /// <summary>The collected syntax candidates for one generator pass.</summary>
     /// <param name="CandidateMethods">The candidate method declarations.</param>
     /// <param name="CandidateInterfaces">The candidate interface declarations.</param>
-    private readonly record struct CandidateSyntax(
+    internal readonly record struct CandidateSyntax(
         ImmutableArray<MethodDeclarationSyntax> CandidateMethods,
         ImmutableArray<InterfaceDeclarationSyntax> CandidateInterfaces);
 
     /// <summary>The method declarations found through Refit's built-in HTTP method attributes.</summary>
-    private readonly record struct StandardHttpMethodCandidates
+    internal readonly record struct StandardHttpMethodCandidates
     {
         /// <summary>Gets the methods decorated with <c>DeleteAttribute</c>.</summary>
         public ImmutableArray<MethodDeclarationSyntax> DeleteMethods { get; init; }
@@ -435,7 +435,7 @@ public class InterfaceStubGeneratorV2 : IIncrementalGenerator
     /// <param name="GeneratedRequestBuilding">Whether inline request construction is enabled.</param>
     /// <param name="EmitGeneratedCodeMarkers">Whether generated files include generated-code analyzer skip markers.</param>
     /// <param name="DisableSourceGenerator">Whether source generation is disabled.</param>
-    private readonly record struct GeneratorOptions(
+    internal readonly record struct GeneratorOptions(
         string? RefitInternalNamespace,
         bool GeneratedRequestBuilding,
         bool EmitGeneratedCodeMarkers,
@@ -444,7 +444,7 @@ public class InterfaceStubGeneratorV2 : IIncrementalGenerator
     /// <summary>The collected syntax candidates plus generator options.</summary>
     /// <param name="CandidateSyntax">The candidate syntax input.</param>
     /// <param name="Options">The generator options input.</param>
-    private readonly record struct SyntaxAndOptions(
+    internal readonly record struct SyntaxAndOptions(
         CandidateSyntax CandidateSyntax,
         GeneratorOptions Options);
 
@@ -456,7 +456,7 @@ public class InterfaceStubGeneratorV2 : IIncrementalGenerator
     /// <param name="EmitGeneratedCodeMarkers">Whether generated files include generated-code analyzer skip markers.</param>
     /// <param name="DisableSourceGenerator">Whether source generation is disabled.</param>
     /// <param name="Compilation">The current compilation.</param>
-    private readonly record struct GeneratorInputs(
+    internal readonly record struct GeneratorInputs(
         ImmutableArray<MethodDeclarationSyntax> CandidateMethods,
         ImmutableArray<InterfaceDeclarationSyntax> CandidateInterfaces,
         string? RefitInternalNamespace,

--- a/src/InterfaceStubGenerator.Shared/Models/GeneratedFieldNames.cs
+++ b/src/InterfaceStubGenerator.Shared/Models/GeneratedFieldNames.cs
@@ -1,0 +1,9 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+namespace Refit.Generator;
+
+/// <summary>The generated backing-field names an interface implementation stores its collaborators in.</summary>
+/// <param name="RequestBuilder">The generated field name that stores the request builder.</param>
+/// <param name="Settings">The generated field name that stores Refit settings.</param>
+internal readonly record struct GeneratedFieldNames(string RequestBuilder, string Settings);

--- a/src/InterfaceStubGenerator.Shared/Models/InlineMethodFragments.cs
+++ b/src/InterfaceStubGenerator.Shared/Models/InlineMethodFragments.cs
@@ -1,0 +1,27 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+namespace Refit.Generator;
+
+/// <summary>The per-method source fragments assembled into an inline generated Refit method.</summary>
+/// <param name="RequestPrologueSource">The request-prologue formatting locals and query-builder setup.</param>
+/// <param name="HttpMethodFieldSource">The cached HTTP-method field declaration, if any.</param>
+/// <param name="HttpMethodExpression">The expression yielding the request's HTTP method.</param>
+/// <param name="RequestUriExpression">The expression yielding the request URI.</param>
+/// <param name="FormFieldsSource">The cached form-field descriptor field declaration, if any.</param>
+/// <param name="ContentSource">The request-content assignment source, if any.</param>
+/// <param name="HeaderSource">The request-header assignment source, if any.</param>
+/// <param name="RequestPropertySource">The request-property assignment source, if any.</param>
+/// <param name="TimeoutSource">The per-call timeout assignment source, if any.</param>
+/// <param name="Opening">The method signature and opening brace.</param>
+internal readonly record struct InlineMethodFragments(
+    string RequestPrologueSource,
+    string HttpMethodFieldSource,
+    string HttpMethodExpression,
+    string RequestUriExpression,
+    string FormFieldsSource,
+    string ContentSource,
+    string HeaderSource,
+    string RequestPropertySource,
+    string TimeoutSource,
+    string Opening);

--- a/src/InterfaceStubGenerator.Shared/Models/InterfaceGenerationContext.cs
+++ b/src/InterfaceStubGenerator.Shared/Models/InterfaceGenerationContext.cs
@@ -31,6 +31,9 @@ namespace Refit.Generator;
 /// <param name="ExternAliases">The per-interface collector recording the extern aliases used while qualifying its types.</param>
 /// <param name="AssemblyAliasCache">A pass-wide cache mapping an assembly symbol to its resolved extern alias (or null),
 /// shared across every interface so the extern-alias metadata-reference lookup runs once per assembly, not per type node.</param>
+/// <param name="QualifiedTypeCache">A pass-wide cache mapping a type symbol to its fully-qualified display string for the
+/// common non-extern-aliased case, shared across every interface so <c>ToDisplayString</c> renders each distinct type once
+/// per pass rather than once per occurrence. The aliased path is never cached because it records used aliases as a side effect.</param>
 /// <param name="PathPrefix">The shared route prefix declared by the interface being processed via <c>[PathPrefix]</c>,
 /// prepended to every method's relative path, or an empty string when the interface declares none.</param>
 internal sealed record InterfaceGenerationContext(
@@ -51,4 +54,5 @@ internal sealed record InterfaceGenerationContext(
     INamedTypeSymbol[] ReturnTypeAdapters,
     HashSet<string> ExternAliases,
     Dictionary<ISymbol, string?> AssemblyAliasCache,
+    Dictionary<ISymbol, string> QualifiedTypeCache,
     string PathPrefix = "");

--- a/src/InterfaceStubGenerator.Shared/Parser.Adapters.cs
+++ b/src/InterfaceStubGenerator.Shared/Parser.Adapters.cs
@@ -47,7 +47,7 @@ internal static partial class Parser
     /// <param name="adapterInterface">The resolved <c>IReturnTypeAdapter`2</c> symbol.</param>
     /// <param name="adapters">The accumulator for discovered adapter types.</param>
     /// <param name="cancellationToken">A token to observe while scanning.</param>
-    private static void CollectReturnTypeAdapters(
+    internal static void CollectReturnTypeAdapters(
         INamespaceSymbol namespaceSymbol,
         INamedTypeSymbol adapterInterface,
         List<INamedTypeSymbol> adapters,
@@ -74,7 +74,7 @@ internal static partial class Parser
     /// <param name="type">The type to inspect.</param>
     /// <param name="adapterInterface">The resolved <c>IReturnTypeAdapter`2</c> symbol.</param>
     /// <param name="adapters">The accumulator for discovered adapter types.</param>
-    private static void CollectReturnTypeAdapterType(
+    internal static void CollectReturnTypeAdapterType(
         INamedTypeSymbol type,
         INamedTypeSymbol adapterInterface,
         List<INamedTypeSymbol> adapters)
@@ -98,7 +98,7 @@ internal static partial class Parser
     /// <param name="closedAdapter">The closed adapter type to instantiate when matched.</param>
     /// <param name="resultType">The result type the HTTP call materializes when matched.</param>
     /// <returns><see langword="true"/> when a discovered adapter surfaces the return type; otherwise <see langword="false"/>.</returns>
-    private static bool TryMatchReturnTypeAdapter(
+    internal static bool TryMatchReturnTypeAdapter(
         ITypeSymbol returnType,
         InterfaceGenerationContext context,
         out INamedTypeSymbol closedAdapter,
@@ -140,7 +140,7 @@ internal static partial class Parser
     /// <param name="returnType">The declared return type supplying the type arguments.</param>
     /// <param name="adapterInterface">The resolved <c>IReturnTypeAdapter`2</c> symbol.</param>
     /// <returns>The closed adapter type, or <see langword="null"/> when it cannot surface the return type.</returns>
-    private static INamedTypeSymbol? CloseAdapterForReturn(
+    internal static INamedTypeSymbol? CloseAdapterForReturn(
         INamedTypeSymbol adapter,
         INamedTypeSymbol returnType,
         INamedTypeSymbol adapterInterface)
@@ -180,7 +180,7 @@ internal static partial class Parser
     /// closes over a <c>Wrapper&lt;A, B&gt;</c> return as <c>Adapter&lt;B, A&gt;</c>. The sole caller invokes this only after the
     /// template return and the return type share a generic definition and arity, so the argument counts are equal.
     /// </remarks>
-    private static bool TryMapAdapterTypeArguments(
+    internal static bool TryMapAdapterTypeArguments(
         INamedTypeSymbol templateReturn,
         INamedTypeSymbol returnType,
         INamedTypeSymbol adapter,
@@ -216,7 +216,7 @@ internal static partial class Parser
     /// <param name="adapter">The adapter type definition owning the type parameters.</param>
     /// <param name="mapped">The per-type-parameter binding slots, filled by position.</param>
     /// <returns><see langword="true"/> when the argument binds consistently.</returns>
-    private static bool TryBindAdapterArgument(
+    internal static bool TryBindAdapterArgument(
         ITypeSymbol templateArgument,
         ITypeSymbol returnArgument,
         INamedTypeSymbol adapter,
@@ -243,7 +243,7 @@ internal static partial class Parser
     /// <param name="returnType">The declared return type the adapter must surface.</param>
     /// <param name="adapterInterface">The resolved <c>IReturnTypeAdapter`2</c> symbol.</param>
     /// <returns>The matching constructed interface, or <see langword="null"/>.</returns>
-    private static INamedTypeSymbol? FindConstructedAdapterInterface(
+    internal static INamedTypeSymbol? FindConstructedAdapterInterface(
         INamedTypeSymbol closedAdapter,
         INamedTypeSymbol returnType,
         INamedTypeSymbol adapterInterface)
@@ -264,7 +264,7 @@ internal static partial class Parser
     /// <param name="type">The type to inspect.</param>
     /// <param name="adapterInterface">The resolved <c>IReturnTypeAdapter`2</c> symbol.</param>
     /// <returns>The implemented adapter interface, or <see langword="null"/>.</returns>
-    private static INamedTypeSymbol? FindImplementedAdapterInterface(
+    internal static INamedTypeSymbol? FindImplementedAdapterInterface(
         INamedTypeSymbol type,
         INamedTypeSymbol adapterInterface)
     {

--- a/src/InterfaceStubGenerator.Shared/Parser.Aliases.cs
+++ b/src/InterfaceStubGenerator.Shared/Parser.Aliases.cs
@@ -22,7 +22,7 @@ internal static partial class Parser
     /// <param name="symbol">The symbol whose containing assembly is inspected.</param>
     /// <param name="context">The generation context supplying the compilation and the pass-wide alias cache.</param>
     /// <returns>The extern alias, or null.</returns>
-    private static string? GetExternAlias(ISymbol symbol, InterfaceGenerationContext context)
+    internal static string? GetExternAlias(ISymbol symbol, InterfaceGenerationContext context)
     {
         var assembly = symbol.ContainingAssembly;
         if (context.Compilation is not { } compilation || assembly is null)
@@ -47,7 +47,7 @@ internal static partial class Parser
     /// <param name="assembly">The assembly to resolve.</param>
     /// <param name="compilation">The compilation supplying the assembly's metadata reference.</param>
     /// <returns>The extern alias, or null when the assembly is reachable via <c>global::</c>.</returns>
-    private static string? ResolveExternAlias(IAssemblySymbol assembly, CSharpCompilation compilation)
+    internal static string? ResolveExternAlias(IAssemblySymbol assembly, CSharpCompilation compilation)
     {
         var aliases = compilation.GetMetadataReference(assembly)?.Properties.Aliases ?? default;
         if (aliases.IsDefaultOrEmpty)
@@ -71,7 +71,7 @@ internal static partial class Parser
     /// <param name="type">The type to inspect.</param>
     /// <param name="context">The generation context supplying the compilation and the pass-wide alias cache.</param>
     /// <returns><see langword="true"/> when the type involves an extern-aliased assembly.</returns>
-    private static bool ContainsAliasedType(ITypeSymbol type, InterfaceGenerationContext context)
+    internal static bool ContainsAliasedType(ITypeSymbol type, InterfaceGenerationContext context)
     {
         if (type is IArrayTypeSymbol array)
         {
@@ -103,7 +103,7 @@ internal static partial class Parser
     /// <param name="type">The type to qualify.</param>
     /// <param name="context">The generation context, whose extern-alias collector records the aliases used.</param>
     /// <returns>The fully-qualified type name.</returns>
-    private static string QualifyType(ITypeSymbol type, InterfaceGenerationContext context) =>
+    internal static string QualifyType(ITypeSymbol type, InterfaceGenerationContext context) =>
 
         // The common case is no aliased type at all: Roslyn's own fully-qualified rendering is exactly right.
         ContainsAliasedType(type, context)
@@ -114,7 +114,7 @@ internal static partial class Parser
     /// <param name="type">The type to render.</param>
     /// <param name="context">The generation context, whose extern-alias collector records the aliases used.</param>
     /// <returns>The rendered type name.</returns>
-    private static string AliasedDisplay(ITypeSymbol type, InterfaceGenerationContext context) =>
+    internal static string AliasedDisplay(ITypeSymbol type, InterfaceGenerationContext context) =>
         type switch
         {
             IArrayTypeSymbol array => AliasedDisplay(array.ElementType, context) + "[]",
@@ -128,7 +128,7 @@ internal static partial class Parser
     /// <param name="named">The named type to render.</param>
     /// <param name="context">The generation context, whose extern-alias collector records the aliases used.</param>
     /// <returns>The rendered type name.</returns>
-    private static string AliasedNamedDisplay(INamedTypeSymbol named, InterfaceGenerationContext context)
+    internal static string AliasedNamedDisplay(INamedTypeSymbol named, InterfaceGenerationContext context)
     {
         var alias = GetExternAlias(named, context);
         if (alias is not null)

--- a/src/InterfaceStubGenerator.Shared/Parser.Aliases.cs
+++ b/src/InterfaceStubGenerator.Shared/Parser.Aliases.cs
@@ -103,12 +103,26 @@ internal static partial class Parser
     /// <param name="type">The type to qualify.</param>
     /// <param name="context">The generation context, whose extern-alias collector records the aliases used.</param>
     /// <returns>The fully-qualified type name.</returns>
-    internal static string QualifyType(ITypeSymbol type, InterfaceGenerationContext context) =>
+    internal static string QualifyType(ITypeSymbol type, InterfaceGenerationContext context)
+    {
+        // The common case is no aliased type at all: Roslyn's own fully-qualified rendering is exactly right. That
+        // rendering depends only on the type symbol, so it is memoized per pass and reused across every occurrence.
+        // The aliased path is never cached: it records the aliases it uses into the per-interface collector.
+        if (ContainsAliasedType(type, context))
+        {
+            return AliasedDisplay(type, context);
+        }
 
-        // The common case is no aliased type at all: Roslyn's own fully-qualified rendering is exactly right.
-        ContainsAliasedType(type, context)
-            ? AliasedDisplay(type, context)
-            : type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+        var cache = context.QualifiedTypeCache;
+        if (cache.TryGetValue(type, out var cached))
+        {
+            return cached;
+        }
+
+        var qualified = type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+        cache[type] = qualified;
+        return qualified;
+    }
 
     /// <summary>Renders a type's fully-qualified name with <c>alias::</c> for extern-aliased assemblies, recursively.</summary>
     /// <param name="type">The type to render.</param>

--- a/src/InterfaceStubGenerator.Shared/Parser.InlineEligibility.cs
+++ b/src/InterfaceStubGenerator.Shared/Parser.InlineEligibility.cs
@@ -74,7 +74,7 @@ internal static partial class Parser
     /// <summary>Classifies a return type into the shape buckets inline eligibility distinguishes.</summary>
     /// <param name="returnType">The declared return type.</param>
     /// <returns>The return shape; unsupported shapes map to <see cref="ReturnTypeInfo.Return"/>.</returns>
-    private static ReturnTypeInfo ClassifyInlineReturnShape(ITypeSymbol returnType)
+    internal static ReturnTypeInfo ClassifyInlineReturnShape(ITypeSymbol returnType)
     {
         if (returnType is not INamedTypeSymbol namedType)
         {
@@ -99,7 +99,7 @@ internal static partial class Parser
     /// <returns><see langword="true"/> when the type is <c>HttpRequestMessage</c>.</returns>
     /// <remarks>Only the <c>Task</c> wrapper is supported: request building is asynchronous (body serialization and the
     /// authorization token getter), so a synchronous <c>HttpRequestMessage</c> return would force a blocking build.</remarks>
-    private static bool IsHttpRequestMessageType(ITypeSymbol type) =>
+    internal static bool IsHttpRequestMessageType(ITypeSymbol type) =>
         type is INamedTypeSymbol { MetadataName: "HttpRequestMessage" } named
         && named.ContainingNamespace.ToDisplayString() == "System.Net.Http";
 }

--- a/src/InterfaceStubGenerator.Shared/Parser.InlineEligibility.cs
+++ b/src/InterfaceStubGenerator.Shared/Parser.InlineEligibility.cs
@@ -77,21 +77,17 @@ internal static partial class Parser
     /// <returns>The return shape; unsupported shapes map to <see cref="ReturnTypeInfo.Return"/>.</returns>
     internal static ReturnTypeInfo ClassifyInlineReturnShape(ITypeSymbol returnType)
     {
-        if (returnType is not INamedTypeSymbol namedType)
-        {
-            return ReturnTypeInfo.Return;
-        }
-
-        var ns = namedType.ContainingNamespace.ToDisplayString();
-        return namedType.MetadataName switch
-        {
-            "Task" when ns == TasksNamespace => ReturnTypeInfo.AsyncVoid,
-            "Task`1" when IsHttpRequestMessageType(namedType.TypeArguments[0]) => ReturnTypeInfo.RequestMessage,
-            "Task`1" or "ValueTask`1" when ns == TasksNamespace => ReturnTypeInfo.AsyncResult,
-            "IAsyncEnumerable`1" when ns == "System.Collections.Generic" => ReturnTypeInfo.AsyncEnumerable,
-            "IObservable`1" when ns == "System" => ReturnTypeInfo.Observable,
-            _ => ReturnTypeInfo.Return
-        };
+        return returnType is not INamedTypeSymbol namedType
+            ? ReturnTypeInfo.Return
+            : namedType.MetadataName switch
+            {
+                "Task" when IsInNamespace(namedType, TasksNamespace) => ReturnTypeInfo.AsyncVoid,
+                "Task`1" when IsHttpRequestMessageType(namedType.TypeArguments[0]) => ReturnTypeInfo.RequestMessage,
+                "Task`1" or "ValueTask`1" when IsInNamespace(namedType, TasksNamespace) => ReturnTypeInfo.AsyncResult,
+                "IAsyncEnumerable`1" when IsInNamespace(namedType, "System.Collections.Generic") => ReturnTypeInfo.AsyncEnumerable,
+                "IObservable`1" when IsInNamespace(namedType, "System") => ReturnTypeInfo.Observable,
+                _ => ReturnTypeInfo.Return
+            };
     }
 
     /// <summary>Determines whether a type is <c>System.Net.Http.HttpRequestMessage</c>, the type argument of the
@@ -102,5 +98,5 @@ internal static partial class Parser
     /// authorization token getter), so a synchronous <c>HttpRequestMessage</c> return would force a blocking build.</remarks>
     internal static bool IsHttpRequestMessageType(ITypeSymbol type) =>
         type is INamedTypeSymbol { MetadataName: "HttpRequestMessage" } named
-        && named.ContainingNamespace.ToDisplayString() == "System.Net.Http";
+        && IsInNamespace(named, "System.Net.Http");
 }

--- a/src/InterfaceStubGenerator.Shared/Parser.InlineEligibility.cs
+++ b/src/InterfaceStubGenerator.Shared/Parser.InlineEligibility.cs
@@ -66,7 +66,8 @@ internal static partial class Parser
             returnTypeAdapterInterface,
             returnTypeAdapters,
             ExternAliases: [],
-            AssemblyAliasCache: new Dictionary<ISymbol, string?>(SymbolEqualityComparer.Default));
+            AssemblyAliasCache: new Dictionary<ISymbol, string?>(SymbolEqualityComparer.Default),
+            QualifiedTypeCache: new Dictionary<ISymbol, string>(SymbolEqualityComparer.Default));
         return ParseRequest(methodSymbol, ClassifyInlineReturnShape(methodSymbol.ReturnType), context)
             .CanGenerateInline;
     }

--- a/src/InterfaceStubGenerator.Shared/Parser.Members.cs
+++ b/src/InterfaceStubGenerator.Shared/Parser.Members.cs
@@ -15,7 +15,7 @@ internal static partial class Parser
     /// <param name="inheritedProperties">The emittable inherited properties collected during the single member walk.</param>
     /// <param name="context">The generation context, used to qualify extern-aliased property types.</param>
     /// <returns>The property models.</returns>
-    private static ImmutableEquatableArray<InterfacePropertyModel> BuildInterfacePropertyModels(
+    internal static ImmutableEquatableArray<InterfacePropertyModel> BuildInterfacePropertyModels(
         in ImmutableArray<ISymbol> members,
         List<IPropertySymbol> inheritedProperties,
         InterfaceGenerationContext context)
@@ -40,7 +40,7 @@ internal static partial class Parser
     /// <summary>Determines whether an interface property should be implemented by the generated stub.</summary>
     /// <param name="property">The property to inspect.</param>
     /// <returns><see langword="true"/> when the property should be emitted.</returns>
-    private static bool IsEmittableProperty(IPropertySymbol property) =>
+    internal static bool IsEmittableProperty(IPropertySymbol property) =>
         !property.IsStatic
         && property.IsAbstract
         && property.Parameters.IsEmpty;
@@ -50,7 +50,7 @@ internal static partial class Parser
     /// <param name="isDerived">Whether the property comes from a base interface.</param>
     /// <param name="context">The generation context, used to qualify extern-aliased property types.</param>
     /// <returns>The property model.</returns>
-    private static InterfacePropertyModel ParseInterfaceProperty(IPropertySymbol property, bool isDerived, InterfaceGenerationContext context)
+    internal static InterfacePropertyModel ParseInterfaceProperty(IPropertySymbol property, bool isDerived, InterfaceGenerationContext context)
     {
         var annotation =
             !property.Type.IsValueType && property.NullableAnnotation == NullableAnnotation.Annotated;
@@ -77,7 +77,7 @@ internal static partial class Parser
     /// <param name="property">The property to inspect.</param>
     /// <param name="propertyType">The fully-qualified property type display string.</param>
     /// <returns><see langword="true"/> when no extra property emission is required.</returns>
-    private static bool IsGeneratedClientProperty(IPropertySymbol property, string propertyType) =>
+    internal static bool IsGeneratedClientProperty(IPropertySymbol property, string propertyType) =>
         property.MetadataName == "Client"
         && propertyType == "global::System.Net.Http.HttpClient"
         && property.GetMethod is not null
@@ -86,14 +86,14 @@ internal static partial class Parser
     /// <summary>Determines whether an interface property name collides with generated stub infrastructure members.</summary>
     /// <param name="property">The property to inspect.</param>
     /// <returns><see langword="true"/> when the property should be emitted explicitly to avoid a member collision.</returns>
-    private static bool HasGeneratedMemberNameCollision(IPropertySymbol property) =>
+    internal static bool HasGeneratedMemberNameCollision(IPropertySymbol property) =>
         property.MetadataName is "Client" or "requestBuilder";
 
     /// <summary>Gets the request-property key declared on an interface property.</summary>
     /// <param name="property">The property to inspect.</param>
     /// <returns>The request-property key, or an empty string when the property is not request-bound.</returns>
     [ExcludeFromCodeCoverage]
-    private static string GetInterfacePropertyRequestKey(IPropertySymbol property)
+    internal static string GetInterfacePropertyRequestKey(IPropertySymbol property)
     {
         foreach (var attribute in property.GetAttributes())
         {
@@ -116,7 +116,7 @@ internal static partial class Parser
     /// <param name="isImplicitInterface">Whether the methods belong to the implicitly implemented interface.</param>
     /// <param name="context">The shared generation context.</param>
     /// <returns>The method models.</returns>
-    private static ImmutableEquatableArray<MethodModel> ParseMethods(
+    internal static ImmutableEquatableArray<MethodModel> ParseMethods(
         List<IMethodSymbol> methods,
         bool isImplicitInterface,
         InterfaceGenerationContext context)
@@ -140,7 +140,7 @@ internal static partial class Parser
     /// <param name="derivedNonRefitMethods">The non-Refit methods inherited from base interfaces.</param>
     /// <param name="context">The generation context, used to qualify extern-aliased types.</param>
     /// <returns>The non-Refit method models.</returns>
-    private static ImmutableEquatableArray<MethodModel> BuildNonRefitMethodModels(
+    internal static ImmutableEquatableArray<MethodModel> BuildNonRefitMethodModels(
         List<IMethodSymbol> nonRefitMethods,
         List<IMethodSymbol> derivedNonRefitMethods,
         InterfaceGenerationContext context)
@@ -173,7 +173,7 @@ internal static partial class Parser
     /// <summary>Determines whether a non-Refit method should be emitted as a method model.</summary>
     /// <param name="method">The candidate method.</param>
     /// <returns><see langword="true"/> if the method is an abstract instance method; otherwise, <see langword="false"/>.</returns>
-    private static bool IsEmittableNonRefitMethod(IMethodSymbol method) =>
+    internal static bool IsEmittableNonRefitMethod(IMethodSymbol method) =>
         !method.IsStatic
         && method.MethodKind != MethodKind.PropertyGet
         && method.MethodKind != MethodKind.PropertySet
@@ -184,7 +184,7 @@ internal static partial class Parser
     /// <param name="isDerived">Whether the method comes from a base interface.</param>
     /// <param name="context">The generation context, used to qualify extern-aliased types.</param>
     /// <returns>The model describing the non-Refit method.</returns>
-    private static MethodModel ParseNonRefitMethod(
+    internal static MethodModel ParseNonRefitMethod(
         IMethodSymbol methodSymbol,
         bool isDerived,
         InterfaceGenerationContext context)
@@ -219,7 +219,7 @@ internal static partial class Parser
     /// <summary>Gets the first explicit interface implementation for a method, if one exists.</summary>
     /// <param name="methodSymbol">The method symbol to inspect.</param>
     /// <returns>The first explicit interface implementation, or <see langword="null"/> when there is none.</returns>
-    private static IMethodSymbol? FirstExplicitInterfaceImplementation(IMethodSymbol methodSymbol)
+    internal static IMethodSymbol? FirstExplicitInterfaceImplementation(IMethodSymbol methodSymbol)
     {
         var implementations = methodSymbol.ExplicitInterfaceImplementations;
         return implementations.IsEmpty ? null : implementations[0];
@@ -228,7 +228,7 @@ internal static partial class Parser
     /// <summary>Classifies a method's return type into its <see cref="ReturnTypeInfo"/> shape.</summary>
     /// <param name="methodSymbol">The method symbol.</param>
     /// <returns>The classified return type information.</returns>
-    private static ReturnTypeInfo GetReturnTypeInfo(IMethodSymbol methodSymbol) =>
+    internal static ReturnTypeInfo GetReturnTypeInfo(IMethodSymbol methodSymbol) =>
         methodSymbol.ReturnType.MetadataName switch
         {
             "Task" => ReturnTypeInfo.AsyncVoid,
@@ -243,7 +243,7 @@ internal static partial class Parser
     /// <summary>Collects the distinct member names declared on the interface, preserving order.</summary>
     /// <param name="members">The directly declared members of the interface.</param>
     /// <returns>The distinct member names.</returns>
-    private static ImmutableEquatableArray<string> CollectMemberNames(in ImmutableArray<ISymbol> members)
+    internal static ImmutableEquatableArray<string> CollectMemberNames(in ImmutableArray<ISymbol> members)
     {
         var seenMemberNames = new HashSet<string>();
         var memberNames = new string[members.Length];
@@ -265,7 +265,7 @@ internal static partial class Parser
     /// <param name="count">The number of populated entries.</param>
     /// <typeparam name="T">The element type.</typeparam>
     /// <returns>The immutable equatable array.</returns>
-    private static ImmutableEquatableArray<T> TrimAndWrap<T>(T[] values, int count)
+    internal static ImmutableEquatableArray<T> TrimAndWrap<T>(T[] values, int count)
         where T : IEquatable<T>
     {
         if (count == 0)

--- a/src/InterfaceStubGenerator.Shared/Parser.MethodSignature.cs
+++ b/src/InterfaceStubGenerator.Shared/Parser.MethodSignature.cs
@@ -14,7 +14,7 @@ internal static partial class Parser
     /// <param name="isOverrideOrExplicitImplementation">Whether the member is an override or explicit implementation.</param>
     /// <param name="context">The generation context, used to qualify extern-aliased constraint types.</param>
     /// <returns>The constraint models for the type parameters.</returns>
-    private static ImmutableEquatableArray<TypeConstraint> GenerateConstraints(
+    internal static ImmutableEquatableArray<TypeConstraint> GenerateConstraints(
         in ImmutableArray<ITypeParameterSymbol> typeParameters,
         bool isOverrideOrExplicitImplementation,
         InterfaceGenerationContext context)
@@ -41,7 +41,7 @@ internal static partial class Parser
     /// <param name="isOverrideOrExplicitImplementation">Whether the member is an override or explicit implementation.</param>
     /// <param name="context">The generation context, used to qualify extern-aliased constraint types.</param>
     /// <returns>The constraint model for the type parameter.</returns>
-    private static TypeConstraint ParseConstraintsForTypeParameter(
+    internal static TypeConstraint ParseConstraintsForTypeParameter(
         ITypeParameterSymbol typeParameter,
         bool isOverrideOrExplicitImplementation,
         InterfaceGenerationContext context)
@@ -62,7 +62,7 @@ internal static partial class Parser
     /// <param name="typeParameter">The type parameter to inspect.</param>
     /// <param name="isOverrideOrExplicitImplementation">Whether the member is an override or explicit implementation.</param>
     /// <returns>The combined well-known constraint flags.</returns>
-    private static KnownTypeConstraint ComputeKnownConstraints(
+    internal static KnownTypeConstraint ComputeKnownConstraints(
         ITypeParameterSymbol typeParameter,
         bool isOverrideOrExplicitImplementation)
     {
@@ -104,7 +104,7 @@ internal static partial class Parser
     /// <param name="param">The parameter symbol to parse.</param>
     /// <param name="context">The generation context, used to qualify extern-aliased types.</param>
     /// <returns>The model describing the parameter.</returns>
-    private static ParameterModel ParseParameter(IParameterSymbol param, InterfaceGenerationContext context)
+    internal static ParameterModel ParseParameter(IParameterSymbol param, InterfaceGenerationContext context)
     {
         var annotation =
             !param.Type.IsValueType && param.NullableAnnotation == NullableAnnotation.Annotated;
@@ -119,7 +119,7 @@ internal static partial class Parser
     /// <param name="parameters">The parameters to parse.</param>
     /// <param name="context">The generation context, used to qualify extern-aliased types.</param>
     /// <returns>The parsed parameter models.</returns>
-    private static ImmutableEquatableArray<ParameterModel> ParseParameters(
+    internal static ImmutableEquatableArray<ParameterModel> ParseParameters(
         in ImmutableArray<IParameterSymbol> parameters,
         InterfaceGenerationContext context)
     {
@@ -141,7 +141,7 @@ internal static partial class Parser
     /// <param name="constraintTypes">The constraint types to parse.</param>
     /// <param name="context">The generation context, used to qualify extern-aliased constraint types.</param>
     /// <returns>The parsed constraint type display names.</returns>
-    private static ImmutableEquatableArray<string> ParseConstraintTypes(
+    internal static ImmutableEquatableArray<string> ParseConstraintTypes(
         in ImmutableArray<ITypeSymbol> constraintTypes,
         InterfaceGenerationContext context)
     {
@@ -162,7 +162,7 @@ internal static partial class Parser
     /// <summary>Determines whether a type or any of its type arguments is a type parameter.</summary>
     /// <param name="symbol">The type symbol to inspect.</param>
     /// <returns><see langword="true"/> if the type involves a type parameter; otherwise, <see langword="false"/>.</returns>
-    private static bool ContainsTypeParameter(ITypeSymbol symbol)
+    internal static bool ContainsTypeParameter(ITypeSymbol symbol)
     {
         if (symbol is ITypeParameterSymbol)
         {
@@ -190,7 +190,7 @@ internal static partial class Parser
     /// <param name="isImplicitInterface">Whether the method belongs to the implicitly implemented interface.</param>
     /// <param name="context">The shared generation context.</param>
     /// <returns>The model describing the Refit method.</returns>
-    private static MethodModel ParseMethod(
+    internal static MethodModel ParseMethod(
         IMethodSymbol methodSymbol,
         bool isImplicitInterface,
         InterfaceGenerationContext context)
@@ -229,7 +229,7 @@ internal static partial class Parser
     /// <param name="methodSymbol">The Refit method symbol.</param>
     /// <param name="attributeName">The attribute type name, for example <c>RequiresUnreferencedCodeAttribute</c>.</param>
     /// <returns><see langword="true"/> when the method carries the attribute.</returns>
-    private static bool HasTrimAnnotation(IMethodSymbol methodSymbol, string attributeName)
+    internal static bool HasTrimAnnotation(IMethodSymbol methodSymbol, string attributeName)
     {
         foreach (var attribute in methodSymbol.GetAttributes())
         {

--- a/src/InterfaceStubGenerator.Shared/Parser.MethodSignature.cs
+++ b/src/InterfaceStubGenerator.Shared/Parser.MethodSignature.cs
@@ -235,7 +235,7 @@ internal static partial class Parser
         {
             var attributeClass = attribute.AttributeClass!;
             if (attributeClass.Name == attributeName
-                && attributeClass.ContainingNamespace.ToDisplayString() == "System.Diagnostics.CodeAnalysis")
+                && IsInNamespace(attributeClass, "System.Diagnostics.CodeAnalysis"))
             {
                 return true;
             }

--- a/src/InterfaceStubGenerator.Shared/Parser.Request.Body.cs
+++ b/src/InterfaceStubGenerator.Shared/Parser.Request.Body.cs
@@ -14,7 +14,7 @@ internal static partial class Parser
     /// <param name="bodyType">The declared body type.</param>
     /// <param name="context">The interface generation context, used to classify the scalar fast path.</param>
     /// <returns>The field descriptors, or <see langword="null"/> when the type is not eligible for the descriptor path.</returns>
-    private static ImmutableEquatableArray<FormFieldModel>? TryBuildFormFields(
+    internal static ImmutableEquatableArray<FormFieldModel>? TryBuildFormFields(
         ITypeSymbol bodyType,
         InterfaceGenerationContext context)
     {
@@ -58,14 +58,14 @@ internal static partial class Parser
     /// <param name="formattableSymbol">The resolved <c>System.IFormattable</c> symbol, or null when unavailable.</param>
     /// <returns><see langword="true"/> for a simple scalar or a collection of simple elements; <see langword="false"/> for
     /// a dictionary, a nested complex object, or a collection of non-simple elements, all of which reflect at runtime.</returns>
-    private static bool IsDescriptorSafeFormProperty(IPropertySymbol property, INamedTypeSymbol? formattableSymbol) =>
+    internal static bool IsDescriptorSafeFormProperty(IPropertySymbol property, INamedTypeSymbol? formattableSymbol) =>
         IsSimpleType(property.Type, formattableSymbol)
         || (TryGetEnumerableElementType(property.Type, out var elementType) && IsSimpleType(elementType!, formattableSymbol));
 
     /// <summary>Determines whether a property contributes a readable public instance form field.</summary>
     /// <param name="property">The property to inspect.</param>
     /// <returns><see langword="true"/> when the property is read through a public instance getter.</returns>
-    private static bool IsReadableFormProperty(IPropertySymbol property) =>
+    internal static bool IsReadableFormProperty(IPropertySymbol property) =>
         !property.IsStatic
         && !property.IsIndexer
         && property.DeclaredAccessibility == Accessibility.Public
@@ -74,7 +74,7 @@ internal static partial class Parser
     /// <summary>Determines whether a body type can be flattened to form fields without reflection.</summary>
     /// <param name="type">The declared body type.</param>
     /// <returns><see langword="true"/> when descriptor-based flattening matches the reflection path.</returns>
-    private static bool IsFormFieldEligibleType(ITypeSymbol type) =>
+    internal static bool IsFormFieldEligibleType(ITypeSymbol type) =>
         type.TypeKind != TypeKind.Interface
         && type.TypeKind != TypeKind.TypeParameter
         && type.TypeKind != TypeKind.Dynamic
@@ -91,7 +91,7 @@ internal static partial class Parser
     /// <summary>Determines whether a type implements the non-generic <see cref="System.Collections.IEnumerable"/>.</summary>
     /// <param name="type">The type to inspect.</param>
     /// <returns><see langword="true"/> when the type is enumerable.</returns>
-    private static bool ImplementsEnumerable(ITypeSymbol type)
+    internal static bool ImplementsEnumerable(ITypeSymbol type)
     {
         // The only caller (IsFormFieldEligibleType) already excludes interface types, so type is never the
         // System.Collections.IEnumerable interface itself; a concrete enumerable always exposes it through AllInterfaces.
@@ -110,7 +110,7 @@ internal static partial class Parser
     /// <param name="property">The property to describe.</param>
     /// <param name="context">The interface generation context, used to classify the scalar fast path.</param>
     /// <returns>The field descriptor.</returns>
-    private static FormFieldModel BuildFormFieldModel(IPropertySymbol property, InterfaceGenerationContext context)
+    internal static FormFieldModel BuildFormFieldModel(IPropertySymbol property, InterfaceGenerationContext context)
     {
         string? aliasName = null;
         string? jsonName = null;
@@ -155,7 +155,7 @@ internal static partial class Parser
     /// <summary>Reads the first string constructor argument from an attribute.</summary>
     /// <param name="attribute">The attribute to inspect.</param>
     /// <returns>The first string argument, or <see langword="null"/>.</returns>
-    private static string? GetFirstStringArgument(AttributeData attribute)
+    internal static string? GetFirstStringArgument(AttributeData attribute)
     {
         foreach (var argument in attribute.ConstructorArguments)
         {
@@ -171,13 +171,13 @@ internal static partial class Parser
     /// <summary>Parses the form-relevant members of a <c>[Query]</c> attribute applied to a property.</summary>
     /// <param name="attribute">The query attribute data.</param>
     /// <returns>The parsed form query data.</returns>
-    private static QueryFormData ParseFormQueryAttribute(AttributeData attribute) =>
+    internal static QueryFormData ParseFormQueryAttribute(AttributeData attribute) =>
         ApplyQueryNamedArguments(attribute, ParseQueryConstructorArguments(attribute));
 
     /// <summary>Parses the constructor arguments of a <c>[Query]</c> attribute.</summary>
     /// <param name="attribute">The query attribute data.</param>
     /// <returns>The form query data carried by the constructor arguments.</returns>
-    private static QueryFormData ParseQueryConstructorArguments(AttributeData attribute)
+    internal static QueryFormData ParseQueryConstructorArguments(AttributeData attribute)
     {
         var delimiter = ".";
         string? prefix = null;
@@ -218,7 +218,7 @@ internal static partial class Parser
     /// <param name="attribute">The query attribute data.</param>
     /// <param name="data">The data parsed from constructor arguments.</param>
     /// <returns>The form query data with named arguments applied.</returns>
-    private static QueryFormData ApplyQueryNamedArguments(AttributeData attribute, QueryFormData data)
+    internal static QueryFormData ApplyQueryNamedArguments(AttributeData attribute, QueryFormData data)
     {
         foreach (var named in attribute.NamedArguments)
         {
@@ -246,7 +246,7 @@ internal static partial class Parser
     /// <summary>Parses the constructor-supplied data from a body attribute.</summary>
     /// <param name="attribute">The attribute data.</param>
     /// <returns>The parsed body serialization and buffering data.</returns>
-    private static BodyAttributeInfo ParseBodyAttribute(AttributeData attribute)
+    internal static BodyAttributeInfo ParseBodyAttribute(AttributeData attribute)
     {
         var serializationMethod = "Default";
         bool? buffered = null;
@@ -279,7 +279,7 @@ internal static partial class Parser
     /// <param name="argument">The constructor argument.</param>
     /// <param name="methodName">Receives the enum member name.</param>
     /// <returns><see langword="true"/> when the argument is a body serialization method.</returns>
-    private static bool TryGetBodySerializationMethodName(in TypedConstant argument, out string methodName)
+    internal static bool TryGetBodySerializationMethodName(in TypedConstant argument, out string methodName)
     {
         // The only enum-typed constructor argument a [Body] attribute accepts is BodySerializationMethod.
         if (argument.Kind == TypedConstantKind.Enum)
@@ -295,7 +295,7 @@ internal static partial class Parser
     /// <summary>Parsed body attribute data.</summary>
     /// <param name="SerializationMethod">The body serialization method name.</param>
     /// <param name="BufferMode">The body buffering mode.</param>
-    private readonly record struct BodyAttributeInfo(
+    internal readonly record struct BodyAttributeInfo(
         string SerializationMethod,
         BodyBufferMode BufferMode);
 
@@ -306,7 +306,7 @@ internal static partial class Parser
     /// <param name="CollectionFormatValue">The explicit collection format value, if any.</param>
     /// <param name="SerializeNull">Whether null values are serialized as empty fields.</param>
     /// <param name="TreatAsString">Whether the raw value is stringified via <c>ToString()</c> before formatting.</param>
-    private readonly record struct QueryFormData(
+    internal readonly record struct QueryFormData(
         string Delimiter,
         string? Prefix,
         string? Format,

--- a/src/InterfaceStubGenerator.Shared/Parser.Request.Helpers.cs
+++ b/src/InterfaceStubGenerator.Shared/Parser.Request.Helpers.cs
@@ -17,6 +17,36 @@ internal static partial class Parser
     /// <summary>The underlying value for <c>BodySerializationMethod.JsonLines</c>.</summary>
     private const int BodySerializationJsonLines = 4;
 
+    /// <summary>Determines whether a symbol's containing namespace equals a dotted namespace name, without allocating.</summary>
+    /// <param name="symbol">The symbol whose containing namespace is compared, or null.</param>
+    /// <param name="dottedNamespace">The expected namespace as a dotted name, for example <c>System.Threading.Tasks</c>.</param>
+    /// <returns><see langword="true"/> when the symbol's containing namespace matches segment for segment.</returns>
+    /// <remarks>Walks the namespace symbol chain segment by segment against the dotted string instead of rendering the
+    /// namespace with <c>ToDisplayString</c>, which allocates a fresh string on every call - a cost paid per type and
+    /// per attribute across the whole compilation on every parse.</remarks>
+    internal static bool IsInNamespace(ISymbol? symbol, string dottedNamespace)
+    {
+        var ns = symbol?.ContainingNamespace;
+        var end = dottedNamespace.Length;
+        while (ns is { IsGlobalNamespace: false })
+        {
+            var start = dottedNamespace.LastIndexOf('.', end - 1) + 1;
+            var name = ns.Name;
+            if (end - start != name.Length
+                || string.CompareOrdinal(dottedNamespace, start, name, 0, name.Length) != 0)
+            {
+                return false;
+            }
+
+            end = start - 1;
+            ns = ns.ContainingNamespace;
+        }
+
+        // Every symbol segment matched a dotted segment; the match is exact only when the dotted name is also fully
+        // consumed (end rewound past its first segment) and the chain terminated at the global namespace.
+        return end == -1 && ns is { IsGlobalNamespace: true };
+    }
+
     /// <summary>Finds the HTTP method attribute on a Refit method.</summary>
     /// <param name="methodSymbol">The method to inspect.</param>
     /// <param name="httpMethodAttribute">The Refit HTTP method base attribute symbol.</param>

--- a/src/InterfaceStubGenerator.Shared/Parser.Request.Helpers.cs
+++ b/src/InterfaceStubGenerator.Shared/Parser.Request.Helpers.cs
@@ -242,7 +242,7 @@ internal static partial class Parser
     /// <summary>Determines whether the braces in a path template are balanced within each segment.</summary>
     /// <param name="path">The path template to validate.</param>
     /// <returns><see langword="true"/> when every segment has balanced braces.</returns>
-    private static bool IsPathTemplateValid(in ReadOnlySpan<char> path)
+    internal static bool IsPathTemplateValid(in ReadOnlySpan<char> path)
     {
         var openingBraces = 0;
         var closingBraces = 0;

--- a/src/InterfaceStubGenerator.Shared/Parser.Request.HttpMethod.cs
+++ b/src/InterfaceStubGenerator.Shared/Parser.Request.HttpMethod.cs
@@ -32,13 +32,13 @@ internal static partial class Parser
     /// <summary>Gets the HTTP method name represented by a Refit method attribute.</summary>
     /// <param name="attributeClass">The resolved HTTP method attribute type.</param>
     /// <returns>The HTTP method name, or an empty string when a custom attribute's verb is not statically readable.</returns>
-    private static string GetHttpMethodName(INamedTypeSymbol attributeClass) =>
+    internal static string GetHttpMethodName(INamedTypeSymbol attributeClass) =>
         MapKnownHttpVerb(attributeClass.MetadataName) ?? ResolveCustomHttpVerb(attributeClass);
 
     /// <summary>Resolves a statically-readable custom HTTP verb, or an empty string when the method must fall back.</summary>
     /// <param name="attributeClass">The custom HTTP method attribute type.</param>
     /// <returns>The verb, or an empty string.</returns>
-    private static string ResolveCustomHttpVerb(INamedTypeSymbol attributeClass) =>
+    internal static string ResolveCustomHttpVerb(INamedTypeSymbol attributeClass) =>
         TryResolveCustomHttpVerb(attributeClass, out var verb) ? verb : string.Empty;
 
     /// <summary>Reads a custom HTTP verb from a derived attribute whose <c>Method</c> getter returns a string literal.</summary>
@@ -52,7 +52,7 @@ internal static partial class Parser
     /// model), so the RF006 analyzer and the generator agree. The reflection builder reads the same verb at runtime, so
     /// the emitted <c>new HttpMethod("VERB")</c> matches it.
     /// </remarks>
-    private static bool TryResolveCustomHttpVerb(INamedTypeSymbol attributeClass, out string verb)
+    internal static bool TryResolveCustomHttpVerb(INamedTypeSymbol attributeClass, out string verb)
     {
         verb = string.Empty;
 
@@ -85,7 +85,7 @@ internal static partial class Parser
     /// here derives from HttpMethodAttribute, which declares an (abstract) HttpMethod Method getter, so the walk always
     /// resolves one and the trailing fallback is unreachable.</remarks>
     [ExcludeFromCodeCoverage]
-    private static (IPropertySymbol Property, IMethodSymbol Getter) FindMethodPropertyGetter(INamedTypeSymbol attributeClass)
+    internal static (IPropertySymbol Property, IMethodSymbol Getter) FindMethodPropertyGetter(INamedTypeSymbol attributeClass)
     {
         for (INamedTypeSymbol? current = attributeClass; current is not null; current = current.BaseType)
         {
@@ -105,7 +105,7 @@ internal static partial class Parser
     /// <param name="syntax">The getter or property syntax.</param>
     /// <returns>The returned expression, or null when the getter is not a single expression.</returns>
     [ExcludeFromCodeCoverage]
-    private static ExpressionSyntax? GetterReturnExpression(SyntaxNode syntax) =>
+    internal static ExpressionSyntax? GetterReturnExpression(SyntaxNode syntax) =>
         syntax switch
         {
             ArrowExpressionClauseSyntax { Expression: { } arrowBody } => arrowBody,

--- a/src/InterfaceStubGenerator.Shared/Parser.Request.Multipart.cs
+++ b/src/InterfaceStubGenerator.Shared/Parser.Request.Multipart.cs
@@ -30,7 +30,7 @@ internal static partial class Parser
     /// <param name="methodSymbol">The method to inspect.</param>
     /// <param name="isMultipart">Receives whether the method carries <c>[Multipart]</c>.</param>
     /// <returns>The boundary text for a multipart method, or an empty string otherwise.</returns>
-    private static string ResolveMultipartBoundary(IMethodSymbol methodSymbol, out bool isMultipart)
+    internal static string ResolveMultipartBoundary(IMethodSymbol methodSymbol, out bool isMultipart)
     {
         var multipartAttribute = FindMultipartAttribute(methodSymbol);
         isMultipart = multipartAttribute is not null;
@@ -40,7 +40,7 @@ internal static partial class Parser
     /// <summary>Finds the <c>[Multipart]</c> attribute on a method, if present.</summary>
     /// <param name="methodSymbol">The method to inspect.</param>
     /// <returns>The multipart attribute data, or <see langword="null"/> when the method is not multipart.</returns>
-    private static AttributeData? FindMultipartAttribute(IMethodSymbol methodSymbol)
+    internal static AttributeData? FindMultipartAttribute(IMethodSymbol methodSymbol)
     {
         foreach (var attribute in methodSymbol.GetAttributes())
         {
@@ -56,7 +56,7 @@ internal static partial class Parser
     /// <summary>Resolves the multipart boundary text for a method, matching the reflection builder's selection.</summary>
     /// <param name="multipartAttribute">The method's multipart attribute.</param>
     /// <returns>The boundary text: the <c>[Multipart(boundary)]</c> argument, or the attribute default.</returns>
-    private static string GetMultipartBoundaryText(AttributeData multipartAttribute) =>
+    internal static string GetMultipartBoundaryText(AttributeData multipartAttribute) =>
         !multipartAttribute.ConstructorArguments.IsEmpty
         && multipartAttribute.ConstructorArguments[0].Value is string boundary
             ? boundary
@@ -65,7 +65,7 @@ internal static partial class Parser
     /// <summary>Determines whether any parameter is an explicit request body binding.</summary>
     /// <param name="parameters">The parsed request parameter models.</param>
     /// <returns><see langword="true"/> when a parameter carries <c>[Body]</c>.</returns>
-    private static bool HasBodyParameter(ImmutableEquatableArray<RequestParameterModel> parameters)
+    internal static bool HasBodyParameter(ImmutableEquatableArray<RequestParameterModel> parameters)
     {
         foreach (var parameter in parameters)
         {
@@ -83,7 +83,7 @@ internal static partial class Parser
     /// <param name="parameterType">The parameter type display string.</param>
     /// <param name="context">The lookup state used to classify the parameter.</param>
     /// <returns>The parsed parameter and eligibility counters.</returns>
-    private static ParsedRequestParameter ClassifyMultipartParameter(
+    internal static ParsedRequestParameter ClassifyMultipartParameter(
         IParameterSymbol parameter,
         string parameterType,
         in LooseParameterContext context)
@@ -106,7 +106,7 @@ internal static partial class Parser
     /// <param name="parameter">The parameter to classify.</param>
     /// <param name="context">The lookup state used to classify the parameter.</param>
     /// <returns>The part descriptor, or <see langword="null"/> when the type is not statically dispatchable.</returns>
-    private static MultipartPartModel? TryBuildMultipartPart(IParameterSymbol parameter, in LooseParameterContext context)
+    internal static MultipartPartModel? TryBuildMultipartPart(IParameterSymbol parameter, in LooseParameterContext context)
     {
         // An opt-in [FormObject] parameter is flattened per-property by the reflection request builder; returning null
         // routes the whole method to that one authoritative implementation instead of duplicating the flattening here.
@@ -134,7 +134,7 @@ internal static partial class Parser
     /// <param name="part">The multipart part descriptor.</param>
     /// <param name="context">The interface generation context, used to qualify extern-aliased types.</param>
     /// <returns>The multipart part request parameter model.</returns>
-    private static RequestParameterModel MultipartRequestParameter(
+    internal static RequestParameterModel MultipartRequestParameter(
         IParameterSymbol parameter,
         string parameterType,
         MultipartPartModel part,
@@ -158,7 +158,7 @@ internal static partial class Parser
     /// <param name="type">The declared parameter type.</param>
     /// <returns>The part kind and whether it expands element-by-element, or <see langword="null"/> when the type is not
     /// statically dispatchable and the method must fall back to the reflection request builder.</returns>
-    private static (MultipartPartKind Kind, bool IsEnumerable)? ClassifyPartType(ITypeSymbol type)
+    internal static (MultipartPartKind Kind, bool IsEnumerable)? ClassifyPartType(ITypeSymbol type)
     {
         // string and byte[] are single parts even though they are enumerable: the reflection builder's
         // IEnumerable<object> check excludes them because char and byte are value types.
@@ -185,7 +185,7 @@ internal static partial class Parser
     /// <summary>Classifies a single (non-enumerable) value type into its multipart dispatch arm.</summary>
     /// <param name="type">The value's declared type.</param>
     /// <returns>The part kind, or <see langword="null"/> when the type is not statically dispatchable.</returns>
-    private static MultipartPartKind? ClassifySingle(ITypeSymbol type)
+    internal static MultipartPartKind? ClassifySingle(ITypeSymbol type)
     {
         // A Guid?/DateTime? part classifies by its underlying formattable type; the null value itself is guarded
         // out at emission, matching the reflection builder's "skip null parameter" behavior.
@@ -239,7 +239,7 @@ internal static partial class Parser
     /// <param name="type">The declared parameter type.</param>
     /// <returns>The element type when the parameter is a reference-typed enumerable (so its runtime value implements
     /// <c>IEnumerable&lt;object&gt;</c>), otherwise <see langword="null"/>.</returns>
-    private static ITypeSymbol? GetReferenceEnumerableElement(ITypeSymbol type)
+    internal static ITypeSymbol? GetReferenceEnumerableElement(ITypeSymbol type)
     {
         if (type is IArrayTypeSymbol { Rank: 1 } array)
         {
@@ -274,13 +274,13 @@ internal static partial class Parser
     /// <summary>Determines whether a type is a single-rank <see cref="byte"/> array.</summary>
     /// <param name="type">The type to inspect.</param>
     /// <returns><see langword="true"/> when the type is <c>byte[]</c>.</returns>
-    private static bool IsByteArray(ITypeSymbol type) =>
+    internal static bool IsByteArray(ITypeSymbol type) =>
         type is IArrayTypeSymbol { Rank: 1, ElementType.SpecialType: SpecialType.System_Byte };
 
     /// <summary>Determines whether a type is <see cref="System.IO.FileInfo"/>.</summary>
     /// <param name="type">The type to inspect.</param>
     /// <returns><see langword="true"/> when the type is <see cref="System.IO.FileInfo"/>.</returns>
-    private static bool IsFileInfoType(ITypeSymbol type) =>
+    internal static bool IsFileInfoType(ITypeSymbol type) =>
         type is
         {
             Name: "FileInfo",
@@ -292,7 +292,7 @@ internal static partial class Parser
     /// <summary>Determines whether a type is <see cref="System.IO.Stream"/> or derives from it.</summary>
     /// <param name="type">The type to inspect.</param>
     /// <returns><see langword="true"/> when the type is assignable to <see cref="System.IO.Stream"/>.</returns>
-    private static bool IsStreamType(ITypeSymbol type)
+    internal static bool IsStreamType(ITypeSymbol type)
     {
         for (var current = type; current is not null; current = current.BaseType)
         {
@@ -314,7 +314,7 @@ internal static partial class Parser
     /// <summary>Determines whether a type is <see cref="System.Net.Http.HttpContent"/> or derives from it.</summary>
     /// <param name="type">The type to inspect.</param>
     /// <returns><see langword="true"/> when the type is assignable to <see cref="System.Net.Http.HttpContent"/>.</returns>
-    private static bool IsHttpContentType(ITypeSymbol type)
+    internal static bool IsHttpContentType(ITypeSymbol type)
     {
         for (var current = type; current is not null; current = current.BaseType)
         {
@@ -337,7 +337,7 @@ internal static partial class Parser
     /// <summary>Determines whether a type is <c>Refit.MultipartItem</c> or derives from it.</summary>
     /// <param name="type">The type to inspect.</param>
     /// <returns><see langword="true"/> when the type is assignable to <c>Refit.MultipartItem</c>.</returns>
-    private static bool IsMultipartItemType(ITypeSymbol type)
+    internal static bool IsMultipartItemType(ITypeSymbol type)
     {
         for (var current = type; current is not null; current = current.BaseType)
         {
@@ -359,7 +359,7 @@ internal static partial class Parser
     /// <param name="type">The type to inspect.</param>
     /// <returns><see langword="true"/> for the BCL value types the reflection builder renders through the form
     /// URL-encoded formatter instead of the content serializer.</returns>
-    private static bool IsMultipartFormattableType(ITypeSymbol type) =>
+    internal static bool IsMultipartFormattableType(ITypeSymbol type) =>
         type is { ContainingNamespace.Name: SystemNamespace, ContainingNamespace.ContainingNamespace.IsGlobalNamespace: true }
         && type.Name is "Guid" or "DateTime" or "DateTimeOffset" or "TimeSpan" or "DateOnly" or "TimeOnly";
 }

--- a/src/InterfaceStubGenerator.Shared/Parser.Request.ParameterKinds.cs
+++ b/src/InterfaceStubGenerator.Shared/Parser.Request.ParameterKinds.cs
@@ -16,7 +16,7 @@ internal static partial class Parser
     /// <summary>Determines whether a type is, or is constructed over, a generic type parameter.</summary>
     /// <param name="type">The type to inspect.</param>
     /// <returns><see langword="true"/> when the type references a type parameter.</returns>
-    private static bool ReferencesTypeParameter(ITypeSymbol type)
+    internal static bool ReferencesTypeParameter(ITypeSymbol type)
     {
         switch (type)
         {
@@ -46,7 +46,7 @@ internal static partial class Parser
     /// <param name="type">The parameter type to classify.</param>
     /// <param name="formattableSymbol">The resolved <c>System.IFormattable</c> symbol, or null when unavailable.</param>
     /// <returns><see langword="true"/> when the type is a simple scalar type supported by inline path formatting.</returns>
-    private static bool IsSimpleType(ITypeSymbol type, INamedTypeSymbol? formattableSymbol)
+    internal static bool IsSimpleType(ITypeSymbol type, INamedTypeSymbol? formattableSymbol)
     {
         // A path value is emitted as UrlParameterFormatter.Format(value, provider, typeof(T)) - the same call the
         // reflection path uses - so any type the formatter can render round-trips identically. That is exactly the
@@ -104,7 +104,7 @@ internal static partial class Parser
     /// <remarks>The nested <c>System.Uri</c> namespace pattern's inner segments are only reached for a type literally
     /// named <c>Uri</c>, a shape the shared scalar fixtures never present, so the walk cannot be exercised end to end.</remarks>
     [ExcludeFromCodeCoverage]
-    private static bool IsUri(ITypeSymbol type) =>
+    internal static bool IsUri(ITypeSymbol type) =>
         type is
         {
             Name: "Uri",
@@ -119,7 +119,7 @@ internal static partial class Parser
     /// Mirrors the reflection builder's <c>typeof(CultureInfo).IsAssignableFrom(type)</c>, so derived cultures are
     /// scalars too rather than objects whose public properties get flattened into the query string.
     /// </remarks>
-    private static bool IsCultureInfo(ITypeSymbol type)
+    internal static bool IsCultureInfo(ITypeSymbol type)
     {
         for (var current = type; current is not null; current = current.BaseType)
         {
@@ -141,7 +141,7 @@ internal static partial class Parser
     /// <summary>Determines whether a type is <see cref="CancellationToken"/> or nullable <see cref="CancellationToken"/>.</summary>
     /// <param name="type">The type to inspect.</param>
     /// <returns><see langword="true"/> when the type is a cancellation token.</returns>
-    private static bool IsCancellationToken(ITypeSymbol type)
+    internal static bool IsCancellationToken(ITypeSymbol type)
     {
         // Structural match instead of allocating a fully-qualified display string for every parameter.
         if (type is INamedTypeSymbol
@@ -168,7 +168,7 @@ internal static partial class Parser
     /// <param name="context">The interface generation context, used to qualify extern-aliased types.</param>
     /// <param name="bodyParameter">Receives the body parameter model.</param>
     /// <returns><see langword="true"/> when the parameter has a body attribute.</returns>
-    private static bool TryParseBodyParameter(
+    internal static bool TryParseBodyParameter(
         IParameterSymbol parameter,
         string parameterType,
         InterfaceGenerationContext context,
@@ -214,7 +214,7 @@ internal static partial class Parser
     /// <param name="context">The interface generation context, used to qualify extern-aliased types.</param>
     /// <param name="headerParameter">Receives the header parameter model.</param>
     /// <returns><see langword="true"/> when the parameter has a supported header attribute.</returns>
-    private static bool TryParseHeaderParameter(
+    internal static bool TryParseHeaderParameter(
         IParameterSymbol parameter,
         string parameterType,
         InterfaceGenerationContext context,
@@ -258,7 +258,7 @@ internal static partial class Parser
     /// <param name="context">The interface generation context, used to qualify extern-aliased types.</param>
     /// <param name="headerCollectionParameter">Receives the header collection parameter model.</param>
     /// <returns><see langword="true"/> when the parameter has a supported header collection attribute.</returns>
-    private static bool TryParseHeaderCollectionParameter(
+    internal static bool TryParseHeaderCollectionParameter(
         IParameterSymbol parameter,
         string parameterType,
         InterfaceGenerationContext context,
@@ -301,7 +301,7 @@ internal static partial class Parser
     /// <param name="context">The interface generation context, used to qualify extern-aliased types.</param>
     /// <param name="urlParameter">Receives the url parameter model.</param>
     /// <returns><see langword="true"/> when the parameter carries <c>[Url]</c>.</returns>
-    private static bool TryParseUrlParameter(
+    internal static bool TryParseUrlParameter(
         IParameterSymbol parameter,
         string parameterType,
         InterfaceGenerationContext context,
@@ -335,7 +335,7 @@ internal static partial class Parser
     /// <summary>Determines whether a <c>[Url]</c> parameter type can be emitted inline.</summary>
     /// <param name="type">The parameter type.</param>
     /// <returns><see langword="true"/> for <see cref="string"/> or <see cref="Uri"/>; other types fall back to reflection.</returns>
-    private static bool IsInlineUrlType(ITypeSymbol type) =>
+    internal static bool IsInlineUrlType(ITypeSymbol type) =>
         type.SpecialType == SpecialType.System_String || IsUri(type);
 
     /// <summary>Tries to parse a request property parameter.</summary>
@@ -344,7 +344,7 @@ internal static partial class Parser
     /// <param name="context">The interface generation context, used to qualify extern-aliased types.</param>
     /// <param name="propertyParameter">Receives the property parameter model.</param>
     /// <returns><see langword="true"/> when the parameter has a property attribute.</returns>
-    private static bool TryParsePropertyParameter(
+    internal static bool TryParsePropertyParameter(
         IParameterSymbol parameter,
         string parameterType,
         InterfaceGenerationContext context,
@@ -385,7 +385,7 @@ internal static partial class Parser
     /// <param name="scheme">The authorization scheme, prepended to the value as <c>"{scheme} "</c>.</param>
     /// <param name="context">The interface generation context, used to qualify extern-aliased types.</param>
     /// <returns>The header parameter model that emits <c>Authorization: {scheme} {value}</c>.</returns>
-    private static RequestParameterModel BuildAuthorizeHeaderParameter(
+    internal static RequestParameterModel BuildAuthorizeHeaderParameter(
         IParameterSymbol parameter,
         string parameterType,
         string scheme,
@@ -410,7 +410,7 @@ internal static partial class Parser
     /// <param name="parameterType">The parameter type display string.</param>
     /// <param name="context">The interface generation context, used to qualify extern-aliased types.</param>
     /// <returns>The unsupported parameter model.</returns>
-    private static RequestParameterModel UnsupportedRequestParameter(
+    internal static RequestParameterModel UnsupportedRequestParameter(
         IParameterSymbol parameter,
         string parameterType,
         InterfaceGenerationContext context) =>
@@ -432,7 +432,7 @@ internal static partial class Parser
     /// <param name="locations">The parameter's location in the URL.</param>
     /// <param name="context">The interface generation context, used to qualify extern-aliased types.</param>
     /// <returns>The path request model.</returns>
-    private static RequestParameterModel PathRequestParameter(
+    internal static RequestParameterModel PathRequestParameter(
         IParameterSymbol parameter,
         string parameterType,
         ImmutableEquatableArray<Range> locations,
@@ -456,7 +456,7 @@ internal static partial class Parser
     /// <param name="parameter">The parameter to inspect.</param>
     /// <param name="context">The interface generation context, used to qualify extern-aliased types.</param>
     /// <returns>The precomputed attribute models.</returns>
-    private static ImmutableEquatableArray<ParameterAttributeModel> BuildParameterAttributes(IParameterSymbol parameter, InterfaceGenerationContext context)
+    internal static ImmutableEquatableArray<ParameterAttributeModel> BuildParameterAttributes(IParameterSymbol parameter, InterfaceGenerationContext context)
     {
         var attributes = parameter.GetAttributes();
         if (attributes.IsEmpty)
@@ -492,7 +492,7 @@ internal static partial class Parser
     /// <param name="argument">The typed constant.</param>
     /// <param name="context">The interface generation context, used to qualify extern-aliased types.</param>
     /// <returns>The source expression, or <c>"null"</c> when the value is null.</returns>
-    private static string ConstantValueToString(TypedConstant argument, InterfaceGenerationContext context)
+    internal static string ConstantValueToString(TypedConstant argument, InterfaceGenerationContext context)
     {
         var result = string.Empty;
 
@@ -516,7 +516,7 @@ internal static partial class Parser
     /// <param name="argument">The array typed constant.</param>
     /// <param name="context">The interface generation context, used to qualify extern-aliased types.</param>
     /// <returns>The <c>new[] { ... }</c> source expression.</returns>
-    private static string RenderConstantArray(TypedConstant argument, InterfaceGenerationContext context)
+    internal static string RenderConstantArray(TypedConstant argument, InterfaceGenerationContext context)
     {
         var parts = new List<string>(argument.Values.Length);
         foreach (var value in argument.Values)
@@ -531,7 +531,7 @@ internal static partial class Parser
     /// <param name="type">The parameter type.</param>
     /// <param name="nullableAnnotation">The parameter nullable annotation.</param>
     /// <returns><see langword="true"/> when generated code should guard the value before dereferencing it.</returns>
-    private static bool CanBeNull(ITypeSymbol type, NullableAnnotation nullableAnnotation) =>
+    internal static bool CanBeNull(ITypeSymbol type, NullableAnnotation nullableAnnotation) =>
         type switch
         {
             INamedTypeSymbol { OriginalDefinition.SpecialType: SpecialType.System_Nullable_T } => true,
@@ -542,7 +542,7 @@ internal static partial class Parser
     /// <summary>Determines whether a header collection parameter matches existing runtime semantics.</summary>
     /// <param name="type">The parameter type.</param>
     /// <returns><see langword="true"/> when the type is supported.</returns>
-    private static bool IsSupportedHeaderCollectionType(ITypeSymbol type) =>
+    internal static bool IsSupportedHeaderCollectionType(ITypeSymbol type) =>
         type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)
         == "global::System.Collections.Generic.IDictionary<string, string>";
 }

--- a/src/InterfaceStubGenerator.Shared/Parser.Request.Parameters.cs
+++ b/src/InterfaceStubGenerator.Shared/Parser.Request.Parameters.cs
@@ -20,7 +20,7 @@ internal static partial class Parser
     /// <param name="context">The interface generation context, used to qualify extern-aliased types.</param>
     /// <param name="canGenerateInline">Receives whether every parameter is supported.</param>
     /// <returns>The parsed request parameter models.</returns>
-    private static ImmutableEquatableArray<RequestParameterModel> ParseRequestParameters(
+    internal static ImmutableEquatableArray<RequestParameterModel> ParseRequestParameters(
         in ImmutableArray<IParameterSymbol> parameters,
         Dictionary<string, List<Range>> parameterLocations,
         INamedTypeSymbol? formattableSymbol,
@@ -90,7 +90,7 @@ internal static partial class Parser
     /// <param name="headerCollectionCount">The number of header collection parameters.</param>
     /// <param name="parameters">The parsed request parameters, scanned for <c>[Authorize]</c> parameters.</param>
     /// <returns><see langword="true"/> when no single-instance binding appears more than once.</returns>
-    private static bool HasInlineableParameterCounts(
+    internal static bool HasInlineableParameterCounts(
         int bodyCount,
         int cancellationTokenCount,
         int headerCollectionCount,
@@ -103,7 +103,7 @@ internal static partial class Parser
     /// <summary>Counts the <c>[Authorize]</c> parameters (Authorization headers carrying a scheme prefix).</summary>
     /// <param name="parameters">The parsed request parameters.</param>
     /// <returns>The number of <c>[Authorize]</c> parameters.</returns>
-    private static int CountAuthorizeParameters(RequestParameterModel[] parameters)
+    internal static int CountAuthorizeParameters(RequestParameterModel[] parameters)
     {
         var count = 0;
         foreach (var parameter in parameters)
@@ -120,7 +120,7 @@ internal static partial class Parser
     /// <summary>Resolves a parameter's URL name, honoring an <c>[AliasAs]</c> attribute.</summary>
     /// <param name="parameter">The parameter symbol.</param>
     /// <returns>The alias name or the declared parameter name.</returns>
-    private static string ResolveUrlName(IParameterSymbol parameter)
+    internal static string ResolveUrlName(IParameterSymbol parameter)
     {
         var aliasAttr = FindParameterAttribute(parameter, AliasAsAttributeDisplayName);
         return aliasAttr is not null ? GetFirstStringArgument(aliasAttr) ?? parameter.Name : parameter.Name;
@@ -129,7 +129,7 @@ internal static partial class Parser
     /// <summary>Determines whether any parameter carries an explicit <c>[Body]</c> attribute.</summary>
     /// <param name="parameters">The method parameters.</param>
     /// <returns><see langword="true"/> when an explicit body parameter exists.</returns>
-    private static bool HasExplicitBodyParameter(in ImmutableArray<IParameterSymbol> parameters)
+    internal static bool HasExplicitBodyParameter(in ImmutableArray<IParameterSymbol> parameters)
     {
         foreach (var parameter in parameters)
         {
@@ -147,7 +147,7 @@ internal static partial class Parser
     /// <param name="context">The lookup state used to classify the parameter.</param>
     /// <param name="implicitBodyAssigned">Tracks whether an earlier parameter already claimed the implicit body.</param>
     /// <returns>The parsed parameter and eligibility counters.</returns>
-    private static ParsedRequestParameter ParseRequestParameter(
+    internal static ParsedRequestParameter ParseRequestParameter(
         IParameterSymbol parameter,
         in LooseParameterContext context,
         ref bool implicitBodyAssigned)
@@ -202,7 +202,7 @@ internal static partial class Parser
     /// <param name="locations">The parameter's placeholder locations, if any.</param>
     /// <param name="context">The interface generation context, used to qualify extern-aliased types.</param>
     /// <returns>The parsed parameter and eligibility counters.</returns>
-    private static ParsedRequestParameter CancellationTokenParameter(
+    internal static ParsedRequestParameter CancellationTokenParameter(
         IParameterSymbol parameter,
         string parameterType,
         ImmutableEquatableArray<Range>? locations,
@@ -229,7 +229,7 @@ internal static partial class Parser
     /// <param name="parameterType">The parameter type display string.</param>
     /// <param name="context">The lookup state used to classify the parameter.</param>
     /// <returns>The parsed path binding, or <see langword="null"/> when the parameter has no placeholder.</returns>
-    private static ParsedRequestParameter? ParseBoundPathParameter(
+    internal static ParsedRequestParameter? ParseBoundPathParameter(
         IParameterSymbol parameter,
         string parameterType,
         in LooseParameterContext context) =>
@@ -246,7 +246,7 @@ internal static partial class Parser
     /// <param name="locations">The placeholder locations.</param>
     /// <param name="context">The lookup state used to classify the parameter.</param>
     /// <returns>The parsed parameter and eligibility counters.</returns>
-    private static ParsedRequestParameter ParseDirectPathParameter(
+    internal static ParsedRequestParameter ParseDirectPathParameter(
         IParameterSymbol parameter,
         string parameterType,
         ImmutableEquatableArray<Range> locations,
@@ -278,7 +278,7 @@ internal static partial class Parser
     /// parameterless <c>ToString()</c>.) An <c>object</c>, interface, or open generic type stays on the reflection path -
     /// it has no usable declared shape.
     /// </remarks>
-    private static bool CanInlinePathParameterType(ITypeSymbol type, INamedTypeSymbol? formattableSymbol) =>
+    internal static bool CanInlinePathParameterType(ITypeSymbol type, INamedTypeSymbol? formattableSymbol) =>
         IsSimpleType(type, formattableSymbol)
         || (type.SpecialType != SpecialType.System_Object
             && type.TypeKind is TypeKind.Class or TypeKind.Struct or TypeKind.Array);
@@ -291,7 +291,7 @@ internal static partial class Parser
     /// <param name="roundTripLocations">The placeholder locations.</param>
     /// <param name="context">The lookup state used to classify the parameter.</param>
     /// <returns>The parsed parameter and eligibility counters.</returns>
-    private static ParsedRequestParameter ParseRoundTripPathParameter(
+    internal static ParsedRequestParameter ParseRoundTripPathParameter(
         IParameterSymbol parameter,
         string parameterType,
         ImmutableEquatableArray<Range> roundTripLocations,
@@ -323,7 +323,7 @@ internal static partial class Parser
     /// <param name="context">The lookup state used to classify the parameter.</param>
     /// <param name="implicitBodyAssigned">Tracks whether an earlier parameter already claimed the implicit body.</param>
     /// <returns>The parsed parameter and eligibility counters.</returns>
-    private static ParsedRequestParameter ClassifyLooseParameter(
+    internal static ParsedRequestParameter ClassifyLooseParameter(
         IParameterSymbol parameter,
         string parameterType,
         in LooseParameterContext context,
@@ -377,7 +377,7 @@ internal static partial class Parser
     /// <summary>Determines whether a parameter matches the reflection builder's implicit body candidacy rules.</summary>
     /// <param name="parameter">The parameter to inspect.</param>
     /// <returns><see langword="true"/> for un-attributed non-string reference-type parameters.</returns>
-    private static bool IsImplicitBodyCandidate(IParameterSymbol parameter) =>
+    internal static bool IsImplicitBodyCandidate(IParameterSymbol parameter) =>
         !parameter.Type.IsValueType
         && parameter.Type.SpecialType != SpecialType.System_String
         && !HasParameterAttribute(parameter, QueryAttributeDisplayName)
@@ -389,7 +389,7 @@ internal static partial class Parser
     /// <param name="context">The interface generation context, used to qualify extern-aliased types.</param>
     /// <param name="implicitBodyAssigned">Tracks whether an earlier parameter already claimed the implicit body.</param>
     /// <returns>The parsed parameter and eligibility counters.</returns>
-    private static ParsedRequestParameter ClaimImplicitBody(
+    internal static ParsedRequestParameter ClaimImplicitBody(
         IParameterSymbol parameter,
         string parameterType,
         InterfaceGenerationContext context,
@@ -412,7 +412,7 @@ internal static partial class Parser
     /// <param name="context">The interface generation context, used to qualify extern-aliased types.</param>
     /// <param name="propertyParameter">The parsed property parameter model.</param>
     /// <returns>The parsed parameter and eligibility counters.</returns>
-    private static ParsedRequestParameter ParsePropertyQueryBinding(
+    internal static ParsedRequestParameter ParsePropertyQueryBinding(
         IParameterSymbol parameter,
         string parameterType,
         string urlName,
@@ -437,7 +437,7 @@ internal static partial class Parser
     /// <param name="query">The query-binding metadata.</param>
     /// <param name="context">The interface generation context, used to qualify extern-aliased types.</param>
     /// <returns>The query request parameter model.</returns>
-    private static RequestParameterModel QueryRequestParameter(
+    internal static RequestParameterModel QueryRequestParameter(
         IParameterSymbol parameter,
         string parameterType,
         QueryParameterModel query,
@@ -462,7 +462,7 @@ internal static partial class Parser
     /// <param name="parameterType">The parameter type display string.</param>
     /// <param name="context">The interface generation context, used to qualify extern-aliased types.</param>
     /// <returns>The implicit body parameter model.</returns>
-    private static RequestParameterModel ImplicitBodyRequestParameter(
+    internal static RequestParameterModel ImplicitBodyRequestParameter(
         IParameterSymbol parameter,
         string parameterType,
         InterfaceGenerationContext context) =>

--- a/src/InterfaceStubGenerator.Shared/Parser.Request.Path.cs
+++ b/src/InterfaceStubGenerator.Shared/Parser.Request.Path.cs
@@ -18,7 +18,7 @@ internal static partial class Parser
     /// path, a flattened residual query. Falls back when a placeholder property is unresolvable or non-simple, or when
     /// a residual property has a shape the query flattener cannot render inline.
     /// </returns>
-    private static ParsedRequestParameter BuildPathObjectBinding(
+    internal static ParsedRequestParameter BuildPathObjectBinding(
         IParameterSymbol parameter,
         string parameterType,
         in LooseParameterContext context)
@@ -55,7 +55,7 @@ internal static partial class Parser
     /// <param name="context">The interface generation context, used to qualify extern-aliased types.</param>
     /// <param name="residualQuery">Receives the residual object query, or null when every property is bound to the path.</param>
     /// <returns><see langword="false"/> when a residual property cannot flatten inline and the parameter must fall back.</returns>
-    private static bool TryBuildPathResidualQuery(
+    internal static bool TryBuildPathResidualQuery(
         IParameterSymbol parameter,
         string urlName,
         HashSet<string> boundPropertyNames,
@@ -113,7 +113,7 @@ internal static partial class Parser
     /// <param name="urlName">The parameter's resolved URL name.</param>
     /// <param name="context">The lookup state carrying the placeholder locations and generation context.</param>
     /// <returns>The property bindings, or null when any placeholder cannot be resolved to a simple readable property.</returns>
-    private static ImmutableEquatableArray<PathObjectBindingModel>? TryBuildPathObjectBindings(
+    internal static ImmutableEquatableArray<PathObjectBindingModel>? TryBuildPathObjectBindings(
         IParameterSymbol parameter,
         string urlName,
         in LooseParameterContext context)
@@ -157,7 +157,7 @@ internal static partial class Parser
     /// <param name="propertyPath">The placeholder text after the parameter name (e.g. <c>Slug</c> or <c>a.b</c>).</param>
     /// <param name="context">The lookup state carrying the generation context.</param>
     /// <returns>The resolved access path, top-level property, final type, formatting strategy and nullability, or null.</returns>
-    private static (string AccessPath, string TopLevelName, string PropertyType, InlineValueFormatModel ValueFormat, bool CanBeNull)?
+    internal static (string AccessPath, string TopLevelName, string PropertyType, InlineValueFormatModel ValueFormat, bool CanBeNull)?
         TryResolvePathPropertyChain(ITypeSymbol rootType, string propertyPath, in LooseParameterContext context)
     {
         var segments = propertyPath.Split('.');
@@ -205,7 +205,7 @@ internal static partial class Parser
     /// <param name="type">The declared parameter type.</param>
     /// <param name="propertyName">The property name from the dotted placeholder.</param>
     /// <returns>The matching property, or null when none is readable.</returns>
-    private static IPropertySymbol? FindReadablePathProperty(ITypeSymbol type, string propertyName)
+    internal static IPropertySymbol? FindReadablePathProperty(ITypeSymbol type, string propertyName)
     {
         // A generic type parameter has no members of its own; the reflection builder binds against the closed generic
         // method's concrete argument. A class or interface constraint exposes those members at compile time, so resolve
@@ -247,7 +247,7 @@ internal static partial class Parser
     /// one class constraint, so the resolution is unambiguous; an interface-only or unconstrained parameter resolves to
     /// itself, which the query flattener rejects, keeping it on the reflection request builder.
     /// </remarks>
-    private static ITypeSymbol ResolveConstraintClassType(ITypeSymbol type)
+    internal static ITypeSymbol ResolveConstraintClassType(ITypeSymbol type)
     {
         if (type is not ITypeParameterSymbol typeParameter)
         {
@@ -273,7 +273,7 @@ internal static partial class Parser
     /// <param name="bindings">The resolved property bindings.</param>
     /// <param name="context">The interface generation context, used to qualify extern-aliased types.</param>
     /// <returns>The path parameter model carrying the property bindings.</returns>
-    private static RequestParameterModel BuildPathObjectParameter(
+    internal static RequestParameterModel BuildPathObjectParameter(
         IParameterSymbol parameter,
         string parameterType,
         ImmutableEquatableArray<PathObjectBindingModel> bindings,

--- a/src/InterfaceStubGenerator.Shared/Parser.Request.Query.Objects.cs
+++ b/src/InterfaceStubGenerator.Shared/Parser.Request.Query.Objects.cs
@@ -24,7 +24,7 @@ internal static partial class Parser
     /// recursion; because the declared type is the runtime type there is no divergence. An <c>object</c>, interface, open,
     /// or collection value keeps falling back, since the runtime value could recurse differently than the declared type.
     /// </remarks>
-    private static ImmutableEquatableArray<QueryObjectPropertyModel>? ResolveDictionaryValueProperties(
+    internal static ImmutableEquatableArray<QueryObjectPropertyModel>? ResolveDictionaryValueProperties(
         ITypeSymbol valueType,
         string? format,
         INamedTypeSymbol? formattableSymbol,
@@ -59,7 +59,7 @@ internal static partial class Parser
     /// type instead of its runtime type. An <c>object</c>, interface, or open generic type has no usable declared shape
     /// and stays on the reflection path.
     /// </remarks>
-    private static bool IsConcreteComplexType(ITypeSymbol type) =>
+    internal static bool IsConcreteComplexType(ITypeSymbol type) =>
         type.TypeKind is TypeKind.Class or TypeKind.Struct
         && type.SpecialType != SpecialType.System_Object
         && !TryGetEnumerableElementType(type, out _);
@@ -69,7 +69,7 @@ internal static partial class Parser
     /// <param name="keyType">Receives the dictionary key type.</param>
     /// <param name="valueType">Receives the dictionary value type.</param>
     /// <returns><see langword="true"/> when the type closes <c>IDictionary&lt;TKey, TValue&gt;</c> exactly once.</returns>
-    private static bool TryGetDictionaryTypes(ITypeSymbol type, out ITypeSymbol? keyType, out ITypeSymbol? valueType)
+    internal static bool TryGetDictionaryTypes(ITypeSymbol type, out ITypeSymbol? keyType, out ITypeSymbol? valueType)
     {
         keyType = null;
         valueType = null;
@@ -107,7 +107,7 @@ internal static partial class Parser
     /// <summary>Determines whether a type is a closed <c>System.Collections.Generic.IDictionary&lt;TKey, TValue&gt;</c>.</summary>
     /// <param name="type">The type to inspect.</param>
     /// <returns><see langword="true"/> when the type is the generic dictionary interface.</returns>
-    private static bool IsGenericDictionaryInterface(ITypeSymbol type) =>
+    internal static bool IsGenericDictionaryInterface(ITypeSymbol type) =>
         type is INamedTypeSymbol
         {
             TypeKind: TypeKind.Interface,
@@ -129,7 +129,7 @@ internal static partial class Parser
     /// declared type. The reflection request builder instead walks the value's <em>runtime</em> type, so passing a
     /// derived instance through a base-typed parameter no longer contributes the derived type's extra properties.
     /// </remarks>
-    private static ImmutableEquatableArray<QueryObjectPropertyModel>? TryBuildQueryObjectProperties(
+    internal static ImmutableEquatableArray<QueryObjectPropertyModel>? TryBuildQueryObjectProperties(
         ITypeSymbol type,
         string? parameterPrefixSegment,
         INamedTypeSymbol? formattableSymbol,
@@ -150,7 +150,7 @@ internal static partial class Parser
     /// <param name="ancestors">The types already being flattened on this path, guarding against reference cycles.</param>
     /// <param name="depth">The current nesting depth.</param>
     /// <returns>The property descriptors, or null when the type must fall back to the reflection request builder.</returns>
-    private static ImmutableEquatableArray<QueryObjectPropertyModel>? TryBuildQueryObjectProperties(
+    internal static ImmutableEquatableArray<QueryObjectPropertyModel>? TryBuildQueryObjectProperties(
         ITypeSymbol type,
         string? parameterPrefixSegment,
         INamedTypeSymbol? formattableSymbol,
@@ -198,7 +198,7 @@ internal static partial class Parser
     /// <param name="seen">The set of property names already flattened, updated when this one is accepted.</param>
     /// <param name="property">Receives the property when the member qualifies.</param>
     /// <returns><see langword="true"/> when the member is a flattenable property.</returns>
-    private static bool IsFlattenableProperty(ISymbol member, HashSet<string> seen, out IPropertySymbol property)
+    internal static bool IsFlattenableProperty(ISymbol member, HashSet<string> seen, out IPropertySymbol property)
     {
         if (member is IPropertySymbol candidate
             && IsReadableFormProperty(candidate)
@@ -221,7 +221,7 @@ internal static partial class Parser
     /// exists; those keep using the reflection request builder. Enumerables (including dictionaries) are excluded
     /// because the reflection builder special-cases them rather than flattening their properties.
     /// </remarks>
-    private static bool IsInlineFlattenableQueryObject(ITypeSymbol type) =>
+    internal static bool IsInlineFlattenableQueryObject(ITypeSymbol type) =>
         type.TypeKind is TypeKind.Class or TypeKind.Struct
         && type.SpecialType != SpecialType.System_Object
         && type.SpecialType != SpecialType.System_String
@@ -232,7 +232,7 @@ internal static partial class Parser
     /// <param name="property">The property to inspect.</param>
     /// <returns><see langword="true"/> when the property carries a recognized ignore attribute.</returns>
     /// <remarks>Matches the reflection builder, which compares attribute full names so any assembly's copy counts.</remarks>
-    private static bool IsIgnoredQueryProperty(IPropertySymbol property)
+    internal static bool IsIgnoredQueryProperty(IPropertySymbol property)
     {
         foreach (var attribute in property.GetAttributes())
         {
@@ -251,7 +251,7 @@ internal static partial class Parser
     /// <summary>Reads the <c>[AliasAs]</c>, <c>[JsonPropertyName]</c> and <c>[Query]</c> data from a property.</summary>
     /// <param name="property">The property to inspect.</param>
     /// <returns>The alias name, the System.Text.Json name, and the parsed query data.</returns>
-    private static (string? Alias, string? Json, QueryFormData Query) ReadQueryPropertyAttributes(IPropertySymbol property)
+    internal static (string? Alias, string? Json, QueryFormData Query) ReadQueryPropertyAttributes(IPropertySymbol property)
     {
         string? aliasName = null;
         string? jsonName = null;
@@ -285,7 +285,7 @@ internal static partial class Parser
     /// <param name="ancestors">The types already being flattened on this path, guarding against reference cycles.</param>
     /// <param name="depth">The current nesting depth.</param>
     /// <returns>The property descriptor, or null when the property's shape must fall back to reflection.</returns>
-    private static QueryObjectPropertyModel? BuildQueryObjectPropertyModel(
+    internal static QueryObjectPropertyModel? BuildQueryObjectPropertyModel(
         IPropertySymbol property,
         string? parameterPrefixSegment,
         INamedTypeSymbol? formattableSymbol,
@@ -372,7 +372,7 @@ internal static partial class Parser
     /// <param name="formattableSymbol">The resolved <c>System.IFormattable</c> symbol, or null when unavailable.</param>
     /// <param name="context">The interface generation context, used to qualify extern-aliased types.</param>
     /// <returns>The dictionary property descriptor, or null when the property is not a simple-keyed and -valued dictionary.</returns>
-    private static QueryObjectPropertyModel? TryBuildDictionaryPropertyModel(
+    internal static QueryObjectPropertyModel? TryBuildDictionaryPropertyModel(
         IPropertySymbol property,
         string? aliasName,
         string? serializerName,
@@ -408,7 +408,7 @@ internal static partial class Parser
     /// <param name="formattableSymbol">The resolved <c>System.IFormattable</c> symbol, or null when unavailable.</param>
     /// <param name="context">The interface generation context, used to qualify extern-aliased types.</param>
     /// <returns>The collection property descriptor, or null when the property is not a collection of simple elements.</returns>
-    private static QueryObjectPropertyModel? TryBuildCollectionPropertyModel(
+    internal static QueryObjectPropertyModel? TryBuildCollectionPropertyModel(
         IPropertySymbol property,
         string? aliasName,
         string? serializerName,

--- a/src/InterfaceStubGenerator.Shared/Parser.Request.Query.cs
+++ b/src/InterfaceStubGenerator.Shared/Parser.Request.Query.cs
@@ -75,7 +75,7 @@ internal static partial class Parser
     /// <param name="attributeClass">The attribute class symbol.</param>
     /// <param name="attributeMetadataName">The attribute's metadata name inside the <c>Refit</c> namespace.</param>
     /// <returns><see langword="true"/> when the attribute matches.</returns>
-    private static bool IsRefitAttribute(INamedTypeSymbol? attributeClass, string attributeMetadataName) =>
+    internal static bool IsRefitAttribute(INamedTypeSymbol? attributeClass, string attributeMetadataName) =>
         attributeClass is not null
         && attributeClass.Name == attributeMetadataName
         && attributeClass.ContainingNamespace is { Name: "Refit", ContainingNamespace.IsGlobalNamespace: true };
@@ -84,7 +84,7 @@ internal static partial class Parser
     /// <param name="parameter">The parameter to inspect.</param>
     /// <param name="attributeMetadataName">The attribute's metadata name inside the <c>Refit</c> namespace.</param>
     /// <returns>The attribute data, or null when absent.</returns>
-    private static AttributeData? FindParameterAttribute(IParameterSymbol parameter, string attributeMetadataName)
+    internal static AttributeData? FindParameterAttribute(IParameterSymbol parameter, string attributeMetadataName)
     {
         foreach (var attribute in parameter.GetAttributes())
         {
@@ -101,14 +101,14 @@ internal static partial class Parser
     /// <param name="parameter">The parameter to inspect.</param>
     /// <param name="attributeMetadataName">The attribute's metadata name inside the <c>Refit</c> namespace.</param>
     /// <returns><see langword="true"/> when the attribute is present.</returns>
-    private static bool HasParameterAttribute(IParameterSymbol parameter, string attributeMetadataName) =>
+    internal static bool HasParameterAttribute(IParameterSymbol parameter, string attributeMetadataName) =>
         FindParameterAttribute(parameter, attributeMetadataName) is not null;
 
     /// <summary>Determines whether any placeholder binds a property of this parameter (a dotted <c>{param.Prop}</c>).</summary>
     /// <param name="parameterLocations">The placeholder names in the URL template.</param>
     /// <param name="urlName">The parameter's resolved URL name.</param>
     /// <returns><see langword="true"/> when a dotted placeholder targets this parameter.</returns>
-    private static bool HasDottedPlaceholderFor(
+    internal static bool HasDottedPlaceholderFor(
         Dictionary<string, List<Range>> parameterLocations,
         string urlName)
     {
@@ -132,7 +132,7 @@ internal static partial class Parser
     /// <param name="context">The interface generation context, used to qualify extern-aliased types.</param>
     /// <param name="query">Receives the query-binding model.</param>
     /// <returns><see langword="true"/> when the parameter's shape is supported by inline query generation.</returns>
-    private static bool TryBuildQueryModel(
+    internal static bool TryBuildQueryModel(
         IParameterSymbol parameter,
         string urlName,
         INamedTypeSymbol? formattableSymbol,
@@ -198,7 +198,7 @@ internal static partial class Parser
     /// <param name="formattableSymbol">The resolved <c>System.IFormattable</c> symbol, or null when unavailable.</param>
     /// <param name="context">The interface generation context, used to qualify extern-aliased types.</param>
     /// <returns>The flattened object query model, or null when the parameter cannot be flattened inline.</returns>
-    private static QueryParameterModel? TryBuildFlattenedObjectQueryModel(
+    internal static QueryParameterModel? TryBuildFlattenedObjectQueryModel(
         IParameterSymbol parameter,
         string urlName,
         bool preEncoded,
@@ -243,7 +243,7 @@ internal static partial class Parser
     /// <param name="formattableSymbol">The resolved <c>System.IFormattable</c> symbol, or null when unavailable.</param>
     /// <param name="context">The interface generation context, used to qualify extern-aliased types.</param>
     /// <returns>The collection query model, or null when the parameter is not a collection of simple elements.</returns>
-    private static QueryParameterModel? TryBuildScalarCollectionModel(
+    internal static QueryParameterModel? TryBuildScalarCollectionModel(
         ITypeSymbol type,
         string urlName,
         bool preEncoded,
@@ -270,7 +270,7 @@ internal static partial class Parser
     /// <param name="formattableSymbol">The resolved <c>System.IFormattable</c> symbol, or null when unavailable.</param>
     /// <param name="context">The interface generation context, used to qualify extern-aliased types.</param>
     /// <returns>The converter query model, or null when the converter type cannot be resolved.</returns>
-    private static QueryParameterModel? BuildConverterQueryModel(
+    internal static QueryParameterModel? BuildConverterQueryModel(
         IParameterSymbol parameter,
         AttributeData converterAttribute,
         in QueryFormData data,
@@ -304,7 +304,7 @@ internal static partial class Parser
     /// <remarks>The absent-argument guard defends against error-recovery symbols and cannot be reached from an
     /// attribute application that compiles.</remarks>
     [ExcludeFromCodeCoverage]
-    private static ITypeSymbol? GetSoleTypeArgument(AttributeData attribute) =>
+    internal static ITypeSymbol? GetSoleTypeArgument(AttributeData attribute) =>
         attribute.ConstructorArguments.IsEmpty
             ? null
             : attribute.ConstructorArguments[0].Value as ITypeSymbol;
@@ -322,7 +322,7 @@ internal static partial class Parser
     /// Only simple keys and values generate inline: the reflection builder inspects each value's <em>runtime</em> type
     /// to decide whether to recurse into it, which a declared-type walk cannot reproduce for <c>object</c> values.
     /// </remarks>
-    private static QueryParameterModel? TryBuildDictionaryQueryModel(
+    internal static QueryParameterModel? TryBuildDictionaryQueryModel(
         ITypeSymbol type,
         string urlName,
         bool preEncoded,
@@ -361,7 +361,7 @@ internal static partial class Parser
     /// <param name="formattableSymbol">The resolved <c>System.IFormattable</c> symbol, or null when unavailable.</param>
     /// <param name="context">The interface generation context, used to qualify extern-aliased types.</param>
     /// <returns>The flag query model; both a scalar flag and a per-element flag collection resolve to a value.</returns>
-    private static QueryParameterModel BuildFlagModel(
+    internal static QueryParameterModel BuildFlagModel(
         IParameterSymbol parameter,
         INamedTypeSymbol? formattableSymbol,
         InterfaceGenerationContext context)
@@ -394,7 +394,7 @@ internal static partial class Parser
     /// <summary>Normalizes a compile-time format string, mapping empty/whitespace to no format.</summary>
     /// <param name="format">The raw format from the query attribute.</param>
     /// <returns>The effective format, or null.</returns>
-    private static string? NormalizeFormat(string? format) =>
+    internal static string? NormalizeFormat(string? format) =>
         string.IsNullOrWhiteSpace(format) ? null : format;
 
     /// <summary>Builds the reflection-free rendering strategy for one statically-known value type.</summary>
@@ -403,7 +403,7 @@ internal static partial class Parser
     /// <param name="formattableSymbol">The resolved <c>System.IFormattable</c> symbol, or null when unavailable.</param>
     /// <param name="context">The interface generation context, used to qualify extern-aliased types.</param>
     /// <returns>The rendering strategy matching the default URL parameter formatter's output.</returns>
-    private static InlineValueFormatModel BuildValueFormat(
+    internal static InlineValueFormatModel BuildValueFormat(
         ITypeSymbol type,
         string? format,
         INamedTypeSymbol? formattableSymbol,
@@ -463,7 +463,7 @@ internal static partial class Parser
     /// <param name="formattableSymbol">The resolved <c>System.IFormattable</c> symbol, or null when unavailable.</param>
     /// <param name="spanFormattableSymbol">The resolved <c>System.ISpanFormattable</c> symbol, or null when unavailable.</param>
     /// <returns>Whether the type implements each interface.</returns>
-    private static (bool Formattable, bool SpanFormattable) ClassifyFormattable(
+    internal static (bool Formattable, bool SpanFormattable) ClassifyFormattable(
         ITypeSymbol type,
         INamedTypeSymbol? formattableSymbol,
         INamedTypeSymbol? spanFormattableSymbol)
@@ -501,7 +501,7 @@ internal static partial class Parser
     /// <returns>Whether the value qualifies for the net6+ URL-safe integer write and the net9+ span-escape write.</returns>
     /// <remarks>net6+: an unformatted integer renders as URL-safe digits, so it is written with no escaping.
     /// net9+: any <c>ISpanFormattable</c> renders into a stack buffer and escapes span-to-string, skipping the ToString.</remarks>
-    private static (bool UrlSafe, bool Escapable) ComputeSpanFormattableTiers(
+    internal static (bool UrlSafe, bool Escapable) ComputeSpanFormattableTiers(
         ITypeSymbol type,
         string? format,
         bool implementsSpanFormattable,
@@ -521,7 +521,7 @@ internal static partial class Parser
     /// <summary>Resolves the compile-time enum members honored by the default URL parameter formatter.</summary>
     /// <param name="enumType">The enum type symbol.</param>
     /// <returns>The member models, or null when duplicate constants make a compile-time switch unfaithful.</returns>
-    private static ImmutableEquatableArray<EnumFormatMemberModel>? BuildEnumFormatMembers(ITypeSymbol enumType)
+    internal static ImmutableEquatableArray<EnumFormatMemberModel>? BuildEnumFormatMembers(ITypeSymbol enumType)
     {
         var members = new List<EnumFormatMemberModel>();
         var seenValues = new HashSet<object>();
@@ -549,7 +549,7 @@ internal static partial class Parser
     /// <summary>Reads the <c>[EnumMember(Value = ...)]</c> override for an enum field.</summary>
     /// <param name="field">The enum field symbol.</param>
     /// <returns>The override value, or null when absent (or declared without a value).</returns>
-    private static string? GetEnumMemberOverride(IFieldSymbol field)
+    internal static string? GetEnumMemberOverride(IFieldSymbol field)
     {
         foreach (var attribute in field.GetAttributes())
         {
@@ -577,14 +577,14 @@ internal static partial class Parser
     /// <returns>The string value, or <see langword="null"/> when the argument is not a string <c>Value</c>.</returns>
     /// <remarks><c>EnumMember</c> declares only the <c>Value</c> named argument, so the key comparison never fails here.</remarks>
     [ExcludeFromCodeCoverage]
-    private static string? TryReadEnumMemberValue(KeyValuePair<string, TypedConstant> namedArgument) =>
+    internal static string? TryReadEnumMemberValue(KeyValuePair<string, TypedConstant> namedArgument) =>
         namedArgument.Key == "Value" ? namedArgument.Value.Value as string : null;
 
     /// <summary>Tries to resolve the single <c>IEnumerable&lt;T&gt;</c> element type of a parameter type.</summary>
     /// <param name="type">The parameter type.</param>
     /// <param name="elementType">Receives the element type.</param>
     /// <returns><see langword="true"/> when exactly one generic enumerable element type is implemented.</returns>
-    private static bool TryGetEnumerableElementType(
+    internal static bool TryGetEnumerableElementType(
         ITypeSymbol type,
         out ITypeSymbol? elementType)
     {
@@ -627,7 +627,7 @@ internal static partial class Parser
     /// <summary>Determines whether a type is a closed <c>System.Collections.Generic.IEnumerable&lt;T&gt;</c>.</summary>
     /// <param name="type">The type to inspect.</param>
     /// <returns><see langword="true"/> when the type is the generic enumerable interface.</returns>
-    private static bool IsGenericEnumerable(ITypeSymbol type) =>
+    internal static bool IsGenericEnumerable(ITypeSymbol type) =>
         type is INamedTypeSymbol
         {
             TypeKind: TypeKind.Interface,
@@ -644,14 +644,14 @@ internal static partial class Parser
     /// <remarks>The nullable-value-element arm is only selected by a <c>Nullable&lt;T&gt;</c> collection element, which the
     /// shared collection fixtures never present, so that outcome cannot be exercised.</remarks>
     [ExcludeFromCodeCoverage]
-    private static bool CanElementBeNull(ITypeSymbol elementType) =>
+    internal static bool CanElementBeNull(ITypeSymbol elementType) =>
         !elementType.IsValueType
         || elementType.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T;
 
     /// <summary>Parses the query-relevant data from a parameter's <c>[Query]</c> attribute, if present.</summary>
     /// <param name="parameter">The parameter to inspect.</param>
     /// <returns>The parsed data, or defaults when the attribute is absent.</returns>
-    private static QueryFormData ParseParameterQueryData(IParameterSymbol parameter)
+    internal static QueryFormData ParseParameterQueryData(IParameterSymbol parameter)
     {
         var attribute = FindParameterAttribute(parameter, QueryAttributeDisplayName);
         return attribute is null ? default : ParseFormQueryAttribute(attribute);

--- a/src/InterfaceStubGenerator.Shared/Parser.Request.cs
+++ b/src/InterfaceStubGenerator.Shared/Parser.Request.cs
@@ -495,18 +495,21 @@ internal static partial class Parser
     {
         if (returnType is INamedTypeSymbol { TypeArguments.Length: 1 } namedType)
         {
-            var ns = namedType.ContainingNamespace.ToDisplayString();
-            if (namedType.MetadataName is "Task`1" or "ValueTask`1" && ns == "System.Threading.Tasks")
+            // The metadata name is checked first (a cheap compare against a cached property) so the namespace walk
+            // only runs for the handful of well-known wrapper shapes, never for an arbitrary user return type.
+            if (namedType.MetadataName is "Task`1" or "ValueTask`1"
+                && IsInNamespace(namedType, "System.Threading.Tasks"))
             {
                 return namedType.TypeArguments[0];
             }
 
-            if (namedType.MetadataName == "IAsyncEnumerable`1" && ns == "System.Collections.Generic")
+            if (namedType.MetadataName == "IAsyncEnumerable`1"
+                && IsInNamespace(namedType, "System.Collections.Generic"))
             {
                 return namedType.TypeArguments[0];
             }
 
-            if (namedType.MetadataName == "IObservable`1" && ns == "System")
+            if (namedType.MetadataName == "IObservable`1" && IsInNamespace(namedType, "System"))
             {
                 return namedType.TypeArguments[0];
             }
@@ -520,7 +523,8 @@ internal static partial class Parser
     /// <returns><see langword="true"/> for API response wrappers.</returns>
     internal static bool IsApiResponseType(ITypeSymbol type) =>
         type is INamedTypeSymbol namedType
-        && namedType.ContainingNamespace.ToDisplayString() == "Refit" && namedType.MetadataName is "IApiResponse" or "ApiResponse`1" or "IApiResponse`1";
+        && namedType.MetadataName is "IApiResponse" or "ApiResponse`1" or "IApiResponse`1"
+        && IsInNamespace(namedType, "Refit");
 
     /// <summary>Gets the response-content deserialization type for a method result type.</summary>
     /// <param name="resultType">The method result type.</param>

--- a/src/InterfaceStubGenerator.Shared/Parser.Request.cs
+++ b/src/InterfaceStubGenerator.Shared/Parser.Request.cs
@@ -15,6 +15,12 @@ internal static partial class Parser
     /// <summary>The <c>System</c> namespace name, matched structurally to identify well-known BCL types.</summary>
     private const string SystemNamespace = "System";
 
+    /// <summary>The shared, permanently empty placeholder map returned for paths that declare no path parameters.</summary>
+    /// <remarks>Most parsed paths carry no <c>{placeholder}</c>, and this map is only ever read (never mutated) by the
+    /// parameter parser, so a single shared instance avoids allocating a throwaway dictionary on every such parse - a
+    /// cost paid on every keystroke because the parser re-runs for the whole compilation on each edit.</remarks>
+    private static readonly Dictionary<string, List<Range>> EmptyPathParameters = new(StringComparer.OrdinalIgnoreCase);
+
     /// <summary>Parses the request metadata needed by generated request construction.</summary>
     /// <param name="methodSymbol">The Refit method symbol.</param>
     /// <param name="returnTypeInfo">The classified return type shape.</param>
@@ -246,7 +252,7 @@ internal static partial class Parser
         var i = pathSpan.IndexOf('{');
         if (i < 0)
         {
-            return [];
+            return EmptyPathParameters;
         }
 
         var paramNames = new Dictionary<string, List<Range>>(StringComparer.OrdinalIgnoreCase);

--- a/src/InterfaceStubGenerator.Shared/Parser.Request.cs
+++ b/src/InterfaceStubGenerator.Shared/Parser.Request.cs
@@ -20,7 +20,7 @@ internal static partial class Parser
     /// <param name="returnTypeInfo">The classified return type shape.</param>
     /// <param name="context">The shared generation context.</param>
     /// <returns>The parsed request metadata.</returns>
-    private static RequestModel ParseRequest(
+    internal static RequestModel ParseRequest(
         IMethodSymbol methodSymbol,
         ReturnTypeInfo returnTypeInfo,
         InterfaceGenerationContext context)
@@ -95,7 +95,7 @@ internal static partial class Parser
     /// <param name="methodSymbol">The Refit method symbol.</param>
     /// <param name="context">The shared generation context.</param>
     /// <returns>The HTTP method, raw path, normalized path, and path parameter placeholders.</returns>
-    private static (string HttpMethod, string Path, string NormalizedPath, Dictionary<string, List<Range>> PathParameters) ResolveRequestTarget(
+    internal static (string HttpMethod, string Path, string NormalizedPath, Dictionary<string, List<Range>> PathParameters) ResolveRequestTarget(
         IMethodSymbol methodSymbol,
         InterfaceGenerationContext context)
     {
@@ -114,7 +114,7 @@ internal static partial class Parser
     /// <param name="returnType">The method's declared return type.</param>
     /// <param name="context">The shared generation context.</param>
     /// <returns>The adapter type expression (or null) and the result type to classify the request against.</returns>
-    private static (string? AdapterTypeExpression, ITypeSymbol ResultTypeSource) ResolveReturnTypeAdapter(
+    internal static (string? AdapterTypeExpression, ITypeSymbol ResultTypeSource) ResolveReturnTypeAdapter(
         ITypeSymbol returnType,
         InterfaceGenerationContext context) =>
         TryMatchReturnTypeAdapter(returnType, context, out var closedAdapter, out var adapterResultType)
@@ -125,7 +125,7 @@ internal static partial class Parser
     /// <param name="returnTypeInfo">The classified return type shape.</param>
     /// <param name="adapterTypeExpression">The registered adapter expression, or null.</param>
     /// <returns><see langword="true"/> when the return shape can be generated inline.</returns>
-    private static bool IsInlineReturnShape(ReturnTypeInfo returnTypeInfo, string? adapterTypeExpression) =>
+    internal static bool IsInlineReturnShape(ReturnTypeInfo returnTypeInfo, string? adapterTypeExpression) =>
         returnTypeInfo is ReturnTypeInfo.AsyncVoid or ReturnTypeInfo.AsyncResult or ReturnTypeInfo.AsyncEnumerable
             or ReturnTypeInfo.Observable or ReturnTypeInfo.RequestMessage
         || adapterTypeExpression is not null;
@@ -133,7 +133,7 @@ internal static partial class Parser
     /// <summary>Reports an error when a method uses a source-generation-only attribute but cannot generate inline.</summary>
     /// <param name="methodSymbol">The Refit method symbol.</param>
     /// <param name="context">The shared generation context.</param>
-    private static void ReportSourceGenOnlyAttributeMisuse(
+    internal static void ReportSourceGenOnlyAttributeMisuse(
         IMethodSymbol methodSymbol,
         InterfaceGenerationContext context)
     {
@@ -161,7 +161,7 @@ internal static partial class Parser
     /// <summary>Determines whether an HTTP method may carry an implicit request body.</summary>
     /// <param name="httpMethod">The HTTP method name.</param>
     /// <returns><see langword="true"/> for POST, PUT and PATCH.</returns>
-    private static bool IsBodyCapableHttpMethod(string httpMethod) =>
+    internal static bool IsBodyCapableHttpMethod(string httpMethod) =>
         httpMethod is "POST" or "PUT" or "PATCH";
 
     /// <summary>Determines whether a method's request can be constructed by generated inline code.</summary>
@@ -178,7 +178,7 @@ internal static partial class Parser
     /// correctly or trim-safely — a complex query object (its properties are only known per value) or a form-url-encoded
     /// body (<c>[DynamicallyAccessedMembers]</c>) — are excluded upstream through <paramref name="parameterEligibility"/>.
     /// </remarks>
-    private static bool CanGenerateInlineRequest(
+    internal static bool CanGenerateInlineRequest(
         bool parameterEligibility,
         bool returnShapeEligible,
         string httpMethod,
@@ -203,7 +203,7 @@ internal static partial class Parser
     /// <returns><see langword="true"/> when the method has no <c>[Url]</c> parameter, or has exactly one alongside an
     /// empty path template and no path placeholders. Other shapes fall back to the reflection builder, whose
     /// validation throws for the invalid combination.</returns>
-    private static bool IsUrlBindingSupported(
+    internal static bool IsUrlBindingSupported(
         in RequestPathForms path,
         ImmutableEquatableArray<RequestParameterModel> parameters)
     {
@@ -233,13 +233,13 @@ internal static partial class Parser
     /// <summary>Determines whether a path template is empty or the bare root, so a <c>[Url]</c> parameter may supply the URI.</summary>
     /// <param name="path">The path template.</param>
     /// <returns><see langword="true"/> when the template is empty or <c>"/"</c>.</returns>
-    private static bool IsEmptyOrRootPath(string path) =>
+    internal static bool IsEmptyOrRootPath(string path) =>
         string.IsNullOrEmpty(path) || path == "/";
 
     /// <summary>Extracts the path parameter placeholder names and their locations from a URL template.</summary>
     /// <param name="path">The normalized path template.</param>
     /// <returns>A map of placeholder name to the ranges where each placeholder occurs in the template.</returns>
-    private static Dictionary<string, List<Range>> ExtractPathParameterPlaceholderNames(string path)
+    internal static Dictionary<string, List<Range>> ExtractPathParameterPlaceholderNames(string path)
     {
         var pathSpan = path.AsSpan();
 
@@ -296,7 +296,7 @@ internal static partial class Parser
     /// <summary>Gets the literal path from a Refit HTTP method attribute.</summary>
     /// <param name="attributeData">The attribute data.</param>
     /// <returns>The path literal.</returns>
-    private static string GetHttpPath(AttributeData attributeData)
+    internal static string GetHttpPath(AttributeData attributeData)
     {
         var arguments = attributeData.ConstructorArguments;
         return !arguments.IsEmpty && arguments[0].Value is string path
@@ -311,7 +311,7 @@ internal static partial class Parser
     /// <param name="partLength">The query segment length.</param>
     /// <param name="queryBuffer">The query buffer, allocated only when a segment is retained.</param>
     /// <param name="queryLength">The number of characters currently written to the query buffer.</param>
-    private static void AppendNonEmptyQueryPart(
+    internal static void AppendNonEmptyQueryPart(
         string path,
         int queryStart,
         int partStart,
@@ -349,7 +349,7 @@ internal static partial class Parser
     /// <returns>The <c>UriFormat</c> enum value, or null when the method has no <c>[QueryUriFormat]</c>.</returns>
     /// <remarks>The value re-encodes the whole built path and query, matching the reflection builder's final
     /// <c>Uri.GetComponents(PathAndQuery, QueryUriFormat)</c> pass, so the attribute no longer forces the runtime builder.</remarks>
-    private static int? ResolveQueryUriFormat(IMethodSymbol methodSymbol)
+    internal static int? ResolveQueryUriFormat(IMethodSymbol methodSymbol)
     {
         foreach (var attribute in methodSymbol.GetAttributes())
         {
@@ -368,7 +368,7 @@ internal static partial class Parser
     /// <remarks>The single-<c>int</c>-argument guards match the attribute's only constructor and cannot fail for a
     /// <c>[QueryUriFormat]</c> application that compiles.</remarks>
     [ExcludeFromCodeCoverage]
-    private static int? TryReadQueryUriFormat(AttributeData attribute) =>
+    internal static int? TryReadQueryUriFormat(AttributeData attribute) =>
         IsRefitAttribute(attribute.AttributeClass, QueryUriFormatAttributeDisplayName)
         && attribute.ConstructorArguments.Length == 1
         && attribute.ConstructorArguments[0].Value is int uriFormat
@@ -378,7 +378,7 @@ internal static partial class Parser
     /// <summary>Reads the per-call timeout in milliseconds from a method's <c>[Timeout]</c> attribute.</summary>
     /// <param name="methodSymbol">The method to inspect.</param>
     /// <returns>The timeout in milliseconds, or 0 when the method has no <c>[Timeout]</c>.</returns>
-    private static int ResolveTimeout(IMethodSymbol methodSymbol)
+    internal static int ResolveTimeout(IMethodSymbol methodSymbol)
     {
         foreach (var attribute in methodSymbol.GetAttributes())
         {
@@ -397,7 +397,7 @@ internal static partial class Parser
     /// <remarks>The single-<c>int</c>-argument guards match the attribute's only constructor and cannot fail for a
     /// <c>[Timeout]</c> application that compiles.</remarks>
     [ExcludeFromCodeCoverage]
-    private static int? TryReadTimeout(AttributeData attribute) =>
+    internal static int? TryReadTimeout(AttributeData attribute) =>
         IsRefitAttribute(attribute.AttributeClass, TimeoutAttributeDisplayName)
         && attribute.ConstructorArguments.Length == 1
         && attribute.ConstructorArguments[0].Value is int milliseconds
@@ -407,7 +407,7 @@ internal static partial class Parser
     /// <summary>Parses the static headers declared on inherited interfaces, the declaring interface, and the method.</summary>
     /// <param name="methodSymbol">The method whose header metadata should be parsed.</param>
     /// <returns>The final static header set.</returns>
-    private static ImmutableEquatableArray<HeaderModel> ParseStaticHeaders(IMethodSymbol methodSymbol)
+    internal static ImmutableEquatableArray<HeaderModel> ParseStaticHeaders(IMethodSymbol methodSymbol)
     {
         var headers = new List<HeaderModel>();
 
@@ -426,7 +426,7 @@ internal static partial class Parser
     /// <summary>Adds headers from a collection of attributes, replacing earlier values for the same header name.</summary>
     /// <param name="headers">The mutable header list.</param>
     /// <param name="attributes">The attributes to inspect.</param>
-    private static void AddStaticHeaders(
+    internal static void AddStaticHeaders(
         List<HeaderModel> headers,
         in ImmutableArray<AttributeData> attributes)
     {
@@ -444,7 +444,7 @@ internal static partial class Parser
     /// <summary>Adds the string values from a <c>HeadersAttribute</c> to the static header list.</summary>
     /// <param name="headers">The mutable header list.</param>
     /// <param name="attribute">The attribute data.</param>
-    private static void AddHeadersAttributeValues(List<HeaderModel> headers, AttributeData attribute)
+    internal static void AddHeadersAttributeValues(List<HeaderModel> headers, AttributeData attribute)
     {
         foreach (var argument in attribute.ConstructorArguments)
         {
@@ -468,7 +468,7 @@ internal static partial class Parser
     /// <param name="returnType">The declared return type, or an adapter's wrapped result type.</param>
     /// <param name="context">The generation context, used to qualify extern-aliased types.</param>
     /// <returns>The parsed return type details.</returns>
-    private static RequestReturnTypes GetRequestReturnTypes(ITypeSymbol returnType, InterfaceGenerationContext context)
+    internal static RequestReturnTypes GetRequestReturnTypes(ITypeSymbol returnType, InterfaceGenerationContext context)
     {
         var resultType = GetReturnResultType(returnType);
         var isApiResponse = IsApiResponseType(resultType);
@@ -485,7 +485,7 @@ internal static partial class Parser
     /// <summary>Gets the result type wrapped by Task or ValueTask.</summary>
     /// <param name="returnType">The declared return type.</param>
     /// <returns>The result type.</returns>
-    private static ITypeSymbol GetReturnResultType(ITypeSymbol returnType)
+    internal static ITypeSymbol GetReturnResultType(ITypeSymbol returnType)
     {
         if (returnType is INamedTypeSymbol { TypeArguments.Length: 1 } namedType)
         {
@@ -512,7 +512,7 @@ internal static partial class Parser
     /// <summary>Determines whether a type is one of Refit's API response wrappers.</summary>
     /// <param name="type">The type to inspect.</param>
     /// <returns><see langword="true"/> for API response wrappers.</returns>
-    private static bool IsApiResponseType(ITypeSymbol type) =>
+    internal static bool IsApiResponseType(ITypeSymbol type) =>
         type is INamedTypeSymbol namedType
         && namedType.ContainingNamespace.ToDisplayString() == "Refit" && namedType.MetadataName is "IApiResponse" or "ApiResponse`1" or "IApiResponse`1";
 
@@ -521,7 +521,7 @@ internal static partial class Parser
     /// <param name="isApiResponse">Whether the result is an API response wrapper.</param>
     /// <param name="context">The generation context, used to qualify extern-aliased types.</param>
     /// <returns>The deserialization target type.</returns>
-    private static string GetDeserializedResultTypeName(ITypeSymbol resultType, bool isApiResponse, InterfaceGenerationContext context)
+    internal static string GetDeserializedResultTypeName(ITypeSymbol resultType, bool isApiResponse, InterfaceGenerationContext context)
     {
         if (!isApiResponse)
         {
@@ -539,7 +539,7 @@ internal static partial class Parser
     /// <param name="DeserializedResultType">The response-body deserialization type.</param>
     /// <param name="IsApiResponse">Whether the result type is an API response wrapper.</param>
     /// <param name="DisposeResponse">Whether the runner should dispose the response.</param>
-    private readonly record struct RequestReturnTypes(
+    internal readonly record struct RequestReturnTypes(
         string ResultType,
         string DeserializedResultType,
         bool IsApiResponse,
@@ -554,7 +554,7 @@ internal static partial class Parser
     /// <param name="ImplicitBodyEligible">Whether an un-attributed complex parameter becomes the implicit request body.</param>
     /// <param name="IsMultipart">Whether the method is multipart, so an un-attributed parameter becomes a form part.</param>
     /// <param name="Generation">The interface generation context, carrying the extern-alias collector for type qualification.</param>
-    private readonly record struct LooseParameterContext(
+    internal readonly record struct LooseParameterContext(
         string UrlName,
         ImmutableEquatableArray<Range>? Locations,
         ImmutableEquatableArray<Range>? RoundTripLocations,
@@ -570,7 +570,7 @@ internal static partial class Parser
     /// <param name="BodyCount">The number of body parameters represented by this parameter.</param>
     /// <param name="CancellationTokenCount">The number of cancellation tokens represented by this parameter.</param>
     /// <param name="HeaderCollectionCount">The number of header collections represented by this parameter.</param>
-    private readonly record struct ParsedRequestParameter(
+    internal readonly record struct ParsedRequestParameter(
         RequestParameterModel Parameter,
         bool CanGenerateInline,
         int BodyCount,
@@ -580,5 +580,5 @@ internal static partial class Parser
     /// <summary>The raw and normalized forms of a method's path template.</summary>
     /// <param name="Raw">The raw path literal from the HTTP method attribute.</param>
     /// <param name="Normalized">The path after constant-path normalization (fragment/empty-query cleanup).</param>
-    private readonly record struct RequestPathForms(string Raw, string Normalized);
+    internal readonly record struct RequestPathForms(string Raw, string Normalized);
 }

--- a/src/InterfaceStubGenerator.Shared/Parser.cs
+++ b/src/InterfaceStubGenerator.Shared/Parser.cs
@@ -172,7 +172,8 @@ internal static partial class Parser
             returnTypeAdapterInterface,
             returnTypeAdapters,
             [],
-            new Dictionary<ISymbol, string?>(SymbolEqualityComparer.Default));
+            new Dictionary<ISymbol, string?>(SymbolEqualityComparer.Default),
+            new Dictionary<ISymbol, string>(SymbolEqualityComparer.Default));
     }
 
     /// <summary>Builds the internal generated namespace from a consumer-provided namespace prefix.</summary>

--- a/src/InterfaceStubGenerator.Shared/Parser.cs
+++ b/src/InterfaceStubGenerator.Shared/Parser.cs
@@ -96,7 +96,7 @@ internal static partial class Parser
     /// <param name="generatedRequestBuilding">Whether generated request construction is enabled.</param>
     /// <param name="emitGeneratedCodeMarkers">Whether generated files include generated-code analyzer skip markers.</param>
     /// <returns>The diagnostics paired with an empty context model.</returns>
-    private static (List<Diagnostic> diagnostics, ContextGenerationModel contextGenerationSpec) CreateEmptyResult(
+    internal static (List<Diagnostic> diagnostics, ContextGenerationModel contextGenerationSpec) CreateEmptyResult(
         List<Diagnostic> diagnostics,
         string refitInternalNamespace,
         bool generatedRequestBuilding,
@@ -120,7 +120,7 @@ internal static partial class Parser
     /// <param name="emitGeneratedCodeMarkers">Whether generated files include generated-code analyzer skip markers.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The generation context for the pass.</returns>
-    private static InterfaceGenerationContext CreateGenerationContext(
+    internal static InterfaceGenerationContext CreateGenerationContext(
         CSharpCompilation compilation,
         List<Diagnostic> diagnostics,
         string refitInternalNamespace,
@@ -178,7 +178,7 @@ internal static partial class Parser
     /// <summary>Builds the internal generated namespace from a consumer-provided namespace prefix.</summary>
     /// <param name="refitInternalNamespace">The optional user or MSBuild-supplied namespace prefix.</param>
     /// <returns>A valid C# namespace for generated Refit internals.</returns>
-    private static string BuildRefitInternalNamespace(string? refitInternalNamespace)
+    internal static string BuildRefitInternalNamespace(string? refitInternalNamespace)
     {
         var rawNamespace = string.IsNullOrWhiteSpace(refitInternalNamespace)
             ? RefitInternalGeneratedSuffix
@@ -210,7 +210,7 @@ internal static partial class Parser
     /// <summary>Normalizes one namespace segment into a valid identifier.</summary>
     /// <param name="part">The namespace segment.</param>
     /// <returns>The normalized segment, or an empty string when the segment is blank.</returns>
-    private static string NormalizeNamespacePart(string part)
+    internal static string NormalizeNamespacePart(string part)
     {
         if (string.IsNullOrWhiteSpace(part))
         {
@@ -256,7 +256,7 @@ internal static partial class Parser
     /// <param name="interfaceToNullableEnabledMap">Receives the nullable-context flag per interface.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A map of interface symbol to its directly declared Refit methods.</returns>
-    private static Dictionary<INamedTypeSymbol, List<IMethodSymbol>> CollectRefitInterfaces(
+    internal static Dictionary<INamedTypeSymbol, List<IMethodSymbol>> CollectRefitInterfaces(
         CSharpCompilation compilation,
         in ImmutableArray<MethodDeclarationSyntax> candidateMethods,
         in ImmutableArray<InterfaceDeclarationSyntax> candidateInterfaces,
@@ -333,7 +333,7 @@ internal static partial class Parser
     /// <param name="context">The shared generation context.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The interface models, one per collected interface.</returns>
-    private static ImmutableEquatableArray<InterfaceModel> BuildInterfaceModels(
+    internal static ImmutableEquatableArray<InterfaceModel> BuildInterfaceModels(
         Dictionary<INamedTypeSymbol, List<IMethodSymbol>> interfaces,
         Dictionary<INamedTypeSymbol, bool> interfaceToNullableEnabledMap,
         InterfaceGenerationContext context,
@@ -381,7 +381,7 @@ internal static partial class Parser
     /// <param name="nullableEnabled">Whether nullable reference types are enabled for the interface.</param>
     /// <param name="context">The shared generation context.</param>
     /// <returns>The model describing the interface.</returns>
-    private static InterfaceModel ProcessInterface(
+    internal static InterfaceModel ProcessInterface(
         string fileName,
         INamedTypeSymbol interfaceSymbol,
         List<IMethodSymbol> refitMethods,
@@ -449,7 +449,7 @@ internal static partial class Parser
     /// <summary>Resolves the shared route prefix declared on an interface via <c>[PathPrefix]</c>.</summary>
     /// <param name="interfaceSymbol">The interface the client is generated for.</param>
     /// <returns>The declared prefix, or an empty string when the interface carries no <c>[PathPrefix]</c>.</returns>
-    private static string ResolvePathPrefix(INamedTypeSymbol interfaceSymbol)
+    internal static string ResolvePathPrefix(INamedTypeSymbol interfaceSymbol)
     {
         foreach (var attribute in interfaceSymbol.GetAttributes())
         {
@@ -467,7 +467,7 @@ internal static partial class Parser
     /// <summary>Builds the deterministically-ordered set of extern aliases an interface's types reference.</summary>
     /// <param name="aliases">The collected extern aliases.</param>
     /// <returns>The sorted extern aliases, or an empty array when none were used.</returns>
-    private static ImmutableEquatableArray<string> BuildSortedExternAliases(HashSet<string> aliases)
+    internal static ImmutableEquatableArray<string> BuildSortedExternAliases(HashSet<string> aliases)
     {
         if (aliases.Count == 0)
         {
@@ -482,7 +482,7 @@ internal static partial class Parser
     /// <summary>Computes the generated identifiers and display names for an interface.</summary>
     /// <param name="interfaceSymbol">The interface symbol being processed.</param>
     /// <returns>The computed names for the interface.</returns>
-    private static InterfaceNames ComputeInterfaceNames(INamedTypeSymbol interfaceSymbol)
+    internal static InterfaceNames ComputeInterfaceNames(INamedTypeSymbol interfaceSymbol)
     {
         // Start with the interface display name including type parameters, then strip the namespace.
         var className = interfaceSymbol.ToDisplayString();
@@ -517,7 +517,7 @@ internal static partial class Parser
     /// <param name="refitMethods">The Refit methods declared on the interface.</param>
     /// <param name="context">The shared generation context.</param>
     /// <returns>The partitioned member sets.</returns>
-    private static MethodPartition PartitionMembers(
+    internal static MethodPartition PartitionMembers(
         INamedTypeSymbol interfaceSymbol,
         in ImmutableArray<ISymbol> members,
         List<IMethodSymbol> refitMethods,
@@ -551,7 +551,7 @@ internal static partial class Parser
     /// <param name="members">The directly declared members of the interface.</param>
     /// <param name="refitMethods">The Refit methods declared on the interface.</param>
     /// <returns>The non-Refit methods declared directly on the interface.</returns>
-    private static List<IMethodSymbol> CollectDirectNonRefitMethods(
+    internal static List<IMethodSymbol> CollectDirectNonRefitMethods(
         in ImmutableArray<ISymbol> members,
         List<IMethodSymbol> refitMethods)
     {
@@ -585,7 +585,7 @@ internal static partial class Parser
     /// <param name="derivedNonRefitMethods">Receives the non-Refit methods inherited from base interfaces.</param>
     /// <param name="inheritedProperties">Receives the emittable properties inherited from base interfaces.</param>
     /// <returns><see langword="true"/> if the interface inherits <c>IDisposable.Dispose</c>; otherwise, <see langword="false"/>.</returns>
-    private static bool CollectDerivedMembers(
+    internal static bool CollectDerivedMembers(
         INamedTypeSymbol interfaceSymbol,
         InterfaceGenerationContext context,
         List<IMethodSymbol> derivedRefitMethods,
@@ -641,14 +641,14 @@ internal static partial class Parser
     /// <param name="method">The candidate method.</param>
     /// <param name="disposableInterfaceSymbol">The <c>IDisposable</c> symbol, if available.</param>
     /// <returns><see langword="true"/> if the method is declared on <c>IDisposable</c>; otherwise, <see langword="false"/>.</returns>
-    private static bool IsDisposeMethod(IMethodSymbol method, ISymbol? disposableInterfaceSymbol) =>
+    internal static bool IsDisposeMethod(IMethodSymbol method, ISymbol? disposableInterfaceSymbol) =>
         method.ContainingType.Equals(disposableInterfaceSymbol, SymbolEqualityComparer.Default);
 
     /// <summary>Removes base methods that the current interface re-declares as explicit Refit members.</summary>
     /// <param name="members">The directly declared members of the interface.</param>
     /// <param name="derivedNonRefitMethods">The non-Refit methods discovered on base interfaces.</param>
     /// <returns>The filtered list of derived non-Refit methods.</returns>
-    private static List<IMethodSymbol> ExcludeExplicitlyImplementedBaseMethods(
+    internal static List<IMethodSymbol> ExcludeExplicitlyImplementedBaseMethods(
         in ImmutableArray<ISymbol> members,
         List<IMethodSymbol> derivedNonRefitMethods)
     {
@@ -696,7 +696,7 @@ internal static partial class Parser
     /// <param name="ClassSuffix">The generated class suffix.</param>
     /// <param name="Namespace">The flattened namespace for generated identifiers.</param>
     /// <param name="InterfaceDisplayName">The fully qualified interface display name.</param>
-    private readonly record struct InterfaceNames(
+    internal readonly record struct InterfaceNames(
         string ClassName,
         string ClassDeclaration,
         string ClassSuffix,
@@ -709,7 +709,7 @@ internal static partial class Parser
     /// <param name="DerivedNonRefitMethods">The non-Refit methods inherited from base interfaces.</param>
     /// <param name="InheritedProperties">The emittable properties inherited from base interfaces, in discovery order.</param>
     /// <param name="HasDispose">Whether the interface inherits <c>IDisposable.Dispose</c>.</param>
-    private readonly record struct MethodPartition(
+    internal readonly record struct MethodPartition(
         List<IMethodSymbol> NonRefitMethods,
         List<IMethodSymbol> DerivedRefitMethods,
         List<IMethodSymbol> DerivedNonRefitMethods,

--- a/src/InterfaceStubGenerator.Shared/PooledStringBuilder.cs
+++ b/src/InterfaceStubGenerator.Shared/PooledStringBuilder.cs
@@ -71,6 +71,27 @@ internal sealed class PooledStringBuilder
         return this;
     }
 
+    /// <summary>Appends the accumulated content of another builder, then returns that builder's buffer to the pool.</summary>
+    /// <param name="other">The builder whose content is copied in; it is emptied and single-use afterward.</param>
+    /// <returns>This builder, for chaining.</returns>
+    /// <remarks>Copies buffer to buffer so a nested fragment builder's content joins this one without materializing an
+    /// intermediate string. The source is drained (its buffer returned to the pool), matching <see cref="ToString"/>.</remarks>
+    public PooledStringBuilder Append(PooledStringBuilder other)
+    {
+        if (other._pos != 0)
+        {
+            EnsureCapacity(_pos + other._pos);
+            Array.Copy(other._buffer, 0, _buffer, _pos, other._pos);
+            _pos += other._pos;
+        }
+
+        var toReturn = other._buffer;
+        other._buffer = [];
+        other._pos = 0;
+        ArrayPool<char>.Shared.Return(toReturn);
+        return this;
+    }
+
     /// <summary>Appends a string followed by a line terminator.</summary>
     /// <param name="value">The string to append, or null.</param>
     /// <returns>This builder, for chaining.</returns>

--- a/src/InterfaceStubGenerator.Shared/PooledStringBuilder.cs
+++ b/src/InterfaceStubGenerator.Shared/PooledStringBuilder.cs
@@ -94,7 +94,7 @@ internal sealed class PooledStringBuilder
 
     /// <summary>Ensures the backing buffer can hold at least the requested number of characters.</summary>
     /// <param name="required">The required total capacity.</param>
-    private void EnsureCapacity(int required)
+    internal void EnsureCapacity(int required)
     {
         if (required <= _buffer.Length)
         {

--- a/src/InterfaceStubGenerator.Shared/PooledStringBuilder.cs
+++ b/src/InterfaceStubGenerator.Shared/PooledStringBuilder.cs
@@ -166,14 +166,9 @@ internal sealed class PooledStringBuilder
     }
 
     /// <summary>Returns a buffer to the thread-local free list, dropping it when the list is full.</summary>
-    /// <param name="buffer">The buffer to return; an empty buffer is ignored.</param>
+    /// <param name="buffer">The rented buffer to return.</param>
     private static void ReturnBuffer(char[] buffer)
     {
-        if (buffer.Length == 0)
-        {
-            return;
-        }
-
         var pool = _pool ??= new char[MaxPooledPerThread][];
         if (_pooledCount >= MaxPooledPerThread)
         {

--- a/src/InterfaceStubGenerator.Shared/PooledStringBuilder.cs
+++ b/src/InterfaceStubGenerator.Shared/PooledStringBuilder.cs
@@ -1,12 +1,11 @@
 // Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
 // ReactiveUI and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
-using System.Buffers;
 using System.Globalization;
 
 namespace Refit.Generator;
 
-/// <summary>A drop-in fluent string builder for the emitter that grows using <see cref="ArrayPool{T}"/> buffers.</summary>
+/// <summary>A drop-in fluent string builder for the emitter that grows using thread-local pooled buffers.</summary>
 /// <remarks>The emitter builds many transient fragment strings. Backing accumulation with a pooled <c>char[]</c> lets the
 /// underlying buffer be reused across emissions instead of allocating fresh <see cref="System.Text.StringBuilder"/>
 /// chunks each time. The final <see cref="ToString"/> returns the buffer to the pool, so an instance is single-use.</remarks>
@@ -18,10 +17,23 @@ internal sealed class PooledStringBuilder
     /// <summary>The buffer growth factor applied when the current backing array is exhausted.</summary>
     private const int GrowthFactor = 2;
 
+    /// <summary>The number of buffers cached per thread; sized to cover the emitter's nesting depth (interface, member,
+    /// method, parameter-info, and query builders alive at once) so nested rents stay on the lock-free path.</summary>
+    private const int MaxPooledPerThread = 16;
+
     /// <summary>The line terminator emitted by the <see cref="AppendLine()"/> overloads.</summary>
     /// <remarks>Fixed to <c>\n</c> for deterministic generated output (matching the emitter's explicit <c>\n</c>
     /// literals); analyzers are banned from reading <c>Environment.NewLine</c>.</remarks>
     private const string NewLine = "\n";
+
+    /// <summary>The per-thread free list of reusable buffers. Thread-local so rent and return never lock; the emitter
+    /// nests builders on one thread, which exhausts the single-slot lock-free tier of the shared array pool.</summary>
+    [ThreadStatic]
+    private static char[][]? _pool;
+
+    /// <summary>The number of populated slots in <see cref="_pool"/>.</summary>
+    [ThreadStatic]
+    private static int _pooledCount;
 
     /// <summary>The pooled array currently backing the builder.</summary>
     private char[] _buffer;
@@ -37,7 +49,7 @@ internal sealed class PooledStringBuilder
 
     /// <summary>Initializes a new instance of the <see cref="PooledStringBuilder"/> class with an initial capacity.</summary>
     /// <param name="capacity">The initial buffer capacity to rent.</param>
-    public PooledStringBuilder(int capacity) => _buffer = ArrayPool<char>.Shared.Rent(Math.Max(capacity, DefaultCapacity));
+    public PooledStringBuilder(int capacity) => _buffer = RentBuffer(Math.Max(capacity, DefaultCapacity));
 
     /// <summary>Appends a string.</summary>
     /// <param name="value">The string to append, or null.</param>
@@ -88,7 +100,7 @@ internal sealed class PooledStringBuilder
         var toReturn = other._buffer;
         other._buffer = [];
         other._pos = 0;
-        ArrayPool<char>.Shared.Return(toReturn);
+        ReturnBuffer(toReturn);
         return this;
     }
 
@@ -109,7 +121,7 @@ internal sealed class PooledStringBuilder
         var toReturn = _buffer;
         _buffer = [];
         _pos = 0;
-        ArrayPool<char>.Shared.Return(toReturn);
+        ReturnBuffer(toReturn);
         return result;
     }
 
@@ -122,10 +134,53 @@ internal sealed class PooledStringBuilder
             return;
         }
 
-        var next = ArrayPool<char>.Shared.Rent(Math.Max(required, _buffer.Length * GrowthFactor));
+        var next = RentBuffer(Math.Max(required, _buffer.Length * GrowthFactor));
         Array.Copy(_buffer, next, _pos);
         var toReturn = _buffer;
         _buffer = next;
-        ArrayPool<char>.Shared.Return(toReturn);
+        ReturnBuffer(toReturn);
+    }
+
+    /// <summary>Rents a buffer of at least the requested length from the thread-local free list, or allocates one.</summary>
+    /// <param name="minimumLength">The minimum buffer length required.</param>
+    /// <returns>A buffer with <see cref="Array.Length"/> at least <paramref name="minimumLength"/>.</returns>
+    private static char[] RentBuffer(int minimumLength)
+    {
+        var pool = _pool;
+        if (pool is not null)
+        {
+            for (var i = _pooledCount - 1; i >= 0; i--)
+            {
+                var candidate = pool[i];
+                if (candidate.Length >= minimumLength)
+                {
+                    pool[i] = pool[_pooledCount - 1];
+                    pool[_pooledCount - 1] = null!;
+                    _pooledCount--;
+                    return candidate;
+                }
+            }
+        }
+
+        return new char[minimumLength];
+    }
+
+    /// <summary>Returns a buffer to the thread-local free list, dropping it when the list is full.</summary>
+    /// <param name="buffer">The buffer to return; an empty buffer is ignored.</param>
+    private static void ReturnBuffer(char[] buffer)
+    {
+        if (buffer.Length == 0)
+        {
+            return;
+        }
+
+        var pool = _pool ??= new char[MaxPooledPerThread][];
+        if (_pooledCount >= MaxPooledPerThread)
+        {
+            return;
+        }
+
+        pool[_pooledCount] = buffer;
+        _pooledCount++;
     }
 }

--- a/src/InterfaceStubGenerator.Shared/UniqueNameBuilder.cs
+++ b/src/InterfaceStubGenerator.Shared/UniqueNameBuilder.cs
@@ -52,6 +52,6 @@ public class UniqueNameBuilder
     /// <summary>Determines whether the name is used in this or any parent scope.</summary>
     /// <param name="name">The name to check.</param>
     /// <returns>True if the name is already used; otherwise, false.</returns>
-    private bool Contains(string name) =>
+    internal bool Contains(string name) =>
         _usedNames.Contains(name);
 }

--- a/src/Refit.slnx
+++ b/src/Refit.slnx
@@ -25,6 +25,7 @@
     </Folder>
     <Folder Name="/Benchmarks/">
         <Project Path="benchmarks/Refit.Benchmarks/Refit.Benchmarks.csproj" />
+        <Project Path="benchmarks/Refit.Generator.Benchmarks/Refit.Generator.Benchmarks.csproj" />
     </Folder>
     <Folder Name="/Solution Items/workflows/">
         <File Path="../.github/workflows/ci-build.yml" />

--- a/src/benchmarks/Refit.Generator.Benchmarks/CorpusSize.cs
+++ b/src/benchmarks/Refit.Generator.Benchmarks/CorpusSize.cs
@@ -1,0 +1,17 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+namespace Refit.Generator.Benchmarks;
+
+/// <summary>The corpus sizes the end-to-end and transform benchmarks sweep across.</summary>
+public enum CorpusSize
+{
+    /// <summary>A single small CRUD interface.</summary>
+    Small,
+
+    /// <summary>A handful of varied interfaces.</summary>
+    Medium,
+
+    /// <summary>Many interfaces with many methods each.</summary>
+    Large,
+}

--- a/src/benchmarks/Refit.Generator.Benchmarks/GeneratorCorpus.cs
+++ b/src/benchmarks/Refit.Generator.Benchmarks/GeneratorCorpus.cs
@@ -1,0 +1,251 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+using System.Text;
+
+namespace Refit.Generator.Benchmarks;
+
+/// <summary>Provides representative Refit interface source corpora used across the generator benchmarks.</summary>
+internal static class GeneratorCorpus
+{
+    /// <summary>The number of interfaces emitted into the large corpus.</summary>
+    private const int LargeInterfaceCount = 40;
+
+    /// <summary>The number of methods emitted per interface in the large corpus.</summary>
+    private const int LargeMethodsPerInterface = 12;
+
+    /// <summary>The initial builder capacity for the large corpus, sized to hold it without regrowth.</summary>
+    private const int LargeCorpusInitialCapacity = 64 * 1024;
+
+    /// <summary>The shared using directives and namespace preamble every corpus source begins with.</summary>
+    private const string Preamble =
+        """
+        using System;
+        using System.Collections.Generic;
+        using System.Net.Http;
+        using System.Threading;
+        using System.Threading.Tasks;
+        using Refit;
+
+        namespace RefitGeneratorBench;
+
+        """;
+
+    /// <summary>The per-method source templates cycled across the large corpus to spread it over binding shapes.
+    /// Each carries a <c>{route}</c> and <c>{n}</c> placeholder replaced per emission.</summary>
+    private static readonly string[] _largeMethodTemplates =
+    [
+        "    [Get(\"{route}/{id}\")]\n    Task<Entity> Get{n}(int id, CancellationToken token);\n",
+        "    [Get(\"{route}\")]\n    Task<List<Entity>> List{n}(int page, int pageSize, string? sort, bool archived);\n",
+        "    [Post(\"{route}\")]\n    Task<Entity> Create{n}([Body] Entity entity);\n",
+        "    [Put(\"{route}/{id}\")]\n    Task Update{n}(int id, [Body] Entity entity, [Header(\"If-Match\")] string etag);\n",
+        "    [Get(\"{route}/search\")]\n    Task<string> Search{n}(string q, [Query(CollectionFormat.Multi)] int[] tags, [AliasAs(\"c\")] string? cursor);\n",
+        "    [Delete(\"{route}/{id}\")]\n    Task Delete{n}(int id);\n",
+    ];
+
+    /// <summary>Gets a single small CRUD interface: the common "one client, a handful of methods" case.</summary>
+    public static string Small { get; } =
+        Preamble +
+        """
+        public sealed class Widget
+        {
+            public int Id { get; set; }
+            public string? Name { get; set; }
+        }
+
+        public interface IWidgetApi
+        {
+            [Post("/widgets")]
+            Task<Widget> Create([Body] Widget payload);
+
+            [Get("/widgets")]
+            Task<List<Widget>> ReadAll();
+
+            [Get("/widgets/{id}")]
+            Task<Widget> ReadOne(int id);
+
+            [Put("/widgets/{id}")]
+            Task Update(int id, [Body] Widget payload);
+
+            [Delete("/widgets/{id}")]
+            Task Delete(int id);
+        }
+        """;
+
+    /// <summary>Gets a mid-sized corpus exercising query, path, header, and body binding across several interfaces.</summary>
+    public static string Medium { get; } = BuildMedium();
+
+    /// <summary>Gets a large multi-interface, multi-method corpus for cold-run and throughput measurement.</summary>
+    public static string Large { get; } = BuildLarge();
+
+    /// <summary>Gets a query-heavy corpus exercising scalar, collection, object, and converter query bindings.</summary>
+    public static string QueryHeavy { get; } =
+        Preamble +
+        """
+        using System.Runtime.Serialization;
+
+        public enum BenchSort
+        {
+            [EnumMember(Value = "date-desc")]
+            DateDescending,
+            Name,
+        }
+
+        public sealed class BenchFilter
+        {
+            public string? Name { get; set; }
+            public int? MinValue { get; set; }
+            public BenchSort Sort { get; set; }
+        }
+
+        public interface IQueryHeavyApi
+        {
+            [Get("/search")]
+            Task<string> Search(string q, int? page, int size, bool archived, BenchSort sort);
+
+            [Get("/csv")]
+            Task<string> Csv([Query(CollectionFormat.Csv)] int[] ids, [AliasAs("t")] string tag);
+
+            [Get("/multi")]
+            Task<string> Multi([Query(CollectionFormat.Multi)] IReadOnlyList<Guid> ids);
+
+            [Get("/flags")]
+            Task<string> Flags([QueryName] string[] flags, [Encoded] string cursor);
+
+            [Get("/object")]
+            Task<string> ByObject([Query] BenchFilter filter, string tag);
+
+            [Get("/fmt")]
+            Task<string> Formatted([Query(Format = "0.00")] double price, [Query(TreatAsString = true)] object raw);
+        }
+        """;
+
+    /// <summary>Gets a multipart-heavy corpus exercising stream, byte-array, string, and typed multipart parts.</summary>
+    public static string MultipartHeavy { get; } =
+        Preamble +
+        """
+        using System.IO;
+
+        public interface IMultipartApi
+        {
+            [Multipart]
+            [Post("/upload/stream")]
+            Task<string> UploadStream(Stream file, string description);
+
+            [Multipart]
+            [Post("/upload/bytes")]
+            Task<string> UploadBytes([AliasAs("blob")] byte[] data, int width, int height);
+
+            [Multipart]
+            [Post("/upload/parts")]
+            Task<string> UploadParts(string title, string author, StreamPart cover, IEnumerable<StreamPart> pages);
+
+            [Multipart]
+            [Post("/upload/typed")]
+            Task<string> UploadTyped([AliasAs("meta")] Dictionary<string, string> metadata, ByteArrayPart thumbnail);
+        }
+        """;
+
+    /// <summary>Gets the corpus source text for a given size.</summary>
+    /// <param name="size">The corpus size.</param>
+    /// <returns>The corpus source text.</returns>
+    public static string SourceFor(CorpusSize size) => size switch
+    {
+        CorpusSize.Small => Small,
+        CorpusSize.Medium => Medium,
+        _ => Large,
+    };
+
+    /// <summary>Builds a mid-sized corpus with a handful of varied interfaces.</summary>
+    /// <returns>The medium corpus source text.</returns>
+    private static string BuildMedium()
+    {
+        var builder = new StringBuilder(Preamble);
+        _ = builder.Append(
+            """
+            public sealed class User
+            {
+                public int Id { get; set; }
+                public string? Name { get; set; }
+                public string? Email { get; set; }
+            }
+
+            public sealed class Order
+            {
+                public int Id { get; set; }
+                public decimal Total { get; set; }
+            }
+
+            public interface IUserApi
+            {
+                [Get("/users")]
+                Task<List<User>> List(int page, int pageSize, string? sort);
+
+                [Get("/users/{id}")]
+                Task<User> Get(int id);
+
+                [Post("/users")]
+                Task<User> Create([Body] User user);
+
+                [Headers("Accept: application/json")]
+                [Put("/users/{id}")]
+                Task Update(int id, [Body] User user, [Header("If-Match")] string etag);
+            }
+
+            public interface IOrderApi
+            {
+                [Get("/orders")]
+                Task<List<Order>> List([Query] int[] statuses, string? cursor);
+
+                [Get("/orders/{id}")]
+                Task<Order> Get(int id, CancellationToken token);
+
+                [Post("/orders/{id}/refund")]
+                Task Refund(int id, [Body] Order order);
+            }
+
+            public interface ISearchApi
+            {
+                [Get("/search")]
+                Task<string> Query(string q, [AliasAs("f")] string[] filters, bool exact);
+            }
+            """);
+        return builder.ToString();
+    }
+
+    /// <summary>Builds a large corpus with many interfaces and methods exercising varied binding shapes.</summary>
+    /// <returns>The large corpus source text.</returns>
+    private static string BuildLarge()
+    {
+        var builder = new StringBuilder(LargeCorpusInitialCapacity);
+        _ = builder.Append(Preamble);
+        _ = builder.Append(
+            """
+            public sealed class Entity
+            {
+                public int Id { get; set; }
+                public string? Name { get; set; }
+                public string? Description { get; set; }
+            }
+
+            """);
+
+        for (var i = 0; i < LargeInterfaceCount; i++)
+        {
+            var route = "/res" + i.ToString(System.Globalization.CultureInfo.InvariantCulture);
+            _ = builder.Append("public interface IResource").Append(i).Append("Api\n{\n");
+            for (var m = 0; m < LargeMethodsPerInterface; m++)
+            {
+                var template = _largeMethodTemplates[m % _largeMethodTemplates.Length];
+                _ = builder.Append(
+                    template
+                        .Replace("{route}", route, StringComparison.Ordinal)
+                        .Replace("{n}", m.ToString(System.Globalization.CultureInfo.InvariantCulture), StringComparison.Ordinal));
+            }
+
+            _ = builder.Append("}\n\n");
+        }
+
+        return builder.ToString();
+    }
+}

--- a/src/benchmarks/Refit.Generator.Benchmarks/GeneratorDriverBenchmarks.cs
+++ b/src/benchmarks/Refit.Generator.Benchmarks/GeneratorDriverBenchmarks.cs
@@ -1,0 +1,61 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Diagnosers;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace Refit.Generator.Benchmarks;
+
+/// <summary>End-to-end generator throughput through <see cref="CSharpGeneratorDriver"/> for cold and incremental runs.</summary>
+/// <remarks>Cold is a first-time run from a fresh driver; incremental re-runs a primed driver after an unrelated edit,
+/// which is what the IDE pays per keystroke. CPU sampling attributes wall-clock to parser vs emitter vs Roslyn driver.</remarks>
+[ShortRunJob]
+[MemoryDiagnoser]
+[EventPipeProfiler(EventPipeProfile.CpuSampling)]
+public class GeneratorDriverBenchmarks
+{
+    /// <summary>The compilation the cold driver runs against.</summary>
+    private Compilation _coldCompilation = null!;
+
+    /// <summary>The fresh driver used for the cold run.</summary>
+    private CSharpGeneratorDriver _coldDriver = null!;
+
+    /// <summary>The compilation the primed driver re-runs against after an unrelated edit.</summary>
+    private Compilation _incrementalCompilation = null!;
+
+    /// <summary>The primed driver used for the incremental run.</summary>
+    private CSharpGeneratorDriver _incrementalDriver = null!;
+
+    /// <summary>Gets or sets the corpus size under benchmark.</summary>
+    [ParamsAllValues]
+    public CorpusSize Size { get; set; }
+
+    /// <summary>Builds the cold and primed incremental driver states for the current corpus size.</summary>
+    [GlobalSetup]
+    public void Setup()
+    {
+        var source = GeneratorCorpus.SourceFor(Size);
+
+        var cold = GeneratorHarness.CreateColdState(source);
+        _coldCompilation = cold.Compilation;
+        _coldDriver = cold.Driver;
+
+        var primed = GeneratorHarness.CreatePrimedState(source);
+        _incrementalCompilation = primed.Compilation;
+        _incrementalDriver = primed.Driver;
+    }
+
+    /// <summary>Runs the generator from a cold driver.</summary>
+    /// <returns>The updated generator driver.</returns>
+    [Benchmark]
+    public GeneratorDriver Cold() =>
+        _coldDriver.RunGeneratorsAndUpdateCompilation(_coldCompilation, out _, out _);
+
+    /// <summary>Re-runs a primed driver after an unrelated edit, exercising the incremental cache.</summary>
+    /// <returns>The updated generator driver.</returns>
+    [Benchmark]
+    public GeneratorDriver Incremental() =>
+        _incrementalDriver.RunGeneratorsAndUpdateCompilation(_incrementalCompilation, out _, out _);
+}

--- a/src/benchmarks/Refit.Generator.Benchmarks/GeneratorHarness.cs
+++ b/src/benchmarks/Refit.Generator.Benchmarks/GeneratorHarness.cs
@@ -1,0 +1,192 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+using System.Collections.Immutable;
+using System.Reflection;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Refit;
+
+namespace Refit.Generator.Benchmarks;
+
+/// <summary>Shared setup for the generator benchmarks: builds compilations, drivers, and parsed models.</summary>
+internal static class GeneratorHarness
+{
+    /// <summary>The assembly name given to the throwaway compilation the generator runs against.</summary>
+    private const string CompilationAssemblyName = "compilation";
+
+    /// <summary>The metadata name of the Refit base HTTP method attribute.</summary>
+    private const string HttpMethodAttributeMetadataName = "Refit.HttpMethodAttribute";
+
+    /// <summary>The metadata reference to the Refit assembly, including its XML documentation.</summary>
+    private static readonly MetadataReference _refitAssembly = MetadataReference.CreateFromFile(
+        typeof(GetAttribute).Assembly.Location,
+        documentation: XmlDocumentationProvider.CreateFromFile(
+            Path.ChangeExtension(typeof(GetAttribute).Assembly.Location, ".xml")));
+
+    /// <summary>The assemblies whose presence the generated code depends on.</summary>
+    private static readonly Type[] _importantAssemblies =
+    [
+        typeof(Binder),
+        typeof(GetAttribute),
+        typeof(Enumerable),
+        typeof(Newtonsoft.Json.JsonConvert),
+        typeof(HttpContent),
+        typeof(Attribute)
+    ];
+
+    /// <summary>Builds a compilation for the source text.</summary>
+    /// <param name="sourceText">The source text to compile.</param>
+    /// <returns>The compilation.</returns>
+    public static CSharpCompilation BuildCompilation(string sourceText)
+    {
+        var references = new List<MetadataReference>();
+        foreach (var assembly in GetAssemblyReferencesForCodegen())
+        {
+            if (!assembly.IsDynamic)
+            {
+                references.Add(MetadataReference.CreateFromFile(assembly.Location));
+            }
+        }
+
+        references.Add(_refitAssembly);
+
+        return CSharpCompilation.Create(
+            CompilationAssemblyName,
+            [CSharpSyntaxTree.ParseText(sourceText)],
+            references,
+            new(OutputKind.ConsoleApplication));
+    }
+
+    /// <summary>Creates a compilation and a fresh (cold) generator driver for the source text.</summary>
+    /// <param name="sourceText">The source text to compile and feed to the generator.</param>
+    /// <returns>The compilation and generator driver.</returns>
+    public static (Compilation Compilation, CSharpGeneratorDriver Driver) CreateColdState(string sourceText)
+    {
+        var compilation = BuildCompilation(sourceText);
+        var driver = CSharpGeneratorDriver.Create(new InterfaceStubGeneratorV2().AsSourceGenerator());
+        return (compilation, driver);
+    }
+
+    /// <summary>Runs the generator once and primes the driver for an incremental (cached) re-run.</summary>
+    /// <param name="sourceText">The source text to compile and feed to the generator.</param>
+    /// <returns>The compilation and primed generator driver, with an unrelated type added to the compilation.</returns>
+    public static (Compilation Compilation, CSharpGeneratorDriver Driver) CreatePrimedState(string sourceText)
+    {
+        var (compilation, driver) = CreateColdState(sourceText);
+        driver = (CSharpGeneratorDriver)driver.RunGeneratorsAndUpdateCompilation(compilation, out _, out _);
+
+        // Add a trivial unrelated type: this mirrors an unrelated keystroke edit, so the re-run measures the
+        // incremental pipeline (candidate re-collection + cache comparison), not a full cold re-parse.
+        compilation = compilation.AddSyntaxTrees(CSharpSyntaxTree.ParseText("struct BenchUnrelated { }"));
+        return (compilation, driver);
+    }
+
+    /// <summary>Collects the syntactic candidates the generator's providers would select from a compilation.</summary>
+    /// <param name="compilation">The compilation to scan.</param>
+    /// <returns>The candidate interface methods and candidate interfaces.</returns>
+    public static (ImmutableArray<MethodDeclarationSyntax> Methods, ImmutableArray<InterfaceDeclarationSyntax> Interfaces)
+        CollectCandidates(CSharpCompilation compilation)
+    {
+        var methods = ImmutableArray.CreateBuilder<MethodDeclarationSyntax>();
+        var interfaces = ImmutableArray.CreateBuilder<InterfaceDeclarationSyntax>();
+        foreach (var tree in compilation.SyntaxTrees)
+        {
+            foreach (var node in tree.GetRoot().DescendantNodes())
+            {
+                switch (node)
+                {
+                    case MethodDeclarationSyntax { Parent: InterfaceDeclarationSyntax, AttributeLists.Count: > 0 } method:
+                    {
+                        methods.Add(method);
+                        break;
+                    }
+
+                    case InterfaceDeclarationSyntax { BaseList: not null } iface:
+                    {
+                        interfaces.Add(iface);
+                        break;
+                    }
+                }
+            }
+        }
+
+        return (methods.ToImmutable(), interfaces.ToImmutable());
+    }
+
+    /// <summary>Runs the parser transform directly, returning the generation model.</summary>
+    /// <param name="compilation">The compilation to parse.</param>
+    /// <param name="candidates">The pre-collected syntactic candidates.</param>
+    /// <returns>The context generation model produced by the parser.</returns>
+    public static ContextGenerationModel Parse(
+        CSharpCompilation compilation,
+        (ImmutableArray<MethodDeclarationSyntax> Methods, ImmutableArray<InterfaceDeclarationSyntax> Interfaces) candidates) =>
+        Parser.GenerateInterfaceStubs(
+            compilation,
+            refitInternalNamespace: null,
+            generatedRequestBuilding: true,
+            emitGeneratedCodeMarkers: true,
+            candidates.Methods,
+            candidates.Interfaces,
+            CancellationToken.None).contextGenerationSpec;
+
+    /// <summary>Resolves the Refit base HTTP method attribute symbol for a compilation.</summary>
+    /// <param name="compilation">The compilation to resolve against.</param>
+    /// <returns>The resolved attribute symbol.</returns>
+    public static INamedTypeSymbol GetHttpMethodBaseAttributeSymbol(CSharpCompilation compilation) =>
+        compilation.GetTypeByMetadataName(HttpMethodAttributeMetadataName)!;
+
+    /// <summary>Resolves <c>System.IFormattable</c> for a compilation.</summary>
+    /// <param name="compilation">The compilation to resolve against.</param>
+    /// <returns>The resolved symbol, or null when unavailable.</returns>
+    public static INamedTypeSymbol? GetFormattableSymbol(CSharpCompilation compilation) =>
+        compilation.GetTypeByMetadataName("System.IFormattable");
+
+    /// <summary>Collects the Refit method symbols declared across a compilation.</summary>
+    /// <param name="compilation">The compilation to scan.</param>
+    /// <returns>The Refit method symbols in declaration order.</returns>
+    public static List<IMethodSymbol> GetRefitMethodSymbols(CSharpCompilation compilation)
+    {
+        var httpAttribute = GetHttpMethodBaseAttributeSymbol(compilation);
+        var (methods, _) = CollectCandidates(compilation);
+        var result = new List<IMethodSymbol>();
+        foreach (var method in methods)
+        {
+            var model = compilation.GetSemanticModel(method.SyntaxTree);
+            var symbol = model.GetDeclaredSymbol(method);
+            if (Parser.IsRefitMethod(symbol, httpAttribute))
+            {
+                result.Add(symbol!);
+            }
+        }
+
+        return result;
+    }
+
+    /// <summary>Gets the distinct, non-dynamic assemblies to reference when compiling the benchmark source.</summary>
+    /// <returns>The distinct, non-dynamic assemblies to reference.</returns>
+    private static Assembly[] GetAssemblyReferencesForCodegen()
+    {
+        var assemblies = new HashSet<Assembly>();
+        foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+        {
+            if (!assembly.IsDynamic)
+            {
+                _ = assemblies.Add(assembly);
+            }
+        }
+
+        foreach (var marker in _importantAssemblies)
+        {
+            if (!marker.Assembly.IsDynamic)
+            {
+                _ = assemblies.Add(marker.Assembly);
+            }
+        }
+
+        var references = new Assembly[assemblies.Count];
+        assemblies.CopyTo(references);
+        return references;
+    }
+}

--- a/src/benchmarks/Refit.Generator.Benchmarks/IdentifierEmissionBenchmarks.cs
+++ b/src/benchmarks/Refit.Generator.Benchmarks/IdentifierEmissionBenchmarks.cs
@@ -1,0 +1,48 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Diagnosers;
+
+namespace Refit.Generator.Benchmarks;
+
+/// <summary>Micro-benchmarks for the emitter's identifier and type-name formatting primitives.</summary>
+/// <remarks>These are invoked per emitted method, parameter, and HTTP verb, so their allocation profile scales with
+/// interface size. Inputs are instance fields so the JIT cannot constant-fold them into the call.</remarks>
+[ShortRunJob]
+[MemoryDiagnoser]
+[EventPipeProfiler(EventPipeProfile.GcVerbose)]
+public class IdentifierEmissionBenchmarks
+{
+    /// <summary>A representative already-prefixed type name (the no-op fast path for <c>EnsureGlobalPrefix</c>).</summary>
+    private readonly string _prefixedTypeName = "global::System.Net.Http.HttpClient";
+
+    /// <summary>A representative unprefixed type name that must receive the global alias prefix.</summary>
+    private readonly string _unprefixedTypeName = "System.Net.Http.HttpClient";
+
+    /// <summary>A representative explicitly-implemented member name carrying an interface prefix.</summary>
+    private readonly string _explicitMemberName = "global::MyNamespace.IMyInterface.MyMethod";
+
+    /// <summary>A representative HTTP verb string.</summary>
+    private readonly string _httpVerb = "GET";
+
+    /// <summary>Adds the global alias prefix to an unprefixed type name.</summary>
+    /// <returns>The prefixed type name.</returns>
+    [Benchmark]
+    public string EnsureGlobalPrefixUnprefixed() => Emitter.EnsureGlobalPrefix(_unprefixedTypeName);
+
+    /// <summary>Returns an already-prefixed type name unchanged (fast path).</summary>
+    /// <returns>The type name.</returns>
+    [Benchmark]
+    public string EnsureGlobalPrefixPrefixed() => Emitter.EnsureGlobalPrefix(_prefixedTypeName);
+
+    /// <summary>Maps an HTTP verb to its generated <c>HttpMethod</c> expression.</summary>
+    /// <returns>The generated expression.</returns>
+    [Benchmark]
+    public string HttpMethodExpression() => Emitter.ToHttpMethodExpression(_httpVerb);
+
+    /// <summary>Strips the explicit-interface prefix from a member name.</summary>
+    /// <returns>The bare member name.</returns>
+    [Benchmark]
+    public string StripExplicitPrefix() => Emitter.StripExplicitInterfacePrefix(_explicitMemberName);
+}

--- a/src/benchmarks/Refit.Generator.Benchmarks/InlineEligibilityBenchmarks.cs
+++ b/src/benchmarks/Refit.Generator.Benchmarks/InlineEligibilityBenchmarks.cs
@@ -1,0 +1,54 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Diagnosers;
+using Microsoft.CodeAnalysis;
+
+namespace Refit.Generator.Benchmarks;
+
+/// <summary>Profiles inline-eligibility classification (<see cref="Parser.CanBuildRequestInline"/>) over varied request shapes.</summary>
+/// <remarks>Each call parses the method's request through the shared classifier the generator and the RF006 analyzer both
+/// use, so this exercises the request-parsing decision path across scalar, collection, object, converter, and format
+/// query bindings. It is the analyzer's per-keystroke cost as well as part of the generator's parse.</remarks>
+[ShortRunJob]
+[MemoryDiagnoser]
+[EventPipeProfiler(EventPipeProfile.CpuSampling)]
+public class InlineEligibilityBenchmarks
+{
+    /// <summary>The Refit method symbols whose request shapes are classified.</summary>
+    private List<IMethodSymbol> _methods = null!;
+
+    /// <summary>The resolved Refit base HTTP method attribute symbol.</summary>
+    private INamedTypeSymbol _httpAttribute = null!;
+
+    /// <summary>The resolved <c>System.IFormattable</c> symbol used by the value-formatting fast path.</summary>
+    private INamedTypeSymbol? _formattable;
+
+    /// <summary>Compiles the query-heavy corpus and resolves the symbols the classifier needs.</summary>
+    [GlobalSetup]
+    public void Setup()
+    {
+        var compilation = GeneratorHarness.BuildCompilation(GeneratorCorpus.QueryHeavy);
+        _methods = GeneratorHarness.GetRefitMethodSymbols(compilation);
+        _httpAttribute = GeneratorHarness.GetHttpMethodBaseAttributeSymbol(compilation);
+        _formattable = GeneratorHarness.GetFormattableSymbol(compilation);
+    }
+
+    /// <summary>Classifies every method's request shape for inline eligibility.</summary>
+    /// <returns>The count of inline-eligible methods, consumed so the work is not elided.</returns>
+    [Benchmark]
+    public int ClassifyAll()
+    {
+        var eligible = 0;
+        foreach (var method in _methods)
+        {
+            if (Parser.CanBuildRequestInline(method, _httpAttribute, _formattable))
+            {
+                eligible++;
+            }
+        }
+
+        return eligible;
+    }
+}

--- a/src/benchmarks/Refit.Generator.Benchmarks/InterfaceEmissionBenchmarks.cs
+++ b/src/benchmarks/Refit.Generator.Benchmarks/InterfaceEmissionBenchmarks.cs
@@ -1,0 +1,60 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Diagnosers;
+
+namespace Refit.Generator.Benchmarks;
+
+/// <summary>Profiles the emitter over parsed models, isolated from parsing.</summary>
+/// <remarks>This is the build-time half of a cold run: string interpolation, member concatenation, and pooled-buffer
+/// churn. Models are parsed once in setup, so the benchmark attributes cost purely to source emission.</remarks>
+[ShortRunJob]
+[MemoryDiagnoser]
+[EventPipeProfiler(EventPipeProfile.GcVerbose)]
+public class InterfaceEmissionBenchmarks
+{
+    /// <summary>The parsed generation model whose shared code is emitted.</summary>
+    private ContextGenerationModel _model = null!;
+
+    /// <summary>The parsed interface models emitted one by one.</summary>
+    private InterfaceModel[] _interfaces = null!;
+
+    /// <summary>Gets or sets the corpus size under benchmark.</summary>
+    [ParamsAllValues]
+    public CorpusSize Size { get; set; }
+
+    /// <summary>Parses the corpus once and captures the interface models for the current size.</summary>
+    [GlobalSetup]
+    public void Setup()
+    {
+        var compilation = GeneratorHarness.BuildCompilation(GeneratorCorpus.SourceFor(Size));
+        var candidates = GeneratorHarness.CollectCandidates(compilation);
+        _model = GeneratorHarness.Parse(compilation, candidates);
+        _interfaces = [.. _model.Interfaces];
+    }
+
+    /// <summary>Emits the implementation source for every parsed interface.</summary>
+    /// <returns>The total emitted source length, consumed so the emit is not elided.</returns>
+    [Benchmark]
+    public int EmitInterfaces()
+    {
+        var total = 0;
+        foreach (var interfaceModel in _interfaces)
+        {
+            total += Emitter.EmitInterface(interfaceModel).Length;
+        }
+
+        return total;
+    }
+
+    /// <summary>Emits the shared preserve-attribute and factory-registration source.</summary>
+    /// <returns>The total emitted source length, consumed so the emit is not elided.</returns>
+    [Benchmark]
+    public int EmitSharedCode()
+    {
+        var total = 0;
+        Emitter.EmitSharedCode(_model, (_, text) => total += text.Length);
+        return total;
+    }
+}

--- a/src/benchmarks/Refit.Generator.Benchmarks/LayoutEmissionBenchmarks.cs
+++ b/src/benchmarks/Refit.Generator.Benchmarks/LayoutEmissionBenchmarks.cs
@@ -1,0 +1,47 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Diagnosers;
+
+namespace Refit.Generator.Benchmarks;
+
+/// <summary>Micro-benchmarks for the emitter's indentation and fragment-concatenation layout primitives.</summary>
+/// <remarks><c>Indent</c> is called for every generated line; the cached-level path must not allocate, while deeper
+/// levels allocate a fresh string. <c>ConcatParts</c> joins the per-member source fragments of an interface.</remarks>
+[ShortRunJob]
+[MemoryDiagnoser]
+[EventPipeProfiler(EventPipeProfile.GcVerbose)]
+public class LayoutEmissionBenchmarks
+{
+    /// <summary>A cached indentation level (within the shared indent cache).</summary>
+    private readonly int _cachedLevel = 3;
+
+    /// <summary>An indentation level beyond the cache that allocates a fresh string.</summary>
+    private readonly int _uncachedLevel = 20;
+
+    /// <summary>Representative per-member source fragments joined into one interface body.</summary>
+    private readonly string[] _parts =
+    [
+        "        public Task<Entity> Get0(int id) { }\n",
+        "        public Task<List<Entity>> List1() { }\n",
+        "        public Task<Entity> Create2(Entity e) { }\n",
+        "        public Task Update3(int id, Entity e) { }\n",
+        "        public Task Delete4(int id) { }\n",
+    ];
+
+    /// <summary>Returns a cached indentation string (no-allocation fast path).</summary>
+    /// <returns>The indentation string.</returns>
+    [Benchmark]
+    public string IndentCached() => Emitter.Indent(_cachedLevel);
+
+    /// <summary>Builds an indentation string beyond the cache (allocation path).</summary>
+    /// <returns>The indentation string.</returns>
+    [Benchmark]
+    public string IndentUncached() => Emitter.Indent(_uncachedLevel);
+
+    /// <summary>Concatenates the interface's per-member source fragments.</summary>
+    /// <returns>The joined source.</returns>
+    [Benchmark]
+    public string ConcatParts() => Emitter.ConcatParts(_parts, _parts.Length);
+}

--- a/src/benchmarks/Refit.Generator.Benchmarks/LiteralEmissionBenchmarks.cs
+++ b/src/benchmarks/Refit.Generator.Benchmarks/LiteralEmissionBenchmarks.cs
@@ -1,0 +1,48 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Diagnosers;
+
+namespace Refit.Generator.Benchmarks;
+
+/// <summary>Micro-benchmarks for the emitter's literal and XML-documentation text primitives.</summary>
+/// <remarks>These run once per emitted query key, header, path, and doc line, so their clean (no-escape) fast paths
+/// dominate emission. Both the common no-escape input and the rarer escaping input are measured. Inputs are instance
+/// fields so the JIT cannot constant-fold them into the call.</remarks>
+[ShortRunJob]
+[MemoryDiagnoser]
+[EventPipeProfiler(EventPipeProfile.GcVerbose)]
+public class LiteralEmissionBenchmarks
+{
+    /// <summary>A representative identifier or key needing no C# or XML escaping (the common case).</summary>
+    private readonly string _cleanValue = "application/json";
+
+    /// <summary>A representative value containing characters that force the escaping path.</summary>
+    private readonly string _escapedValue = "line\"one\"\n<tag & more>";
+
+    /// <summary>Renders a clean value as a C# string literal (no-escape fast path).</summary>
+    /// <returns>The emitted literal.</returns>
+    [Benchmark]
+    public string CSharpLiteralClean() => Emitter.ToCSharpStringLiteral(_cleanValue);
+
+    /// <summary>Renders a value needing escaping as a C# string literal (escaping path).</summary>
+    /// <returns>The emitted literal.</returns>
+    [Benchmark]
+    public string CSharpLiteralEscaped() => Emitter.ToCSharpStringLiteral(_escapedValue);
+
+    /// <summary>Renders a nullable value as a C# string literal.</summary>
+    /// <returns>The emitted literal.</returns>
+    [Benchmark]
+    public string NullableCSharpLiteral() => Emitter.ToNullableCSharpStringLiteral(_cleanValue);
+
+    /// <summary>Escapes a clean value for XML documentation (no-escape fast path).</summary>
+    /// <returns>The emitted documentation text.</returns>
+    [Benchmark]
+    public string XmlDocClean() => Emitter.ToXmlDocumentationText(_cleanValue);
+
+    /// <summary>Escapes a value containing XML metacharacters for documentation (escaping path).</summary>
+    /// <returns>The emitted documentation text.</returns>
+    [Benchmark]
+    public string XmlDocEscaped() => Emitter.ToXmlDocumentationText(_escapedValue);
+}

--- a/src/benchmarks/Refit.Generator.Benchmarks/ModelEqualityBenchmarks.cs
+++ b/src/benchmarks/Refit.Generator.Benchmarks/ModelEqualityBenchmarks.cs
@@ -1,0 +1,50 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Diagnosers;
+
+namespace Refit.Generator.Benchmarks;
+
+/// <summary>Micro-benchmarks for the value-equality that drives incremental-generator caching.</summary>
+/// <remarks>After an unrelated edit the driver re-runs the transform and compares the new model against the cached one
+/// through <see cref="ImmutableEquatableArray{T}"/> equality. That comparison is the per-keystroke gate that decides
+/// whether emission is skipped, so its cost (and the fact that equal models produce no allocation) is measured here.</remarks>
+[ShortRunJob]
+[MemoryDiagnoser]
+[EventPipeProfiler(EventPipeProfile.GcVerbose)]
+public class ModelEqualityBenchmarks
+{
+    /// <summary>The parsed interface models from the first pass (the cached side of the comparison).</summary>
+    private ImmutableEquatableArray<InterfaceModel> _cached = null!;
+
+    /// <summary>An equal-but-distinct set of interface models from a second pass (the recomputed side).</summary>
+    private ImmutableEquatableArray<InterfaceModel> _recomputed = null!;
+
+    /// <summary>Gets or sets the corpus size under benchmark.</summary>
+    [ParamsAllValues]
+    public CorpusSize Size { get; set; }
+
+    /// <summary>Parses the corpus twice, producing two equal-but-distinct model sets.</summary>
+    [GlobalSetup]
+    public void Setup()
+    {
+        var source = GeneratorCorpus.SourceFor(Size);
+
+        var firstCompilation = GeneratorHarness.BuildCompilation(source);
+        _cached = GeneratorHarness.Parse(firstCompilation, GeneratorHarness.CollectCandidates(firstCompilation)).Interfaces;
+
+        var secondCompilation = GeneratorHarness.BuildCompilation(source);
+        _recomputed = GeneratorHarness.Parse(secondCompilation, GeneratorHarness.CollectCandidates(secondCompilation)).Interfaces;
+    }
+
+    /// <summary>Compares the recomputed model set against the cached one, as the driver does per keystroke.</summary>
+    /// <returns><see langword="true"/> when the models are equal (the expected cache-hit result).</returns>
+    [Benchmark]
+    public bool Equals() => _cached.Equals(_recomputed);
+
+    /// <summary>Computes the hash code of the cached model set.</summary>
+    /// <returns>The hash code.</returns>
+    [Benchmark]
+    public int HashCode() => _cached.GetHashCode();
+}

--- a/src/benchmarks/Refit.Generator.Benchmarks/NamespaceNormalizationBenchmarks.cs
+++ b/src/benchmarks/Refit.Generator.Benchmarks/NamespaceNormalizationBenchmarks.cs
@@ -1,0 +1,32 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Diagnosers;
+
+namespace Refit.Generator.Benchmarks;
+
+/// <summary>Micro-benchmarks for the parser's internal-namespace construction.</summary>
+/// <remarks>The internal namespace is built once per generation pass. It is not a per-method hot path, but its
+/// <see cref="System.Text.StringBuilder"/>-per-segment shape is a candidate for allocation reduction.</remarks>
+[ShortRunJob]
+[MemoryDiagnoser]
+[EventPipeProfiler(EventPipeProfile.GcVerbose)]
+public class NamespaceNormalizationBenchmarks
+{
+    /// <summary>An absent consumer prefix, exercising the default-segment-only path.</summary>
+    private readonly string? _defaultPrefix;
+
+    /// <summary>A representative multi-segment consumer namespace prefix.</summary>
+    private readonly string _consumerNamespace = "Contoso.Api.Clients.Generated";
+
+    /// <summary>Builds the internal namespace from an empty prefix (default segment only).</summary>
+    /// <returns>The normalized internal namespace.</returns>
+    [Benchmark]
+    public string BuildDefault() => Parser.BuildRefitInternalNamespace(_defaultPrefix);
+
+    /// <summary>Builds the internal namespace from a multi-segment consumer prefix.</summary>
+    /// <returns>The normalized internal namespace.</returns>
+    [Benchmark]
+    public string BuildFromPrefix() => Parser.BuildRefitInternalNamespace(_consumerNamespace);
+}

--- a/src/benchmarks/Refit.Generator.Benchmarks/ParserTransformBenchmarks.cs
+++ b/src/benchmarks/Refit.Generator.Benchmarks/ParserTransformBenchmarks.cs
@@ -1,0 +1,42 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+using System.Collections.Immutable;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Diagnosers;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Refit.Generator.Benchmarks;
+
+/// <summary>Profiles the parser transform (<see cref="Parser.GenerateInterfaceStubs"/>) in isolation from the driver.</summary>
+/// <remarks>This is the semantic-model-bound half of a cold run: symbol resolution, member walks, and request parsing.
+/// It excludes syntax-provider collection and driver bookkeeping, so it attributes cost to the generator's own parse.</remarks>
+[ShortRunJob]
+[MemoryDiagnoser]
+[EventPipeProfiler(EventPipeProfile.CpuSampling)]
+public class ParserTransformBenchmarks
+{
+    /// <summary>The compilation the parser transform runs against.</summary>
+    private CSharpCompilation _compilation = null!;
+
+    /// <summary>The pre-collected syntactic candidates fed to the transform.</summary>
+    private (ImmutableArray<MethodDeclarationSyntax> Methods, ImmutableArray<InterfaceDeclarationSyntax> Interfaces) _candidates;
+
+    /// <summary>Gets or sets the corpus size under benchmark.</summary>
+    [ParamsAllValues]
+    public CorpusSize Size { get; set; }
+
+    /// <summary>Builds the compilation and collects syntactic candidates once for the current corpus size.</summary>
+    [GlobalSetup]
+    public void Setup()
+    {
+        _compilation = GeneratorHarness.BuildCompilation(GeneratorCorpus.SourceFor(Size));
+        _candidates = GeneratorHarness.CollectCandidates(_compilation);
+    }
+
+    /// <summary>Runs the parser transform over the collected candidates.</summary>
+    /// <returns>The parsed interface count, consumed so the transform is not elided and no model is boxed.</returns>
+    [Benchmark]
+    public int Parse() => GeneratorHarness.Parse(_compilation, _candidates).Interfaces.Count;
+}

--- a/src/benchmarks/Refit.Generator.Benchmarks/PooledBufferBenchmarks.cs
+++ b/src/benchmarks/Refit.Generator.Benchmarks/PooledBufferBenchmarks.cs
@@ -1,0 +1,36 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Diagnosers;
+
+namespace Refit.Generator.Benchmarks;
+
+/// <summary>Micro-benchmarks for <see cref="PooledStringBuilder"/>, the emitter's fluent accumulation buffer.</summary>
+/// <remarks>The emitter builds many transient fragments through this buffer; the pooled backing array is meant to be
+/// reused across emissions instead of allocating fresh chunks. This measures the rent, append, grow, and return cycle.</remarks>
+[ShortRunJob]
+[MemoryDiagnoser]
+[EventPipeProfiler(EventPipeProfile.GcVerbose)]
+public class PooledBufferBenchmarks
+{
+    /// <summary>A representative generated statement appended repeatedly to exercise growth beyond the default rent.</summary>
+    private readonly string _statement = "                ______parts.Add(new global::System.Collections.Generic.KeyValuePair<string, object?>(\"key\", value));\n";
+
+    /// <summary>The number of statements appended, chosen to force at least one buffer growth.</summary>
+    private readonly int _statementCount = 24;
+
+    /// <summary>Rents a pooled buffer, appends a block of statements forcing growth, and returns the buffer.</summary>
+    /// <returns>The accumulated source length, consumed so the work is not elided.</returns>
+    [Benchmark]
+    public int AppendBlock()
+    {
+        var builder = new PooledStringBuilder();
+        for (var i = 0; i < _statementCount; i++)
+        {
+            _ = builder.Append(_statement);
+        }
+
+        return builder.ToString().Length;
+    }
+}

--- a/src/benchmarks/Refit.Generator.Benchmarks/Program.cs
+++ b/src/benchmarks/Refit.Generator.Benchmarks/Program.cs
@@ -1,0 +1,17 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+using BenchmarkDotNet.Running;
+
+// The generator benchmarks are always selected by filter (there is no single "default" suite),
+// so route every invocation through the switcher.
+_ = BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+
+/// <summary>The generated top-level program's declaring type, sealed so the JIT can devirtualize its members.</summary>
+internal sealed partial class Program
+{
+    /// <summary>Initializes a new instance of the <see cref="Program"/> class. Unused; the entry point is the generated top-level <c>Main</c>.</summary>
+    private Program()
+    {
+    }
+}

--- a/src/benchmarks/Refit.Generator.Benchmarks/Refit.Generator.Benchmarks.csproj
+++ b/src/benchmarks/Refit.Generator.Benchmarks/Refit.Generator.Benchmarks.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>$(RefitBenchmarkTargets)</TargetFrameworks>
+    <IsPackable>false</IsPackable>
+    <IsAotCompatible>false</IsAotCompatible>
+    <EnableAotAnalyzer>false</EnableAotAnalyzer>
+    <EnableTrimAnalyzer>false</EnableTrimAnalyzer>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Refit.Newtonsoft.Json\Refit.Newtonsoft.Json.csproj" />
+    <ProjectReference Include="..\..\Refit\Refit.csproj" />
+    <!-- Referenced as a normal assembly (not an analyzer): the benchmarks drive the generator
+         directly through CSharpGeneratorDriver and call its internal parser/emitter components. -->
+    <ProjectReference Include="..\..\InterfaceStubGenerator.Roslyn48\InterfaceStubGenerator.Roslyn48.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" />
+    <!-- Kept on the same Roslyn version BenchmarkDotNet pulls in so the benchmark's
+         Microsoft.CodeAnalysis.* assemblies stay on a single consistent version. -->
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />
+  </ItemGroup>
+</Project>

--- a/src/benchmarks/Refit.Generator.Benchmarks/UniqueNameBuilderBenchmarks.cs
+++ b/src/benchmarks/Refit.Generator.Benchmarks/UniqueNameBuilderBenchmarks.cs
@@ -1,0 +1,36 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Diagnosers;
+
+namespace Refit.Generator.Benchmarks;
+
+/// <summary>Micro-benchmarks for <see cref="UniqueNameBuilder"/>, allocated fresh per emitted interface.</summary>
+/// <remarks>Each interface reserves its member names then draws unique field and local names, so the reserve-then-draw
+/// cycle (and its backing <see cref="System.Collections.Generic.HashSet{T}"/>) runs once per generated client.</remarks>
+[ShortRunJob]
+[MemoryDiagnoser]
+[EventPipeProfiler(EventPipeProfile.GcVerbose)]
+public class UniqueNameBuilderBenchmarks
+{
+    /// <summary>Representative interface member names reserved before names are drawn.</summary>
+    private readonly string[] _memberNames =
+    [
+        "Client", "Dispose", "Get0", "List1", "Create2", "Update3", "Delete4", "Search5",
+    ];
+
+    /// <summary>Reserves the member names then draws the generated field and local names one interface would need.</summary>
+    /// <returns>The last drawn name, consumed so the work is not elided.</returns>
+    [Benchmark]
+    public string ReserveThenDraw()
+    {
+        var builder = new UniqueNameBuilder();
+        builder.Reserve(_memberNames);
+        _ = builder.New("_requestBuilder");
+        _ = builder.New("_settings");
+
+        // Draw a name that collides with a reserved member, forcing the disambiguation loop.
+        return builder.New("Client");
+    }
+}

--- a/src/tests/Refit.GeneratorTests/Incremental/CrossFileInheritanceTest.cs
+++ b/src/tests/Refit.GeneratorTests/Incremental/CrossFileInheritanceTest.cs
@@ -1,0 +1,221 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace Refit.GeneratorTests.Incremental;
+
+/// <summary>
+/// Locks in the generator's cross-file base-interface dependency: a derived interface's implementation embeds
+/// the Refit methods it inherits from its base interfaces, so editing a base interface in a different source
+/// file must regenerate the derived interface even though the derived interface's own syntax is untouched. A
+/// per-interface parse cache keyed only on the derived interface's syntax would serve stale output here.
+/// </summary>
+public class CrossFileInheritanceTest
+{
+    /// <summary>The simple name of the base interface.</summary>
+    private const string BaseApiName = "IBaseApi";
+
+    /// <summary>The simple name of the derived interface.</summary>
+    private const string DerivedApiName = "IDerivedApi";
+
+    /// <summary>The simple name of the first standalone interface.</summary>
+    private const string FirstApiName = "IFirstApi";
+
+    /// <summary>The simple name of the second standalone interface.</summary>
+    private const string SecondApiName = "ISecondApi";
+
+    /// <summary>The base Refit interface, placed in its own syntax tree.</summary>
+    private const string BaseInterfaceSource =
+        """
+        using System.Threading.Tasks;
+        using Refit;
+
+        namespace RefitGeneratorTest;
+
+        public interface IBaseApi
+        {
+            [Get("/base")]
+            Task<string> GetBase();
+        }
+        """;
+
+    /// <summary>The derived Refit interface inheriting the base, placed in its own syntax tree.</summary>
+    private const string DerivedInterfaceSource =
+        """
+        using System.Threading.Tasks;
+        using Refit;
+
+        namespace RefitGeneratorTest;
+
+        public interface IDerivedApi : IBaseApi
+        {
+            [Get("/derived")]
+            Task<string> GetDerived();
+        }
+        """;
+
+    /// <summary>The base interface after a new Refit method is added to it.</summary>
+    private const string BaseInterfaceWithAddedMethod =
+        """
+        public interface IBaseApi
+        {
+            [Get("/base")]
+            Task<string> GetBase();
+
+            [Get("/base-extra")]
+            Task<string> GetBaseExtra();
+        }
+        """;
+
+    /// <summary>A first standalone Refit interface with no inheritance relationship to the second.</summary>
+    private const string FirstUnrelatedSource =
+        """
+        using System.Threading.Tasks;
+        using Refit;
+
+        namespace RefitGeneratorTest;
+
+        public interface IFirstApi
+        {
+            [Get("/first")]
+            Task<string> GetFirst();
+        }
+        """;
+
+    /// <summary>A second standalone Refit interface with no inheritance relationship to the first.</summary>
+    private const string SecondUnrelatedSource =
+        """
+        using System.Threading.Tasks;
+        using Refit;
+
+        namespace RefitGeneratorTest;
+
+        public interface ISecondApi
+        {
+            [Get("/second")]
+            Task<string> GetSecond();
+        }
+        """;
+
+    /// <summary>The first standalone interface after a new Refit method is added to it.</summary>
+    private const string FirstUnrelatedWithAddedMethod =
+        """
+        public interface IFirstApi
+        {
+            [Get("/first")]
+            Task<string> GetFirst();
+
+            [Get("/first-extra")]
+            Task<string> GetFirstExtra();
+        }
+        """;
+
+    /// <summary>Base and derived interfaces declared together in a single source file.</summary>
+    private const string BaseAndDerivedInOneFileSource =
+        """
+        using System.Threading.Tasks;
+        using Refit;
+
+        namespace RefitGeneratorTest;
+
+        public interface IBaseApi
+        {
+            [Get("/base")]
+            Task<string> GetBase();
+        }
+
+        public interface IDerivedApi : IBaseApi
+        {
+            [Get("/derived")]
+            Task<string> GetDerived();
+        }
+        """;
+
+    /// <summary>Adding a Refit method to a base interface in another file regenerates the derived interface.</summary>
+    /// <returns>A task that represents the asynchronous test.</returns>
+    [Test]
+    public async Task EditingBaseInterfaceInAnotherFileRegeneratesDerivedInterface()
+    {
+        var baseTree = CSharpSyntaxTree.ParseText(BaseInterfaceSource, CSharpParseOptions.Default);
+        var derivedTree = CSharpSyntaxTree.ParseText(DerivedInterfaceSource, CSharpParseOptions.Default);
+        var compilation1 = Fixture.CreateLibrary(baseTree, derivedTree);
+
+        var driver1 = TestHelper.GenerateTracked(compilation1);
+        await TestHelper.AssertBuildRefitReasonForInterface(driver1, BaseApiName, IncrementalStepRunReason.New);
+        await TestHelper.AssertBuildRefitReasonForInterface(driver1, DerivedApiName, IncrementalStepRunReason.New);
+
+        var compilation2 = TestHelper.ReplaceTypeDeclarationInTree(
+            compilation1,
+            baseTree,
+            BaseApiName,
+            BaseInterfaceWithAddedMethod);
+
+        var driver2 = driver1.RunGenerators(compilation2);
+
+        // The edited base regenerates, and the derived interface regenerates because it embeds the base's Refit
+        // methods even though the derived interface's own file was not touched.
+        await TestHelper.AssertBuildRefitReasonForInterface(driver2, BaseApiName, IncrementalStepRunReason.Modified);
+        await TestHelper.AssertBuildRefitReasonForInterface(
+            driver2,
+            DerivedApiName,
+            IncrementalStepRunReason.Modified);
+    }
+
+    /// <summary>Editing an unrelated interface in another file leaves the other interface's output unchanged.</summary>
+    /// <returns>A task that represents the asynchronous test.</returns>
+    [Test]
+    public async Task EditingUnrelatedInterfaceInAnotherFileLeavesOtherInterfaceUnchanged()
+    {
+        var firstTree = CSharpSyntaxTree.ParseText(FirstUnrelatedSource, CSharpParseOptions.Default);
+        var secondTree = CSharpSyntaxTree.ParseText(SecondUnrelatedSource, CSharpParseOptions.Default);
+        var compilation1 = Fixture.CreateLibrary(firstTree, secondTree);
+
+        var driver1 = TestHelper.GenerateTracked(compilation1);
+        await TestHelper.AssertBuildRefitReasonForInterface(driver1, FirstApiName, IncrementalStepRunReason.New);
+        await TestHelper.AssertBuildRefitReasonForInterface(driver1, SecondApiName, IncrementalStepRunReason.New);
+
+        var compilation2 = TestHelper.ReplaceTypeDeclarationInTree(
+            compilation1,
+            firstTree,
+            FirstApiName,
+            FirstUnrelatedWithAddedMethod);
+
+        var driver2 = driver1.RunGenerators(compilation2);
+
+        // The edited interface regenerates; the untouched, unrelated interface's output is reused.
+        await TestHelper.AssertBuildRefitReasonForInterface(driver2, FirstApiName, IncrementalStepRunReason.Modified);
+        await TestHelper.AssertBuildRefitReasonForInterface(
+            driver2,
+            SecondApiName,
+            IncrementalStepRunReason.Unchanged);
+    }
+
+    /// <summary>Adding a Refit method to a base interface in the same file regenerates the derived interface.</summary>
+    /// <returns>A task that represents the asynchronous test.</returns>
+    [Test]
+    public async Task EditingBaseInterfaceInSameFileRegeneratesDerivedInterface()
+    {
+        var syntaxTree = CSharpSyntaxTree.ParseText(BaseAndDerivedInOneFileSource, CSharpParseOptions.Default);
+        var compilation1 = Fixture.CreateLibrary(syntaxTree);
+
+        var driver1 = TestHelper.GenerateTracked(compilation1);
+        await TestHelper.AssertBuildRefitReasonForInterface(driver1, BaseApiName, IncrementalStepRunReason.New);
+        await TestHelper.AssertBuildRefitReasonForInterface(driver1, DerivedApiName, IncrementalStepRunReason.New);
+
+        var compilation2 = TestHelper.ReplaceMemberDeclaration(
+            compilation1,
+            BaseApiName,
+            BaseInterfaceWithAddedMethod);
+
+        var driver2 = driver1.RunGenerators(compilation2);
+
+        // Editing the base's Refit surface must flow into the derived interface's embedded base methods.
+        await TestHelper.AssertBuildRefitReasonForInterface(driver2, BaseApiName, IncrementalStepRunReason.Modified);
+        await TestHelper.AssertBuildRefitReasonForInterface(
+            driver2,
+            DerivedApiName,
+            IncrementalStepRunReason.Modified);
+    }
+}

--- a/src/tests/Refit.GeneratorTests/Incremental/TestHelper.cs
+++ b/src/tests/Refit.GeneratorTests/Incremental/TestHelper.cs
@@ -52,6 +52,31 @@ internal static class TestHelper
         return compilation.ReplaceSyntaxTree(compilation.SyntaxTrees[0], newTree);
     }
 
+    /// <summary>Replaces a named type declaration inside one syntax tree of a multi-tree compilation.</summary>
+    /// <param name="compilation">The multi-tree compilation to modify.</param>
+    /// <param name="tree">The syntax tree that contains the type declaration to replace.</param>
+    /// <param name="typeName">The name of the type declaration to replace.</param>
+    /// <param name="newDeclaration">The replacement type declaration source.</param>
+    /// <returns>The updated compilation with the other syntax trees left untouched.</returns>
+    internal static CSharpCompilation ReplaceTypeDeclarationInTree(
+        CSharpCompilation compilation,
+        SyntaxTree tree,
+        string typeName,
+        string newDeclaration)
+    {
+        var root = tree.GetCompilationUnitRoot();
+        var typeDeclaration = root
+            .DescendantNodes()
+            .OfType<TypeDeclarationSyntax>()
+            .Single(x => x.Identifier.Text == typeName);
+        var updatedTypeDeclaration = SyntaxFactory.ParseMemberDeclaration(newDeclaration)!;
+
+        var newRoot = root.ReplaceNode(typeDeclaration, updatedTypeDeclaration);
+        var newTree = tree.WithRootAndOptions(newRoot, tree.Options);
+
+        return compilation.ReplaceSyntaxTree(tree, newTree);
+    }
+
     /// <summary>Replaces a local variable declaration in the compilation with new source.</summary>
     /// <param name="compilation">The compilation to modify.</param>
     /// <param name="variableName">The name of the local variable to replace.</param>
@@ -95,6 +120,33 @@ internal static class TestHelper
             reasons.ReportDiagnosticsStep,
             outputIndex);
         await AssertRunReason(runResult, RefitGeneratorStepName.BuildRefit, reasons.BuildRefitStep, outputIndex);
+    }
+
+    /// <summary>Asserts the build-Refit run reason for the interface with the given simple name.</summary>
+    /// <remarks>
+    /// The build-Refit step emits one output per interface, so a per-interface assertion is required when a
+    /// compilation contains more than one interface. The output is located by matching the interface's display
+    /// name rather than a positional index, because the emission order follows the parser's collection order.
+    /// </remarks>
+    /// <param name="driver">The generator driver to inspect.</param>
+    /// <param name="interfaceName">The simple (unqualified) interface name whose output is inspected.</param>
+    /// <param name="expectedReason">The expected build-Refit run reason for that interface.</param>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    internal static async Task AssertBuildRefitReasonForInterface(
+        GeneratorDriver driver,
+        string interfaceName,
+        IncrementalStepRunReason expectedReason)
+    {
+        var qualifiedSuffix = "." + interfaceName;
+        var interfaceOutput = driver
+            .GetRunResult()
+            .Results[0]
+            .TrackedSteps[RefitGeneratorStepName.BuildRefit]
+            .SelectMany(static step => step.Outputs)
+            .Single(output => output.Value is InterfaceModel model
+                && model.InterfaceDisplayName.EndsWith(qualifiedSuffix, StringComparison.Ordinal));
+
+        await Assert.That(interfaceOutput.Reason).IsEqualTo(expectedReason);
     }
 
     /// <summary>Asserts that a single tracked step ran for the expected reason.</summary>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Performance / refactor. No behavioral change and no public API change.

## What is the new behavior?

The Roslyn source generator allocates dramatically less on both hot paths, with byte-for-byte identical generated output:

- Emit / build path: interface implementations, the class wrapper, request prologue, query statements, request properties, return statements, and factory registrations are now written directly into a shared pooled `PooledStringBuilder` instead of building intermediate strings (interpolation that lowers to `String.Concat`, per-fragment `ToString()`, per-registration temporaries). The pooled builder is backed by a lock-free thread-local free list.
- Parse / incremental path: per-pass memoization of non-aliased type qualification (one `ToDisplayString` per distinct type instead of once per occurrence) and allocation-free well-known-namespace matching (a namespace-symbol walk instead of rendering a display string).
- Adds a dedicated `Refit.Generator.Benchmarks` BenchmarkDotNet project (overall plus per-component, EventPipe-profiled) so generator allocation is tracked going forward, plus a regression test that locks in cross-file base-interface incremental regeneration.

## What is the current behavior?

The generator materialized many short-lived strings during emission and re-rendered type and namespace display strings during parsing, so a cold build and each per-keystroke incremental run allocated far more than the size of the generated text.

## What might this PR break?

None. Generated output is byte-for-byte identical, verified by the full generator snapshot/output suite (469 tests, including cross-file inheritance incremental-caching guards). No public API changes.

## Checklist
- [ ] I have read the Contribute guide
- [x] Tests have been added or updated (for bug fixes / features)
- [ ] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the `main` branch
- [x] PR title follows Conventional Commits

## Additional information

Allocation measured with BenchmarkDotNet (`Allocated`, managed, inclusive) plus EventPipe GcVerbose traces to attribute each source. Large corpus = 40 interfaces x 12 methods:

| Path | Before | After | Delta |
| --- | --- | --- | --- |
| Emit interfaces (cold) Large | 23585 KB | 6716 KB | -71.5% |
| Emit shared code (cold) Large | 143 KB | 87 KB | -38.9% |
| Parse transform (cold) Large | 1453 KB | 1065 KB | -27.0% |
| Incremental parse (per keystroke) Large | 1653 KB | 1265 KB | -23.5% |

Small and Medium corpora show similar emit reductions (about -66% and -69%). After these changes, emit allocation is dominated by the unavoidable final source string handed to the compiler; the remaining intermediates are under 1 percent of emit allocation. An attempted per-interface incremental parse restructure was built, measured (it did not avoid transform re-execution and risked cross-file caching correctness), and reverted; that investigation is captured by the new incremental regression tests.
