### PR TITLE
feat: add CollectionFormat.Indexed for indexed query collection expansion

### DIFF
--- a/README.md
+++ b/README.md
@@ -574,6 +574,39 @@ var gitHubApi = RestService.For<IGitHubApi>("https://api.github.com",
     });
 ```
 
+#### Indexed object collections (DeepObject / OpenAPI deepObject style)
+
+Use `CollectionFormat.Indexed` to expand a collection of objects into indexed key–value pairs, where each element's
+properties are flattened under the parameter name followed by the element index and the property name:
+
+```
+items[0].Id=1&items[0].Value=a&items[1].Id=2
+```
+
+This matches the OpenAPI 3 `deepObject` serialization style and is useful for APIs that expect an ordered list of
+objects in the query string.
+
+```csharp
+public class OrderItem
+{
+    public int ProductId { get; set; }
+    public int Quantity  { get; set; }
+}
+
+[Get("/orders")]
+Task<Order> GetOrders([Query(CollectionFormat.Indexed)] IReadOnlyList<OrderItem> items);
+
+GetOrders(new[] {
+    new OrderItem { ProductId = 1, Quantity = 2 },
+    new OrderItem { ProductId = 5, Quantity = 1 }
+})
+>>> "/orders?items[0].ProductId=1&items[0].Quantity=2&items[1].ProductId=5&items[1].Quantity=1"
+```
+
+Property names honor `[AliasAs]`, `[JsonPropertyName]` (when `RefitSettings.HonorContentSerializerPropertyNamesInQuery`
+is set) and `[Query(Prefix)]`, exactly like a normal `[Query]` object parameter. Null elements in the collection are
+skipped and the index counter still advances so the remaining indices remain stable.
+
 #### Unescape Querystring parameters
 
 Use the `QueryUriFormat` attribute to specify if the query parameters should be url escaped

--- a/src/InterfaceStubGenerator.Shared/Emitter.Inline.Query.Object.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.Inline.Query.Object.cs
@@ -640,4 +640,98 @@ internal static partial class Emitter
         var prefix = ToNullableCSharpStringLiteral(property.PrefixSegment);
         return $"global::Refit.GeneratedRequestRunner.BuildQueryKey({emission.SettingsLocal}, {clrName}, null, {prefix})";
     }
+
+    /// <summary>Appends the statements that iterate a <c>[Query(CollectionFormat.Indexed)]</c> collection,
+    /// flattening each element's properties under an indexed key prefix: <c>key[0].Prop=val</c>.</summary>
+    /// <param name="sb">The statement builder.</param>
+    /// <param name="parameter">The parameter model.</param>
+    /// <param name="query">The query-binding metadata.</param>
+    /// <param name="providerField">The cached attribute-provider field name.</param>
+    /// <param name="emission">The shared emission locals and helper state.</param>
+    private static void AppendIndexedCollectionQueryStatements(
+        PooledStringBuilder sb,
+        RequestParameterModel parameter,
+        QueryParameterModel query,
+        string providerField,
+        in InlineValueEmission emission)
+    {
+        var bodyIndent = Indent(MethodBodyIndentation);
+        var guarded = parameter.CanBeNull;
+        var outerIndent = guarded ? bodyIndent + "    " : bodyIndent;
+
+        if (guarded)
+        {
+            _ = sb.Append(bodyIndent).Append(IfParameterPrefix).Append(parameter.Name).AppendLine(NotNullCheckSuffix)
+                .Append(bodyIndent).AppendLine("{");
+        }
+
+        // Wrap in a block so the index local is scoped to this parameter and cannot clash with other parameters.
+        var idxLocal = emission.QueryValueLocal + "_idx";
+        var blockIndent = outerIndent + "    ";
+        var foreachIndent = blockIndent + "    ";
+
+        _ = sb.Append(outerIndent).AppendLine("{")
+            .Append(blockIndent).Append("var ").Append(idxLocal).AppendLine(" = 0;")
+            .Append(blockIndent).Append(ForeachVarKeyword).Append(emission.QueryValueLocal)
+                .Append(" in @").Append(parameter.Name).AppendLine(")")
+            .Append(blockIndent).AppendLine("{");
+
+        AppendIndexedElement(sb, parameter, query, providerField, idxLocal, foreachIndent, emission);
+
+        _ = sb.Append(foreachIndent).Append(idxLocal).AppendLine("++;")
+            .Append(blockIndent).AppendLine("}") // close foreach body
+            .Append(outerIndent).AppendLine("}"); // close wrapper block
+
+        if (!guarded)
+        {
+            return;
+        }
+
+        _ = sb.Append(bodyIndent).AppendLine("}");
+    }
+
+    /// <summary>Appends one element's optional null guard, indexed key declaration, and flattened property statements.</summary>
+    /// <param name="sb">The statement builder.</param>
+    /// <param name="parameter">The enclosing parameter model.</param>
+    /// <param name="query">The query-binding metadata whose <c>ObjectProperties</c> describes each element's shape.</param>
+    /// <param name="providerField">The cached attribute-provider field name.</param>
+    /// <param name="idxLocal">The generated index counter local name.</param>
+    /// <param name="foreachIndent">The indentation inside the foreach body.</param>
+    /// <param name="emission">The shared emission locals and helper state.</param>
+    private static void AppendIndexedElement(
+        PooledStringBuilder sb,
+        RequestParameterModel parameter,
+        QueryParameterModel query,
+        string providerField,
+        string idxLocal,
+        string foreachIndent,
+        in InlineValueEmission emission)
+    {
+        var keyLocal = $"{emission.QueryValueLocal}_key";
+        var itemIndent = foreachIndent;
+
+        _ = sb.Append(itemIndent).Append("var ").Append(keyLocal).Append(" = ")
+            .Append("$").Append('"').Append(query.Key)
+            .Append("[{").Append(idxLocal).Append(".ToString(global::System.Globalization.CultureInfo.InvariantCulture)").Append("}]").Append('"').AppendLine(";");
+
+        if (query.ElementCanBeNull)
+        {
+            _ = sb.Append(foreachIndent).Append("if (").Append(emission.QueryValueLocal).AppendLine(NotNullCheckSuffix)
+                .Append(foreachIndent).AppendLine("{");
+            itemIndent = foreachIndent + "    ";
+        }
+
+        // Flatten the element's properties under the indexed key; pass null as collection format so nested
+        // collection properties fall back to settings default instead of inheriting Indexed.
+        var context = new QueryObjectContext(parameter, providerField, null, ToLowerInvariantString(query.PreEncoded));
+        var scope = new ObjectFlattenScope(emission.QueryValueLocal, keyLocal, query.NestingDelimiter, "_" + parameter.Name, itemIndent);
+        AppendObjectPropertyList(sb, context, query.ObjectProperties!, scope, emission);
+
+        if (!query.ElementCanBeNull)
+        {
+            return;
+        }
+
+        _ = sb.Append(foreachIndent).AppendLine("}");
+    }
 }

--- a/src/InterfaceStubGenerator.Shared/Emitter.Inline.Query.Object.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.Inline.Query.Object.cs
@@ -69,10 +69,13 @@ internal static partial class Emitter
         foreach (var property in properties)
         {
             var valueLocal = emission.QueryValueLocal + scope.LocalSuffix + "_" + property.ClrName;
+
             var keyExpression = scope.ParentKeyExpr is { } parentKey
-                ? BuildNestedKeyExpression(property, parentKey, scope.Delimiter, emission)
+                ? BuildNestedKeyExpression(property, parentKey, scope.Delimiter, emission, context)
                 : BuildQueryObjectKeyExpression(property, emission);
-            var site = new QueryPropertySite(valueLocal, keyExpression, context.PreEncoded, scope.Indentation + "    ");
+
+            var pairCall = context.PreEscapedKeys ? ".AddPreEscapedKey(" : AddQueryPairCall;
+            var site = new QueryPropertySite(valueLocal, keyExpression, context.PreEncoded, scope.Indentation + "    ", pairCall);
 
             if (property.Nested is { } children)
             {
@@ -176,7 +179,7 @@ internal static partial class Emitter
             .Append(valueIndent).Append("if (!string.IsNullOrWhiteSpace(").Append(entryKeyLocal).AppendLine("))")
             .Append(valueIndent).AppendLine("{")
             .Append(valueIndent).Append("    ").Append(emission.QueryBuilderLocal)
-            .Append(AddQueryPairCall).Append(site.KeyExpression).Append(" + ").Append(ToCSharpStringLiteral(scope.Delimiter))
+            .Append(site.AddPairCall).Append(site.KeyExpression).Append(" + ").Append(ToCSharpStringLiteral(scope.Delimiter))
             .Append(" + ").Append(entryKeyLocal).Append(", ").Append(valueExpression).Append(", ")
             .Append(context.PreEncoded).AppendLine(");")
             .Append(valueIndent).AppendLine("}");
@@ -271,7 +274,7 @@ internal static partial class Emitter
             _ = sb.Append(innerIndent).Append("if (").Append(site.ValueLocal).AppendLine(NullEqualityCheckSuffix)
                 .Append(innerIndent).AppendLine("{")
                 .Append(innerIndent).Append("    ").Append(emission.QueryBuilderLocal)
-                .Append(AddQueryPairCall).Append(keyLocal).Append(EmptyValueArgument).Append(site.PreEncoded).AppendLine(");")
+                .Append(site.AddPairCall).Append(keyLocal).Append(EmptyValueArgument).Append(site.PreEncoded).AppendLine(");")
                 .Append(innerIndent).AppendLine("}")
                 .Append(innerIndent).AppendLine("else")
                 .Append(innerIndent).AppendLine("{");
@@ -291,12 +294,14 @@ internal static partial class Emitter
     /// <param name="parentKeyExpr">The runtime key expression (a local) of the enclosing object.</param>
     /// <param name="delimiter">The nesting delimiter.</param>
     /// <param name="emission">The shared emission locals and helper state.</param>
+    /// <param name="context">The enclosing parameter, provider field, and collection-format context.</param>
     /// <returns>The composed key expression: parent key, delimiter, this property's own prefix, then its name.</returns>
     internal static string BuildNestedKeyExpression(
         QueryObjectPropertyModel property,
         string parentKeyExpr,
         string delimiter,
-        in InlineValueEmission emission)
+        in InlineValueEmission emission,
+        in QueryObjectContext context)
     {
         var prefixExpr = $"{parentKeyExpr} + {ToCSharpStringLiteral(delimiter + (property.PrefixSegment ?? string.Empty))}";
 
@@ -306,8 +311,10 @@ internal static partial class Emitter
             return $"{prefixExpr} + {ToCSharpStringLiteral(alias)}";
         }
 
-        var formatterCall =
-            $"global::Refit.GeneratedRequestRunner.BuildQueryKey({emission.SettingsLocal}, {ToCSharpStringLiteral(property.ClrName)}, null, {prefixExpr})";
+        var propertyNameExpr = ToCSharpStringLiteral(property.ClrName);
+        var formatterCall = context.PreEscapedKeys
+            ? $"{prefixExpr} + {propertyNameExpr}"
+            : $"global::Refit.GeneratedRequestRunner.BuildQueryKey({emission.SettingsLocal}, {propertyNameExpr}, null, {prefixExpr})";
 
         // A [JsonPropertyName] name is honored only when the runtime setting is enabled.
         return property.SerializerName is { } serializerName
@@ -352,7 +359,7 @@ internal static partial class Emitter
             _ = sb.Append(indent).Append("if (").Append(site.ValueLocal).AppendLine(NullEqualityCheckSuffix)
                 .Append(indent).AppendLine("{")
                 .Append(indent).Append("    ").Append(emission.QueryBuilderLocal)
-                .Append(AddQueryPairCall).Append(keyLocal).Append(EmptyValueArgument).Append(site.PreEncoded).AppendLine(");")
+                .Append(site.AddPairCall).Append(keyLocal).Append(EmptyValueArgument).Append(site.PreEncoded).AppendLine(");")
                 .Append(indent).AppendLine("}")
                 .Append(indent).AppendLine("else")
                 .Append(indent).AppendLine("{");
@@ -479,7 +486,7 @@ internal static partial class Emitter
         _ = sb.Append(indent).Append("if (").Append(site.ValueLocal).AppendLine(NullEqualityCheckSuffix)
             .Append(indent).AppendLine("{")
             .Append(indent).Append("    ").Append(emission.QueryBuilderLocal)
-            .Append(AddQueryPairCall).Append(site.KeyExpression).Append(EmptyValueArgument)
+            .Append(site.AddPairCall).Append(site.KeyExpression).Append(EmptyValueArgument)
             .Append(site.PreEncoded).AppendLine(");")
             .Append(indent).AppendLine("}")
             .Append(indent).AppendLine("else")
@@ -536,7 +543,7 @@ internal static partial class Emitter
             : $"{emission.UseDefaultFormattingLocal} ? ({fastExpression}) : {customExpression}";
 
         _ = sb.Append(site.Indentation).Append(emission.QueryBuilderLocal)
-            .Append(AddQueryPairCall).Append(site.KeyExpression).Append(", ").Append(valueExpression).Append(", ")
+            .Append(site.AddPairCall).Append(site.KeyExpression).Append(", ").Append(valueExpression).Append(", ")
             .Append(site.PreEncoded).AppendLine(");");
     }
 
@@ -573,7 +580,7 @@ internal static partial class Emitter
             .Append(indent).Append("if (").Append(formattedLocal).AppendLine(NotNullCheckSuffix)
             .Append(indent).AppendLine("{")
             .Append(indent).Append("    ").Append(emission.QueryBuilderLocal)
-            .Append(AddQueryPairCall).Append(site.KeyExpression).Append(", ")
+            .Append(site.AddPairCall).Append(site.KeyExpression).Append(", ")
             .Append(emission.UseDefaultFormattingLocal).Append(" ? ").Append(formattedLocal)
             .Append(" : ").Append(customExpression)
             .Append(", ").Append(site.PreEncoded).AppendLine(");")
@@ -648,9 +655,9 @@ internal static partial class Emitter
     /// <param name="query">The query-binding metadata.</param>
     /// <param name="providerField">The cached attribute-provider field name.</param>
     /// <param name="emission">The shared emission locals and helper state.</param>
-    private static void AppendIndexedCollectionQueryStatements(
+    internal static void AppendIndexedCollectionQueryStatements(
         PooledStringBuilder sb,
-        RequestParameterModel parameter,
+        in RequestParameterModel parameter,
         QueryParameterModel query,
         string providerField,
         in InlineValueEmission emission)
@@ -698,9 +705,9 @@ internal static partial class Emitter
     /// <param name="idxLocal">The generated index counter local name.</param>
     /// <param name="foreachIndent">The indentation inside the foreach body.</param>
     /// <param name="emission">The shared emission locals and helper state.</param>
-    private static void AppendIndexedElement(
+    internal static void AppendIndexedElement(
         PooledStringBuilder sb,
-        RequestParameterModel parameter,
+        in RequestParameterModel parameter,
         QueryParameterModel query,
         string providerField,
         string idxLocal,
@@ -723,9 +730,10 @@ internal static partial class Emitter
 
         // Flatten the element's properties under the indexed key; pass null as collection format so nested
         // collection properties fall back to settings default instead of inheriting Indexed.
-        var context = new QueryObjectContext(parameter, providerField, null, ToLowerInvariantString(query.PreEncoded));
+        // PreEscapedKeys tells every leaf property to use AddPreEscapedKey so the brackets in the key are not re-encoded.
+        var context = new QueryObjectContext(parameter, providerField, null, ToLowerInvariantString(query.PreEncoded), true);
         var scope = new ObjectFlattenScope(emission.QueryValueLocal, keyLocal, query.NestingDelimiter, "_" + parameter.Name, itemIndent);
-        AppendObjectPropertyList(sb, context, query.ObjectProperties!, scope, emission);
+        AppendObjectPropertyList(sb, context, query.ObjectProperties!.Value, scope, emission);
 
         if (!query.ElementCanBeNull)
         {

--- a/src/InterfaceStubGenerator.Shared/Emitter.Inline.Query.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.Inline.Query.cs
@@ -87,7 +87,7 @@ internal static partial class Emitter
             {
                 // A converter formats its own values, so the generated method needs no default-formatting branch.
                 { Converter: not null } => false,
-                { ObjectProperties: { } properties } => ObjectPropertiesNeedFormattingLocal(properties),
+                { Shape: QueryParameterShape.Object or QueryParameterShape.IndexedCollection, ObjectProperties: { } properties } => ObjectPropertiesNeedFormattingLocal(properties),
                 { Dictionary: { } dictionary } =>
                     dictionary.KeyFormat.Kind != InlineFormatKind.FormatterOnly
                     || query.ValueFormat.Kind != InlineFormatKind.FormatterOnly,
@@ -267,6 +267,12 @@ internal static partial class Emitter
             case QueryParameterShape.Object:
             {
                 AppendObjectQueryStatements(sb, parameter, query, providerField, emission);
+                break;
+            }
+
+            case QueryParameterShape.IndexedCollection:
+            {
+                AppendIndexedCollectionQueryStatements(sb, parameter, query, providerField, emission);
                 break;
             }
 

--- a/src/InterfaceStubGenerator.Shared/Emitter.Inline.Query.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.Inline.Query.cs
@@ -580,22 +580,27 @@ internal static partial class Emitter
     /// <param name="KeyExpression">The query key expression, constant or key-formatter call.</param>
     /// <param name="PreEncoded">The rendered <c>preEncoded</c> boolean literal.</param>
     /// <param name="Indentation">The indentation of the statements emitting this property.</param>
+    /// <param name="AddPairCall">The query-builder call fragment for emitting a pair; defaults to <see cref="AddQueryPairCall"/>.</param>
     internal readonly record struct QueryPropertySite(
         string ValueLocal,
         string KeyExpression,
         string PreEncoded,
-        string Indentation);
+        string Indentation,
+        string AddPairCall = AddQueryPairCall);
 
     /// <summary>The enclosing-parameter context shared by every flattened property of one query object.</summary>
     /// <param name="Parameter">The enclosing query-object parameter.</param>
     /// <param name="ProviderField">The cached attribute-provider field name for the parameter.</param>
     /// <param name="ParameterCollectionFormat">The parameter's <c>[Query(CollectionFormat)]</c>, or null.</param>
     /// <param name="PreEncoded">The rendered <c>preEncoded</c> boolean literal for the parameter.</param>
+    /// <param name="PreEscapedKeys">When <see langword="true"/>, leaf properties emit via <c>.AddPreEscapedKey(</c>
+    /// so runtime keys containing literal bracket characters are not re-encoded.</param>
     internal readonly record struct QueryObjectContext(
         RequestParameterModel Parameter,
         string ProviderField,
         int? ParameterCollectionFormat,
-        string PreEncoded);
+        string PreEncoded,
+        bool PreEscapedKeys = false);
 
     /// <summary>The per-nesting-level state threaded through recursive query-object flattening.</summary>
     /// <param name="AccessExpr">The C# expression accessing the current object (e.g. <c>@filter</c> or a nested local).</param>

--- a/src/InterfaceStubGenerator.Shared/Models/InterfaceGenerationContext.cs
+++ b/src/InterfaceStubGenerator.Shared/Models/InterfaceGenerationContext.cs
@@ -38,6 +38,8 @@ namespace Refit.Generator;
 /// <param name="FormattableClassificationCache">A pass-wide cache mapping a value type symbol to whether it implements
 /// <c>IFormattable</c> and <c>ISpanFormattable</c>, shared across every interface so the interface walk (which materializes a
 /// fresh public <c>AllInterfaces</c> array on each access) runs once per distinct type rather than once per parameter occurrence.</param>
+/// <param name="IndexedCollectionFormatValue">The underlying integer value of <c>CollectionFormat.Indexed</c> resolved once from the
+/// compilation, or <see langword="null"/> when the <c>Refit.CollectionFormat</c> type cannot be found.</param>
 /// <param name="PathPrefix">The shared route prefix declared by the interface being processed via <c>[PathPrefix]</c>,
 /// prepended to every method's relative path, or an empty string when the interface declares none.</param>
 internal readonly record struct InterfaceGenerationContext(
@@ -61,4 +63,5 @@ internal readonly record struct InterfaceGenerationContext(
     Dictionary<ISymbol, string?> AssemblyAliasCache,
     Dictionary<ISymbol, string> QualifiedTypeCache,
     Dictionary<ISymbol, (bool Formattable, bool SpanFormattable)> FormattableClassificationCache,
+    int? IndexedCollectionFormatValue = null,
     string PathPrefix = "");

--- a/src/InterfaceStubGenerator.Shared/Models/QueryParameterShape.cs
+++ b/src/InterfaceStubGenerator.Shared/Models/QueryParameterShape.cs
@@ -25,5 +25,9 @@ internal enum QueryParameterShape
     Dictionary,
 
     /// <summary>A value flattened by a user-supplied <c>IQueryConverter&lt;T&gt;</c> named with <c>[QueryConverter]</c>.</summary>
-    Converter
+    Converter,
+
+    /// <summary>A collection of objects whose properties are flattened with an indexed key prefix:
+    /// <c>key[0].Prop=val&amp;key[1].Prop=val</c>, matching <c>CollectionFormat.Indexed</c>.</summary>
+    IndexedCollection
 }

--- a/src/InterfaceStubGenerator.Shared/Parser.Request.Query.cs
+++ b/src/InterfaceStubGenerator.Shared/Parser.Request.Query.cs
@@ -289,36 +289,27 @@ internal static partial class Parser
                 BuildValueFormat(elementType!, format, formattableSymbol, context))
             : null;
 
-    /// <summary>Determines whether <paramref name="collectionFormatValue"/> is the underlying integer value of
-    /// <c>CollectionFormat.Indexed</c> by resolving the enum member from the compilation rather than comparing
-    /// against a hardcoded literal, so the check stays correct if the enum is ever reordered.</summary>
-    /// <param name="collectionFormatValue">The collection format value from the attribute, or null.</param>
-    /// <param name="context">The generation context supplying the compilation.</param>
-    /// <returns><see langword="true"/> when the value matches <c>CollectionFormat.Indexed</c>.</returns>
-    internal static bool IsIndexedCollectionFormat(int? collectionFormatValue, in InterfaceGenerationContext context)
+    /// <summary>Resolves the underlying integer value of <c>CollectionFormat.Indexed</c> from the compilation once
+    /// per generation pass, so per-parameter checks are a direct integer comparison rather than a symbol lookup.</summary>
+    /// <param name="compilation">The compilation to resolve against.</param>
+    /// <returns>The integer value, or <see langword="null"/> when the type cannot be found.</returns>
+    internal static int? ResolveIndexedCollectionFormatValue(Compilation compilation)
     {
-        if (collectionFormatValue is null)
-        {
-            return false;
-        }
-
-        // Resolve the CollectionFormat enum type from the compilation and find the Indexed member's constant value.
-        // This avoids hardcoding the integer and stays correct if the enum is ever reordered.
-        var collectionFormatType = context.Compilation?.GetTypeByMetadataName(CollectionFormatTypeName);
+        var collectionFormatType = compilation.GetTypeByMetadataName(CollectionFormatTypeName);
         if (collectionFormatType is null)
         {
-            return false;
+            return null;
         }
 
         foreach (var member in collectionFormatType.GetMembers())
         {
             if (member is IFieldSymbol { HasConstantValue: true, Name: IndexedMemberName } field)
             {
-                return collectionFormatValue == (int)field.ConstantValue!;
+                return (int)field.ConstantValue!;
             }
         }
 
-        return false;
+        return null;
     }
 
     /// <summary>Builds the query model for a <c>[Query(CollectionFormat.Indexed)]</c> parameter whose element type
@@ -341,7 +332,7 @@ internal static partial class Parser
         INamedTypeSymbol? formattableSymbol,
         in InterfaceGenerationContext context)
     {
-        if (!IsIndexedCollectionFormat(data.CollectionFormatValue, context))
+        if (data.CollectionFormatValue.HasValue && data.CollectionFormatValue != context.IndexedCollectionFormatValue)
         {
             return null;
         }

--- a/src/InterfaceStubGenerator.Shared/Parser.Request.Query.cs
+++ b/src/InterfaceStubGenerator.Shared/Parser.Request.Query.cs
@@ -17,8 +17,11 @@ internal static partial class Parser
     /// <summary>The maximum nested-object depth flattened inline before the whole parameter falls back to reflection.</summary>
     private const int MaxNestingDepth = 32;
 
-    /// <summary>The underlying integer value of <c>CollectionFormat.Indexed</c>, used by the parser without a direct reference to the Refit assembly.</summary>
-    private const int IndexedCollectionFormatValue = 6;
+    /// <summary>The metadata name of <c>Refit.CollectionFormat</c>.</summary>
+    private const string CollectionFormatTypeName = "Refit.CollectionFormat";
+
+    /// <summary>The member name of <c>CollectionFormat.Indexed</c>.</summary>
+    private const string IndexedMemberName = "Indexed";
 
     /// <summary>The metadata name of <c>Refit.QueryAttribute</c>.</summary>
     private const string QueryAttributeDisplayName = "QueryAttribute";
@@ -286,6 +289,38 @@ internal static partial class Parser
                 BuildValueFormat(elementType!, format, formattableSymbol, context))
             : null;
 
+    /// <summary>Determines whether <paramref name="collectionFormatValue"/> is the underlying integer value of
+    /// <c>CollectionFormat.Indexed</c> by resolving the enum member from the compilation rather than comparing
+    /// against a hardcoded literal, so the check stays correct if the enum is ever reordered.</summary>
+    /// <param name="collectionFormatValue">The collection format value from the attribute, or null.</param>
+    /// <param name="context">The generation context supplying the compilation.</param>
+    /// <returns><see langword="true"/> when the value matches <c>CollectionFormat.Indexed</c>.</returns>
+    internal static bool IsIndexedCollectionFormat(int? collectionFormatValue, in InterfaceGenerationContext context)
+    {
+        if (collectionFormatValue is null)
+        {
+            return false;
+        }
+
+        // Resolve the CollectionFormat enum type from the compilation and find the Indexed member's constant value.
+        // This avoids hardcoding the integer and stays correct if the enum is ever reordered.
+        var collectionFormatType = context.Compilation?.GetTypeByMetadataName(CollectionFormatTypeName);
+        if (collectionFormatType is null)
+        {
+            return false;
+        }
+
+        foreach (var member in collectionFormatType.GetMembers())
+        {
+            if (member is IFieldSymbol { HasConstantValue: true, Name: IndexedMemberName } field)
+            {
+                return collectionFormatValue == (int)field.ConstantValue!;
+            }
+        }
+
+        return false;
+    }
+
     /// <summary>Builds the query model for a <c>[Query(CollectionFormat.Indexed)]</c> parameter whose element type
     /// is a complex object that can be flattened inline, or null when the parameter does not match.</summary>
     /// <param name="parameter">The parameter to classify.</param>
@@ -306,7 +341,7 @@ internal static partial class Parser
         INamedTypeSymbol? formattableSymbol,
         in InterfaceGenerationContext context)
     {
-        if (data.CollectionFormatValue != IndexedCollectionFormatValue)
+        if (!IsIndexedCollectionFormat(data.CollectionFormatValue, context))
         {
             return null;
         }

--- a/src/InterfaceStubGenerator.Shared/Parser.Request.Query.cs
+++ b/src/InterfaceStubGenerator.Shared/Parser.Request.Query.cs
@@ -288,14 +288,14 @@ internal static partial class Parser
     /// <param name="context">The interface generation context, used to qualify extern-aliased types.</param>
     /// <returns>The deep-object collection model, or null when the parameter is not a Indexed collection or
     /// the element type cannot be flattened inline.</returns>
-    private static QueryParameterModel? TryBuildIndexedCollectionModel(
+    internal static QueryParameterModel? TryBuildIndexedCollectionModel(
         IParameterSymbol parameter,
         string urlName,
         bool preEncoded,
         in QueryFormData data,
         string? format,
         INamedTypeSymbol? formattableSymbol,
-        InterfaceGenerationContext context)
+        in InterfaceGenerationContext context)
     {
         if (data.CollectionFormatValue != IndexedCollectionFormatValue)
         {

--- a/src/InterfaceStubGenerator.Shared/Parser.Request.Query.cs
+++ b/src/InterfaceStubGenerator.Shared/Parser.Request.Query.cs
@@ -17,6 +17,9 @@ internal static partial class Parser
     /// <summary>The maximum nested-object depth flattened inline before the whole parameter falls back to reflection.</summary>
     private const int MaxNestingDepth = 32;
 
+    /// <summary>The underlying integer value of <c>CollectionFormat.Indexed</c>, used by the parser without a direct reference to the Refit assembly.</summary>
+    private const int IndexedCollectionFormatValue = 6;
+
     /// <summary>The metadata name of <c>Refit.QueryAttribute</c>.</summary>
     private const string QueryAttributeDisplayName = "QueryAttribute";
 
@@ -185,6 +188,12 @@ internal static partial class Parser
             return true;
         }
 
+        query = TryBuildIndexedCollectionModel(parameter, urlName, preEncoded, data, format, formattableSymbol, context);
+        if (query is not null)
+        {
+            return true;
+        }
+
         query = TryBuildFlattenedObjectQueryModel(parameter, urlName, preEncoded, data, format, formattableSymbol, context);
         return query is not null;
     }
@@ -261,6 +270,54 @@ internal static partial class Parser
                 CanElementBeNull(elementType!),
                 BuildValueFormat(elementType!, format, formattableSymbol, context))
             : null;
+
+    /// <summary>Builds the query model for a <c>[Query(CollectionFormat.Indexed)]</c> parameter whose element type
+    /// is a complex object that can be flattened inline, or null when the parameter does not match.</summary>
+    /// <param name="parameter">The parameter to classify.</param>
+    /// <param name="urlName">The resolved query key.</param>
+    /// <param name="preEncoded">Whether the parameter carries <c>[Encoded]</c>.</param>
+    /// <param name="data">The parameter's parsed <c>[Query]</c> data.</param>
+    /// <param name="format">The effective compile-time format, or null.</param>
+    /// <param name="formattableSymbol">The resolved <c>System.IFormattable</c> symbol, or null when unavailable.</param>
+    /// <param name="context">The interface generation context, used to qualify extern-aliased types.</param>
+    /// <returns>The deep-object collection model, or null when the parameter is not a Indexed collection or
+    /// the element type cannot be flattened inline.</returns>
+    private static QueryParameterModel? TryBuildIndexedCollectionModel(
+        IParameterSymbol parameter,
+        string urlName,
+        bool preEncoded,
+        in QueryFormData data,
+        string? format,
+        INamedTypeSymbol? formattableSymbol,
+        InterfaceGenerationContext context)
+    {
+        if (data.CollectionFormatValue != IndexedCollectionFormatValue)
+        {
+            return null;
+        }
+
+        if (!TryGetEnumerableElementType(parameter.Type, out var elementType)
+            || IsSimpleType(elementType!, formattableSymbol))
+        {
+            return null;
+        }
+
+        if (TryBuildQueryObjectProperties(elementType!, null, formattableSymbol, context) is not { } elementProperties)
+        {
+            return null;
+        }
+
+        return new(
+            urlName,
+            QueryParameterShape.IndexedCollection,
+            TreatAsString: false,
+            preEncoded,
+            data.CollectionFormatValue,
+            CanElementBeNull(elementType!),
+            BuildValueFormat(elementType!, format, formattableSymbol, context),
+            elementProperties,
+            NestingDelimiter: string.IsNullOrEmpty(data.Delimiter) ? "." : data.Delimiter);
+    }
 
     /// <summary>Builds the query model for a <c>[QueryConverter]</c> parameter, or null when the type is unresolved.</summary>
     /// <param name="parameter">The parameter carrying the converter.</param>

--- a/src/InterfaceStubGenerator.Shared/Parser.Request.Query.cs
+++ b/src/InterfaceStubGenerator.Shared/Parser.Request.Query.cs
@@ -332,7 +332,7 @@ internal static partial class Parser
         INamedTypeSymbol? formattableSymbol,
         in InterfaceGenerationContext context)
     {
-        if (data.CollectionFormatValue.HasValue && data.CollectionFormatValue != context.IndexedCollectionFormatValue)
+        if (!data.CollectionFormatValue.HasValue || data.CollectionFormatValue != context.IndexedCollectionFormatValue)
         {
             return null;
         }

--- a/src/InterfaceStubGenerator.Shared/Parser.cs
+++ b/src/InterfaceStubGenerator.Shared/Parser.cs
@@ -567,32 +567,32 @@ internal static partial class Parser
                 switch (member)
                 {
                     case IMethodSymbol method when IsDisposeMethod(method, disposableInterfaceSymbol):
-                        {
-                            hasDispose = true;
-                            break;
-                        }
+                    {
+                        hasDispose = true;
+                        break;
+                    }
 
                     case IMethodSymbol method when IsRefitMethod(method, context.HttpMethodBaseAttributeSymbol):
-                        {
-                            derivedRefitMethods.Add(method);
-                            break;
-                        }
+                    {
+                        derivedRefitMethods.Add(method);
+                        break;
+                    }
 
                     case IMethodSymbol method:
-                        {
-                            // Each inherited interface contributes its own members once across AllInterfaces, so a method
-                            // symbol never repeats here and no per-method de-duplication is needed.
-                            derivedNonRefitMethods.Add(method);
-                            break;
-                        }
+                    {
+                        // Each inherited interface contributes its own members once across AllInterfaces, so a method
+                        // symbol never repeats here and no per-method de-duplication is needed.
+                        derivedNonRefitMethods.Add(method);
+                        break;
+                    }
 
                     case IPropertySymbol property
                         when IsEmittableProperty(property)
                             && (seenInheritedProperties ??= new(SymbolEqualityComparer.Default)).Add(property):
-                        {
-                            inheritedProperties.Add(property);
-                            break;
-                        }
+                    {
+                        inheritedProperties.Add(property);
+                        break;
+                    }
                 }
             }
         }

--- a/src/InterfaceStubGenerator.Shared/Parser.cs
+++ b/src/InterfaceStubGenerator.Shared/Parser.cs
@@ -170,6 +170,8 @@ internal static partial class Parser
         var returnTypeAdapterInterface = ResolveReturnTypeAdapterInterface(compilation);
         var returnTypeAdapters = DiscoverReturnTypeAdapters(compilation, returnTypeAdapterInterface, cancellationToken);
 
+        var indexedCollectionFormatValue = ResolveIndexedCollectionFormatValue(compilation);
+
         return new InterfaceGenerationContext(
             diagnostics,
             preserveAttributeDisplayName,
@@ -190,7 +192,8 @@ internal static partial class Parser
             [],
             new Dictionary<ISymbol, string?>(SymbolEqualityComparer.Default),
             new Dictionary<ISymbol, string>(SymbolEqualityComparer.Default),
-            new Dictionary<ISymbol, (bool Formattable, bool SpanFormattable)>(SymbolEqualityComparer.Default));
+            new Dictionary<ISymbol, (bool Formattable, bool SpanFormattable)>(SymbolEqualityComparer.Default),
+            indexedCollectionFormatValue);
     }
 
     /// <summary>Collects the interfaces with Refit methods, declared or inherited, into a single map.</summary>
@@ -564,32 +567,32 @@ internal static partial class Parser
                 switch (member)
                 {
                     case IMethodSymbol method when IsDisposeMethod(method, disposableInterfaceSymbol):
-                    {
-                        hasDispose = true;
-                        break;
-                    }
+                        {
+                            hasDispose = true;
+                            break;
+                        }
 
                     case IMethodSymbol method when IsRefitMethod(method, context.HttpMethodBaseAttributeSymbol):
-                    {
-                        derivedRefitMethods.Add(method);
-                        break;
-                    }
+                        {
+                            derivedRefitMethods.Add(method);
+                            break;
+                        }
 
                     case IMethodSymbol method:
-                    {
-                        // Each inherited interface contributes its own members once across AllInterfaces, so a method
-                        // symbol never repeats here and no per-method de-duplication is needed.
-                        derivedNonRefitMethods.Add(method);
-                        break;
-                    }
+                        {
+                            // Each inherited interface contributes its own members once across AllInterfaces, so a method
+                            // symbol never repeats here and no per-method de-duplication is needed.
+                            derivedNonRefitMethods.Add(method);
+                            break;
+                        }
 
                     case IPropertySymbol property
                         when IsEmittableProperty(property)
                             && (seenInheritedProperties ??= new(SymbolEqualityComparer.Default)).Add(property):
-                    {
-                        inheritedProperties.Add(property);
-                        break;
-                    }
+                        {
+                            inheritedProperties.Add(property);
+                            break;
+                        }
                 }
             }
         }

--- a/src/Refit.Reflection/QueryParameterEntry.cs
+++ b/src/Refit.Reflection/QueryParameterEntry.cs
@@ -7,4 +7,5 @@ namespace Refit;
 /// <summary>One pending query-string entry collected while building a request.</summary>
 /// <param name="Key">The query key, unescaped.</param>
 /// <param name="Value">The formatted value, or <see langword="null"/> to omit the entry.</param>
-internal readonly record struct QueryParameterEntry(string Key, string? Value);
+/// <param name="KeyPreEscaped">Whether the key is already escaped and should be appended verbatim without re-encoding.</param>
+internal readonly record struct QueryParameterEntry(string Key, string? Value, bool KeyPreEscaped = false);

--- a/src/Refit.Reflection/RequestBuilderImplementation.Payload.cs
+++ b/src/Refit.Reflection/RequestBuilderImplementation.Payload.cs
@@ -459,7 +459,7 @@ internal partial class RequestBuilderImplementation
             if (DoNotConvertToQueryMap(item))
             {
                 var type = item.GetType();
-                queryParamsToAdd.Add(new(indexedKey, GeneratedRequestRunner.FormatUrlParameter(_settings, item, type, type)));
+                queryParamsToAdd.Add(new(indexedKey, GeneratedRequestRunner.FormatUrlParameter(_settings, item, type, type), KeyPreEscaped: true));
             }
             else
             {
@@ -470,7 +470,8 @@ internal partial class RequestBuilderImplementation
                     var valueType = kvp.Value?.GetType() ?? typeof(object);
                     queryParamsToAdd.Add(new(
                         indexedKey + attr.Delimiter + kvp.Key,
-                        GeneratedRequestRunner.FormatUrlParameter(_settings, kvp.Value, valueType, valueType)));
+                        GeneratedRequestRunner.FormatUrlParameter(_settings, kvp.Value, valueType, valueType),
+                        KeyPreEscaped: true));
                 }
             }
 

--- a/src/Refit.Reflection/RequestBuilderImplementation.Payload.cs
+++ b/src/Refit.Reflection/RequestBuilderImplementation.Payload.cs
@@ -43,41 +43,41 @@ internal partial class RequestBuilderImplementation
         switch (restMethod.BodyParameterInfo.Item1)
         {
             case BodySerializationMethod.UrlEncoded:
-                {
-                    ret.Content = param is string str
-                        ? new StringContent(
-                            StringHelpers.EscapeDataString(str),
-                            Encoding.UTF8,
-                            "application/x-www-form-urlencoded")
-                        : new FormUrlEncodedContent(new FormValueMultimap(param, _settings));
-                    break;
-                }
+            {
+                ret.Content = param is string str
+                    ? new StringContent(
+                        StringHelpers.EscapeDataString(str),
+                        Encoding.UTF8,
+                        "application/x-www-form-urlencoded")
+                    : new FormUrlEncodedContent(new FormValueMultimap(param, _settings));
+                break;
+            }
 
             case BodySerializationMethod.JsonLines:
-                {
-                    ret.Content = new JsonLinesContent(AsJsonLinesSequence(param), _serializer);
-                    break;
-                }
+            {
+                ret.Content = new JsonLinesContent(AsJsonLinesSequence(param), _serializer);
+                break;
+            }
 
             case BodySerializationMethod.Default or BodySerializationMethod.Serialized:
-                {
-                    AddSerializedBodyToRequest(restMethod, param, ret);
-                    break;
-                }
+            {
+                AddSerializedBodyToRequest(restMethod, param, ret);
+                break;
+            }
 
             default:
+            {
+                // The obsolete legacy JSON serialization method must still serialize, because
+                // already-compiled callers can pass it. Treating it as Default would incorrectly
+                // send string bodies as raw text. It is matched by value rather than by name so
+                // this file never references the obsolete member.
+                if (GeneratedRequestRunner.IsObsoleteJsonSerializationMethod(restMethod.BodyParameterInfo.Item1))
                 {
-                    // The obsolete legacy JSON serialization method must still serialize, because
-                    // already-compiled callers can pass it. Treating it as Default would incorrectly
-                    // send string bodies as raw text. It is matched by value rather than by name so
-                    // this file never references the obsolete member.
-                    if (GeneratedRequestRunner.IsObsoleteJsonSerializationMethod(restMethod.BodyParameterInfo.Item1))
-                    {
-                        AddSerializedBodyToRequest(restMethod, param, ret);
-                    }
-
-                    break;
+                    AddSerializedBodyToRequest(restMethod, param, ret);
                 }
+
+                break;
+            }
         }
     }
 
@@ -423,7 +423,8 @@ internal partial class RequestBuilderImplementation
         if (parameterCollectionFormat != CollectionFormat.Indexed
             || param is string
             || param is IDictionary
-            || param is not IEnumerable collection)
+            || param is not IEnumerable collection
+            || DoNotConvertToQueryMap(param))
         {
             return false;
         }
@@ -454,23 +455,16 @@ internal partial class RequestBuilderImplementation
             }
 
             var indexedKey = $"{paramKey}[{index}]";
-            if (DoNotConvertToQueryMap(item))
+
+            var queryMap = BuildQueryMap(item, attr.Delimiter);
+            for (var j = 0; j < queryMap.Count; j++)
             {
-                var type = item.GetType();
-                queryParamsToAdd.Add(new(indexedKey, GeneratedRequestRunner.FormatUrlParameter(_settings, item, type, type), KeyPreEscaped: true));
-            }
-            else
-            {
-                var queryMap = BuildQueryMap(item, attr.Delimiter);
-                for (var j = 0; j < queryMap.Count; j++)
-                {
-                    var kvp = queryMap[j];
-                    var valueType = kvp.Value?.GetType() ?? typeof(object);
-                    queryParamsToAdd.Add(new(
-                        indexedKey + attr.Delimiter + kvp.Key,
-                        GeneratedRequestRunner.FormatUrlParameter(_settings, kvp.Value, valueType, valueType),
-                        KeyPreEscaped: true));
-                }
+                var kvp = queryMap[j];
+                var valueType = kvp.Value?.GetType() ?? typeof(object);
+                queryParamsToAdd.Add(new(
+                    indexedKey + attr.Delimiter + kvp.Key,
+                    GeneratedRequestRunner.FormatUrlParameter(_settings, kvp.Value, valueType, valueType),
+                    KeyPreEscaped: true));
             }
 
             index++;

--- a/src/Refit.Reflection/RequestBuilderImplementation.Payload.cs
+++ b/src/Refit.Reflection/RequestBuilderImplementation.Payload.cs
@@ -43,41 +43,41 @@ internal partial class RequestBuilderImplementation
         switch (restMethod.BodyParameterInfo.Item1)
         {
             case BodySerializationMethod.UrlEncoded:
-            {
-                ret.Content = param is string str
-                    ? new StringContent(
-                        StringHelpers.EscapeDataString(str),
-                        Encoding.UTF8,
-                        "application/x-www-form-urlencoded")
-                    : new FormUrlEncodedContent(new FormValueMultimap(param, _settings));
-                break;
-            }
-
-            case BodySerializationMethod.JsonLines:
-            {
-                ret.Content = new JsonLinesContent(AsJsonLinesSequence(param), _serializer);
-                break;
-            }
-
-            case BodySerializationMethod.Default or BodySerializationMethod.Serialized:
-            {
-                AddSerializedBodyToRequest(restMethod, param, ret);
-                break;
-            }
-
-            default:
-            {
-                // The obsolete legacy JSON serialization method must still serialize, because
-                // already-compiled callers can pass it. Treating it as Default would incorrectly
-                // send string bodies as raw text. It is matched by value rather than by name so
-                // this file never references the obsolete member.
-                if (GeneratedRequestRunner.IsObsoleteJsonSerializationMethod(restMethod.BodyParameterInfo.Item1))
                 {
-                    AddSerializedBodyToRequest(restMethod, param, ret);
+                    ret.Content = param is string str
+                        ? new StringContent(
+                            StringHelpers.EscapeDataString(str),
+                            Encoding.UTF8,
+                            "application/x-www-form-urlencoded")
+                        : new FormUrlEncodedContent(new FormValueMultimap(param, _settings));
+                    break;
                 }
 
-                break;
-            }
+            case BodySerializationMethod.JsonLines:
+                {
+                    ret.Content = new JsonLinesContent(AsJsonLinesSequence(param), _serializer);
+                    break;
+                }
+
+            case BodySerializationMethod.Default or BodySerializationMethod.Serialized:
+                {
+                    AddSerializedBodyToRequest(restMethod, param, ret);
+                    break;
+                }
+
+            default:
+                {
+                    // The obsolete legacy JSON serialization method must still serialize, because
+                    // already-compiled callers can pass it. Treating it as Default would incorrectly
+                    // send string bodies as raw text. It is matched by value rather than by name so
+                    // this file never references the obsolete member.
+                    if (GeneratedRequestRunner.IsObsoleteJsonSerializationMethod(restMethod.BodyParameterInfo.Item1))
+                    {
+                        AddSerializedBodyToRequest(restMethod, param, ret);
+                    }
+
+                    break;
+                }
         }
     }
 
@@ -157,6 +157,16 @@ internal partial class RequestBuilderImplementation
             return;
         }
 
+        var parameterCollectionFormat = attr.IsCollectionFormatSpecified
+            ? attr.CollectionFormat
+            : (CollectionFormat?)null;
+
+        if (parameterCollectionFormat is not null
+            && TryAppendIndexedCollectionQuery(queryParamsToAdd, param, attr, restMethod.QueryParameterMap[i], parameterCollectionFormat))
+        {
+            return;
+        }
+
         if (DoNotConvertToQueryMap(param))
         {
             AppendQueryParameter(
@@ -168,9 +178,6 @@ internal partial class RequestBuilderImplementation
             return;
         }
 
-        var parameterCollectionFormat = attr.IsCollectionFormatSpecified
-            ? attr.CollectionFormat
-            : (CollectionFormat?)null;
         var queryMap = BuildQueryMap(param, attr.Delimiter, parameterInfo, parameterCollectionFormat);
         for (var queryMapIndex = 0; queryMapIndex < queryMap.Count; queryMapIndex++)
         {
@@ -398,6 +405,77 @@ internal partial class RequestBuilderImplementation
                     param,
                     parameterInfo,
                     parameterInfo.ParameterType)));
+    }
+
+    /// <summary>Checks whether the parameter is a <c>CollectionFormat.Indexed</c> collection, and if so appends
+    /// its indexed-prefix query pairs and returns <see langword="true"/>.</summary>
+    /// <param name="queryParamsToAdd">The list receiving query parameters.</param>
+    /// <param name="param">The parameter value.</param>
+    /// <param name="attr">The query attribute governing key naming.</param>
+    /// <param name="paramKey">The base query key for the parameter.</param>
+    /// <param name="parameterCollectionFormat">The resolved collection format, or null to use the settings default.</param>
+    /// <returns><see langword="true"/> when the parameter was handled as a Indexed collection.</returns>
+    private bool TryAppendIndexedCollectionQuery(
+        List<QueryParameterEntry> queryParamsToAdd,
+        object param,
+        QueryAttribute attr,
+        string paramKey,
+        CollectionFormat? parameterCollectionFormat)
+    {
+        if (parameterCollectionFormat != CollectionFormat.Indexed
+            || param is string
+            || param is IDictionary
+            || param is not IEnumerable collection)
+        {
+            return false;
+        }
+
+        AppendIndexedCollectionParameters(queryParamsToAdd, collection, attr, paramKey);
+        return true;
+    }
+
+    /// <summary>Expands a <c>[Query(CollectionFormat.Indexed)]</c> collection into indexed-prefix query pairs,
+    /// producing <c>key[0].Prop=val&amp;key[1].Prop=val</c> for each element's flattened properties.</summary>
+    /// <param name="queryParamsToAdd">The list receiving query parameters.</param>
+    /// <param name="collection">The enumerable parameter value.</param>
+    /// <param name="attr">The query attribute governing key naming.</param>
+    /// <param name="paramKey">The base query key for the parameter.</param>
+    private void AppendIndexedCollectionParameters(
+        List<QueryParameterEntry> queryParamsToAdd,
+        IEnumerable collection,
+        QueryAttribute attr,
+        string paramKey)
+    {
+        var index = 0;
+        foreach (var item in collection)
+        {
+            if (item is null)
+            {
+                index++;
+                continue;
+            }
+
+            var indexedKey = $"{paramKey}[{index}]";
+            if (DoNotConvertToQueryMap(item))
+            {
+                var type = item.GetType();
+                queryParamsToAdd.Add(new(indexedKey, GeneratedRequestRunner.FormatUrlParameter(_settings, item, type, type)));
+            }
+            else
+            {
+                var queryMap = BuildQueryMap(item, attr.Delimiter);
+                for (var j = 0; j < queryMap.Count; j++)
+                {
+                    var kvp = queryMap[j];
+                    var valueType = kvp.Value?.GetType() ?? typeof(object);
+                    queryParamsToAdd.Add(new(
+                        indexedKey + attr.Delimiter + kvp.Key,
+                        GeneratedRequestRunner.FormatUrlParameter(_settings, kvp.Value, valueType, valueType)));
+                }
+            }
+
+            index++;
+        }
     }
 
     /// <summary>Formats an enumerable parameter value according to the effective collection format.</summary>

--- a/src/Refit.Reflection/RequestBuilderImplementation.QueryAndHeaders.cs
+++ b/src/Refit.Reflection/RequestBuilderImplementation.QueryAndHeaders.cs
@@ -185,7 +185,7 @@ internal partial class RequestBuilderImplementation
                 vsb.Append('&');
             }
 
-            var key = StringHelpers.EscapeDataString(queryParam.Key);
+            var key = queryParam.KeyPreEscaped ? queryParam.Key : StringHelpers.EscapeDataString(queryParam.Key);
 #if NET6_0_OR_GREATER
             // if first query does not start with ? then prepend it
             if (vsb.Length == 0 && key.Length > 0 && key[0] != '?')

--- a/src/Refit/CollectionFormat.cs
+++ b/src/Refit/CollectionFormat.cs
@@ -22,5 +22,10 @@ public enum CollectionFormat
     Pipes,
 
     /// <summary>Multiple parameter instances.</summary>
-    Multi
+    Multi,
+
+    /// <summary>A collection of objects expanded with an indexed key prefix: <c>key[0].Prop=val&amp;key[1].Prop=val</c>.
+    /// Applies to <see cref="System.Collections.Generic.IEnumerable{T}"/> parameters whose element type has public
+    /// readable properties. Mirrors the OpenAPI 3 <c>Indexed</c> serialization style.</summary>
+    Indexed
 }

--- a/src/Refit/PublicAPI/net10.0/PublicAPI.Shipped.txt
+++ b/src/Refit/PublicAPI/net10.0/PublicAPI.Shipped.txt
@@ -91,6 +91,7 @@ Refit.CamelCaseUrlParameterKeyFormatter.Format(string! key) -> string!
 Refit.CollectionFormat
 Refit.CollectionFormat.Csv = 1 -> Refit.CollectionFormat
 Refit.CollectionFormat.Multi = 5 -> Refit.CollectionFormat
+Refit.CollectionFormat.Indexed = 6 -> Refit.CollectionFormat
 Refit.CollectionFormat.Pipes = 4 -> Refit.CollectionFormat
 Refit.CollectionFormat.RefitParameterFormatter = 0 -> Refit.CollectionFormat
 Refit.CollectionFormat.Ssv = 2 -> Refit.CollectionFormat

--- a/src/Refit/PublicAPI/net11.0/PublicAPI.Shipped.txt
+++ b/src/Refit/PublicAPI/net11.0/PublicAPI.Shipped.txt
@@ -91,6 +91,7 @@ Refit.CamelCaseUrlParameterKeyFormatter.Format(string! key) -> string!
 Refit.CollectionFormat
 Refit.CollectionFormat.Csv = 1 -> Refit.CollectionFormat
 Refit.CollectionFormat.Multi = 5 -> Refit.CollectionFormat
+Refit.CollectionFormat.Indexed = 6 -> Refit.CollectionFormat
 Refit.CollectionFormat.Pipes = 4 -> Refit.CollectionFormat
 Refit.CollectionFormat.RefitParameterFormatter = 0 -> Refit.CollectionFormat
 Refit.CollectionFormat.Ssv = 2 -> Refit.CollectionFormat

--- a/src/Refit/PublicAPI/net462/PublicAPI.Shipped.txt
+++ b/src/Refit/PublicAPI/net462/PublicAPI.Shipped.txt
@@ -91,6 +91,7 @@ Refit.CamelCaseUrlParameterKeyFormatter.Format(string! key) -> string!
 Refit.CollectionFormat
 Refit.CollectionFormat.Csv = 1 -> Refit.CollectionFormat
 Refit.CollectionFormat.Multi = 5 -> Refit.CollectionFormat
+Refit.CollectionFormat.Indexed = 6 -> Refit.CollectionFormat
 Refit.CollectionFormat.Pipes = 4 -> Refit.CollectionFormat
 Refit.CollectionFormat.RefitParameterFormatter = 0 -> Refit.CollectionFormat
 Refit.CollectionFormat.Ssv = 2 -> Refit.CollectionFormat

--- a/src/Refit/PublicAPI/net470/PublicAPI.Shipped.txt
+++ b/src/Refit/PublicAPI/net470/PublicAPI.Shipped.txt
@@ -91,6 +91,7 @@ Refit.CamelCaseUrlParameterKeyFormatter.Format(string! key) -> string!
 Refit.CollectionFormat
 Refit.CollectionFormat.Csv = 1 -> Refit.CollectionFormat
 Refit.CollectionFormat.Multi = 5 -> Refit.CollectionFormat
+Refit.CollectionFormat.Indexed = 6 -> Refit.CollectionFormat
 Refit.CollectionFormat.Pipes = 4 -> Refit.CollectionFormat
 Refit.CollectionFormat.RefitParameterFormatter = 0 -> Refit.CollectionFormat
 Refit.CollectionFormat.Ssv = 2 -> Refit.CollectionFormat

--- a/src/Refit/PublicAPI/net471/PublicAPI.Shipped.txt
+++ b/src/Refit/PublicAPI/net471/PublicAPI.Shipped.txt
@@ -91,6 +91,7 @@ Refit.CamelCaseUrlParameterKeyFormatter.Format(string! key) -> string!
 Refit.CollectionFormat
 Refit.CollectionFormat.Csv = 1 -> Refit.CollectionFormat
 Refit.CollectionFormat.Multi = 5 -> Refit.CollectionFormat
+Refit.CollectionFormat.Indexed = 6 -> Refit.CollectionFormat
 Refit.CollectionFormat.Pipes = 4 -> Refit.CollectionFormat
 Refit.CollectionFormat.RefitParameterFormatter = 0 -> Refit.CollectionFormat
 Refit.CollectionFormat.Ssv = 2 -> Refit.CollectionFormat

--- a/src/Refit/PublicAPI/net472/PublicAPI.Shipped.txt
+++ b/src/Refit/PublicAPI/net472/PublicAPI.Shipped.txt
@@ -91,6 +91,7 @@ Refit.CamelCaseUrlParameterKeyFormatter.Format(string! key) -> string!
 Refit.CollectionFormat
 Refit.CollectionFormat.Csv = 1 -> Refit.CollectionFormat
 Refit.CollectionFormat.Multi = 5 -> Refit.CollectionFormat
+Refit.CollectionFormat.Indexed = 6 -> Refit.CollectionFormat
 Refit.CollectionFormat.Pipes = 4 -> Refit.CollectionFormat
 Refit.CollectionFormat.RefitParameterFormatter = 0 -> Refit.CollectionFormat
 Refit.CollectionFormat.Ssv = 2 -> Refit.CollectionFormat

--- a/src/Refit/PublicAPI/net48/PublicAPI.Shipped.txt
+++ b/src/Refit/PublicAPI/net48/PublicAPI.Shipped.txt
@@ -91,6 +91,7 @@ Refit.CamelCaseUrlParameterKeyFormatter.Format(string! key) -> string!
 Refit.CollectionFormat
 Refit.CollectionFormat.Csv = 1 -> Refit.CollectionFormat
 Refit.CollectionFormat.Multi = 5 -> Refit.CollectionFormat
+Refit.CollectionFormat.Indexed = 6 -> Refit.CollectionFormat
 Refit.CollectionFormat.Pipes = 4 -> Refit.CollectionFormat
 Refit.CollectionFormat.RefitParameterFormatter = 0 -> Refit.CollectionFormat
 Refit.CollectionFormat.Ssv = 2 -> Refit.CollectionFormat

--- a/src/Refit/PublicAPI/net481/PublicAPI.Shipped.txt
+++ b/src/Refit/PublicAPI/net481/PublicAPI.Shipped.txt
@@ -91,6 +91,7 @@ Refit.CamelCaseUrlParameterKeyFormatter.Format(string! key) -> string!
 Refit.CollectionFormat
 Refit.CollectionFormat.Csv = 1 -> Refit.CollectionFormat
 Refit.CollectionFormat.Multi = 5 -> Refit.CollectionFormat
+Refit.CollectionFormat.Indexed = 6 -> Refit.CollectionFormat
 Refit.CollectionFormat.Pipes = 4 -> Refit.CollectionFormat
 Refit.CollectionFormat.RefitParameterFormatter = 0 -> Refit.CollectionFormat
 Refit.CollectionFormat.Ssv = 2 -> Refit.CollectionFormat

--- a/src/Refit/PublicAPI/net8.0/PublicAPI.Shipped.txt
+++ b/src/Refit/PublicAPI/net8.0/PublicAPI.Shipped.txt
@@ -91,6 +91,7 @@ Refit.CamelCaseUrlParameterKeyFormatter.Format(string! key) -> string!
 Refit.CollectionFormat
 Refit.CollectionFormat.Csv = 1 -> Refit.CollectionFormat
 Refit.CollectionFormat.Multi = 5 -> Refit.CollectionFormat
+Refit.CollectionFormat.Indexed = 6 -> Refit.CollectionFormat
 Refit.CollectionFormat.Pipes = 4 -> Refit.CollectionFormat
 Refit.CollectionFormat.RefitParameterFormatter = 0 -> Refit.CollectionFormat
 Refit.CollectionFormat.Ssv = 2 -> Refit.CollectionFormat

--- a/src/Refit/PublicAPI/net9.0/PublicAPI.Shipped.txt
+++ b/src/Refit/PublicAPI/net9.0/PublicAPI.Shipped.txt
@@ -91,6 +91,7 @@ Refit.CamelCaseUrlParameterKeyFormatter.Format(string! key) -> string!
 Refit.CollectionFormat
 Refit.CollectionFormat.Csv = 1 -> Refit.CollectionFormat
 Refit.CollectionFormat.Multi = 5 -> Refit.CollectionFormat
+Refit.CollectionFormat.Indexed = 6 -> Refit.CollectionFormat
 Refit.CollectionFormat.Pipes = 4 -> Refit.CollectionFormat
 Refit.CollectionFormat.RefitParameterFormatter = 0 -> Refit.CollectionFormat
 Refit.CollectionFormat.Ssv = 2 -> Refit.CollectionFormat

--- a/src/tests/.editorconfig
+++ b/src/tests/.editorconfig
@@ -22,7 +22,6 @@ dotnet_diagnostic.S5332.severity = none # Using http protocol is insecure (test 
 ###################
 dotnet_diagnostic.SST2016.severity = none # Prefer DateTimeOffset over DateTime on a visible signature — test models exercise DateTime handling deliberately
 dotnet_diagnostic.SST2410.severity = none # A created disposable is never disposed — test-local disposables are short-lived and GC-reclaimed
-dotnet_diagnostic.SST1522.severity = none # File length maximum — live test harnesses are intentionally consolidated in one file
 
 ###################
 # PerformanceSharp (PSH) — relaxed for test projects

--- a/src/tests/.editorconfig
+++ b/src/tests/.editorconfig
@@ -22,6 +22,7 @@ dotnet_diagnostic.S5332.severity = none # Using http protocol is insecure (test 
 ###################
 dotnet_diagnostic.SST2016.severity = none # Prefer DateTimeOffset over DateTime on a visible signature — test models exercise DateTime handling deliberately
 dotnet_diagnostic.SST2410.severity = none # A created disposable is never disposed — test-local disposables are short-lived and GC-reclaimed
+dotnet_diagnostic.SST1522.severity = none # File length maximum — live test harnesses are intentionally consolidated in one file
 
 ###################
 # PerformanceSharp (PSH) — relaxed for test projects

--- a/src/tests/Refit.GeneratorTests/IndexedCollectionGenerationTests.cs
+++ b/src/tests/Refit.GeneratorTests/IndexedCollectionGenerationTests.cs
@@ -1,0 +1,199 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Refit.GeneratorTests;
+
+/// <summary>
+/// Verifies that a <c>[Query(CollectionFormat.Indexed)]</c> parameter whose element type is a flattened object
+/// generates inline (no reflection fallback) and emits the expected indexed-prefix query: <c>key[0].Prop=val</c>.
+/// </summary>
+public sealed class IndexedCollectionGenerationTests
+{
+    /// <summary>The generated implementation source hint name.</summary>
+    private const string Hint = "IGeneratedClient.g.cs";
+
+    /// <summary>The reflective request-builder call emitted by fallback paths.</summary>
+    private const string ReflectiveFallback = "BuildRestResultFuncForMethod";
+
+    /// <summary>Source with a nullable Indexed collection parameter.</summary>
+    private const string NullableIndexedSource =
+        """
+        #nullable enable
+        using System.Collections.Generic;
+        using System.Threading.Tasks;
+        using Refit;
+
+        namespace RefitGeneratorTest;
+
+        public sealed class Item
+        {
+            public int Id { get; set; }
+            public string? Value { get; set; }
+        }
+
+        public interface IGeneratedClient
+        {
+            [Get("/items")]
+            Task<string> Search([Query(CollectionFormat.Indexed)] IReadOnlyList<Item>? items);
+        }
+        """;
+
+    /// <summary>Source with a non-nullable Indexed collection parameter (value-type element).</summary>
+    private const string NonNullableIndexedSource =
+        """
+        #nullable enable
+        using System.Collections.Generic;
+        using System.Threading.Tasks;
+        using Refit;
+
+        namespace RefitGeneratorTest;
+
+        public struct Point
+        {
+            public int X { get; set; }
+            public int Y { get; set; }
+        }
+
+        public interface IGeneratedClient
+        {
+            [Get("/points")]
+            Task<string> Plot([Query(CollectionFormat.Indexed)] List<Point> points);
+        }
+        """;
+
+    /// <summary>Source where the element type has a nested object property - should fall back to reflection
+    /// because the nested type is complex and the reflection builder walks runtime types.</summary>
+    private const string IndexedWithSimpleScalarCollectionSource =
+        """
+        #nullable enable
+        using System.Collections.Generic;
+        using System.Threading.Tasks;
+        using Refit;
+
+        namespace RefitGeneratorTest;
+
+        public sealed class Tag
+        {
+            public string? Name { get; set; }
+            [Query(CollectionFormat.Multi)] public int[]? Ids { get; set; }
+        }
+
+        public interface IGeneratedClient
+        {
+            [Get("/tags")]
+            Task<string> Search([Query(CollectionFormat.Indexed)] List<Tag> tags);
+        }
+        """;
+
+    /// <summary>Source where the element type has an [AliasAs] property name override.</summary>
+    private const string IndexedWithAliasSource =
+        """
+        #nullable enable
+        using System.Collections.Generic;
+        using System.Threading.Tasks;
+        using Refit;
+
+        namespace RefitGeneratorTest;
+
+        public sealed class Filter
+        {
+            [AliasAs("n")] public string? Name { get; set; }
+            public int Count { get; set; }
+        }
+
+        public interface IGeneratedClient
+        {
+            [Get("/filters")]
+            Task<string> Search([Query(CollectionFormat.Indexed)] List<Filter>? filters);
+        }
+        """;
+
+    /// <summary>Verifies a nullable Indexed collection parameter flattens inline with no reflection fallback.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task NullableIndexedCollectionGeneratesInline()
+    {
+        var result = Fixture.RunGenerator(NullableIndexedSource, generatedRequestBuilding: true);
+
+        await Assert.That(result.CompilesWithoutErrors).IsTrue();
+        await Assert.That(result.GeneratedSources[Hint]).DoesNotContain(ReflectiveFallback);
+    }
+
+    /// <summary>Verifies a non-nullable Indexed collection of value-type elements generates inline.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task NonNullableIndexedCollectionGeneratesInline()
+    {
+        var result = Fixture.RunGenerator(NonNullableIndexedSource, generatedRequestBuilding: true);
+
+        await Assert.That(result.CompilesWithoutErrors).IsTrue();
+        await Assert.That(result.GeneratedSources[Hint]).DoesNotContain(ReflectiveFallback);
+    }
+
+    /// <summary>Verifies a Indexed collection whose element type has a scalar collection property flattens inline
+    /// (the collection property on the element uses the settings-default CollectionFormat).</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task IndexedWithElementCollectionPropertyGeneratesInline()
+    {
+        var result = Fixture.RunGenerator(IndexedWithSimpleScalarCollectionSource, generatedRequestBuilding: true);
+
+        await Assert.That(result.CompilesWithoutErrors).IsTrue();
+        await Assert.That(result.GeneratedSources[Hint]).DoesNotContain(ReflectiveFallback);
+    }
+
+    /// <summary>Verifies a Indexed collection whose element type has an [AliasAs] property generates inline.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task IndexedWithAliasedPropertyGeneratesInline()
+    {
+        var result = Fixture.RunGenerator(IndexedWithAliasSource, generatedRequestBuilding: true);
+
+        await Assert.That(result.CompilesWithoutErrors).IsTrue();
+        await Assert.That(result.GeneratedSources[Hint]).DoesNotContain(ReflectiveFallback);
+    }
+
+    /// <summary>Verifies the generated source contains indexed key expressions like <c>"items[" + idx + "]"</c>.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task GeneratedSourceContainsIndexedKeyExpression()
+    {
+        var result = Fixture.RunGenerator(NullableIndexedSource, generatedRequestBuilding: true);
+        var generated = result.GeneratedSources[Hint];
+
+        await Assert.That(result.CompilesWithoutErrors).IsTrue();
+
+        await Assert.That(generated).Contains("items[{");
+    }
+
+    /// <summary>Verifies a Indexed parameter whose element type is a scalar (not complex) generates inline
+    /// as a regular <c>Collection</c> shape, not the indexed-object expansion.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task IndexedWithScalarElementGeneratesAsRegularCollection()
+    {
+        const string source =
+            """
+            #nullable enable
+            using System.Collections.Generic;
+            using System.Threading.Tasks;
+            using Refit;
+
+            namespace RefitGeneratorTest;
+
+            public interface IGeneratedClient
+            {
+                [Get("/v")]
+                Task<string> Values([Query(CollectionFormat.Indexed)] List<int> values);
+            }
+            """;
+
+        var result = Fixture.RunGenerator(source, generatedRequestBuilding: true);
+
+        await Assert.That(result.CompilesWithoutErrors).IsTrue();
+
+        // A scalar element has no object properties to flatten — handled as regular Collection inline generation.
+        await Assert.That(result.GeneratedSources[Hint]).DoesNotContain(ReflectiveFallback);
+    }
+}

--- a/src/tests/Refit.GeneratorTests/QueryRequestBuildingLiveTests.Helpers.cs
+++ b/src/tests/Refit.GeneratorTests/QueryRequestBuildingLiveTests.Helpers.cs
@@ -1,0 +1,420 @@
+﻿// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Net;
+using System.Text;
+
+namespace Refit.GeneratorTests;
+/// <summary>
+/// Compiles, loads and invokes generated query request building, asserting the final <see cref="Uri"/> and its
+/// parity with the reflection request builder for every query parameter shape that generates inline.
+/// </summary>
+public sealed partial class QueryRequestBuildingLiveTests
+{
+    /// <summary>Formats every value through the default rules and upper-cases the result.</summary>
+    private sealed class UpperCaseUrlParameterFormatter : DefaultUrlParameterFormatter
+    {
+        /// <inheritdoc/>
+        public override string? Format(
+            object? value,
+            System.Reflection.ICustomAttributeProvider attributeProvider,
+            Type type) =>
+            base.Format(value, attributeProvider, type)?.ToUpperInvariant();
+    }
+
+    /// <summary>Captures each outgoing request and returns a fixed JSON string response.</summary>
+    private sealed class CapturingHandler : HttpMessageHandler
+    {
+        /// <summary>The last request sent through the handler.</summary>
+        private HttpRequestMessage? _lastRequest;
+
+        /// <summary>Gets the body content captured for the last request, or null.</summary>
+        public string? LastContent { get; private set; }
+
+        /// <summary>Takes the last captured request, clearing the slot.</summary>
+        /// <returns>The captured request.</returns>
+        public HttpRequestMessage TakeLastRequest()
+        {
+            var request = _lastRequest ?? throw new InvalidOperationException("No request was captured.");
+            _lastRequest = null;
+            return request;
+        }
+
+        /// <inheritdoc/>
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            _lastRequest = request;
+
+            // Streamed request bodies are disposed with the request, so snapshot the content here.
+            LastContent = request.Content is null
+                ? null
+                : await request.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("\"done\"", Encoding.UTF8, "application/json")
+            };
+        }
+    }
+
+    /// <summary>Hosts one compiled generated client plus the reflection builder for parity assertions.</summary>
+    /// <param name="context">The collectible load context holding the compiled assembly.</param>
+    /// <param name="handler">The capturing message handler.</param>
+    /// <param name="client">The HTTP client shared by both request paths.</param>
+    /// <param name="interfaceType">The compiled Refit interface type.</param>
+    /// <param name="generatedApi">The generated client instance.</param>
+    /// <param name="requestBuilder">The reflection request builder for the compiled interface.</param>
+    private sealed class LiveQueryHarness(
+        CollectibleAssemblyLoadContext context,
+        CapturingHandler handler,
+        HttpClient client,
+        Type interfaceType,
+        object generatedApi,
+        IRequestBuilder requestBuilder) : IDisposable
+    {
+        /// <summary>The base address the relative request URIs resolve against.</summary>
+        private const string BaseAddress = "https://example.test/base/";
+
+        /// <summary>The interface source compiled through the generator for every scenario.</summary>
+        private const string ApiSource =
+            """
+            using System;
+            using System.Collections.Generic;
+            using System.Runtime.Serialization;
+            using System.Threading.Tasks;
+            using Refit;
+
+            namespace Refit.LiveQuery;
+
+            public enum SearchSort
+            {
+                [EnumMember(Value = "date-desc")]
+                DateDescending,
+                Name,
+            }
+
+            public sealed class CreatePayload
+            {
+                public string? Name { get; set; }
+            }
+
+            public sealed class RouteInfo
+            {
+                public string? Slug { get; set; }
+
+                public int Version { get; set; }
+            }
+
+            public sealed class NestedCustomer
+            {
+                public string? Id { get; set; }
+            }
+
+            public sealed class NestedOrder
+            {
+                public NestedCustomer? Customer { get; set; }
+
+                public string? Note { get; set; }
+            }
+
+            public sealed class RouteToken
+            {
+                public string? Value { get; set; }
+
+                public override string ToString() => Value ?? string.Empty;
+            }
+
+            public sealed class Bounds
+            {
+                public int Min { get; set; }
+
+                public int Max { get; set; }
+
+                public override string ToString() => Min + ".." + Max;
+            }
+
+            public sealed class RangeQuery
+            {
+                [Query(Format = "g")]
+                public Bounds? Window { get; set; }
+            }
+
+            // Deliberately not sealed: exercises the concrete (non-sealed) declared-type flatten. The test value is not a
+            // subtype, so the declared-type flatten matches the reflection builder's runtime-type flatten exactly.
+            public class Facet
+            {
+                public string? Name { get; set; }
+
+                public int Count { get; set; }
+            }
+
+            // The HTTP QUERY method (currently a draft standard): a custom verb attribute carrying a body.
+            public sealed class QueryVerbAttribute : HttpMethodAttribute
+            {
+                public QueryVerbAttribute(string path) : base(path) { }
+
+                public override System.Net.Http.HttpMethod Method => new System.Net.Http.HttpMethod("QUERY");
+            }
+
+            public sealed class Item
+            {
+                public int Id { get; set; }
+
+                public string? Value { get; set; }
+            }
+
+            public interface ILiveQueryApi
+            {
+                [Get("/search")]
+                Task<string> Plain(string q);
+
+                [Get("/token/{token}")]
+                Task<string> TokenPath(RouteToken token);
+
+                [Get("/docs/{info.Slug}/rev/{info.Version}")]
+                Task<string> DottedPath(RouteInfo info);
+
+                [Get("/tags/{info.Slug}")]
+                Task<string> DottedPathResidual(RouteInfo info);
+
+                [Get("/orders/{order.Customer.Id}")]
+                Task<string> NestedPath(NestedOrder order);
+
+                [Get("/signin")]
+                Task<string> Alias([AliasAs("login")] string user, [AliasAs("kind")] string kind);
+
+                [Get("/multi")]
+                Task<string> Multiple(string a, int b, bool c);
+
+                [Get("/nullskip")]
+                Task<string> NullSkip(string? a, string b);
+
+                [Get("/fmt")]
+                Task<string> Formatted([Query(Format = "0.00")] double price);
+
+                [Get("/csv")]
+                Task<string> Csv([Query(CollectionFormat.Csv)] int[] ids);
+
+                [Get("/expand")]
+                Task<string> Expanded([Query(CollectionFormat.Multi)] int[] ids);
+
+                [Get("/pipes")]
+                Task<string> Pipes([Query(CollectionFormat.Pipes)] string[] values);
+
+                [Get("/list")]
+                Task<string> DefaultList(List<int> ids);
+
+                [Get("/enum")]
+                Task<string> Sorted(SearchSort sort);
+
+                [Get("/page")]
+                Task<string> Paged(int? page);
+
+                [Get("/big")]
+                Task<string> Big(long id);
+
+                [Get("/treat")]
+                Task<string> Treated([Query(TreatAsString = true)] double raw);
+
+                [Get("/tmpl?fixed=1")]
+                Task<string> Templated(string extra);
+
+                [QueryUriFormat(UriFormat.Unescaped)]
+                [Get("/soql")]
+                Task<string> UnescapedQuery(string q);
+
+                [Get("/range")]
+                Task<string> RangeSearch([Query] RangeQuery query);
+
+                [Get("/facets")]
+                Task<string> Facets(Dictionary<string, Facet> facets);
+
+                [QueryVerb("/documents")]
+                Task<string> QueryDocuments([Body] CreatePayload body);
+
+                [QueryVerb("/rows")]
+                Task<string> QueryRows([Query] RangeQuery filter);
+
+                [Get("/when")]
+                Task<string> When(DateTimeOffset at);
+
+                [Post("/create")]
+                Task<string> Create(CreatePayload payload, string tag);
+
+                [Get("/flags")]
+                Task<string> Flag([QueryName] string flag);
+
+                [Get("/flags/many")]
+                Task<string> Flags([QueryName] string[] flags);
+
+                [Get("/encq")]
+                Task<string> EncodedQuery([Encoded] string v);
+
+                [Get("/encp/{id}")]
+                Task<string> EncodedPath([Encoded] string id);
+
+                [Get("/cal/{**rest}")]
+                Task<string> EncodedRoundTrip([Encoded] string rest);
+
+                [Get("/push/{deviceId}/{notifMsgId?}")]
+                Task<string> TrailingOptional(string deviceId, string? notifMsgId);
+
+                [Get("/indexed")]
+                Task<string> IndexedSearch([Query(CollectionFormat.Indexed)] List<Item>? items);
+            }
+            """;
+
+        /// <summary>Gets the body content captured for the most recent request, or null.</summary>
+        public string? LastCapturedContent => handler.LastContent;
+
+        /// <summary>Compiles the scenario interface and creates the generated and reflection clients.</summary>
+        /// <param name="settings">The Refit settings, or null for defaults.</param>
+        /// <returns>The live harness.</returns>
+        [RequiresUnreferencedCode("Loads a generated assembly and reflects over generated types and members.")]
+        public static LiveQueryHarness Create(RefitSettings? settings = null)
+        {
+            settings ??= new RefitSettings();
+            var result = Fixture.RunGenerator(ApiSource, generatedRequestBuilding: true);
+            if (!result.CompilesWithoutErrors)
+            {
+                throw new InvalidOperationException(
+                    "Generated compilation failed: " + string.Join(Environment.NewLine, result.CompilationErrors));
+            }
+
+            var (assembly, loadContext) = Fixture.EmitAndLoad(result);
+            var interfaceType = assembly.GetType("Refit.LiveQuery.ILiveQueryApi", throwOnError: true)!;
+            var generatedType = assembly
+                .GetTypes()
+                .Single(type => type.IsClass && interfaceType.IsAssignableFrom(type));
+
+            var handler = new CapturingHandler();
+            var client = new HttpClient(handler) { BaseAddress = new(BaseAddress) };
+            var requestBuilder = RequestBuilder.ForType(interfaceType, settings);
+            var generatedApi = Activator.CreateInstance(generatedType, [client, requestBuilder])!;
+            return new(loadContext, handler, client, interfaceType, generatedApi, requestBuilder);
+        }
+
+        /// <summary>Creates a compiled scenario enum value from its underlying value.</summary>
+        /// <param name="typeName">The compiled enum type's full name.</param>
+        /// <param name="value">The underlying enum value.</param>
+        /// <returns>The boxed enum value.</returns>
+        [RequiresUnreferencedCode("Reflects over generated types and members.")]
+        public object CreateEnumValue(string typeName, int value) =>
+            Enum.ToObject(interfaceType.Assembly.GetType(typeName, throwOnError: true)!, value);
+
+        /// <summary>Creates an instance of a compiled scenario type with the given properties assigned.</summary>
+        /// <param name="typeName">The compiled type's full name.</param>
+        /// <param name="properties">The property name/value pairs to assign.</param>
+        /// <returns>The created instance.</returns>
+        [RequiresUnreferencedCode("Reflects over generated types and members.")]
+        public object CreateApiValue(string typeName, params (string Name, object? Value)[] properties)
+        {
+            var type = interfaceType.Assembly.GetType(typeName, throwOnError: true)!;
+            var instance = Activator.CreateInstance(type)!;
+            foreach (var (name, value) in properties)
+            {
+                type.GetProperty(name)!.SetValue(instance, value);
+            }
+
+            return instance;
+        }
+
+        /// <summary>Creates a <c>Dictionary&lt;string, TValue&gt;</c> of a compiled scenario value type.</summary>
+        /// <param name="valueTypeName">The compiled value type's full name.</param>
+        /// <param name="entries">The key/value entries to add.</param>
+        /// <returns>The created dictionary.</returns>
+        [RequiresUnreferencedCode("Reflects over generated types and members.")]
+        [RequiresDynamicCode("Constructs a closed Dictionary type over the compiled scenario value type.")]
+        public object CreateStringKeyedDictionary(string valueTypeName, params (string Key, object? Value)[] entries)
+        {
+            var valueType = interfaceType.Assembly.GetType(valueTypeName, throwOnError: true)!;
+            var dictionaryType = typeof(Dictionary<,>).MakeGenericType(typeof(string), valueType);
+            var dictionary = Activator.CreateInstance(dictionaryType)!;
+            var add = dictionaryType.GetMethod("Add")!;
+            foreach (var (key, value) in entries)
+            {
+                _ = add.Invoke(dictionary, [key, value]);
+            }
+
+            return dictionary;
+        }
+
+        /// <summary>Creates a <c>List&lt;TValue&gt;</c> of a compiled scenario value type.</summary>
+        /// <param name="valueTypeName">The compiled value type's full name.</param>
+        /// <param name="items">The items to add to the list.</param>
+        /// <returns>The created list instance.</returns>
+        [RequiresUnreferencedCode("Reflects over generated types and members.")]
+        [RequiresDynamicCode("Constructs a closed List type over the compiled scenario value type.")]
+        public object CreateApiList(string valueTypeName, params object?[] items)
+        {
+            var valueType = interfaceType.Assembly.GetType(valueTypeName, throwOnError: true)!;
+            var listType = typeof(List<>).MakeGenericType(valueType);
+            var list = Activator.CreateInstance(listType)!;
+            var add = listType.GetMethod("Add")!;
+            foreach (var item in items)
+            {
+                _ = add.Invoke(list, [item]);
+            }
+
+            return list;
+        }
+
+        /// <summary>Invokes a method on the generated client and asserts the captured relative URI.</summary>
+        /// <param name="methodName">The interface method name.</param>
+        /// <param name="args">The argument values.</param>
+        /// <param name="expectedPathAndQuery">The expected path and query, or null to skip the assertion.</param>
+        /// <returns>The captured request.</returns>
+        [RequiresUnreferencedCode("Reflects over generated types and members.")]
+        public async Task<HttpRequestMessage> InvokeGeneratedAsync(
+            string methodName,
+            object?[] args,
+            string? expectedPathAndQuery)
+        {
+            var task = (Task)interfaceType.GetMethod(methodName)!.Invoke(generatedApi, args)!;
+            await task.ConfigureAwait(false);
+            var request = handler.TakeLastRequest();
+            if (expectedPathAndQuery is not null)
+            {
+                await Assert.That(request.RequestUri!.PathAndQuery).IsEqualTo(expectedPathAndQuery);
+            }
+
+            return request;
+        }
+
+        /// <summary>Invokes a method through both request paths and asserts the URIs are identical.</summary>
+        /// <param name="methodName">The interface method name.</param>
+        /// <param name="args">The argument values.</param>
+        /// <param name="expectedPathAndQuery">The expected path and query, or null to only assert parity.</param>
+        /// <returns>The request captured from the generated path.</returns>
+        [RequiresUnreferencedCode("Reflects over generated types and members.")]
+        [RequiresDynamicCode("Builds the reflection request delegate for parity comparison.")]
+        public async Task<HttpRequestMessage> AssertParityAsync(
+            string methodName,
+            object?[] args,
+            string? expectedPathAndQuery)
+        {
+            var generatedRequest = await InvokeGeneratedAsync(methodName, args, expectedPathAndQuery).ConfigureAwait(false);
+
+            var reflectionFunc = requestBuilder.BuildRestResultFuncForMethod(methodName);
+            var reflectionTask = (Task)reflectionFunc(client, args!)!;
+            await reflectionTask.ConfigureAwait(false);
+            var reflectionRequest = handler.TakeLastRequest();
+
+            await Assert.That(generatedRequest.Method).IsEqualTo(reflectionRequest.Method);
+            await Assert.That(generatedRequest.RequestUri!.AbsoluteUri)
+                .IsEqualTo(reflectionRequest.RequestUri!.AbsoluteUri);
+            return generatedRequest;
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            client.Dispose();
+            handler.Dispose();
+            context.Dispose();
+        }
+    }
+}

--- a/src/tests/Refit.GeneratorTests/QueryRequestBuildingLiveTests.Helpers.cs
+++ b/src/tests/Refit.GeneratorTests/QueryRequestBuildingLiveTests.Helpers.cs
@@ -83,6 +83,7 @@ public sealed partial class QueryRequestBuildingLiveTests
             using System.Collections.Generic;
             using System.Runtime.Serialization;
             using System.Threading.Tasks;
+            using System.Text.Json.Serialization;
             using Refit;
 
             namespace Refit.LiveQuery;
@@ -172,6 +173,12 @@ public sealed partial class QueryRequestBuildingLiveTests
                 public int Id { get; set; }
 
                 public string? Value { get; set; }
+            }
+            public sealed class Name
+            {
+                [JsonPropertyName("First Name")]
+                public string? FirstName { get; set; }
+                public string? LastName { get; set; }
             }
 
             public interface ILiveQueryApi
@@ -275,6 +282,12 @@ public sealed partial class QueryRequestBuildingLiveTests
 
                 [Get("/indexed")]
                 Task<string> IndexedSearch([Query(CollectionFormat.Indexed)] List<Item>? items);
+
+                [Get("/indexedListInt")]
+                Task<string> IndexedListSearch([Query(CollectionFormat.Indexed)] List<int>? items);
+
+                [Get("/indexedNameWithSerialized")]
+                Task<string> indexedNameWithSerialized([Query(CollectionFormat.Indexed)] List<Name>? items);
             }
             """;
 

--- a/src/tests/Refit.GeneratorTests/QueryRequestBuildingLiveTests.Helpers.cs
+++ b/src/tests/Refit.GeneratorTests/QueryRequestBuildingLiveTests.Helpers.cs
@@ -7,10 +7,8 @@ using System.Net;
 using System.Text;
 
 namespace Refit.GeneratorTests;
-/// <summary>
-/// Compiles, loads and invokes generated query request building, asserting the final <see cref="Uri"/> and its
-/// parity with the reflection request builder for every query parameter shape that generates inline.
-/// </summary>
+
+/// <summary> Helpers used on any QueryRequestBuildingLiveTests.</summary>
 public sealed partial class QueryRequestBuildingLiveTests
 {
     /// <summary>Formats every value through the default rules and upper-cases the result.</summary>

--- a/src/tests/Refit.GeneratorTests/QueryRequestBuildingLiveTests.Helpers.cs
+++ b/src/tests/Refit.GeneratorTests/QueryRequestBuildingLiveTests.Helpers.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
 // ReactiveUI and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
@@ -7,10 +7,8 @@ using System.Net;
 using System.Text;
 
 namespace Refit.GeneratorTests;
-/// <summary>
-/// Compiles, loads and invokes generated query request building, asserting the final <see cref="Uri"/> and its
-/// parity with the reflection request builder for every query parameter shape that generates inline.
-/// </summary>
+
+/// <summary> Helpers used on any QueryRequestBuildingLiveTests.</summary>
 public sealed partial class QueryRequestBuildingLiveTests
 {
     /// <summary>Formats every value through the default rules and upper-cases the result.</summary>

--- a/src/tests/Refit.GeneratorTests/QueryRequestBuildingLiveTests.cs
+++ b/src/tests/Refit.GeneratorTests/QueryRequestBuildingLiveTests.cs
@@ -278,7 +278,21 @@ public sealed partial class QueryRequestBuildingLiveTests
         await harness.AssertParityAsync(indexedSearchMethodName, [null], "/base/indexed");
         var item0 = harness.CreateApiValue(typeName, (id, 1), (value, "a"));
         var indexedList = harness.CreateApiList(typeName, item0);
-        _ = await harness.AssertParityAsync(indexedSearchMethodName, [indexedList], $"/base/indexed?{parameter}[0].{id}=1&{parameter}[0].{value}=a");
+        await harness.AssertParityAsync(indexedSearchMethodName, [indexedList], $"/base/indexed?{parameter}[0].{id}=1&{parameter}[0].{value}=a");
+
+        const string indexedSearchWithListIntMethodName = "IndexedListSearch";
+        await harness.AssertParityAsync(indexedSearchWithListIntMethodName, [null], "/base/indexedListInt");
+        List<int> values = [1, 2];
+        await harness.AssertParityAsync(indexedSearchWithListIntMethodName, [values], $"/base/indexedListInt?{parameter}=1%2C2");
+
+        const string name = "FirstName";
+        const string jsonPropertyName = "First%20Name";
+        const string lastName = "LastName";
+        const string indexedSearchSerialized = "indexedNameWithSerialized";
+        const string typeNameSerialized = "Refit.LiveQuery.Name";
+        var nameSerialized = harness.CreateApiValue(typeNameSerialized, (name, "John"), (lastName, "Doe"));
+        var indexedNameSerialized = harness.CreateApiList(typeNameSerialized, nameSerialized);
+        await harness.AssertParityAsync(indexedSearchSerialized, [indexedNameSerialized], $"/base/indexedNameWithSerialized?{parameter}[0].{jsonPropertyName}=John&{parameter}[0].{lastName}=Doe");
     }
 
     /// <summary>Verifies a custom URL parameter formatter still runs for every generated value.</summary>

--- a/src/tests/Refit.GeneratorTests/QueryRequestBuildingLiveTests.cs
+++ b/src/tests/Refit.GeneratorTests/QueryRequestBuildingLiveTests.cs
@@ -48,9 +48,6 @@ public sealed partial class QueryRequestBuildingLiveTests
     /// <summary>The upper bound of the formatted complex query-object property scenario.</summary>
     private const int WindowMax = 9;
 
-    /// <summary>The full type name of the <c>Item</c> scenario type used by the Indexed test.</summary>
-    private const string IndexedItemTypeName = "Refit.LiveQuery.Item";
-
     /// <summary>Csv-joined identifiers.</summary>
     private static readonly int[] CsvIds = [1, 2, 3];
 
@@ -273,13 +270,14 @@ public sealed partial class QueryRequestBuildingLiveTests
     {
         using var harness = LiveQueryHarness.Create();
 
-        const string id = "id";
-        const string value = "value";
+        const string id = "Id";
+        const string value = "Value";
         const string parameter = "items";
         const string indexedSearchMethodName = "IndexedSearch";
+        const string typeName = "Refit.LiveQuery.Item";
         await harness.AssertParityAsync(indexedSearchMethodName, [null], "/base/indexed");
-        var item0 = harness.CreateApiValue(IndexedItemTypeName, (id, 1), (value, "a"));
-        var indexedList = harness.CreateApiList(IndexedItemTypeName, item0);
+        var item0 = harness.CreateApiValue(typeName, (id, 1), (value, "a"));
+        var indexedList = harness.CreateApiList(typeName, item0);
         _ = await harness.AssertParityAsync(indexedSearchMethodName, [indexedList], $"/base/indexed?{parameter}[0].{id}=1&{parameter}[0].{value}=a");
     }
 

--- a/src/tests/Refit.GeneratorTests/QueryRequestBuildingLiveTests.cs
+++ b/src/tests/Refit.GeneratorTests/QueryRequestBuildingLiveTests.cs
@@ -50,6 +50,21 @@ public sealed partial class QueryRequestBuildingLiveTests
     /// <summary>The upper bound of the formatted complex query-object property scenario.</summary>
     private const int WindowMax = 9;
 
+    /// <summary>The method name for the Indexed collection scenario.</summary>
+    private const string IndexedSearchMethodName = "IndexedSearch";
+
+    /// <summary>The full type name of the <c>Item</c> scenario type used by the Indexed test.</summary>
+    private const string IndexedItemTypeName = "Refit.LiveQuery.Item";
+
+    /// <summary>The name of the Indexed parameter.</summary>
+    private const string IndexedParameterName = "items";
+
+    /// <summary>The name of the Id property on <c>Item</c>.</summary>
+    private const string IndexedIdPropertyName = "Id";
+
+    /// <summary>The name of the Value property on <c>Item</c>.</summary>
+    private const string IndexedValuePropertyName = "Value";
+
     /// <summary>Csv-joined identifiers.</summary>
     private static readonly int[] CsvIds = [1, 2, 3];
 
@@ -242,6 +257,14 @@ public sealed partial class QueryRequestBuildingLiveTests
         await harness.AssertParityAsync("DefaultList", [ListIds], "/base/list?ids=4%2C5");
         await harness.AssertParityAsync("Csv", [EmptyIds], "/base/csv?ids=");
         await harness.AssertParityAsync(ExpandedMethodName, [EmptyIds], "/base/expand");
+
+        const string id = IndexedIdPropertyName;
+        const string value = IndexedValuePropertyName;
+        const string parameter = IndexedParameterName;
+        await harness.AssertParityAsync(IndexedSearchMethodName, [null], "/base/indexed");
+        var item0 = harness.CreateApiValue(IndexedItemTypeName, (id, 1), (value, "a"));
+        var indexedList = harness.CreateApiList(IndexedItemTypeName, item0);
+        await harness.AssertParityAsync(IndexedSearchMethodName, [indexedList], $"/base/indexed?{parameter}%5B0%5D.{id}=1&{parameter}%5B0%5D.{value}=a");
     }
 
     /// <summary>Verifies a custom URL parameter formatter still runs for every generated value.</summary>
@@ -417,6 +440,13 @@ public sealed partial class QueryRequestBuildingLiveTests
                 public override System.Net.Http.HttpMethod Method => new System.Net.Http.HttpMethod("QUERY");
             }
 
+            public sealed class Item
+            {
+                public int Id { get; set; }
+
+                public string? Value { get; set; }
+            }
+
             public interface ILiveQueryApi
             {
                 [Get("/search")]
@@ -512,6 +542,9 @@ public sealed partial class QueryRequestBuildingLiveTests
 
                 [Get("/push/{deviceId}/{notifMsgId?}")]
                 Task<string> TrailingOptional(string deviceId, string? notifMsgId);
+
+                [Get("/indexed")]
+                Task<string> IndexedSearch([Query(CollectionFormat.Indexed)] List<Item>? items);
             }
             """;
 
@@ -588,6 +621,26 @@ public sealed partial class QueryRequestBuildingLiveTests
             }
 
             return dictionary;
+        }
+
+        /// <summary>Creates a <c>List&lt;TValue&gt;</c> of a compiled scenario value type.</summary>
+        /// <param name="valueTypeName">The compiled value type's full name.</param>
+        /// <param name="items">The items to add to the list.</param>
+        /// <returns>The created list instance.</returns>
+        [RequiresUnreferencedCode("Reflects over generated types and members.")]
+        [RequiresDynamicCode("Constructs a closed List type over the compiled scenario value type.")]
+        public object CreateApiList(string valueTypeName, params object?[] items)
+        {
+            var valueType = interfaceType.Assembly.GetType(valueTypeName, throwOnError: true)!;
+            var listType = typeof(List<>).MakeGenericType(valueType);
+            var list = Activator.CreateInstance(listType)!;
+            var add = listType.GetMethod("Add")!;
+            foreach (var item in items)
+            {
+                _ = add.Invoke(list, [item]);
+            }
+
+            return list;
         }
 
         /// <summary>Invokes a method on the generated client and asserts the captured relative URI.</summary>

--- a/src/tests/Refit.GeneratorTests/QueryRequestBuildingLiveTests.cs
+++ b/src/tests/Refit.GeneratorTests/QueryRequestBuildingLiveTests.cs
@@ -3,8 +3,6 @@
 // See the LICENSE file in the project root for full license information.
 
 using System.Diagnostics.CodeAnalysis;
-using System.Net;
-using System.Text;
 
 namespace Refit.GeneratorTests;
 
@@ -50,20 +48,8 @@ public sealed partial class QueryRequestBuildingLiveTests
     /// <summary>The upper bound of the formatted complex query-object property scenario.</summary>
     private const int WindowMax = 9;
 
-    /// <summary>The method name for the Indexed collection scenario.</summary>
-    private const string IndexedSearchMethodName = "IndexedSearch";
-
     /// <summary>The full type name of the <c>Item</c> scenario type used by the Indexed test.</summary>
     private const string IndexedItemTypeName = "Refit.LiveQuery.Item";
-
-    /// <summary>The name of the Indexed parameter.</summary>
-    private const string IndexedParameterName = "items";
-
-    /// <summary>The name of the Id property on <c>Item</c>.</summary>
-    private const string IndexedIdPropertyName = "Id";
-
-    /// <summary>The name of the Value property on <c>Item</c>.</summary>
-    private const string IndexedValuePropertyName = "Value";
 
     /// <summary>Csv-joined identifiers.</summary>
     private static readonly int[] CsvIds = [1, 2, 3];
@@ -257,14 +243,25 @@ public sealed partial class QueryRequestBuildingLiveTests
         await harness.AssertParityAsync("DefaultList", [ListIds], "/base/list?ids=4%2C5");
         await harness.AssertParityAsync("Csv", [EmptyIds], "/base/csv?ids=");
         await harness.AssertParityAsync(ExpandedMethodName, [EmptyIds], "/base/expand");
+    }
 
-        const string id = IndexedIdPropertyName;
-        const string value = IndexedValuePropertyName;
-        const string parameter = IndexedParameterName;
-        await harness.AssertParityAsync(IndexedSearchMethodName, [null], "/base/indexed");
+    /// <summary>Verifies generated query URIs match the reflection builder for collection expansion.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    [RequiresUnreferencedCode("Loads a generated assembly and reflects over generated types and members.")]
+    [RequiresDynamicCode("Compares generated request building against the reflection request builder.")]
+    public async Task IndexedCollectionQueryParametersMatchReflection()
+    {
+        using var harness = LiveQueryHarness.Create();
+
+        const string id = "id";
+        const string value = "value";
+        const string parameter = "items";
+        const string indexedSearchMethodName = "IndexedSearch";
+        await harness.AssertParityAsync(indexedSearchMethodName, [null], "/base/indexed");
         var item0 = harness.CreateApiValue(IndexedItemTypeName, (id, 1), (value, "a"));
         var indexedList = harness.CreateApiList(IndexedItemTypeName, item0);
-        await harness.AssertParityAsync(IndexedSearchMethodName, [indexedList], $"/base/indexed?{parameter}%5B0%5D.{id}=1&{parameter}%5B0%5D.{value}=a");
+        _ = await harness.AssertParityAsync(indexedSearchMethodName, [indexedList], $"/base/indexed?{parameter}[0].{id}=1&{parameter}[0].{value}=a");
     }
 
     /// <summary>Verifies a custom URL parameter formatter still runs for every generated value.</summary>
@@ -328,410 +325,5 @@ public sealed partial class QueryRequestBuildingLiveTests
             "EncodedRoundTrip",
             ["9000/events/3bf@zoho.com"],
             "/base/cal/9000/events/3bf@zoho.com");
-    }
-
-    /// <summary>Formats every value through the default rules and upper-cases the result.</summary>
-    private sealed class UpperCaseUrlParameterFormatter : DefaultUrlParameterFormatter
-    {
-        /// <inheritdoc/>
-        public override string? Format(
-            object? value,
-            System.Reflection.ICustomAttributeProvider attributeProvider,
-            Type type) =>
-            base.Format(value, attributeProvider, type)?.ToUpperInvariant();
-    }
-
-    /// <summary>Hosts one compiled generated client plus the reflection builder for parity assertions.</summary>
-    /// <param name="context">The collectible load context holding the compiled assembly.</param>
-    /// <param name="handler">The capturing message handler.</param>
-    /// <param name="client">The HTTP client shared by both request paths.</param>
-    /// <param name="interfaceType">The compiled Refit interface type.</param>
-    /// <param name="generatedApi">The generated client instance.</param>
-    /// <param name="requestBuilder">The reflection request builder for the compiled interface.</param>
-    private sealed class LiveQueryHarness(
-        CollectibleAssemblyLoadContext context,
-        CapturingHandler handler,
-        HttpClient client,
-        Type interfaceType,
-        object generatedApi,
-        IRequestBuilder requestBuilder) : IDisposable
-    {
-        /// <summary>The base address the relative request URIs resolve against.</summary>
-        private const string BaseAddress = "https://example.test/base/";
-
-        /// <summary>The interface source compiled through the generator for every scenario.</summary>
-        private const string ApiSource =
-            """
-            using System;
-            using System.Collections.Generic;
-            using System.Runtime.Serialization;
-            using System.Threading.Tasks;
-            using Refit;
-
-            namespace Refit.LiveQuery;
-
-            public enum SearchSort
-            {
-                [EnumMember(Value = "date-desc")]
-                DateDescending,
-                Name,
-            }
-
-            public sealed class CreatePayload
-            {
-                public string? Name { get; set; }
-            }
-
-            public sealed class RouteInfo
-            {
-                public string? Slug { get; set; }
-
-                public int Version { get; set; }
-            }
-
-            public sealed class NestedCustomer
-            {
-                public string? Id { get; set; }
-            }
-
-            public sealed class NestedOrder
-            {
-                public NestedCustomer? Customer { get; set; }
-
-                public string? Note { get; set; }
-            }
-
-            public sealed class RouteToken
-            {
-                public string? Value { get; set; }
-
-                public override string ToString() => Value ?? string.Empty;
-            }
-
-            public sealed class Bounds
-            {
-                public int Min { get; set; }
-
-                public int Max { get; set; }
-
-                public override string ToString() => Min + ".." + Max;
-            }
-
-            public sealed class RangeQuery
-            {
-                [Query(Format = "g")]
-                public Bounds? Window { get; set; }
-            }
-
-            // Deliberately not sealed: exercises the concrete (non-sealed) declared-type flatten. The test value is not a
-            // subtype, so the declared-type flatten matches the reflection builder's runtime-type flatten exactly.
-            public class Facet
-            {
-                public string? Name { get; set; }
-
-                public int Count { get; set; }
-            }
-
-            // The HTTP QUERY method (currently a draft standard): a custom verb attribute carrying a body.
-            public sealed class QueryVerbAttribute : HttpMethodAttribute
-            {
-                public QueryVerbAttribute(string path) : base(path) { }
-
-                public override System.Net.Http.HttpMethod Method => new System.Net.Http.HttpMethod("QUERY");
-            }
-
-            public sealed class Item
-            {
-                public int Id { get; set; }
-
-                public string? Value { get; set; }
-            }
-
-            public interface ILiveQueryApi
-            {
-                [Get("/search")]
-                Task<string> Plain(string q);
-
-                [Get("/token/{token}")]
-                Task<string> TokenPath(RouteToken token);
-
-                [Get("/docs/{info.Slug}/rev/{info.Version}")]
-                Task<string> DottedPath(RouteInfo info);
-
-                [Get("/tags/{info.Slug}")]
-                Task<string> DottedPathResidual(RouteInfo info);
-
-                [Get("/orders/{order.Customer.Id}")]
-                Task<string> NestedPath(NestedOrder order);
-
-                [Get("/signin")]
-                Task<string> Alias([AliasAs("login")] string user, [AliasAs("kind")] string kind);
-
-                [Get("/multi")]
-                Task<string> Multiple(string a, int b, bool c);
-
-                [Get("/nullskip")]
-                Task<string> NullSkip(string? a, string b);
-
-                [Get("/fmt")]
-                Task<string> Formatted([Query(Format = "0.00")] double price);
-
-                [Get("/csv")]
-                Task<string> Csv([Query(CollectionFormat.Csv)] int[] ids);
-
-                [Get("/expand")]
-                Task<string> Expanded([Query(CollectionFormat.Multi)] int[] ids);
-
-                [Get("/pipes")]
-                Task<string> Pipes([Query(CollectionFormat.Pipes)] string[] values);
-
-                [Get("/list")]
-                Task<string> DefaultList(List<int> ids);
-
-                [Get("/enum")]
-                Task<string> Sorted(SearchSort sort);
-
-                [Get("/page")]
-                Task<string> Paged(int? page);
-
-                [Get("/big")]
-                Task<string> Big(long id);
-
-                [Get("/treat")]
-                Task<string> Treated([Query(TreatAsString = true)] double raw);
-
-                [Get("/tmpl?fixed=1")]
-                Task<string> Templated(string extra);
-
-                [QueryUriFormat(UriFormat.Unescaped)]
-                [Get("/soql")]
-                Task<string> UnescapedQuery(string q);
-
-                [Get("/range")]
-                Task<string> RangeSearch([Query] RangeQuery query);
-
-                [Get("/facets")]
-                Task<string> Facets(Dictionary<string, Facet> facets);
-
-                [QueryVerb("/documents")]
-                Task<string> QueryDocuments([Body] CreatePayload body);
-
-                [QueryVerb("/rows")]
-                Task<string> QueryRows([Query] RangeQuery filter);
-
-                [Get("/when")]
-                Task<string> When(DateTimeOffset at);
-
-                [Post("/create")]
-                Task<string> Create(CreatePayload payload, string tag);
-
-                [Get("/flags")]
-                Task<string> Flag([QueryName] string flag);
-
-                [Get("/flags/many")]
-                Task<string> Flags([QueryName] string[] flags);
-
-                [Get("/encq")]
-                Task<string> EncodedQuery([Encoded] string v);
-
-                [Get("/encp/{id}")]
-                Task<string> EncodedPath([Encoded] string id);
-
-                [Get("/cal/{**rest}")]
-                Task<string> EncodedRoundTrip([Encoded] string rest);
-
-                [Get("/push/{deviceId}/{notifMsgId?}")]
-                Task<string> TrailingOptional(string deviceId, string? notifMsgId);
-
-                [Get("/indexed")]
-                Task<string> IndexedSearch([Query(CollectionFormat.Indexed)] List<Item>? items);
-            }
-            """;
-
-        /// <summary>Gets the body content captured for the most recent request, or null.</summary>
-        public string? LastCapturedContent => handler.LastContent;
-
-        /// <summary>Compiles the scenario interface and creates the generated and reflection clients.</summary>
-        /// <param name="settings">The Refit settings, or null for defaults.</param>
-        /// <returns>The live harness.</returns>
-        [RequiresUnreferencedCode("Loads a generated assembly and reflects over generated types and members.")]
-        public static LiveQueryHarness Create(RefitSettings? settings = null)
-        {
-            settings ??= new RefitSettings();
-            var result = Fixture.RunGenerator(ApiSource, generatedRequestBuilding: true);
-            if (!result.CompilesWithoutErrors)
-            {
-                throw new InvalidOperationException(
-                    "Generated compilation failed: " + string.Join(Environment.NewLine, result.CompilationErrors));
-            }
-
-            var (assembly, loadContext) = Fixture.EmitAndLoad(result);
-            var interfaceType = assembly.GetType("Refit.LiveQuery.ILiveQueryApi", throwOnError: true)!;
-            var generatedType = assembly
-                .GetTypes()
-                .Single(type => type.IsClass && interfaceType.IsAssignableFrom(type));
-
-            var handler = new CapturingHandler();
-            var client = new HttpClient(handler) { BaseAddress = new(BaseAddress) };
-            var requestBuilder = RequestBuilder.ForType(interfaceType, settings);
-            var generatedApi = Activator.CreateInstance(generatedType, [client, requestBuilder])!;
-            return new(loadContext, handler, client, interfaceType, generatedApi, requestBuilder);
-        }
-
-        /// <summary>Creates a compiled scenario enum value from its underlying value.</summary>
-        /// <param name="typeName">The compiled enum type's full name.</param>
-        /// <param name="value">The underlying enum value.</param>
-        /// <returns>The boxed enum value.</returns>
-        [RequiresUnreferencedCode("Reflects over generated types and members.")]
-        public object CreateEnumValue(string typeName, int value) =>
-            Enum.ToObject(interfaceType.Assembly.GetType(typeName, throwOnError: true)!, value);
-
-        /// <summary>Creates an instance of a compiled scenario type with the given properties assigned.</summary>
-        /// <param name="typeName">The compiled type's full name.</param>
-        /// <param name="properties">The property name/value pairs to assign.</param>
-        /// <returns>The created instance.</returns>
-        [RequiresUnreferencedCode("Reflects over generated types and members.")]
-        public object CreateApiValue(string typeName, params (string Name, object? Value)[] properties)
-        {
-            var type = interfaceType.Assembly.GetType(typeName, throwOnError: true)!;
-            var instance = Activator.CreateInstance(type)!;
-            foreach (var (name, value) in properties)
-            {
-                type.GetProperty(name)!.SetValue(instance, value);
-            }
-
-            return instance;
-        }
-
-        /// <summary>Creates a <c>Dictionary&lt;string, TValue&gt;</c> of a compiled scenario value type.</summary>
-        /// <param name="valueTypeName">The compiled value type's full name.</param>
-        /// <param name="entries">The key/value entries to add.</param>
-        /// <returns>The created dictionary.</returns>
-        [RequiresUnreferencedCode("Reflects over generated types and members.")]
-        [RequiresDynamicCode("Constructs a closed Dictionary type over the compiled scenario value type.")]
-        public object CreateStringKeyedDictionary(string valueTypeName, params (string Key, object? Value)[] entries)
-        {
-            var valueType = interfaceType.Assembly.GetType(valueTypeName, throwOnError: true)!;
-            var dictionaryType = typeof(Dictionary<,>).MakeGenericType(typeof(string), valueType);
-            var dictionary = Activator.CreateInstance(dictionaryType)!;
-            var add = dictionaryType.GetMethod("Add")!;
-            foreach (var (key, value) in entries)
-            {
-                _ = add.Invoke(dictionary, [key, value]);
-            }
-
-            return dictionary;
-        }
-
-        /// <summary>Creates a <c>List&lt;TValue&gt;</c> of a compiled scenario value type.</summary>
-        /// <param name="valueTypeName">The compiled value type's full name.</param>
-        /// <param name="items">The items to add to the list.</param>
-        /// <returns>The created list instance.</returns>
-        [RequiresUnreferencedCode("Reflects over generated types and members.")]
-        [RequiresDynamicCode("Constructs a closed List type over the compiled scenario value type.")]
-        public object CreateApiList(string valueTypeName, params object?[] items)
-        {
-            var valueType = interfaceType.Assembly.GetType(valueTypeName, throwOnError: true)!;
-            var listType = typeof(List<>).MakeGenericType(valueType);
-            var list = Activator.CreateInstance(listType)!;
-            var add = listType.GetMethod("Add")!;
-            foreach (var item in items)
-            {
-                _ = add.Invoke(list, [item]);
-            }
-
-            return list;
-        }
-
-        /// <summary>Invokes a method on the generated client and asserts the captured relative URI.</summary>
-        /// <param name="methodName">The interface method name.</param>
-        /// <param name="args">The argument values.</param>
-        /// <param name="expectedPathAndQuery">The expected path and query, or null to skip the assertion.</param>
-        /// <returns>The captured request.</returns>
-        [RequiresUnreferencedCode("Reflects over generated types and members.")]
-        public async Task<HttpRequestMessage> InvokeGeneratedAsync(
-            string methodName,
-            object?[] args,
-            string? expectedPathAndQuery)
-        {
-            var task = (Task)interfaceType.GetMethod(methodName)!.Invoke(generatedApi, args)!;
-            await task.ConfigureAwait(false);
-            var request = handler.TakeLastRequest();
-            if (expectedPathAndQuery is not null)
-            {
-                await Assert.That(request.RequestUri!.PathAndQuery).IsEqualTo(expectedPathAndQuery);
-            }
-
-            return request;
-        }
-
-        /// <summary>Invokes a method through both request paths and asserts the URIs are identical.</summary>
-        /// <param name="methodName">The interface method name.</param>
-        /// <param name="args">The argument values.</param>
-        /// <param name="expectedPathAndQuery">The expected path and query, or null to only assert parity.</param>
-        /// <returns>The request captured from the generated path.</returns>
-        [RequiresUnreferencedCode("Reflects over generated types and members.")]
-        [RequiresDynamicCode("Builds the reflection request delegate for parity comparison.")]
-        public async Task<HttpRequestMessage> AssertParityAsync(
-            string methodName,
-            object?[] args,
-            string? expectedPathAndQuery)
-        {
-            var generatedRequest = await InvokeGeneratedAsync(methodName, args, expectedPathAndQuery).ConfigureAwait(false);
-
-            var reflectionFunc = requestBuilder.BuildRestResultFuncForMethod(methodName);
-            var reflectionTask = (Task)reflectionFunc(client, args!)!;
-            await reflectionTask.ConfigureAwait(false);
-            var reflectionRequest = handler.TakeLastRequest();
-
-            await Assert.That(generatedRequest.Method).IsEqualTo(reflectionRequest.Method);
-            await Assert.That(generatedRequest.RequestUri!.AbsoluteUri)
-                .IsEqualTo(reflectionRequest.RequestUri!.AbsoluteUri);
-            return generatedRequest;
-        }
-
-        /// <inheritdoc/>
-        public void Dispose()
-        {
-            client.Dispose();
-            handler.Dispose();
-            context.Dispose();
-        }
-    }
-
-    /// <summary>Captures each outgoing request and returns a fixed JSON string response.</summary>
-    private sealed class CapturingHandler : HttpMessageHandler
-    {
-        /// <summary>The last request sent through the handler.</summary>
-        private HttpRequestMessage? _lastRequest;
-
-        /// <summary>Gets the body content captured for the last request, or null.</summary>
-        public string? LastContent { get; private set; }
-
-        /// <summary>Takes the last captured request, clearing the slot.</summary>
-        /// <returns>The captured request.</returns>
-        public HttpRequestMessage TakeLastRequest()
-        {
-            var request = _lastRequest ?? throw new InvalidOperationException("No request was captured.");
-            _lastRequest = null;
-            return request;
-        }
-
-        /// <inheritdoc/>
-        protected override async Task<HttpResponseMessage> SendAsync(
-            HttpRequestMessage request,
-            CancellationToken cancellationToken)
-        {
-            _lastRequest = request;
-
-            // Streamed request bodies are disposed with the request, so snapshot the content here.
-            LastContent = request.Content is null
-                ? null
-                : await request.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
-            return new HttpResponseMessage(HttpStatusCode.OK)
-            {
-                Content = new StringContent("\"done\"", Encoding.UTF8, "application/json")
-            };
-        }
     }
 }


### PR DESCRIPTION



<!-- Please read our [Contribute guide](https://www.reactiveui.net/contribute/index.html) before opening a PR, and give this PR a title that follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `fix:`, `feat:`, `docs:`, `build:`). -->

## What kind of change does this PR introduce?
Feature Closes #2256

## What is the new behavior?
Adds a new CollectionFormat.Indexed value that expands an IEnumerable<T> of complex objects into indexed key-prefix query parameters:
  ?items[0].Id=1&items[0].Value=a&items[1].Id=2

Both the source generator (inline, zero-reflection) and the reflection request builder paths are implemented. The generator parses an IEnumerable<T> parameter with CollectionFormat.Indexed and a complex element type into the new QueryParameterShape.DeepObjectCollection shape, emitting a loop with an incrementing index local and flattening each element's properties under the key[index].Property naming scheme.


## What is the current behavior?
It was possible with QueryFormatter

## What might this PR break?
n/a

## Checklist
- [X] I have read the [Contribute guide](https://www.reactiveui.net/contribute/index.html)
- [X] Tests have been added or updated (for bug fixes / features)
- [X] Docs have been added or updated (for bug fixes / features)
- [X] Changes target the `main` branch
- [X] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

