### PR TITLE
perf: reduce runtime Refit memory allocations

### DIFF
--- a/src/Refit/ApiException.cs
+++ b/src/Refit/ApiException.cs
@@ -385,7 +385,7 @@ public class ApiException : ApiExceptionBase
     /// <param name="content">The response content to read.</param>
     /// <param name="maxChars">The maximum number of characters to read, or <see langword="null"/> for unbounded.</param>
     /// <returns>The (possibly truncated) response body.</returns>
-    private static async Task<string> ReadContentCappedAsync(HttpContent content, int? maxChars)
+    internal static async Task<string> ReadContentCappedAsync(HttpContent content, int? maxChars)
     {
         if (maxChars is not { } limit)
         {
@@ -426,13 +426,13 @@ public class ApiException : ApiExceptionBase
     /// <param name="statusCode">The HTTP status code.</param>
     /// <param name="reasonPhrase">The reason phrase.</param>
     /// <returns>The formatted exception message.</returns>
-    private static string CreateMessage(HttpStatusCode statusCode, string? reasonPhrase) =>
+    internal static string CreateMessage(HttpStatusCode statusCode, string? reasonPhrase) =>
         $"Response status code does not indicate success: {(int)statusCode} ({reasonPhrase}).";
 
     /// <summary>Reads the request body string captured before sending, if request-content capture was enabled.</summary>
     /// <param name="request">The request message that carries the captured content option.</param>
     /// <returns>The captured request content, or <see langword="null"/> when none was captured.</returns>
-    private static string? GetCapturedRequestContent(HttpRequestMessage request)
+    internal static string? GetCapturedRequestContent(HttpRequestMessage request)
     {
 #if NET6_0_OR_GREATER
         return request.Options.TryGetValue(

--- a/src/Refit/ApiResponseExtensions.cs
+++ b/src/Refit/ApiResponseExtensions.cs
@@ -85,7 +85,7 @@ public static class ApiResponseExtensions
     /// <summary>Gets the captured error, or a fallback when an unsuccessful response did not record one.</summary>
     /// <param name="response">The unsuccessful response.</param>
     /// <returns>The exception to surface to the caller.</returns>
-    private static Exception GetError(IApiResponse response) =>
+    internal static Exception GetError(IApiResponse response) =>
         (Exception?)response.Error
         ?? new InvalidOperationException("The response was unsuccessful but did not capture an error.");
 }

--- a/src/Refit/ApiResponse{T}.cs
+++ b/src/Refit/ApiResponse{T}.cs
@@ -170,7 +170,7 @@ public sealed class ApiResponse<T>(
     /// <summary>Releases the underlying response when disposing.</summary>
     /// <param name="disposing">Whether the method is being called from <see cref="Dispose()"/>.</param>
     [ExcludeFromCodeCoverage] // There is no finalizer, so Dispose(false) never runs and the !disposing guard is unreachable.
-    private void Dispose(bool disposing)
+    internal void Dispose(bool disposing)
     {
         if (!disposing)
         {
@@ -181,7 +181,7 @@ public sealed class ApiResponse<T>(
     }
 
     /// <summary>Disposes the underlying response once, guarding against repeated disposal.</summary>
-    private void DisposeResponse()
+    internal void DisposeResponse()
     {
         if (_disposed)
         {
@@ -195,11 +195,11 @@ public sealed class ApiResponse<T>(
 
     /// <summary>Throws the appropriate API exception for an unsuccessful response.</summary>
     /// <returns>A task that represents the asynchronous validation operation.</returns>
-    private ValueTask<ApiResponse<T>> EnsureSlowAsync() => ThrowsApiExceptionAsync();
+    internal ValueTask<ApiResponse<T>> EnsureSlowAsync() => ThrowsApiExceptionAsync();
 
     /// <summary>Throws the appropriate API exception for an unsuccessful response.</summary>
     /// <returns>A task that represents the asynchronous throw operation.</returns>
-    private async ValueTask<ApiResponse<T>> ThrowsApiExceptionAsync()
+    internal async ValueTask<ApiResponse<T>> ThrowsApiExceptionAsync()
     {
         var responseMessage = response
                               ?? throw new InvalidOperationException(

--- a/src/Refit/Buffers/PooledBufferWriter.Stream.NETStandard21.cs
+++ b/src/Refit/Buffers/PooledBufferWriter.Stream.NETStandard21.cs
@@ -16,7 +16,7 @@ namespace Refit.Buffers;
 internal sealed partial class PooledBufferWriter
 {
     /// <summary>An in-memory <see cref="Stream"/> that uses memory buffers rented from a shared pool.</summary>
-    private sealed partial class PooledMemoryStream : Stream
+    internal sealed partial class PooledMemoryStream : Stream
     {
         /// <summary>Asynchronously copies the remaining buffered bytes to the destination stream.</summary>
         /// <param name="destination">The stream to copy the buffered bytes to.</param>

--- a/src/Refit/Buffers/PooledBufferWriter.Stream.cs
+++ b/src/Refit/Buffers/PooledBufferWriter.Stream.cs
@@ -10,9 +10,9 @@ internal sealed partial class PooledBufferWriter
 {
     /// <summary>An in-memory <see cref="Stream"/> that uses memory buffers rented from a shared pool.</summary>
 #if NET6_0_OR_GREATER
-    private sealed partial class PooledMemoryStream : Stream
+    internal sealed partial class PooledMemoryStream : Stream
 #else
-    private sealed class PooledMemoryStream : Stream
+    internal sealed class PooledMemoryStream : Stream
 #endif
     {
         /// <summary>The current used length for <see cref="_pooledBuffer"/>.</summary>

--- a/src/Refit/Buffers/PooledBufferWriter.ThrowExceptions.cs
+++ b/src/Refit/Buffers/PooledBufferWriter.ThrowExceptions.cs
@@ -11,36 +11,36 @@ internal sealed partial class PooledBufferWriter
     /// <summary>Creates an <see cref="ArgumentOutOfRangeException"/> for a method that received a negative "count" parameter.</summary>
     /// <returns>The exception to throw.</returns>
     [MethodImpl(MethodImplOptions.NoInlining)]
-    private static ArgumentOutOfRangeException CreateArgumentOutOfRangeExceptionForNegativeCount() =>
+    internal static ArgumentOutOfRangeException CreateArgumentOutOfRangeExceptionForNegativeCount() =>
         new("count", "The count can't be < 0");
 
     /// <summary>Creates an <see cref="ArgumentOutOfRangeException"/> for a method that received a negative "offset" parameter.</summary>
     /// <returns>The exception to throw.</returns>
     [MethodImpl(MethodImplOptions.NoInlining)]
-    private static ArgumentOutOfRangeException CreateArgumentOutOfRangeExceptionForNegativeOffset() =>
+    internal static ArgumentOutOfRangeException CreateArgumentOutOfRangeExceptionForNegativeOffset() =>
         new("offset", "The offset can't be < 0");
 
     /// <summary>Creates an <see cref="ArgumentOutOfRangeException"/> for when <see cref="Advance"/> advances too far.</summary>
     /// <returns>The exception to throw.</returns>
     [MethodImpl(MethodImplOptions.NoInlining)]
-    private static ArgumentOutOfRangeException CreateArgumentOutOfRangeExceptionForAdvancedTooFar() =>
+    internal static ArgumentOutOfRangeException CreateArgumentOutOfRangeExceptionForAdvancedTooFar() =>
         new("count", "Advanced too far");
 
     /// <summary>Creates an <see cref="ArgumentException"/> for when the end of a <see cref="PooledMemoryStream"/> has been exceeded.</summary>
     /// <returns>The exception to throw.</returns>
     [MethodImpl(MethodImplOptions.NoInlining)]
-    private static ArgumentException CreateArgumentOutOfRangeExceptionForEndOfStreamReached() =>
+    internal static ArgumentException CreateArgumentOutOfRangeExceptionForEndOfStreamReached() =>
         new("The end of the stream has been exceeded");
 
     /// <summary>Creates an <see cref="ObjectDisposedException"/> for when a <see cref="PooledMemoryStream"/> method is called on a disposed instance.</summary>
     /// <returns>The exception to throw.</returns>
     [MethodImpl(MethodImplOptions.NoInlining)]
-    private static ObjectDisposedException CreateObjectDisposedException() =>
+    internal static ObjectDisposedException CreateObjectDisposedException() =>
         new("The stream in use has alreadybeen disposed");
 
     /// <summary>Creates a <see cref="NotSupportedException"/> for when an operation in <see cref="PooledMemoryStream"/> is not supported.</summary>
     /// <returns>The exception to throw.</returns>
     [MethodImpl(MethodImplOptions.NoInlining)]
-    private static NotSupportedException CreateNotSupportedException() =>
+    internal static NotSupportedException CreateNotSupportedException() =>
         new("The stream doesn't support the requested operation");
 }

--- a/src/Refit/Buffers/PooledBufferWriter.cs
+++ b/src/Refit/Buffers/PooledBufferWriter.cs
@@ -82,7 +82,7 @@ internal sealed partial class PooledBufferWriter : IBufferWriter<byte>, IDisposa
     /// <summary>Ensures the buffer in use has the free capacity to contain the specified amount of new data.</summary>
     /// <param name="count">The size in bytes of the new data to insert into the buffer.</param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private void EnsureFreeCapacity(int count)
+    internal void EnsureFreeCapacity(int count)
     {
         if (count < 0)
         {

--- a/src/Refit/CamelCaseStringEnumConverter.cs
+++ b/src/Refit/CamelCaseStringEnumConverter.cs
@@ -49,21 +49,74 @@ internal sealed class CamelCaseStringEnumConverter : JsonConverterFactory
         return (JsonConverter)Activator.CreateInstance(converterType)!;
     }
 
+    /// <summary>Gets the preferred serialized name for the given enum field.</summary>
+    /// <param name="field">The enum field to inspect.</param>
+    /// <returns>The preferred serialized name.</returns>
+    internal static string GetPreferredSerializedName(FieldInfo field)
+    {
+#if NET9_0_OR_GREATER
+        var enumMemberNameAttribute = field.GetCustomAttribute<JsonStringEnumMemberNameAttribute>();
+        return enumMemberNameAttribute?.Name ?? ToCamelCase(field.Name);
+#else
+        return ToCamelCase(field.Name);
+#endif
+    }
+
+    /// <summary>Converts the given value to camelCase.</summary>
+    /// <param name="value">The value to convert.</param>
+    /// <returns>The camelCase form of the value.</returns>
+    internal static string ToCamelCase(string value) =>
+        string.IsNullOrEmpty(value) || !char.IsUpper(value[0])
+            ? value
+#if NET8_0_OR_GREATER
+
+            // Produce the camelCase form in a single allocation: copy the source, then lowercase the first character
+            // in place. The "char.ToLowerInvariant(value[0]) + value[1..]" form allocates an extra substring tail.
+            : string.Create(value.Length, value, static (span, source) =>
+            {
+                source.AsSpan().CopyTo(span);
+                span[0] = char.ToLowerInvariant(source[0]);
+            });
+#else
+            : char.ToLowerInvariant(value[0]) + value[1..];
+#endif
+
+    /// <summary>Determines whether the reader is positioned on a JSON null or an empty/whitespace string.</summary>
+    /// <param name="reader">The reader to inspect.</param>
+    /// <returns><see langword="true"/> when the value should be treated as null.</returns>
+    internal static bool IsNullOrEmptyString(ref Utf8JsonReader reader) =>
+        reader.TokenType == JsonTokenType.Null
+        || (reader.TokenType is JsonTokenType.String or JsonTokenType.PropertyName
+            && string.IsNullOrWhiteSpace(reader.GetString()));
+
     /// <summary>A strongly-typed JSON converter that maps enum values to and from their camelCase names.</summary>
     /// <typeparam name="TEnum">The enum type whose fields are inspected.</typeparam>
-    private sealed class EnumConverter<
+    internal sealed class EnumConverter<
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] TEnum> : JsonConverter<TEnum>
         where TEnum : struct, Enum
     {
+        /// <summary>The upper bound of serialized names per enum field: its camelCase name plus its declared name.</summary>
+        private const int MaxNamesPerField = 2;
+
         /// <summary>Maps serialized names to enum values using ordinal comparison.</summary>
-        private readonly Dictionary<string, TEnum> _namesToValues = GetNamesToValues(StringComparer.Ordinal);
+        private readonly Dictionary<string, TEnum> _namesToValues;
 
         /// <summary>Maps serialized names to enum values using case-insensitive comparison.</summary>
-        private readonly Dictionary<string, TEnum> _namesToValuesIgnoreCase =
-            GetNamesToValues(StringComparer.OrdinalIgnoreCase);
+        private readonly Dictionary<string, TEnum> _namesToValuesIgnoreCase;
 
         /// <summary>Maps enum values to their preferred serialized names.</summary>
-        private readonly Dictionary<TEnum, string> _valuesToNames = GetValuesToNames();
+        private readonly Dictionary<TEnum, string> _valuesToNames;
+
+        /// <summary>Initializes a new instance of the <see cref="EnumConverter{TEnum}"/> class, building the three
+        /// serialized-name maps from a single scan of the enum's fields.</summary>
+        /// <remarks>Public because the converter factory instantiates it through <see cref="Activator.CreateInstance(Type)"/>,
+        /// which resolves only a public parameterless constructor.</remarks>
+        public EnumConverter() =>
+            (_namesToValues, _namesToValuesIgnoreCase, _valuesToNames) = BuildNameMaps();
+
+        /// <summary>Gets the number of names-to-values entries, exposed so a benchmark can force and observe the
+        /// converter's one-time name-map construction.</summary>
+        internal int MapEntryCount => _namesToValues.Count;
 
         /// <inheritdoc/>
         public override TEnum Read(
@@ -106,81 +159,48 @@ internal sealed class CamelCaseStringEnumConverter : JsonConverterFactory
             writer.WritePropertyName(EnumHelpers.Info<TEnum>.FormatNumericValue(value));
         }
 
-        /// <summary>Builds a map of serialized names to enum values using the given comparer.</summary>
-        /// <param name="comparer">The comparer used for the resulting dictionary keys.</param>
-        /// <returns>A dictionary mapping serialized names to enum values.</returns>
-        private static Dictionary<string, TEnum> GetNamesToValues(StringComparer comparer)
+        /// <summary>Builds the three serialized-name maps from a single scan of the enum's fields, so the field
+        /// metadata and each field's camelCase name are computed once instead of once per map.</summary>
+        /// <returns>The ordinal and case-insensitive names-to-values maps and the values-to-names map.</returns>
+        internal static (
+            Dictionary<string, TEnum> NamesToValues,
+            Dictionary<string, TEnum> NamesToValuesIgnoreCase,
+            Dictionary<TEnum, string> ValuesToNames) BuildNameMaps()
         {
-            var map = new Dictionary<string, TEnum>(comparer);
+            var fields = typeof(TEnum).GetFields(BindingFlags.Public | BindingFlags.Static);
 
-            foreach (var field in typeof(TEnum).GetFields(BindingFlags.Public | BindingFlags.Static))
+            // Each field contributes its camelCase name and, when different, its declared name, so two entries per field
+            // is the upper bound for the name-keyed maps; presizing to it avoids the grow-and-rehash cycle.
+            var namesToValues = new Dictionary<string, TEnum>(fields.Length * MaxNamesPerField, StringComparer.Ordinal);
+            var namesToValuesIgnoreCase = new Dictionary<string, TEnum>(fields.Length * MaxNamesPerField, StringComparer.OrdinalIgnoreCase);
+            var valuesToNames = new Dictionary<TEnum, string>(fields.Length);
+
+            foreach (var field in fields)
             {
                 var value = EnumHelpers.Info<TEnum>.ParseName(field.Name);
-                foreach (var name in GetSerializedNames(field))
+                var preferredName = GetPreferredSerializedName(field);
+
+                // The single camelCase name string is shared as a key in both name maps and as the reverse-map value.
+                namesToValues[preferredName] = value;
+                namesToValuesIgnoreCase[preferredName] = value;
+
+                // The declared name is a second lookup key only when it differs from the camelCase preferred name.
+                if (!string.Equals(field.Name, preferredName, StringComparison.Ordinal))
                 {
-                    map[name] = value;
+                    namesToValues[field.Name] = value;
+                    namesToValuesIgnoreCase[field.Name] = value;
                 }
+
+                valuesToNames[value] = preferredName;
             }
 
-            return map;
+            return (namesToValues, namesToValuesIgnoreCase, valuesToNames);
         }
-
-        /// <summary>Builds a map of enum values to their preferred serialized names.</summary>
-        /// <returns>A dictionary mapping enum values to serialized names.</returns>
-        private static Dictionary<TEnum, string> GetValuesToNames()
-        {
-            var map = new Dictionary<TEnum, string>();
-
-            foreach (var field in typeof(TEnum).GetFields(BindingFlags.Public | BindingFlags.Static))
-            {
-                var value = EnumHelpers.Info<TEnum>.ParseName(field.Name);
-                map[value] = GetPreferredSerializedName(field);
-            }
-
-            return map;
-        }
-
-        /// <summary>Yields the serialized names that should map to the given enum field.</summary>
-        /// <param name="field">The enum field to inspect.</param>
-        /// <returns>The serialized names for the field.</returns>
-        private static IEnumerable<string> GetSerializedNames(FieldInfo field)
-        {
-            var preferredName = GetPreferredSerializedName(field);
-            yield return preferredName;
-
-            if (string.Equals(field.Name, preferredName, StringComparison.Ordinal))
-            {
-                yield break;
-            }
-
-            yield return field.Name;
-        }
-
-        /// <summary>Gets the preferred serialized name for the given enum field.</summary>
-        /// <param name="field">The enum field to inspect.</param>
-        /// <returns>The preferred serialized name.</returns>
-        private static string GetPreferredSerializedName(FieldInfo field)
-        {
-#if NET9_0_OR_GREATER
-            var enumMemberNameAttribute = field.GetCustomAttribute<JsonStringEnumMemberNameAttribute>();
-            return enumMemberNameAttribute?.Name ?? ToCamelCase(field.Name);
-#else
-            return ToCamelCase(field.Name);
-#endif
-        }
-
-        /// <summary>Converts the given value to camelCase.</summary>
-        /// <param name="value">The value to convert.</param>
-        /// <returns>The camelCase form of the value.</returns>
-        private static string ToCamelCase(string value) =>
-            string.IsNullOrEmpty(value) || !char.IsUpper(value[0])
-                ? value
-                : char.ToLowerInvariant(value[0]) + value[1..];
 
         /// <summary>Reads an enum value from either a string name or a numeric value.</summary>
         /// <param name="reader">The reader positioned on the value to read.</param>
         /// <returns>The parsed enum value.</returns>
-        private TEnum ReadValue(ref Utf8JsonReader reader)
+        internal TEnum ReadValue(ref Utf8JsonReader reader)
         {
             if (reader.TokenType is JsonTokenType.String or JsonTokenType.PropertyName)
             {
@@ -214,7 +234,7 @@ internal sealed class CamelCaseStringEnumConverter : JsonConverterFactory
 
     /// <summary>A strongly-typed JSON converter for nullable enums that maps values to and from camelCase names.</summary>
     /// <typeparam name="TEnum">The underlying enum type.</typeparam>
-    private sealed class NullableEnumConverter<
+    internal sealed class NullableEnumConverter<
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] TEnum> : JsonConverter<TEnum?>
         where TEnum : struct, Enum
     {
@@ -261,13 +281,5 @@ internal sealed class CamelCaseStringEnumConverter : JsonConverterFactory
 
             _inner.WriteAsPropertyName(writer, value.Value, options);
         }
-
-        /// <summary>Determines whether the reader is positioned on a JSON null or an empty/whitespace string.</summary>
-        /// <param name="reader">The reader to inspect.</param>
-        /// <returns><see langword="true"/> when the value should be treated as null.</returns>
-        private static bool IsNullOrEmptyString(ref Utf8JsonReader reader) =>
-            reader.TokenType == JsonTokenType.Null
-            || (reader.TokenType is JsonTokenType.String or JsonTokenType.PropertyName
-                && string.IsNullOrWhiteSpace(reader.GetString()));
     }
 }

--- a/src/Refit/CamelCaseUrlParameterKeyFormatter.cs
+++ b/src/Refit/CamelCaseUrlParameterKeyFormatter.cs
@@ -36,7 +36,7 @@ public class CamelCaseUrlParameterKeyFormatter : IUrlParameterKeyFormatter
 
     /// <summary>Lowercases the leading uppercase run of characters in place.</summary>
     /// <param name="chars">The characters to adjust.</param>
-    private static void FixCasing(Span<char> chars)
+    internal static void FixCasing(Span<char> chars)
     {
         for (var i = 0; i < chars.Length; i++)
         {

--- a/src/Refit/DefaultApiExceptionFactory.cs
+++ b/src/Refit/DefaultApiExceptionFactory.cs
@@ -20,7 +20,7 @@ public class DefaultApiExceptionFactory(RefitSettings refitSettings)
     /// <param name="responseMessage">The response message.</param>
     /// <param name="refitSettings">The Refit settings.</param>
     /// <returns>The created exception.</returns>
-    private static async ValueTask<Exception?> CreateExceptionAsync(
+    internal static async ValueTask<Exception?> CreateExceptionAsync(
         HttpResponseMessage responseMessage,
         RefitSettings refitSettings)
     {

--- a/src/Refit/DefaultFormUrlEncodedParameterFormatter.cs
+++ b/src/Refit/DefaultFormUrlEncodedParameterFormatter.cs
@@ -2,8 +2,6 @@
 // ReactiveUI and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Globalization;
-
 namespace Refit;
 
 /// <summary>Default form Url-encoded parameter formatter.</summary>
@@ -23,9 +21,6 @@ public class DefaultFormUrlEncodedParameterFormatter : IFormUrlEncodedParameterF
         var parameterType = value.GetType();
         var enumMemberValue = EnumHelpers.GetEnumMemberValue(parameterType, value);
 
-        return string.Format(
-            CultureInfo.InvariantCulture,
-            string.IsNullOrWhiteSpace(formatString) ? "{0}" : $"{{0:{formatString}}}",
-            enumMemberValue ?? value);
+        return InvariantValueRenderer.Render(enumMemberValue ?? value, formatString);
     }
 }

--- a/src/Refit/DefaultUrlParameterFormatter.cs
+++ b/src/Refit/DefaultUrlParameterFormatter.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for full license information.
 
 using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
 using System.Reflection;
 
 namespace Refit;
@@ -21,10 +20,10 @@ public class DefaultUrlParameterFormatter : IUrlParameterFormatter
         && GeneralFormats.Count == 0;
 
     /// <summary>Gets the registered format strings keyed by container and parameter type.</summary>
-    private Dictionary<(Type containerType, Type parameterType), string> SpecificFormats { get; } = [];
+    internal Dictionary<(Type containerType, Type parameterType), string> SpecificFormats { get; } = [];
 
     /// <summary>Gets the registered format strings keyed by parameter type.</summary>
-    private Dictionary<Type, string> GeneralFormats { get; } = [];
+    internal Dictionary<Type, string> GeneralFormats { get; } = [];
 
     /// <summary>
     /// Add format for specified parameter type contained within container class of specified type.
@@ -75,20 +74,25 @@ public class DefaultUrlParameterFormatter : IUrlParameterFormatter
 
         formatString = ResolveFormatString(formatString, type, parameterType);
 
-        return string.Format(
-            CultureInfo.InvariantCulture,
-            string.IsNullOrWhiteSpace(formatString) ? "{0}" : $"{{0:{formatString}}}",
-            enumMemberValue ?? value);
+        return InvariantValueRenderer.Render(enumMemberValue ?? value, formatString);
     }
 
     /// <summary>Gets the first query attribute from an attribute provider.</summary>
     /// <param name="attributeProvider">The attribute provider to inspect.</param>
     /// <returns>The first query attribute, or null when absent.</returns>
-    private static QueryAttribute? GetFirstQueryAttribute(ICustomAttributeProvider attributeProvider)
+    internal static QueryAttribute? GetFirstQueryAttribute(ICustomAttributeProvider attributeProvider)
     {
-        // GetCustomAttributes is type-filtered, so every element is a QueryAttribute; take the first, if any.
+        // IsDefined avoids materializing an attribute array when none is present. That matters for a Type provider
+        // (used when formatting collection elements), whose GetCustomAttributes allocates even for an empty result,
+        // whereas a PropertyInfo or ParameterInfo already returns a cached empty array. When the attribute is
+        // present, GetCustomAttributes is type-filtered, so the first element is the QueryAttribute.
+        if (!attributeProvider.IsDefined(typeof(QueryAttribute), true))
+        {
+            return null;
+        }
+
         var attributes = attributeProvider.GetCustomAttributes(typeof(QueryAttribute), true);
-        return attributes.Length > 0 ? attributes[0] as QueryAttribute : null;
+        return attributes[0] as QueryAttribute;
     }
 
     /// <summary>Selects the effective format string, preferring the attribute format, then specific, then general formats.</summary>
@@ -96,7 +100,7 @@ public class DefaultUrlParameterFormatter : IUrlParameterFormatter
     /// <param name="type">The container class type.</param>
     /// <param name="parameterType">The runtime type of the value.</param>
     /// <returns>The resolved format string, or null when none applies.</returns>
-    private string? ResolveFormatString(string? formatString, Type type, Type parameterType)
+    internal string? ResolveFormatString(string? formatString, Type type, Type parameterType)
     {
         if (string.IsNullOrWhiteSpace(formatString) &&
             SpecificFormats.TryGetValue((type, parameterType), out var specificFormat))

--- a/src/Refit/EnumHelpers.cs
+++ b/src/Refit/EnumHelpers.cs
@@ -46,7 +46,7 @@ internal static class EnumHelpers
         "Trimming",
         "IL2070:DynamicallyAccessedMembers",
         Justification = "Enum field metadata is inspected for EnumMemberAttribute formatting on runtime enum values.")]
-    private static Dictionary<string, string?> CreateEnumMemberValueMap(Type enumType)
+    internal static Dictionary<string, string?> CreateEnumMemberValueMap(Type enumType)
     {
         var fields = enumType.GetFields(BindingFlags.Public | BindingFlags.Static);
         var enumMemberValues = new Dictionary<string, string?>(fields.Length, StringComparer.Ordinal);
@@ -63,6 +63,12 @@ internal static class EnumHelpers
         return enumMemberValues;
     }
 
+    /// <summary>Determines whether the given enum backing type code is unsigned.</summary>
+    /// <param name="underlyingTypeCode">The enum backing type code.</param>
+    /// <returns><see langword="true"/> when the enum backing type is unsigned.</returns>
+    internal static bool IsUnsignedBackingType(TypeCode underlyingTypeCode) =>
+        underlyingTypeCode is TypeCode.Byte or TypeCode.UInt16 or TypeCode.UInt32 or TypeCode.UInt64;
+
     /// <summary>Provides cached helpers for a single enum type.</summary>
     /// <typeparam name="TEnum">The enum type.</typeparam>
     internal static class Info<
@@ -77,7 +83,7 @@ internal static class EnumHelpers
         /// <param name="value">The enum value to format.</param>
         /// <returns>The invariant numeric string.</returns>
         internal static string FormatNumericValue(TEnum value) =>
-            IsUnsignedBackingType()
+            IsUnsignedBackingType(_underlyingTypeCode)
                 ? ToUInt64(value).ToString(CultureInfo.InvariantCulture)
                 : ToInt64(value).ToString(CultureInfo.InvariantCulture);
 
@@ -122,7 +128,7 @@ internal static class EnumHelpers
         /// <param name="value">The enum value to write.</param>
         internal static void WriteJsonNumericValue(Utf8JsonWriter writer, TEnum value)
         {
-            if (IsUnsignedBackingType())
+            if (IsUnsignedBackingType(_underlyingTypeCode))
             {
                 writer.WriteNumberValue(ToUInt64(value));
                 return;
@@ -157,16 +163,11 @@ internal static class EnumHelpers
                 _ => throw new JsonException($"Enum {typeof(TEnum)} does not use an unsigned backing type.")
             };
 
-        /// <summary>Determines whether the enum backing type is unsigned.</summary>
-        /// <returns><see langword="true"/> when the enum backing type is unsigned.</returns>
-        private static bool IsUnsignedBackingType() =>
-            _underlyingTypeCode is TypeCode.Byte or TypeCode.UInt16 or TypeCode.UInt32 or TypeCode.UInt64;
-
         /// <summary>Converts a numeric backing value to the enum type without boxing.</summary>
         /// <typeparam name="TUnderlying">The enum backing value type.</typeparam>
         /// <param name="value">The numeric backing value.</param>
         /// <returns>The enum value.</returns>
-        private static TEnum ToEnum<TUnderlying>(TUnderlying value)
+        internal static TEnum ToEnum<TUnderlying>(TUnderlying value)
             where TUnderlying : struct =>
             Unsafe.As<TUnderlying, TEnum>(ref value);
     }

--- a/src/Refit/FormValueMultimap.cs
+++ b/src/Refit/FormValueMultimap.cs
@@ -21,8 +21,13 @@ internal sealed class FormValueMultimap : IEnumerable<KeyValuePair<string?, stri
     /// <summary>The default delimiter composing a nested field key from its parent key, matching the query-flattening default.</summary>
     private const string DefaultNestingDelimiter = ".";
 
-    /// <summary>Caches the readable public properties for each source type without keeping collectible types alive.</summary>
-    private static readonly ConditionalWeakTable<Type, PropertyInfo[]> _propertyCache = new();
+    /// <summary>Caches the per-property attribute metadata for each source type without keeping collectible types alive.</summary>
+    /// <remarks>The reflection form path reads <see cref="AliasAsAttribute"/> and <see cref="QueryAttribute"/> for every
+    /// property on every request. Those attributes are compile-time metadata that never change for a type, so they are
+    /// read once and reused, collapsing the per-property attribute lookups (the dominant allocation on this path) into a
+    /// single one-time-per-type cost. Field names still consult the settings' content serializer and key formatter per
+    /// call, so settings-dependent naming is never frozen.</remarks>
+    private static readonly ConditionalWeakTable<Type, FormPropertyMetadata[]> _metadataCache = new();
 
     /// <summary>Holds the collected form key/value entries.</summary>
     private readonly List<KeyValuePair<string?, string?>> _formEntries = [];
@@ -47,11 +52,11 @@ internal sealed class FormValueMultimap : IEnumerable<KeyValuePair<string?, stri
     /// <summary>Initializes a new instance of the <see cref="FormValueMultimap"/> class from a source object.</summary>
     /// <param name="source">The source object or dictionary to convert into form entries.</param>
     /// <param name="settings">The Refit settings controlling formatting.</param>
-    /// <param name="declaredProperties">The declared source type properties, if available.</param>
-    private FormValueMultimap(
+    /// <param name="declaredMetadata">The cached attribute metadata for the declared source type, if available.</param>
+    internal FormValueMultimap(
         object? source,
         RefitSettings settings,
-        PropertyInfo[]? declaredProperties)
+        FormPropertyMetadata[]? declaredMetadata)
     {
         ArgumentExceptionHelper.ThrowIfNull(settings);
 
@@ -69,7 +74,7 @@ internal sealed class FormValueMultimap : IEnumerable<KeyValuePair<string?, stri
             return;
         }
 
-        AddObject(source, declaredProperties ?? GetCachedProperties(source.GetType()), settings, null, DefaultNestingDelimiter, 0);
+        AddObject(source, declaredMetadata ?? GetCachedMetadata(source.GetType()), settings, null, DefaultNestingDelimiter, 0);
     }
 
     /// <summary>Gets a key for each entry. If multiple entries share the same key, the key is returned multiple times.</summary>
@@ -97,7 +102,7 @@ internal sealed class FormValueMultimap : IEnumerable<KeyValuePair<string?, stri
             : new FormValueMultimap(
                 source,
                 settings,
-                GetCachedProperties(source));
+                GetCachedMetadata(source));
 
     /// <summary>Creates a form value map from source-generated field descriptors, avoiding reflection.</summary>
     /// <typeparam name="TBody">The declared body type.</typeparam>
@@ -133,29 +138,51 @@ internal sealed class FormValueMultimap : IEnumerable<KeyValuePair<string?, stri
         return map;
     }
 
-    /// <summary>Resolves the cached readable public properties for the given source type.</summary>
+    /// <summary>Resolves the cached per-property attribute metadata for the given source type.</summary>
     /// <param name="type">The type to inspect.</param>
-    /// <returns>The cached readable public properties.</returns>
+    /// <returns>The cached attribute metadata for each readable public property.</returns>
     [UnconditionalSuppressMessage(
         "Trimming",
         "IL2111:Method with DynamicallyAccessedMembersAttribute is accessed via reflection",
         Justification = "The cache callback receives the same Type key that carries the public property metadata requirement.")]
-    private static PropertyInfo[] GetCachedProperties(Type type)
-        => _propertyCache.GetValue(type, ReflectionPropertyHelpers.GetReadablePublicInstanceProperties);
+    internal static FormPropertyMetadata[] GetCachedMetadata(Type type)
+        => _metadataCache.GetValue(type, BuildMetadata);
 
-    /// <summary>Resolves the cached readable public properties for the given declared source type.</summary>
+    /// <summary>Resolves the cached per-property attribute metadata for the given declared source type.</summary>
     /// <typeparam name="TSource">The declared source type to inspect.</typeparam>
     /// <param name="source">A value of the declared source type.</param>
-    /// <returns>The cached readable public properties.</returns>
-    private static PropertyInfo[] GetCachedProperties<
+    /// <returns>The cached attribute metadata for each readable public property.</returns>
+    internal static FormPropertyMetadata[] GetCachedMetadata<
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)]
         TSource>(TSource source)
     {
         _ = source;
 
-        return _propertyCache.GetValue(
-            typeof(TSource),
-            static _ => ReflectionPropertyHelpers.GetReadablePublicInstanceProperties(typeof(TSource)));
+        return _metadataCache.GetValue(typeof(TSource), static _ => BuildMetadata(typeof(TSource)));
+    }
+
+    /// <summary>Reads the attribute metadata for each readable public property of the given type.</summary>
+    /// <param name="type">The type whose properties are inspected.</param>
+    /// <returns>The attribute metadata array, in property order.</returns>
+    /// <remarks>Runs once per type as the cache miss callback: the <see cref="AliasAsAttribute"/> name and the
+    /// <see cref="QueryAttribute"/> are read here and reused for every subsequent request instead of being re-read per
+    /// property per call.</remarks>
+    internal static FormPropertyMetadata[] BuildMetadata(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)]
+        Type type)
+    {
+        var properties = ReflectionPropertyHelpers.GetReadablePublicInstanceProperties(type);
+        var metadata = new FormPropertyMetadata[properties.Length];
+        for (var i = 0; i < properties.Length; i++)
+        {
+            var property = properties[i];
+            metadata[i] = new(
+                property,
+                property.GetCustomAttribute<AliasAsAttribute>(true)?.Name,
+                property.GetCustomAttribute<QueryAttribute>(true));
+        }
+
+        return metadata;
     }
 
     /// <summary>Gets the delimiter string for a delimited collection format.</summary>
@@ -163,7 +190,7 @@ internal sealed class FormValueMultimap : IEnumerable<KeyValuePair<string?, stri
     /// <returns>The delimiter string.</returns>
     /// <remarks>Mirrors the query-flattening delimiter map: the default <see cref="CollectionFormat.RefitParameterFormatter"/>
     /// and <see cref="CollectionFormat.Csv"/> both join with a comma.</remarks>
-    private static string GetDelimiter(CollectionFormat collectionFormat) =>
+    internal static string GetDelimiter(CollectionFormat collectionFormat) =>
         collectionFormat switch
         {
             CollectionFormat.Ssv => " ",
@@ -177,7 +204,7 @@ internal sealed class FormValueMultimap : IEnumerable<KeyValuePair<string?, stri
     /// <returns><see langword="true"/> for the simple string/formattable types the query-flattening path emits directly.</returns>
     /// <remarks>Mirrors the query path's simple-type predicate: string, bool, char, <see cref="IFormattable"/> (enums,
     /// numbers, dates, <see cref="Guid"/>, ...), <see cref="Uri"/>, and <see cref="CultureInfo"/>.</remarks>
-    private static bool IsSimpleFormValue(object value) =>
+    internal static bool IsSimpleFormValue(object value) =>
         value is string or bool or char or IFormattable or Uri or CultureInfo;
 
     /// <summary>Composes a form field key from an optional parent prefix and a child name.</summary>
@@ -185,7 +212,7 @@ internal sealed class FormValueMultimap : IEnumerable<KeyValuePair<string?, stri
     /// <param name="name">The child field name or dictionary key.</param>
     /// <param name="delimiter">The delimiter placed between the prefix and the name.</param>
     /// <returns>The composed key.</returns>
-    private static string? ComposeKey(string? keyPrefix, string? name, string? delimiter) =>
+    internal static string? ComposeKey(string? keyPrefix, string? name, string? delimiter) =>
         keyPrefix is null ? name : keyPrefix + delimiter + name;
 
     /// <summary>Formats and joins a collection-valued form field without LINQ adapters.</summary>
@@ -198,7 +225,7 @@ internal sealed class FormValueMultimap : IEnumerable<KeyValuePair<string?, stri
         "Correctness",
         "SST2410:A created disposable is never disposed",
         Justification = "ValueStringBuilder.ToString() disposes the builder and returns its pooled buffer; Dispose is idempotent.")]
-    private static string JoinFormattedValues(
+    internal static string JoinFormattedValues(
         IEnumerable enumerable,
         string delimiter,
         string? format,
@@ -234,7 +261,7 @@ internal sealed class FormValueMultimap : IEnumerable<KeyValuePair<string?, stri
     /// <param name="keyPrefix">The parent key prefix, or <see langword="null"/> for a top-level dictionary.</param>
     /// <param name="delimiter">The delimiter composing an entry key under the prefix.</param>
     /// <param name="depth">The current nesting depth.</param>
-    private void AddDictionary(
+    internal void AddDictionary(
         IDictionary dictionary,
         RefitSettings settings,
         string? keyPrefix,
@@ -262,28 +289,28 @@ internal sealed class FormValueMultimap : IEnumerable<KeyValuePair<string?, stri
 
     /// <summary>Adds the entries reflected from an object source, composing nested keys under the given prefix.</summary>
     /// <param name="source">The object source.</param>
-    /// <param name="properties">The properties to read from the source.</param>
+    /// <param name="metadata">The cached attribute metadata for the source's readable public properties.</param>
     /// <param name="settings">The Refit settings controlling formatting.</param>
     /// <param name="keyPrefix">The parent key prefix, or <see langword="null"/> for a top-level object.</param>
     /// <param name="delimiter">The delimiter composing each property key under the prefix.</param>
     /// <param name="depth">The current nesting depth.</param>
-    private void AddObject(
+    internal void AddObject(
         object source,
-        PropertyInfo[] properties,
+        FormPropertyMetadata[] metadata,
         RefitSettings settings,
         string? keyPrefix,
         string? delimiter,
         int depth)
     {
-        for (var i = 0; i < properties.Length; i++)
+        for (var i = 0; i < metadata.Length; i++)
         {
-            var property = properties[i];
+            var property = metadata[i].Property;
             var value = property.GetValue(source, null);
 
-            // see if there's a query attribute
-            var attrib = property.GetCustomAttribute<QueryAttribute>(true);
+            // The query attribute was read once when the metadata was cached for this type.
+            var attrib = metadata[i].Query;
 
-            var fieldName = ComposeKey(keyPrefix, GetFieldNameForProperty(property), delimiter);
+            var fieldName = ComposeKey(keyPrefix, GetFieldNameForProperty(metadata[i]), delimiter);
 
             if (value is null)
             {
@@ -315,7 +342,7 @@ internal sealed class FormValueMultimap : IEnumerable<KeyValuePair<string?, stri
     /// <param name="settings">The Refit settings controlling formatting.</param>
     /// <param name="delimiter">The delimiter composing nested keys under this field.</param>
     /// <param name="depth">The current nesting depth.</param>
-    private void AppendValue(
+    internal void AppendValue(
         string? fieldName,
         object value,
         string? format,
@@ -359,7 +386,7 @@ internal sealed class FormValueMultimap : IEnumerable<KeyValuePair<string?, stri
             return;
         }
 
-        AddObject(value, GetCachedProperties(value.GetType()), settings, fieldName, delimiter, depth + 1);
+        AddObject(value, GetCachedMetadata(value.GetType()), settings, fieldName, delimiter, depth + 1);
         ExitComplex();
     }
 
@@ -368,7 +395,7 @@ internal sealed class FormValueMultimap : IEnumerable<KeyValuePair<string?, stri
     /// <param name="depth">The current nesting depth.</param>
     /// <returns><see langword="true"/> when flattening may proceed; <see langword="false"/> when the value is too deep
     /// or already being flattened on this path, in which case it is dropped.</returns>
-    private bool TryEnterComplex(object value, int depth)
+    internal bool TryEnterComplex(object value, int depth)
     {
         if (depth >= MaxNestingDepth)
         {
@@ -389,7 +416,7 @@ internal sealed class FormValueMultimap : IEnumerable<KeyValuePair<string?, stri
     }
 
     /// <summary>Leaves the most recently entered complex value, restoring the recursion path for the next sibling.</summary>
-    private void ExitComplex() =>
+    internal void ExitComplex() =>
 
         // _ancestors is non-null here: TryEnterComplex allocated it and pushed the matching value.
         _ancestors!.RemoveAt(_ancestors.Count - 1);
@@ -401,7 +428,7 @@ internal sealed class FormValueMultimap : IEnumerable<KeyValuePair<string?, stri
     /// <param name="format">The value format string, if any.</param>
     /// <param name="collectionFormat">The resolved collection format.</param>
     /// <param name="settings">The Refit settings controlling formatting.</param>
-    private void AddCollection(
+    internal void AddCollection(
         string? fieldName,
         IEnumerable enumerable,
         object value,
@@ -453,11 +480,11 @@ internal sealed class FormValueMultimap : IEnumerable<KeyValuePair<string?, stri
     /// <summary>Adds a key/value pair to the form entries.</summary>
     /// <param name="key">The form field key.</param>
     /// <param name="value">The form field value.</param>
-    private void Add(string? key, string? value) => _formEntries.Add(new(key, value));
+    internal void Add(string? key, string? value) => _formEntries.Add(new(key, value));
 
     /// <summary>Returns each key from the collected form entries.</summary>
     /// <returns>The form keys.</returns>
-    private IEnumerable<string?> GetKeys()
+    internal IEnumerable<string?> GetKeys()
     {
         for (var i = 0; i < _formEntries.Count; i++)
         {
@@ -465,18 +492,30 @@ internal sealed class FormValueMultimap : IEnumerable<KeyValuePair<string?, stri
         }
     }
 
-    /// <summary>Resolves the form field name for the given property.</summary>
-    /// <param name="propertyInfo">The property to resolve the name for.</param>
+    /// <summary>Resolves the form field name for the given property from its cached attribute metadata.</summary>
+    /// <param name="metadata">The cached attribute metadata for the property.</param>
     /// <returns>The resolved form field name.</returns>
-    private string GetFieldNameForProperty(PropertyInfo propertyInfo)
+    /// <remarks>The <see cref="AliasAsAttribute"/> name and <see cref="QueryAttribute"/> come from the per-type cache;
+    /// the content serializer and key formatter are still consulted per call because they are settings-dependent.</remarks>
+    internal string GetFieldNameForProperty(in FormPropertyMetadata metadata)
     {
-        var name = propertyInfo.GetCustomAttribute<AliasAsAttribute>(true)?.Name
-                   ?? _contentSerializer.GetFieldNameForProperty(propertyInfo)
-                   ?? _urlParameterKeyFormatter.Format(propertyInfo.Name);
+        var name = metadata.AliasName
+                   ?? _contentSerializer.GetFieldNameForProperty(metadata.Property)
+                   ?? _urlParameterKeyFormatter.Format(metadata.Property.Name);
 
-        var qattrib = propertyInfo.GetCustomAttribute<QueryAttribute>(true);
+        var qattrib = metadata.Query;
         return qattrib is not null && !string.IsNullOrWhiteSpace(qattrib.Prefix)
             ? qattrib.Prefix + qattrib.Delimiter + name
             : name;
     }
+
+    /// <summary>The cached, settings-independent attribute metadata for a single readable public property on a form
+    /// source type, read once when the property list is first cached and reused for every request.</summary>
+    /// <param name="Property">The reflected property.</param>
+    /// <param name="AliasName">The <see cref="AliasAsAttribute.Name"/> override, or <see langword="null"/> when absent.</param>
+    /// <param name="Query">The <see cref="QueryAttribute"/> applied to the property, or <see langword="null"/> when absent.</param>
+    internal readonly record struct FormPropertyMetadata(
+        PropertyInfo Property,
+        string? AliasName,
+        QueryAttribute? Query);
 }

--- a/src/Refit/GeneratedParameterAttributeProvider.cs
+++ b/src/Refit/GeneratedParameterAttributeProvider.cs
@@ -42,7 +42,7 @@ public sealed class GeneratedParameterAttributeProvider(Dictionary<Type, object[
     /// <summary>Flattens the per-type attribute arrays into a single array without nested iteration.</summary>
     /// <param name="attributes">The attribute arrays keyed by attribute type.</param>
     /// <returns>Every attribute in a single array.</returns>
-    private static object[] FlattenAttributes(Dictionary<Type, object[]> attributes)
+    internal static object[] FlattenAttributes(Dictionary<Type, object[]> attributes)
     {
         var totalCount = 0;
         foreach (var attributeArray in attributes.Values)

--- a/src/Refit/GeneratedQueryStringBuilder.cs
+++ b/src/Refit/GeneratedQueryStringBuilder.cs
@@ -264,7 +264,7 @@ public ref struct GeneratedQueryStringBuilder
     /// <param name="format">The compile-time format, or null for the default rendering.</param>
     /// <returns>The number of characters written into <paramref name="buffer"/>.</returns>
     [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage] // The grow back-edge only fires for a value larger than the stack buffer; the compiler's loop second-jump stays unreachable in practice.
-    private static int FormatWithGrowth<T>(T value, ref Span<char> buffer, ref char[]? rented, string? format)
+    internal static int FormatWithGrowth<T>(T value, ref Span<char> buffer, ref char[]? rented, string? format)
         where T : ISpanFormattable
     {
         int written;
@@ -284,7 +284,7 @@ public ref struct GeneratedQueryStringBuilder
 #endif
 
     /// <summary>Appends the <c>?</c> or <c>&amp;</c> separator, materializing the text buffer on first use.</summary>
-    private void AppendSeparator()
+    internal void AppendSeparator()
     {
         if (!_hasAppended)
         {
@@ -302,7 +302,7 @@ public ref struct GeneratedQueryStringBuilder
     /// <param name="value">The non-null formatted value.</param>
     /// <param name="keyEscaped">Whether the key is already escaped by the generator and appended verbatim.</param>
     /// <param name="preEncoded">Whether the value (and, when not <paramref name="keyEscaped"/>, the key) is caller-encoded.</param>
-    private void AppendPair(string name, string value, bool keyEscaped, bool preEncoded)
+    internal void AppendPair(string name, string value, bool keyEscaped, bool preEncoded)
     {
         AppendSeparator();
         _text.Append(keyEscaped || preEncoded ? name : StringHelpers.EscapeDataString(name));
@@ -318,7 +318,7 @@ public ref struct GeneratedQueryStringBuilder
     /// <param name="format">The compile-time format, or null.</param>
     /// <param name="keyEscaped">Whether the key is already escaped by the generator and appended verbatim.</param>
     /// <param name="preEncoded">Whether the value (and, when not <paramref name="keyEscaped"/>, the key) is caller-encoded.</param>
-    private void AppendFormattedPair<T>(string name, T value, string? format, bool keyEscaped, bool preEncoded)
+    internal void AppendFormattedPair<T>(string name, T value, string? format, bool keyEscaped, bool preEncoded)
         where T : ISpanFormattable
     {
         AppendSeparator();
@@ -334,7 +334,7 @@ public ref struct GeneratedQueryStringBuilder
     /// <param name="value">The value to render.</param>
     /// <param name="format">The compile-time format, or null for the default rendering.</param>
     /// <param name="escape">Whether the formatted span is URI-data-escaped before it is appended.</param>
-    private readonly void AppendFormattedValue<T>(ref ValueStringBuilder target, T value, string? format, bool escape)
+    internal readonly void AppendFormattedValue<T>(ref ValueStringBuilder target, T value, string? format, bool escape)
         where T : ISpanFormattable
     {
         Span<char> buffer = stackalloc char[FormatBufferLength];

--- a/src/Refit/GeneratedRequestRunner.Sending.cs
+++ b/src/Refit/GeneratedRequestRunner.Sending.cs
@@ -191,7 +191,7 @@ public static partial class GeneratedRequestRunner
     /// <param name="consumerCancellationToken">The per-subscription (or per-enumeration) cancellation token.</param>
     /// <returns>The token the request should run against, and the linked source to dispose once the request completes
     /// (null when no source was allocated).</returns>
-    private static (CancellationToken Token, CancellationTokenSource? LinkedSource) ResolveRequestCancellationToken(
+    internal static (CancellationToken Token, CancellationTokenSource? LinkedSource) ResolveRequestCancellationToken(
         CancellationToken methodCancellationToken,
         CancellationToken consumerCancellationToken)
     {
@@ -207,7 +207,7 @@ public static partial class GeneratedRequestRunner
     /// <summary>Reads the per-call timeout stashed by <see cref="SetRequestTimeout"/>, or 0 when none was set.</summary>
     /// <param name="request">The generated request message to inspect.</param>
     /// <returns>The per-call timeout in milliseconds, or 0 when none was set.</returns>
-    private static int GetRequestTimeout(HttpRequestMessage request) =>
+    internal static int GetRequestTimeout(HttpRequestMessage request) =>
 #if NET6_0_OR_GREATER
         request.Options.TryGetValue(new HttpRequestOptionsKey<int>(TimeoutOptionKey), out var timeoutMilliseconds)
             ? timeoutMilliseconds

--- a/src/Refit/GeneratedRequestRunner.cs
+++ b/src/Refit/GeneratedRequestRunner.cs
@@ -287,6 +287,12 @@ public static partial class GeneratedRequestRunner
             return StringHelpers.EscapeDataString(FormatUrlParameter(settings, null, attributeProvider, type) ?? string.Empty);
         }
 
+#if NET8_0_OR_GREATER
+        // The pristine default formatter returns a string value unchanged (a format string is ignored for a string),
+        // so each section can be percent-encoded straight from the source span with no intermediate substring and no
+        // formatter round-trip.
+        var escapeInline = UsesDefaultUrlParameterFormatting(settings);
+#endif
         var sb = new ValueStringBuilder(stackalloc char[256]);
         var sectionStart = 0;
         for (var i = 0; i <= value.Length; i++)
@@ -301,8 +307,18 @@ public static partial class GeneratedRequestRunner
                 sb.Append('/');
             }
 
-            var section = value.Substring(sectionStart, i - sectionStart);
-            sb.Append(StringHelpers.EscapeDataString(FormatUrlParameter(settings, section, attributeProvider, type) ?? string.Empty));
+#if NET8_0_OR_GREATER
+            if (escapeInline)
+            {
+                StringHelpers.AppendUriDataEscaped(ref sb, value.AsSpan(sectionStart, i - sectionStart));
+            }
+            else
+            {
+                AppendFormattedSection(ref sb, value[sectionStart..i], settings, attributeProvider, type);
+            }
+#else
+            AppendFormattedSection(ref sb, value[sectionStart..i], settings, attributeProvider, type);
+#endif
             sectionStart = i + 1;
         }
 
@@ -573,7 +589,7 @@ public static partial class GeneratedRequestRunner
     /// <summary>Resolves the single-character delimiter for a non-multi collection format.</summary>
     /// <param name="collectionFormat">The collection format.</param>
     /// <returns>The delimiter character.</returns>
-    private static char CollectionDelimiter(CollectionFormat collectionFormat) =>
+    internal static char CollectionDelimiter(CollectionFormat collectionFormat) =>
         collectionFormat switch
         {
             CollectionFormat.Ssv => ' ',
@@ -592,7 +608,7 @@ public static partial class GeneratedRequestRunner
         "Correctness",
         "SST2410:A created disposable is never disposed",
         Justification = "ValueStringBuilder.ToString() disposes the builder and returns its pooled buffer; Dispose is idempotent.")]
-    private static string JoinFormattedElements(
+    internal static string JoinFormattedElements(
         IEnumerable values,
         RefitSettings settings,
         Type elementProviderType,
@@ -622,7 +638,7 @@ public static partial class GeneratedRequestRunner
     /// there still renders an empty segment exactly as before. The separator is trimmed only when it is a '/', so a null
     /// value in a query position (for example <c>?key={value?}</c>) collapses to an empty value rather than eating an
     /// unrelated character.</remarks>
-    private static void DropOptionalSegmentSeparator(ref ValueStringBuilder sb, ReadOnlySpan<char> template, int endIdx)
+    internal static void DropOptionalSegmentSeparator(ref ValueStringBuilder sb, ReadOnlySpan<char> template, int endIdx)
     {
         // An optional {name?} placeholder ends with the two-character "?}" suffix, so the '?' sits one char before endIdx.
         const int optionalMarkerSuffixLength = 2;
@@ -640,7 +656,7 @@ public static partial class GeneratedRequestRunner
     /// <param name="settings">The Refit settings supplying the registry and default formatter.</param>
     /// <param name="value">The value about to be formatted, or null.</param>
     /// <returns>The registered formatter for the value's exact runtime type, or the configured default formatter.</returns>
-    private static IUrlParameterFormatter ResolveUrlParameterFormatter(RefitSettings settings, object? value) =>
+    internal static IUrlParameterFormatter ResolveUrlParameterFormatter(RefitSettings settings, object? value) =>
         value is not null
         && settings.UrlParameterFormatterMap.Count > 0
         && settings.UrlParameterFormatterMap.TryGetValue(value.GetType(), out var formatter)
@@ -652,7 +668,7 @@ public static partial class GeneratedRequestRunner
     /// <param name="relativePathTemplate">The original path template, used in the error message.</param>
     /// <param name="allowUnmatchedParameter">Whether to allow unmatched URL parameters.</param>
     /// <returns>The validated path, returned unchanged.</returns>
-    private static string ThrowIfUnmatchedParameter(string path, string relativePathTemplate, bool allowUnmatchedParameter)
+    internal static string ThrowIfUnmatchedParameter(string path, string relativePathTemplate, bool allowUnmatchedParameter)
     {
         if (allowUnmatchedParameter)
         {
@@ -679,7 +695,7 @@ public static partial class GeneratedRequestRunner
     /// <summary>Rejects a no-leading-slash path under legacy resolution, matching the reflection request builder.</summary>
     /// <param name="relativePath">The resolved relative request path.</param>
     /// <exception cref="ArgumentException">The path is non-empty and does not start with '/'.</exception>
-    private static void RequireLeadingSlashUnderLegacy(string relativePath)
+    internal static void RequireLeadingSlashUnderLegacy(string relativePath)
     {
         if (relativePath.Length == 0 || relativePath[0] == '/')
         {
@@ -693,14 +709,14 @@ public static partial class GeneratedRequestRunner
     /// <summary>Builds the message describing an invalid <c>[Url]</c> parameter value.</summary>
     /// <param name="value">The rejected value.</param>
     /// <returns>The exception message.</returns>
-    private static string FormatAbsoluteUrlError(object? value) =>
+    internal static string FormatAbsoluteUrlError(object? value) =>
         $"The [Url] parameter value \"{value}\" must be an absolute URI (for example \"https://host/path\").";
 
     /// <summary>Adds one pre-boxed configured request property or option value.</summary>
     /// <param name="request">The request to modify.</param>
     /// <param name="key">The property key.</param>
     /// <param name="value">The pre-boxed property value.</param>
-    private static void AddBoxedRequestProperty(HttpRequestMessage request, string key, object value)
+    internal static void AddBoxedRequestProperty(HttpRequestMessage request, string key, object value)
     {
 #if NET6_0_OR_GREATER
         request.Options.Set(new(key), value);
@@ -715,7 +731,7 @@ public static partial class GeneratedRequestRunner
     /// <param name="body">The body value.</param>
     /// <param name="serializationMethod">The configured body serialization method.</param>
     /// <returns>The serialized HTTP content.</returns>
-    private static HttpContent CreateSerializedBodyContent<TBody>(
+    internal static HttpContent CreateSerializedBodyContent<TBody>(
         RefitSettings settings,
         TBody body,
         BodySerializationMethod serializationMethod)
@@ -748,21 +764,21 @@ public static partial class GeneratedRequestRunner
     /// <summary>Determines whether request bodies should be serialized synchronously through the configured serializer.</summary>
     /// <param name="settings">The Refit settings to inspect.</param>
     /// <returns><see langword="true"/> when synchronous body serialization is enabled and supported.</returns>
-    private static bool UsesSynchronousSerialization(RefitSettings settings) =>
+    internal static bool UsesSynchronousSerialization(RefitSettings settings) =>
         settings.RequestBodySerialization != RequestBodySerializationMode.Default
         && settings.ContentSerializer is ISynchronousContentSerializer;
 
     /// <summary>Determines whether the HTTP method must not carry generated placeholder content for content headers.</summary>
     /// <param name="method">The HTTP method to inspect.</param>
     /// <returns><see langword="true"/> for bodyless methods.</returns>
-    private static bool IsBodyless(HttpMethod method) =>
+    internal static bool IsBodyless(HttpMethod method) =>
         method == HttpMethod.Get || method == HttpMethod.Head;
 
     /// <summary>Checks whether a header collection contains a key without throwing for unsupported header types.</summary>
     /// <param name="headers">The header collection to inspect.</param>
     /// <param name="name">The header name.</param>
     /// <returns><see langword="true"/> when the header key exists; otherwise <see langword="false"/>.</returns>
-    private static bool ContainsHeader(System.Net.Http.Headers.HttpHeaders headers, string name)
+    internal static bool ContainsHeader(System.Net.Http.Headers.HttpHeaders headers, string name)
     {
 #if NET6_0_OR_GREATER
         // NonValidated checks key presence (case-insensitively, like the store) without parsing or materializing the
@@ -785,5 +801,19 @@ public static partial class GeneratedRequestRunner
     /// <summary>Removes CR and LF characters from a generated header name or value.</summary>
     /// <param name="value">The header name or value.</param>
     /// <returns>The sanitized value.</returns>
-    private static string EnsureSafeHeaderValue(string value) => StringHelpers.RemoveCrOrLf(value);
+    internal static string EnsureSafeHeaderValue(string value) => StringHelpers.RemoveCrOrLf(value);
+
+    /// <summary>Formats a single catch-all path section through the configured formatter and appends its escaped form.</summary>
+    /// <param name="sb">The path builder receiving the escaped section.</param>
+    /// <param name="section">The raw path section.</param>
+    /// <param name="settings">The Refit settings supplying the URL parameter formatter registry and default.</param>
+    /// <param name="attributeProvider">The parameter's attribute provider passed to the formatter.</param>
+    /// <param name="type">The parameter's declared type passed to the formatter.</param>
+    private static void AppendFormattedSection(
+        ref ValueStringBuilder sb,
+        string section,
+        RefitSettings settings,
+        ICustomAttributeProvider attributeProvider,
+        Type type) =>
+        sb.Append(StringHelpers.EscapeDataString(FormatUrlParameter(settings, section, attributeProvider, type) ?? string.Empty));
 }

--- a/src/Refit/HttpHeaderApplier.cs
+++ b/src/Refit/HttpHeaderApplier.cs
@@ -48,7 +48,7 @@ internal static class HttpHeaderApplier
     /// <returns><see langword="true"/> when the header was stored; <see langword="false"/> when it belongs on the
     /// content collection instead, mirroring the <c>false</c> return of <c>TryAddWithoutValidation</c>.</returns>
     /// <exception cref="FormatException">The value is malformed for this header's parser.</exception>
-    private static bool TryAddValidated(System.Net.Http.Headers.HttpHeaders headers, string name, string value)
+    internal static bool TryAddValidated(System.Net.Http.Headers.HttpHeaders headers, string name, string value)
     {
         try
         {

--- a/src/Refit/InvariantValueRenderer.cs
+++ b/src/Refit/InvariantValueRenderer.cs
@@ -1,0 +1,34 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Globalization;
+
+namespace Refit;
+
+/// <summary>Renders a non-null parameter value to its string form under the invariant culture.</summary>
+/// <remarks>Shared by the default URL and form-url-encoded parameter formatters. It reproduces the observable result
+/// of <c>string.Format(CultureInfo.InvariantCulture, "{0}"/"{0:format}", value)</c> without the composite-format
+/// parsing and the intermediate result copy: a string is returned verbatim, and a formattable value is rendered
+/// directly through <see cref="IFormattable.ToString(string, IFormatProvider)"/>.</remarks>
+internal static class InvariantValueRenderer
+{
+    /// <summary>Renders the value using the invariant culture and an optional format string.</summary>
+    /// <param name="value">The non-null value to render.</param>
+    /// <param name="formatString">The format string, or <see langword="null"/>/whitespace for no format.</param>
+    /// <returns>The rendered string.</returns>
+    internal static string Render(object value, string? formatString)
+    {
+        // A string is emitted verbatim: composite formatting has no alignment component here, and a format specifier
+        // is ignored for a non-IFormattable argument, so the original string is returned unchanged.
+        if (value is string text)
+        {
+            return text;
+        }
+
+        var format = string.IsNullOrWhiteSpace(formatString) ? null : formatString;
+        return value is IFormattable formattable
+            ? formattable.ToString(format, CultureInfo.InvariantCulture)
+            : value.ToString() ?? string.Empty;
+    }
+}

--- a/src/Refit/PushStreamContent.cs
+++ b/src/Refit/PushStreamContent.cs
@@ -89,6 +89,21 @@ internal class PushStreamContent : HttpContent
         Headers.ContentType = mediaType ?? new MediaTypeHeaderValue("application/octet-stream");
     }
 
+    /// <summary>Wraps a synchronous stream callback in a task-returning callback.</summary>
+    /// <param name="onStreamAvailable">The synchronous action to wrap.</param>
+    /// <returns>A task-returning callback that invokes the action.</returns>
+    internal static Func<Stream, HttpContent, TransportContext?, Task> Taskify(
+        Action<Stream, HttpContent, TransportContext?> onStreamAvailable)
+    {
+        ArgumentExceptionHelper.ThrowIfNull(onStreamAvailable);
+
+        return (stream, content, transportContext) =>
+        {
+            onStreamAvailable(stream, content, transportContext);
+            return Task.CompletedTask;
+        };
+    }
+
     /// <summary>
     /// When this method is called, it calls the action provided in the constructor with the output
     /// stream to write to. Once the action has completed its work it closes the stream which will
@@ -126,21 +141,6 @@ internal class PushStreamContent : HttpContent
         // We can't know the length of the content being pushed to the output stream.
         length = -1;
         return false;
-    }
-
-    /// <summary>Wraps a synchronous stream callback in a task-returning callback.</summary>
-    /// <param name="onStreamAvailable">The synchronous action to wrap.</param>
-    /// <returns>A task-returning callback that invokes the action.</returns>
-    private static Func<Stream, HttpContent, TransportContext?, Task> Taskify(
-        Action<Stream, HttpContent, TransportContext?> onStreamAvailable)
-    {
-        ArgumentExceptionHelper.ThrowIfNull(onStreamAvailable);
-
-        return (stream, content, transportContext) =>
-        {
-            onStreamAvailable(stream, content, transportContext);
-            return Task.CompletedTask;
-        };
     }
 
     /// <summary>A delegating stream that signals completion when it is disposed.</summary>

--- a/src/Refit/Refit.csproj
+++ b/src/Refit/Refit.csproj
@@ -12,6 +12,7 @@
   <ItemGroup>
     <InternalsVisibleTo Include="Refit.Tests"/>
     <InternalsVisibleTo Include="Refit.Reflection"/>
+    <InternalsVisibleTo Include="Refit.Benchmarks"/>
     <PackageReference Include="ReactiveUI.Primitives" ExcludeAssets="analyzers"/>
   </ItemGroup>
 

--- a/src/Refit/RefitSettings.cs
+++ b/src/Refit/RefitSettings.cs
@@ -315,7 +315,7 @@ public class RefitSettings
     /// <param name="jsonNamingPolicy">The naming policy applied to JSON body property names.</param>
     /// <param name="urlParameterKeyFormatter">The formatter applied to query and form-url-encoded keys.</param>
     /// <returns>The configured settings.</returns>
-    private static RefitSettings ForNamingConvention(
+    internal static RefitSettings ForNamingConvention(
         JsonNamingPolicy jsonNamingPolicy,
         IUrlParameterKeyFormatter urlParameterKeyFormatter)
     {
@@ -333,7 +333,7 @@ public class RefitSettings
     /// <see cref="CancellationToken.IsCancellationRequested"/> is <see langword="true"/>, and wraps every
     /// other exception in an <see cref="ApiRequestException"/> that captures the request and these settings.
     /// </returns>
-    private Func<HttpRequestMessage, Exception, CancellationToken, Exception> DefaultTransportExceptionFactory()
+    internal Func<HttpRequestMessage, Exception, CancellationToken, Exception> DefaultTransportExceptionFactory()
         => (req, ex, ct) =>
              ex is OperationCanceledException && ct.IsCancellationRequested ? ex : new ApiRequestException(req, req.Method, this, ex);
 }

--- a/src/Refit/ReflectionPropertyHelpers.cs
+++ b/src/Refit/ReflectionPropertyHelpers.cs
@@ -49,6 +49,6 @@ internal static class ReflectionPropertyHelpers
     /// <summary>Determines whether a property can be read through its public getter.</summary>
     /// <param name="property">The property to inspect.</param>
     /// <returns><see langword="true"/> when the property is readable; otherwise <see langword="false"/>.</returns>
-    private static bool IsReadablePublicProperty(PropertyInfo property) =>
+    internal static bool IsReadablePublicProperty(PropertyInfo property) =>
         property.CanRead && property.GetMethod!.IsPublic; // A readable property (CanRead) always has a non-null GetMethod.
 }

--- a/src/Refit/ReflectionRequestBuilderResolver.cs
+++ b/src/Refit/ReflectionRequestBuilderResolver.cs
@@ -29,7 +29,7 @@ internal static class ReflectionRequestBuilderResolver
     /// <returns>The factory instance.</returns>
     [RequiresUnreferencedCode("The reflection request builder requires runtime type lookup and request metadata.")]
     [ExcludeFromCodeCoverage] // The not-installed throw is unreachable in-process: Refit.Reflection is always present when this resolver runs.
-    private static IRequestBuilderFactory CreateFactory() =>
+    internal static IRequestBuilderFactory CreateFactory() =>
         Type.GetType(FactoryTypeName, throwOnError: false) is { } factoryType
         && Activator.CreateInstance(factoryType) is IRequestBuilderFactory factory
             ? factory

--- a/src/Refit/RequestExecutionHelpers.Streaming.cs
+++ b/src/Refit/RequestExecutionHelpers.Streaming.cs
@@ -21,7 +21,7 @@ internal static partial class RequestExecutionHelpers
         "SST2307:Generic method type parameters should be inferable from the parameters",
         Justification = "Type parameter intentionally specified explicitly by generated and reflection callers.")]
     [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage] // async-iterator dispose-mode epilogue: the compiler-generated <>w__disposeMode false-edge cannot be exercised or removed.
-    private static async IAsyncEnumerable<T?> StreamResponseIteratorAsync<T>(
+    internal static async IAsyncEnumerable<T?> StreamResponseIteratorAsync<T>(
         HttpClient client,
         HttpRequestMessage request,
         RefitSettings settings,
@@ -84,7 +84,7 @@ internal static partial class RequestExecutionHelpers
     /// <summary>Chooses the streaming frame format from the response content type.</summary>
     /// <param name="content">The response content whose media type is inspected.</param>
     /// <returns>The detected streaming format.</returns>
-    private static StreamingContentFormat DetectStreamingFormat(HttpContent content)
+    internal static StreamingContentFormat DetectStreamingFormat(HttpContent content)
     {
         var mediaType = content.Headers.ContentType?.MediaType;
         if (string.Equals(mediaType, "text/event-stream", StringComparison.OrdinalIgnoreCase))

--- a/src/Refit/RequestExecutionHelpers.cs
+++ b/src/Refit/RequestExecutionHelpers.cs
@@ -287,7 +287,7 @@ internal static partial class RequestExecutionHelpers
     /// <param name="options">The send and response-processing options.</param>
     /// <param name="cancellationToken">A token to cancel the request.</param>
     /// <returns>A task that completes once the request has been prepared.</returns>
-    private static async Task PrepareRequestAsync(
+    internal static async Task PrepareRequestAsync(
         HttpRequestMessage request,
         RefitSettings settings,
         RequestExecutionOptions options,
@@ -322,7 +322,7 @@ internal static partial class RequestExecutionHelpers
         "Design",
         "SST2307:Generic method type parameters should be inferable from the parameters",
         Justification = "TBody is intentionally passed explicitly by callers for ApiResponse<T> failure wrapping.")]
-    private static async Task<SendResult<T>> SendOrCaptureExceptionAsync<T, TBody>(
+    internal static async Task<SendResult<T>> SendOrCaptureExceptionAsync<T, TBody>(
         HttpClient client,
         HttpRequestMessage request,
         RefitSettings settings,
@@ -363,7 +363,7 @@ internal static partial class RequestExecutionHelpers
     /// <param name="exception">The exception to rethrow.</param>
     /// <returns>Never returns; the return type only lets callers write <c>throw Rethrow(...)</c> as a terminator.</returns>
     [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage] // The trailing return is unreachable: ExceptionDispatchInfo.Throw() always throws first.
-    private static Exception Rethrow(Exception exception)
+    internal static Exception Rethrow(Exception exception)
     {
         System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(exception).Throw();
         return exception;
@@ -384,7 +384,7 @@ internal static partial class RequestExecutionHelpers
         "Design",
         "SST2307:Generic method type parameters should be inferable from the parameters",
         Justification = "TBody is intentionally passed explicitly by generated and reflection callers for ApiResponse<T> body deserialization.")]
-    private static async Task<T?> DispatchResponseAsync<T, TBody>(
+    internal static async Task<T?> DispatchResponseAsync<T, TBody>(
         HttpRequestMessage request,
         HttpResponseMessage response,
         HttpContent content,
@@ -433,7 +433,7 @@ internal static partial class RequestExecutionHelpers
         "Design",
         "SST2307:Generic method type parameters should be inferable from the parameters",
         Justification = "TBody is intentionally passed explicitly by callers for ApiResponse<T> body deserialization.")]
-    private static async ValueTask<T?> BuildApiResponseAsync<T, TBody>(
+    internal static async ValueTask<T?> BuildApiResponseAsync<T, TBody>(
         HttpRequestMessage request,
         HttpResponseMessage response,
         HttpContent content,
@@ -478,7 +478,7 @@ internal static partial class RequestExecutionHelpers
         "Design",
         "SST2307:Generic method type parameters should be inferable from the parameters",
         Justification = "Callers intentionally close the result type; type inference is not part of this helper contract.")]
-    private static async ValueTask<T?> DeserializeOrThrowAsync<T>(
+    internal static async ValueTask<T?> DeserializeOrThrowAsync<T>(
         HttpRequestMessage request,
         HttpResponseMessage response,
         HttpContent content,
@@ -525,7 +525,7 @@ internal static partial class RequestExecutionHelpers
     /// <param name="settings">The Refit settings to use.</param>
     /// <param name="exception">The original exception.</param>
     /// <returns>The wrapped exception, or null when a configured factory returns null.</returns>
-    private static async ValueTask<Exception?> CreateDeserializationExceptionAsync(
+    internal static async ValueTask<Exception?> CreateDeserializationExceptionAsync(
         HttpRequestMessage request,
         HttpResponseMessage response,
         RefitSettings settings,
@@ -552,7 +552,7 @@ internal static partial class RequestExecutionHelpers
         "Design",
         "SST2307:Generic method type parameters should be inferable from the parameters",
         Justification = "Callers intentionally close the result type; type inference is not part of this helper contract.")]
-    private static async ValueTask<T?> DeserializeContentAsync<T>(
+    internal static async ValueTask<T?> DeserializeContentAsync<T>(
         HttpResponseMessage response,
         HttpContent content,
         RefitSettings settings,
@@ -618,7 +618,7 @@ internal static partial class RequestExecutionHelpers
         "Design",
         "SST2307:Generic method type parameters should be inferable from the parameters",
         Justification = "Callers intentionally close the result type; type inference is not part of this helper contract.")]
-    private static async ValueTask<T?> DeserializeSerializedContentAsync<T>(
+    internal static async ValueTask<T?> DeserializeSerializedContentAsync<T>(
         HttpResponseMessage response,
         HttpContent content,
         RefitSettings settings,
@@ -641,7 +641,7 @@ internal static partial class RequestExecutionHelpers
     /// <param name="content">The content to buffer.</param>
     /// <param name="cancellationToken">A token to cancel buffering.</param>
     /// <returns>A task that completes once buffering has been attempted.</returns>
-    private static async Task TryBufferContentAsync(HttpContent content, CancellationToken cancellationToken)
+    internal static async Task TryBufferContentAsync(HttpContent content, CancellationToken cancellationToken)
     {
         try
         {
@@ -655,13 +655,13 @@ internal static partial class RequestExecutionHelpers
 
     /// <summary>The outcome of attempting to send a request.</summary>
     /// <typeparam name="T">The result type returned to the caller.</typeparam>
-    private readonly record struct SendResult<T>
+    internal readonly record struct SendResult<T>
     {
         /// <summary>Initializes a new instance of the <see cref="SendResult{T}"/> struct.</summary>
         /// <param name="hasResponse">Whether the send produced a response.</param>
         /// <param name="response">The response, or null when the send failed.</param>
         /// <param name="failureResult">The captured failure result, valid only when <paramref name="hasResponse"/> is false.</param>
-        private SendResult(bool hasResponse, HttpResponseMessage? response, T? failureResult)
+        internal SendResult(bool hasResponse, HttpResponseMessage? response, T? failureResult)
         {
             HasResponse = hasResponse;
             Response = response;

--- a/src/Refit/RestService.cs
+++ b/src/Refit/RestService.cs
@@ -429,7 +429,7 @@ public static class RestService
     /// <returns>The generated implementation type.</returns>
     [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
     [RequiresUnreferencedCode("Resolving a generated client type by name requires runtime type lookup.")]
-    private static Type GetGeneratedType(
+    internal static Type GetGeneratedType(
         [DynamicallyAccessedMembers(
             DynamicallyAccessedMemberTypes.Interfaces |
             DynamicallyAccessedMemberTypes.PublicMethods |
@@ -445,7 +445,7 @@ public static class RestService
     /// <summary>Creates the exception thrown when no source-generated implementation is available.</summary>
     /// <param name="refitInterfaceType">The Refit interface type.</param>
     /// <returns>The generated-client exception.</returns>
-    private static InvalidOperationException CreateMissingGeneratedFactoryException(Type refitInterfaceType)
+    internal static InvalidOperationException CreateMissingGeneratedFactoryException(Type refitInterfaceType)
     {
         var message =
             refitInterfaceType.Name

--- a/src/Refit/SeparatedCaseFormatter.cs
+++ b/src/Refit/SeparatedCaseFormatter.cs
@@ -49,7 +49,7 @@ internal static class SeparatedCaseFormatter
     /// <param name="key">The identifier being formatted.</param>
     /// <param name="index">The index of the uppercase character.</param>
     /// <returns><see langword="true"/> when a separator should be inserted before the character.</returns>
-    private static bool NeedsSeparatorBefore(string key, int index)
+    internal static bool NeedsSeparatorBefore(string key, int index)
     {
         var previous = key[index - 1];
 

--- a/src/Refit/StringHelpers.cs
+++ b/src/Refit/StringHelpers.cs
@@ -160,7 +160,7 @@ internal static class StringHelpers
     /// <param name="value">The value to inspect.</param>
     /// <returns>The first CR or LF index, or -1 when none is present.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static int IndexOfCrOrLf(string value) =>
+    internal static int IndexOfCrOrLf(string value) =>
 #if NET8_0_OR_GREATER
         value.AsSpan().IndexOfAny(_lineBreakCharacters);
 #else
@@ -172,7 +172,7 @@ internal static class StringHelpers
     /// <param name="c">The character to test.</param>
     /// <returns><see langword="true"/> for an unreserved character.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static bool IsUriUnreserved(char c) =>
+    internal static bool IsUriUnreserved(char c) =>
         c is (>= 'A' and <= 'Z') or (>= 'a' and <= 'z') or (>= '0' and <= '9') or '-' or '.' or '_' or '~';
 #endif
 }

--- a/src/Refit/SystemTextJsonContentSerializer.cs
+++ b/src/Refit/SystemTextJsonContentSerializer.cs
@@ -223,7 +223,7 @@ public sealed class SystemTextJsonContentSerializer(JsonSerializerOptions jsonSe
     /// <param name="type">The declared type to inspect.</param>
     /// <param name="jsonSerializerOptions">The serializer options to consult for type metadata.</param>
     /// <returns><see langword="true"/> if the type is polymorphic; otherwise <see langword="false"/>.</returns>
-    private static bool DeclaredTypeIsPolymorphic(Type type, JsonSerializerOptions jsonSerializerOptions)
+    internal static bool DeclaredTypeIsPolymorphic(Type type, JsonSerializerOptions jsonSerializerOptions)
     {
 #if NET8_0_OR_GREATER
         return type.IsDefined(typeof(JsonPolymorphicAttribute), false)
@@ -243,7 +243,7 @@ public sealed class SystemTextJsonContentSerializer(JsonSerializerOptions jsonSe
     /// <param name="lineStart">The offset of the line.</param>
     /// <param name="lineLength">The length of the line.</param>
     /// <returns><see langword="true"/> when the line contains only spaces and tabs.</returns>
-    private static bool IsBlankLine(byte[] lineBuffer, int lineStart, int lineLength)
+    internal static bool IsBlankLine(byte[] lineBuffer, int lineStart, int lineLength)
     {
         var line = new ReadOnlySpan<byte>(lineBuffer, lineStart, lineLength);
         if (!line.IsEmpty && line[line.Length - 1] == (byte)'\r')
@@ -267,7 +267,7 @@ public sealed class SystemTextJsonContentSerializer(JsonSerializerOptions jsonSe
     /// <param name="length">The number of buffered bytes to preserve.</param>
     /// <param name="growthFactor">The factor by which the buffer capacity grows.</param>
     /// <returns>The larger rented buffer holding the preserved prefix.</returns>
-    private static byte[] GrowLineScanBuffer(byte[] buffer, int length, int growthFactor)
+    internal static byte[] GrowLineScanBuffer(byte[] buffer, int length, int growthFactor)
     {
         var larger = ArrayPool<byte>.Shared.Rent(buffer.Length * growthFactor);
         Buffer.BlockCopy(buffer, 0, larger, 0, length);
@@ -281,7 +281,7 @@ public sealed class SystemTextJsonContentSerializer(JsonSerializerOptions jsonSe
     /// <param name="type">The runtime type to resolve metadata for.</param>
     /// <param name="jsonSerializerOptions">The serializer options to consult.</param>
     /// <returns>The JSON type metadata.</returns>
-    private static JsonTypeInfo GetJsonTypeInfo(Type type, JsonSerializerOptions jsonSerializerOptions) =>
+    internal static JsonTypeInfo GetJsonTypeInfo(Type type, JsonSerializerOptions jsonSerializerOptions) =>
         jsonSerializerOptions.GetTypeInfo(type); // Returns non-null metadata for the requested type or throws; there is no null case to guard.
 
 #if NET11_0_OR_GREATER
@@ -293,7 +293,7 @@ public sealed class SystemTextJsonContentSerializer(JsonSerializerOptions jsonSe
         "Design",
         "SST2307:Generic method type parameters should be inferable from the parameters",
         Justification = "Type parameter intentionally specified explicitly by callers.")]
-    private static JsonTypeInfo<T> GetJsonTypeInfo<T>(JsonSerializerOptions jsonSerializerOptions) =>
+    internal static JsonTypeInfo<T> GetJsonTypeInfo<T>(JsonSerializerOptions jsonSerializerOptions) =>
         jsonSerializerOptions.GetTypeInfo<T>();
 #endif
 #endif
@@ -306,7 +306,7 @@ public sealed class SystemTextJsonContentSerializer(JsonSerializerOptions jsonSe
         "Design",
         "SST2307:Generic method type parameters should be inferable from the parameters",
         Justification = "Type parameter intentionally specified explicitly by callers.")]
-    private JsonTypeInfo<T> GetJsonTypeInfo<T>() =>
+    internal JsonTypeInfo<T> GetJsonTypeInfo<T>() =>
 #if NET11_0_OR_GREATER
         GetJsonTypeInfo<T>(jsonSerializerOptions); // Returns the strongly typed metadata for the exact type T, never null.
 #else
@@ -318,7 +318,7 @@ public sealed class SystemTextJsonContentSerializer(JsonSerializerOptions jsonSe
     /// <param name="item">The item to serialize.</param>
     /// <param name="runtimeType">The runtime type to serialize the item as.</param>
     /// <returns>The serialized HTTP content.</returns>
-    private JsonContent ToHttpContentRuntimeTyped(object item, Type runtimeType)
+    internal JsonContent ToHttpContentRuntimeTyped(object item, Type runtimeType)
     {
 #if NET8_0_OR_GREATER
         return jsonSerializerOptions.TypeInfoResolver is not null
@@ -335,7 +335,7 @@ public sealed class SystemTextJsonContentSerializer(JsonSerializerOptions jsonSe
     /// <returns>The serialized HTTP content.</returns>
     [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = ReflectionFallbackJustification)]
     [UnconditionalSuppressMessage("AOT", "IL3050", Justification = ReflectionFallbackJustification)]
-    private JsonContent ToHttpContentRuntimeReflection(object item, Type runtimeType) =>
+    internal JsonContent ToHttpContentRuntimeReflection(object item, Type runtimeType) =>
         JsonContent.Create(item, runtimeType, options: jsonSerializerOptions);
 
     /// <summary>Serializes the item using reflection-based metadata (used when the options provide no resolver).</summary>
@@ -344,7 +344,7 @@ public sealed class SystemTextJsonContentSerializer(JsonSerializerOptions jsonSe
     /// <returns>The serialized HTTP content.</returns>
     [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = ReflectionFallbackJustification)]
     [UnconditionalSuppressMessage("AOT", "IL3050", Justification = ReflectionFallbackJustification)]
-    private JsonContent ToHttpContentReflection<T>(T item) =>
+    internal JsonContent ToHttpContentReflection<T>(T item) =>
         JsonContent.Create(item, options: jsonSerializerOptions);
 
     /// <summary>Deserializes the content using reflection-based metadata (used when the options provide no resolver).</summary>
@@ -358,7 +358,7 @@ public sealed class SystemTextJsonContentSerializer(JsonSerializerOptions jsonSe
         Justification = "Type parameter intentionally specified explicitly by callers.")]
     [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = ReflectionFallbackJustification)]
     [UnconditionalSuppressMessage("AOT", "IL3050", Justification = ReflectionFallbackJustification)]
-    private Task<T?> FromHttpContentReflectionAsync<T>(HttpContent content, CancellationToken cancellationToken) =>
+    internal Task<T?> FromHttpContentReflectionAsync<T>(HttpContent content, CancellationToken cancellationToken) =>
         content.ReadFromJsonAsync<T>(jsonSerializerOptions, cancellationToken);
 
     /// <summary>Serializes an item to UTF-8 JSON bytes, using source-gen metadata when a resolver is configured.</summary>
@@ -369,7 +369,7 @@ public sealed class SystemTextJsonContentSerializer(JsonSerializerOptions jsonSe
         "Design",
         "SST2307:Generic method type parameters should be inferable from the parameters",
         Justification = "Type parameter intentionally specified explicitly by callers.")]
-    private byte[] SerializeToUtf8Bytes<T>(T item)
+    internal byte[] SerializeToUtf8Bytes<T>(T item)
     {
 #if NET8_0_OR_GREATER
         return jsonSerializerOptions.TypeInfoResolver is not null
@@ -390,7 +390,7 @@ public sealed class SystemTextJsonContentSerializer(JsonSerializerOptions jsonSe
         "Design",
         "SST2307:Generic method type parameters should be inferable from the parameters",
         Justification = "Type parameter intentionally specified explicitly by callers.")]
-    private byte[] SerializeToUtf8BytesReflection<T>(T item) =>
+    internal byte[] SerializeToUtf8BytesReflection<T>(T item) =>
         JsonSerializer.SerializeToUtf8Bytes(item, jsonSerializerOptions);
 
     /// <summary>Writes an item to a <see cref="Utf8JsonWriter"/>, using source-gen metadata when a resolver is configured.</summary>
@@ -401,7 +401,7 @@ public sealed class SystemTextJsonContentSerializer(JsonSerializerOptions jsonSe
         "Design",
         "SST2307:Generic method type parameters should be inferable from the parameters",
         Justification = "Type parameter intentionally specified explicitly by callers.")]
-    private void SerializeToWriter<T>(T item, Utf8JsonWriter writer)
+    internal void SerializeToWriter<T>(T item, Utf8JsonWriter writer)
     {
 #if NET8_0_OR_GREATER
         if (jsonSerializerOptions.TypeInfoResolver is not null)
@@ -427,7 +427,7 @@ public sealed class SystemTextJsonContentSerializer(JsonSerializerOptions jsonSe
         "Design",
         "SST2307:Generic method type parameters should be inferable from the parameters",
         Justification = "Type parameter intentionally specified explicitly by callers.")]
-    private void SerializeToWriterReflection<T>(T item, Utf8JsonWriter writer) =>
+    internal void SerializeToWriterReflection<T>(T item, Utf8JsonWriter writer) =>
         JsonSerializer.Serialize(writer, item, jsonSerializerOptions);
 
     /// <summary>Streams the elements of a single top-level JSON array.</summary>
@@ -439,7 +439,7 @@ public sealed class SystemTextJsonContentSerializer(JsonSerializerOptions jsonSe
         "Design",
         "SST2307:Generic method type parameters should be inferable from the parameters",
         Justification = "Type parameter intentionally specified explicitly by callers.")]
-    private IAsyncEnumerable<T?> DeserializeJsonArrayAsync<T>(Stream stream, CancellationToken cancellationToken)
+    internal IAsyncEnumerable<T?> DeserializeJsonArrayAsync<T>(Stream stream, CancellationToken cancellationToken)
     {
 #if NET8_0_OR_GREATER
         return jsonSerializerOptions.TypeInfoResolver is not null
@@ -461,7 +461,7 @@ public sealed class SystemTextJsonContentSerializer(JsonSerializerOptions jsonSe
         "Design",
         "SST2307:Generic method type parameters should be inferable from the parameters",
         Justification = "Type parameter intentionally specified explicitly by callers.")]
-    private IAsyncEnumerable<T?> DeserializeJsonArrayReflectionAsync<T>(Stream stream, CancellationToken cancellationToken) =>
+    internal IAsyncEnumerable<T?> DeserializeJsonArrayReflectionAsync<T>(Stream stream, CancellationToken cancellationToken) =>
         JsonSerializer.DeserializeAsyncEnumerable<T>(stream, jsonSerializerOptions, cancellationToken);
 
     /// <summary>Streams newline-delimited JSON values from the response body.</summary>
@@ -473,7 +473,7 @@ public sealed class SystemTextJsonContentSerializer(JsonSerializerOptions jsonSe
         "Design",
         "SST2307:Generic method type parameters should be inferable from the parameters",
         Justification = "Type parameter intentionally specified explicitly by callers.")]
-    private IAsyncEnumerable<T?> DeserializeJsonLinesAsync<T>(Stream stream, CancellationToken cancellationToken)
+    internal IAsyncEnumerable<T?> DeserializeJsonLinesAsync<T>(Stream stream, CancellationToken cancellationToken)
     {
 #if NET9_0_OR_GREATER
         // .NET 9 added the topLevelValues overload, which reads a stream of whitespace-separated
@@ -498,7 +498,7 @@ public sealed class SystemTextJsonContentSerializer(JsonSerializerOptions jsonSe
         "Design",
         "SST2307:Generic method type parameters should be inferable from the parameters",
         Justification = "Type parameter intentionally specified explicitly by callers.")]
-    private IAsyncEnumerable<T?> DeserializeJsonLinesTopLevelReflectionAsync<T>(Stream stream, CancellationToken cancellationToken) =>
+    internal IAsyncEnumerable<T?> DeserializeJsonLinesTopLevelReflectionAsync<T>(Stream stream, CancellationToken cancellationToken) =>
         JsonSerializer.DeserializeAsyncEnumerable<T>(stream, topLevelValues: true, jsonSerializerOptions, cancellationToken);
 #else
     /// <summary>Reads newline-delimited JSON from a stream using a pooled UTF-8 buffer, deserializing each line.</summary>
@@ -511,7 +511,7 @@ public sealed class SystemTextJsonContentSerializer(JsonSerializerOptions jsonSe
         "SST2307:Generic method type parameters should be inferable from the parameters",
         Justification = "Type parameter intentionally specified explicitly by callers.")]
     [ExcludeFromCodeCoverage] // async-iterator dispose-mode epilogue: the compiler-generated <>w__disposeMode false-edge cannot be exercised or removed.
-    private async IAsyncEnumerable<T?> DeserializeJsonLinesManualAsync<T>(
+    internal async IAsyncEnumerable<T?> DeserializeJsonLinesManualAsync<T>(
         Stream stream,
         [EnumeratorCancellation] CancellationToken cancellationToken)
     {
@@ -589,7 +589,7 @@ public sealed class SystemTextJsonContentSerializer(JsonSerializerOptions jsonSe
         "Design",
         "SST2307:Generic method type parameters should be inferable from the parameters",
         Justification = "Type parameter intentionally specified explicitly by callers.")]
-    private T? DeserializeLine<T>(byte[] buffer, int start, int length)
+    internal T? DeserializeLine<T>(byte[] buffer, int start, int length)
     {
         // DeserializeLine is only called for non-blank lines, so the span is never empty here.
         var span = new ReadOnlySpan<byte>(buffer, start, length);
@@ -617,7 +617,7 @@ public sealed class SystemTextJsonContentSerializer(JsonSerializerOptions jsonSe
         "Design",
         "SST2307:Generic method type parameters should be inferable from the parameters",
         Justification = "Type parameter intentionally specified explicitly by callers.")]
-    private T? DeserializeLineReflection<T>(ReadOnlySpan<byte> utf8Json) =>
+    internal T? DeserializeLineReflection<T>(ReadOnlySpan<byte> utf8Json) =>
         JsonSerializer.Deserialize<T>(utf8Json, jsonSerializerOptions);
 #endif
 
@@ -631,7 +631,7 @@ public sealed class SystemTextJsonContentSerializer(JsonSerializerOptions jsonSe
         "SST2307:Generic method type parameters should be inferable from the parameters",
         Justification = "Type parameter intentionally specified explicitly by callers.")]
     [ExcludeFromCodeCoverage] // async-iterator dispose-mode epilogue: the compiler-generated <>w__disposeMode false-edge cannot be exercised or removed.
-    private async IAsyncEnumerable<T?> DeserializeServerSentEventsAsync<T>(
+    internal async IAsyncEnumerable<T?> DeserializeServerSentEventsAsync<T>(
         Stream stream,
         [EnumeratorCancellation] CancellationToken cancellationToken)
     {
@@ -651,7 +651,7 @@ public sealed class SystemTextJsonContentSerializer(JsonSerializerOptions jsonSe
         "Design",
         "SST2307:Generic method type parameters should be inferable from the parameters",
         Justification = "Type parameter intentionally specified explicitly by callers.")]
-    private T? DeserializeSseData<T>(string eventType, ReadOnlySpan<byte> data)
+    internal T? DeserializeSseData<T>(string eventType, ReadOnlySpan<byte> data)
     {
         _ = eventType;
 #if NET8_0_OR_GREATER
@@ -673,7 +673,7 @@ public sealed class SystemTextJsonContentSerializer(JsonSerializerOptions jsonSe
         "Design",
         "SST2307:Generic method type parameters should be inferable from the parameters",
         Justification = "Type parameter intentionally specified explicitly by callers.")]
-    private T? DeserializeSseDataReflection<T>(ReadOnlySpan<byte> utf8Json) =>
+    internal T? DeserializeSseDataReflection<T>(ReadOnlySpan<byte> utf8Json) =>
         JsonSerializer.Deserialize<T>(utf8Json, jsonSerializerOptions);
 
     /// <summary>Deserializes a buffered string using reflection-based metadata.</summary>
@@ -686,6 +686,6 @@ public sealed class SystemTextJsonContentSerializer(JsonSerializerOptions jsonSe
         "Design",
         "SST2307:Generic method type parameters should be inferable from the parameters",
         Justification = "Type parameter intentionally specified explicitly by callers.")]
-    private T? DeserializeFromStringReflection<T>(string content) =>
+    internal T? DeserializeFromStringReflection<T>(string content) =>
         JsonSerializer.Deserialize<T>(content, jsonSerializerOptions);
 }

--- a/src/Refit/SystemTextJsonQueryConverter.cs
+++ b/src/Refit/SystemTextJsonQueryConverter.cs
@@ -2,9 +2,6 @@
 // ReactiveUI and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Collections;
-using System.Text.Json;
-
 namespace Refit;
 
 /// <summary>
@@ -24,9 +21,6 @@ namespace Refit;
 /// </remarks>
 public sealed class SystemTextJsonQueryConverter<T> : IQueryConverter<T>
 {
-    /// <summary>The recursion cap that bounds a cyclic runtime object graph.</summary>
-    private const int MaxDepth = 32;
-
     /// <inheritdoc/>
     public void Flatten(T value, string keyPrefix, ref GeneratedQueryStringBuilder builder, RefitSettings settings)
     {
@@ -41,95 +35,6 @@ public sealed class SystemTextJsonQueryConverter<T> : IQueryConverter<T>
                 $"SystemTextJsonQueryConverter requires {nameof(RefitSettings)}.{nameof(RefitSettings.ContentSerializer)} to be a {nameof(SystemTextJsonContentSerializer)}.");
         }
 
-        FlattenObject(value, keyPrefix, ref builder, settings, serializer.SerializerOptions, 0);
+        SystemTextJsonQueryFlattener.FlattenObject(value, keyPrefix, ref builder, settings, serializer.SerializerOptions, 0);
     }
-
-    /// <summary>Determines whether a value renders as a single query value rather than a nested object.</summary>
-    /// <param name="value">The value to inspect.</param>
-    /// <returns><see langword="true"/> for strings and formattable scalars.</returns>
-    private static bool IsSimpleQueryValue(object value) =>
-        value is string or bool or char or IFormattable or Uri or System.Globalization.CultureInfo;
-
-    /// <summary>Walks a value's JSON properties and appends each non-null one.</summary>
-    /// <param name="value">The object to flatten.</param>
-    /// <param name="keyPrefix">The key prefix for this object's properties.</param>
-    /// <param name="builder">The query-string builder to append to.</param>
-    /// <param name="settings">The active Refit settings.</param>
-    /// <param name="options">The serializer options supplying the type metadata.</param>
-    /// <param name="depth">The current recursion depth.</param>
-    private static void FlattenObject(
-        object value,
-        string keyPrefix,
-        ref GeneratedQueryStringBuilder builder,
-        RefitSettings settings,
-        JsonSerializerOptions options,
-        int depth)
-    {
-        var properties = options.GetTypeInfo(value.GetType()).Properties;
-        for (var i = 0; i < properties.Count; i++)
-        {
-            var property = properties[i];
-            if (property.Get is not { } getter)
-            {
-                continue;
-            }
-
-            var propertyValue = getter(value);
-            if (propertyValue is not null)
-            {
-                AppendValue(property.Name, propertyValue, keyPrefix, ref builder, settings, options, depth);
-            }
-        }
-    }
-
-    /// <summary>Appends one property value as a scalar, a collection, or a nested object.</summary>
-    /// <param name="name">The JSON property name.</param>
-    /// <param name="propertyValue">The non-null property value.</param>
-    /// <param name="keyPrefix">The enclosing object's key prefix.</param>
-    /// <param name="builder">The query-string builder to append to.</param>
-    /// <param name="settings">The active Refit settings.</param>
-    /// <param name="options">The serializer options supplying the type metadata.</param>
-    /// <param name="depth">The current recursion depth.</param>
-    private static void AppendValue(
-        string name,
-        object propertyValue,
-        string keyPrefix,
-        ref GeneratedQueryStringBuilder builder,
-        RefitSettings settings,
-        JsonSerializerOptions options,
-        int depth)
-    {
-        var key = keyPrefix + name;
-        if (IsSimpleQueryValue(propertyValue))
-        {
-            builder.Add(key, Format(propertyValue, settings), false);
-            return;
-        }
-
-        if (propertyValue is IEnumerable enumerable)
-        {
-            builder.BeginCollection(key, settings.CollectionFormat, false);
-            foreach (var element in enumerable)
-            {
-                builder.AddCollectionValue(element is null ? null : Format(element, settings));
-            }
-
-            builder.EndCollection();
-            return;
-        }
-
-        if (depth >= MaxDepth)
-        {
-            return;
-        }
-
-        FlattenObject(propertyValue, key + ".", ref builder, settings, options, depth + 1);
-    }
-
-    /// <summary>Formats one value through the configured URL parameter formatter.</summary>
-    /// <param name="value">The value to format.</param>
-    /// <param name="settings">The active Refit settings.</param>
-    /// <returns>The formatted value.</returns>
-    private static string? Format(object value, RefitSettings settings) =>
-        settings.UrlParameterFormatter.Format(value, value.GetType(), value.GetType());
 }

--- a/src/Refit/SystemTextJsonQueryFlattener.cs
+++ b/src/Refit/SystemTextJsonQueryFlattener.cs
@@ -1,0 +1,107 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Collections;
+using System.Text.Json;
+
+namespace Refit;
+
+/// <summary>
+/// The type-parameter-independent flattening engine behind <see cref="SystemTextJsonQueryConverter{T}"/>. Kept
+/// non-generic so a single copy of the walk is shared across every closed converter instantiation.
+/// </summary>
+internal static class SystemTextJsonQueryFlattener
+{
+    /// <summary>The recursion cap that bounds a cyclic runtime object graph.</summary>
+    private const int MaxDepth = 32;
+
+    /// <summary>Determines whether a value renders as a single query value rather than a nested object.</summary>
+    /// <param name="value">The value to inspect.</param>
+    /// <returns><see langword="true"/> for strings and formattable scalars.</returns>
+    internal static bool IsSimpleQueryValue(object value) =>
+        value is string or bool or char or IFormattable or Uri or System.Globalization.CultureInfo;
+
+    /// <summary>Walks a value's JSON properties and appends each non-null one.</summary>
+    /// <param name="value">The object to flatten.</param>
+    /// <param name="keyPrefix">The key prefix for this object's properties.</param>
+    /// <param name="builder">The query-string builder to append to.</param>
+    /// <param name="settings">The active Refit settings.</param>
+    /// <param name="options">The serializer options supplying the type metadata.</param>
+    /// <param name="depth">The current recursion depth.</param>
+    internal static void FlattenObject(
+        object value,
+        string keyPrefix,
+        ref GeneratedQueryStringBuilder builder,
+        RefitSettings settings,
+        JsonSerializerOptions options,
+        int depth)
+    {
+        var properties = options.GetTypeInfo(value.GetType()).Properties;
+        for (var i = 0; i < properties.Count; i++)
+        {
+            var property = properties[i];
+            if (property.Get is not { } getter)
+            {
+                continue;
+            }
+
+            var propertyValue = getter(value);
+            if (propertyValue is not null)
+            {
+                AppendValue(property.Name, propertyValue, keyPrefix, ref builder, settings, options, depth);
+            }
+        }
+    }
+
+    /// <summary>Appends one property value as a scalar, a collection, or a nested object.</summary>
+    /// <param name="name">The JSON property name.</param>
+    /// <param name="propertyValue">The non-null property value.</param>
+    /// <param name="keyPrefix">The enclosing object's key prefix.</param>
+    /// <param name="builder">The query-string builder to append to.</param>
+    /// <param name="settings">The active Refit settings.</param>
+    /// <param name="options">The serializer options supplying the type metadata.</param>
+    /// <param name="depth">The current recursion depth.</param>
+    internal static void AppendValue(
+        string name,
+        object propertyValue,
+        string keyPrefix,
+        ref GeneratedQueryStringBuilder builder,
+        RefitSettings settings,
+        JsonSerializerOptions options,
+        int depth)
+    {
+        var key = keyPrefix + name;
+        if (IsSimpleQueryValue(propertyValue))
+        {
+            builder.Add(key, Format(propertyValue, settings), false);
+            return;
+        }
+
+        if (propertyValue is IEnumerable enumerable)
+        {
+            builder.BeginCollection(key, settings.CollectionFormat, false);
+            foreach (var element in enumerable)
+            {
+                builder.AddCollectionValue(element is null ? null : Format(element, settings));
+            }
+
+            builder.EndCollection();
+            return;
+        }
+
+        if (depth >= MaxDepth)
+        {
+            return;
+        }
+
+        FlattenObject(propertyValue, key + ".", ref builder, settings, options, depth + 1);
+    }
+
+    /// <summary>Formats one value through the configured URL parameter formatter.</summary>
+    /// <param name="value">The value to format.</param>
+    /// <param name="settings">The active Refit settings.</param>
+    /// <returns>The formatted value.</returns>
+    internal static string? Format(object value, RefitSettings settings) =>
+        settings.UrlParameterFormatter.Format(value, value.GetType(), value.GetType());
+}

--- a/src/Refit/ValidationApiException.cs
+++ b/src/Refit/ValidationApiException.cs
@@ -53,7 +53,7 @@ public class ValidationApiException : ApiException
 
     /// <summary>Initializes a new instance of the <see cref="ValidationApiException"/> class from an existing ApiException.</summary>
     /// <param name="apiException">The originating API exception to wrap.</param>
-    private ValidationApiException(ApiException apiException)
+    internal ValidationApiException(ApiException apiException)
         : base(
             apiException.RequestMessage,
             apiException.HttpMethod,
@@ -108,7 +108,7 @@ public class ValidationApiException : ApiException
     /// <summary>Validates the exception content and builds the base validation exception.</summary>
     /// <param name="exception">The API exception to convert.</param>
     /// <returns>A new validation exception wrapping the API exception.</returns>
-    private static ValidationApiException CreateCore(ApiException exception)
+    internal static ValidationApiException CreateCore(ApiException exception)
     {
         ArgumentExceptionHelper.ThrowIfNull(exception);
 
@@ -128,7 +128,7 @@ public class ValidationApiException : ApiException
     /// <summary>Deserializes RFC 7807 problem details without requiring public setters on extension data.</summary>
     /// <param name="content">The JSON problem details content.</param>
     /// <returns>The deserialized problem details.</returns>
-    private static ProblemDetails DeserializeProblemDetails(string content)
+    internal static ProblemDetails DeserializeProblemDetails(string content)
     {
 #if NET10_0_OR_GREATER
         var rootElement = JsonElement.Parse(content);
@@ -153,7 +153,7 @@ public class ValidationApiException : ApiException
     /// <summary>Reads a single problem-details property.</summary>
     /// <param name="problemDetails">The problem details instance to populate.</param>
     /// <param name="property">The JSON property to read.</param>
-    private static void ReadProblemDetailsProperty(
+    internal static void ReadProblemDetailsProperty(
         ProblemDetails problemDetails,
         JsonProperty property)
     {
@@ -200,13 +200,13 @@ public class ValidationApiException : ApiException
     /// <param name="property">The JSON property.</param>
     /// <param name="name">The expected property name.</param>
     /// <returns><see langword="true"/> when the names match.</returns>
-    private static bool IsJsonProperty(JsonProperty property, string name) =>
+    internal static bool IsJsonProperty(JsonProperty property, string name) =>
         string.Equals(property.Name, name, StringComparison.OrdinalIgnoreCase);
 
     /// <summary>Reads a nullable JSON string value.</summary>
     /// <param name="element">The JSON element.</param>
     /// <returns>The string value.</returns>
-    private static string? ReadString(JsonElement element) =>
+    internal static string? ReadString(JsonElement element) =>
         element.ValueKind == JsonValueKind.Null
             ? null
             : element.GetString();
@@ -214,7 +214,7 @@ public class ValidationApiException : ApiException
     /// <summary>Reads validation errors from a JSON object.</summary>
     /// <param name="element">The JSON element.</param>
     /// <param name="errors">The error dictionary to populate.</param>
-    private static void ReadErrors(
+    internal static void ReadErrors(
         JsonElement element,
         Dictionary<string, string[]> errors)
     {
@@ -232,7 +232,7 @@ public class ValidationApiException : ApiException
     /// <summary>Reads error messages from a JSON value.</summary>
     /// <param name="element">The JSON element.</param>
     /// <returns>The error messages.</returns>
-    private static string[] ReadErrorMessages(JsonElement element)
+    internal static string[] ReadErrorMessages(JsonElement element)
     {
         if (element.ValueKind == JsonValueKind.Array)
         {
@@ -253,7 +253,7 @@ public class ValidationApiException : ApiException
     /// <summary>Reads a single error message.</summary>
     /// <param name="element">The JSON element.</param>
     /// <returns>The error message.</returns>
-    private static string ReadErrorMessage(JsonElement element) =>
+    internal static string ReadErrorMessage(JsonElement element) =>
         element.ValueKind == JsonValueKind.String
             ? element.GetString()! // A String-kind element always yields a non-null string.
             : element.GetRawText();
@@ -261,7 +261,7 @@ public class ValidationApiException : ApiException
     /// <summary>Reads extension data using the same inferred primitives as the System.Text.Json converter.</summary>
     /// <param name="element">The JSON element.</param>
     /// <returns>The extension value.</returns>
-    private static object ReadExtensionValue(JsonElement element) =>
+    internal static object ReadExtensionValue(JsonElement element) =>
         element.ValueKind switch
         {
             JsonValueKind.True => true,

--- a/src/Refit/ValueStringBuilder.cs
+++ b/src/Refit/ValueStringBuilder.cs
@@ -62,7 +62,7 @@ internal ref struct ValueStringBuilder
     /// <remarks>ToString() clears the builder, so we need a side-effect free debugger display.</remarks>
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage] // Only evaluated by the debugger, never by tests.
-    private readonly string DebuggerDisplay => AsSpan().ToString();
+    internal readonly string DebuggerDisplay => AsSpan().ToString();
 
     /// <summary>Gets a reference to the character at the specified index.</summary>
     /// <param name="index">The zero-based index of the character.</param>
@@ -321,7 +321,7 @@ internal ref struct ValueStringBuilder
 
     /// <summary>Appends a string using the slow path that may grow the buffer.</summary>
     /// <param name="s">The string to append.</param>
-    private void AppendSlow(string s)
+    internal void AppendSlow(string s)
     {
         var pos = _pos;
         if (pos > _chars.Length - s.Length)
@@ -340,7 +340,7 @@ internal ref struct ValueStringBuilder
     /// <summary>Grows the buffer and then appends the character.</summary>
     /// <param name="c">The character to append.</param>
     [MethodImpl(MethodImplOptions.NoInlining)]
-    private void GrowAndAppend(char c)
+    internal void GrowAndAppend(char c)
     {
         Grow(1);
         Append(c);
@@ -351,7 +351,7 @@ internal ref struct ValueStringBuilder
     /// Number of chars requested beyond current position.
     /// </param>
     [MethodImpl(MethodImplOptions.NoInlining)]
-    private void Grow(int additionalCapacityBeyondPos)
+    internal void Grow(int additionalCapacityBeyondPos)
     {
         Debug.Assert(additionalCapacityBeyondPos > 0, "Grow must be called with a positive additional capacity.");
         Debug.Assert(

--- a/src/benchmarks/Refit.Benchmarks/ContentSerializerHelperBenchmarks.cs
+++ b/src/benchmarks/Refit.Benchmarks/ContentSerializerHelperBenchmarks.cs
@@ -1,0 +1,73 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Reflection;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Diagnosers;
+
+namespace Refit.Benchmarks;
+
+/// <summary>
+/// Allocation micro-benchmarks for the <see cref="SystemTextJsonContentSerializer"/> helpers that surround the JSON
+/// engine: default options construction, JSON property-name resolution, polymorphism detection, and the reflection
+/// serialize/deserialize round-trip. The source-generated fast path is covered by the request body serialization
+/// benchmark; this isolates the reflection-metadata helpers.
+/// </summary>
+[MemoryDiagnoser]
+[EventPipeProfiler(EventPipeProfile.GcVerbose)]
+[ShortRunJob]
+[GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]
+[CategoriesColumn]
+public class ContentSerializerHelperBenchmarks
+{
+    /// <summary>The reflection-based serializer under test.</summary>
+    private readonly SystemTextJsonContentSerializer _serializer = new();
+
+    /// <summary>The declared type inspected by the polymorphism check.</summary>
+    private readonly Type _declaredType = typeof(User);
+
+    /// <summary>A JSON object serialized and deserialized by the round-trip benchmarks.</summary>
+    private User _user = null!;
+
+    /// <summary>The reflected property whose JSON field name is resolved.</summary>
+    private PropertyInfo _property = null!;
+
+    /// <summary>The JSON string deserialized by the round-trip benchmark.</summary>
+    private string _json = null!;
+
+    /// <summary>Builds the payload, reflected property, and serialized JSON before the benchmarks run.</summary>
+    [GlobalSetup]
+    public void Setup()
+    {
+        _user = new() { Id = 1, Name = "Ada", Bio = "mathematician", Url = "https://x/y" };
+        _property = _declaredType.GetProperty(nameof(User.Name))!;
+        _json = System.Text.Encoding.UTF8.GetString(_serializer.SerializeToUtf8Bytes(_user));
+    }
+
+    /// <summary>Resolves the JSON field name for a property (attribute lookup).</summary>
+    /// <returns>The resolved field name length, or zero when unset.</returns>
+    [Benchmark]
+    [BenchmarkCategory("Metadata")]
+    public int GetFieldNameForProperty() => _serializer.GetFieldNameForProperty(_property)?.Length ?? 0;
+
+    /// <summary>Determines whether the declared type is configured for polymorphic serialization.</summary>
+    /// <returns>1 when polymorphic; otherwise 0.</returns>
+    [Benchmark]
+    [BenchmarkCategory("Metadata")]
+    public int DeclaredTypeIsPolymorphic() =>
+        SystemTextJsonContentSerializer.DeclaredTypeIsPolymorphic(_declaredType, _serializer.SerializerOptions) ? 1 : 0;
+
+    /// <summary>Serializes a JSON object to UTF-8 bytes through the reflection path.</summary>
+    /// <returns>The serialized byte count.</returns>
+    [Benchmark]
+    [BenchmarkCategory("RoundTrip")]
+    public int SerializeToUtf8Bytes() => _serializer.SerializeToUtf8Bytes(_user).Length;
+
+    /// <summary>Deserializes a JSON string through the reflection path.</summary>
+    /// <returns>The deserialized identifier.</returns>
+    [Benchmark]
+    [BenchmarkCategory("RoundTrip")]
+    public int DeserializeFromString() => _serializer.DeserializeFromString<User>(_json)!.Id;
+}

--- a/src/benchmarks/Refit.Benchmarks/EnumHandlingBenchmarks.cs
+++ b/src/benchmarks/Refit.Benchmarks/EnumHandlingBenchmarks.cs
@@ -1,0 +1,121 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Reflection;
+using System.Text.Json;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Diagnosers;
+
+namespace Refit.Benchmarks;
+
+/// <summary>
+/// Allocation micro-benchmarks for enum handling: the <c>EnumHelpers</c> <c>[EnumMember]</c> value lookup and cache
+/// build, the undefined-value numeric formatting, the <c>CamelCaseStringEnumConverter</c> name helpers and
+/// serialized-name dictionary construction, and a JSON round-trip through the camelCase enum converter.
+/// </summary>
+[MemoryDiagnoser]
+[EventPipeProfiler(EventPipeProfile.GcVerbose)]
+[ShortRunJob]
+[GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]
+[CategoriesColumn]
+public class EnumHandlingBenchmarks
+{
+    /// <summary>The runtime enum type inspected by the lookups.</summary>
+    private readonly Type _enumType = typeof(QuerySort);
+
+    /// <summary>A boxed enum value carrying an <c>[EnumMember]</c> override.</summary>
+    private readonly object _valueWithMember = QuerySort.DateDescending;
+
+    /// <summary>A boxed enum value with no <c>[EnumMember]</c> override.</summary>
+    private readonly object _valueWithoutMember = QuerySort.Name;
+
+    /// <summary>An undefined enum value formatted through the numeric path.</summary>
+    private readonly QuerySort _undefinedValue = (QuerySort)999;
+
+    /// <summary>A defined enum value serialized through the converter.</summary>
+    private readonly QuerySort _definedValue = QuerySort.Name;
+
+    /// <summary>A Pascal-cased name converted to camelCase.</summary>
+    private readonly string _pascalName = "DateDescending";
+
+    /// <summary>The enum field carrying an <c>[EnumMember]</c> override.</summary>
+    private FieldInfo _memberField = null!;
+
+    /// <summary>Options carrying the camelCase enum converter used by the round-trip benchmarks.</summary>
+    private JsonSerializerOptions _options = null!;
+
+    /// <summary>The serialized camelCase name deserialized by the round-trip benchmark.</summary>
+    private string _serializedName = null!;
+
+    /// <summary>Resolves the reflected field and serializer options before the benchmarks run.</summary>
+    [GlobalSetup]
+    public void Setup()
+    {
+        _memberField = _enumType.GetField(nameof(QuerySort.DateDescending))!;
+        _options = SystemTextJsonContentSerializer.GetDefaultJsonSerializerOptions();
+        _serializedName = JsonSerializer.Serialize(_definedValue, _options);
+    }
+
+    /// <summary>Looks up the cached <c>[EnumMember]</c> value for a member that declares one.</summary>
+    /// <returns>The looked-up value length.</returns>
+    [Benchmark]
+    [BenchmarkCategory("Lookup")]
+    public int GetEnumMemberValueWithMember() =>
+        (EnumHelpers.GetEnumMemberValue(_enumType, _valueWithMember) ?? string.Empty).Length;
+
+    /// <summary>Looks up the cached <c>[EnumMember]</c> value for a member that declares none.</summary>
+    /// <returns>The looked-up value length.</returns>
+    [Benchmark]
+    [BenchmarkCategory("Lookup")]
+    public int GetEnumMemberValueNoMember() =>
+        (EnumHelpers.GetEnumMemberValue(_enumType, _valueWithoutMember) ?? string.Empty).Length;
+
+    /// <summary>Builds the uncached <c>[EnumMember]</c> value map for the enum type.</summary>
+    /// <returns>The map entry count.</returns>
+    [Benchmark]
+    [BenchmarkCategory("Build")]
+    public int CreateEnumMemberValueMap() => EnumHelpers.CreateEnumMemberValueMap(_enumType).Count;
+
+    /// <summary>Constructs the camelCase enum converter, building all three serialized-name maps from a single field scan.</summary>
+    /// <returns>The names-to-values entry count, forcing the maps to be built.</returns>
+    [Benchmark]
+    [BenchmarkCategory("Build")]
+    public int ConstructEnumConverter()
+    {
+        // Reading a shared field anchors this construction benchmark to the instance so BenchmarkDotNet can invoke it.
+        _ = _enumType;
+        return new CamelCaseStringEnumConverter.EnumConverter<QuerySort>().MapEntryCount;
+    }
+
+    /// <summary>Formats an undefined enum value through the numeric backing-type path.</summary>
+    /// <returns>The formatted value length.</returns>
+    [Benchmark]
+    [BenchmarkCategory("Format")]
+    public int FormatNumericValue() => EnumHelpers.Info<QuerySort>.FormatNumericValue(_undefinedValue).Length;
+
+    /// <summary>Converts a Pascal-cased name to camelCase.</summary>
+    /// <returns>The converted value length.</returns>
+    [Benchmark]
+    [BenchmarkCategory("Format")]
+    public int ToCamelCase() => CamelCaseStringEnumConverter.ToCamelCase(_pascalName).Length;
+
+    /// <summary>Resolves the preferred serialized name for an enum field.</summary>
+    /// <returns>The resolved name length.</returns>
+    [Benchmark]
+    [BenchmarkCategory("Format")]
+    public int GetPreferredSerializedName() => CamelCaseStringEnumConverter.GetPreferredSerializedName(_memberField).Length;
+
+    /// <summary>Serializes a defined enum value through the camelCase converter.</summary>
+    /// <returns>The serialized name length.</returns>
+    [Benchmark]
+    [BenchmarkCategory("RoundTrip")]
+    public int SerializeEnum() => JsonSerializer.Serialize(_definedValue, _options).Length;
+
+    /// <summary>Deserializes a camelCase name back to its enum value through the converter.</summary>
+    /// <returns>The deserialized enum value as an integer.</returns>
+    [Benchmark]
+    [BenchmarkCategory("RoundTrip")]
+    public int DeserializeEnum() => (int)JsonSerializer.Deserialize<QuerySort>(_serializedName, _options);
+}

--- a/src/benchmarks/Refit.Benchmarks/FormValueMappingBenchmarks.cs
+++ b/src/benchmarks/Refit.Benchmarks/FormValueMappingBenchmarks.cs
@@ -1,0 +1,121 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Collections;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Diagnosers;
+
+namespace Refit.Benchmarks;
+
+/// <summary>
+/// Allocation micro-benchmarks for the form-url-encoded mapping layer: <c>FormValueMultimap</c> construction through
+/// both the reflection and source-generated descriptor paths (isolated from the <see cref="FormUrlEncodedContent"/>
+/// wrapping), its collection joining helper, and <see cref="DefaultFormUrlEncodedParameterFormatter"/> value formatting.
+/// </summary>
+[MemoryDiagnoser]
+[EventPipeProfiler(EventPipeProfile.GcVerbose)]
+[ShortRunJob]
+[GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]
+[CategoriesColumn]
+public class FormValueMappingBenchmarks
+{
+    /// <summary>A representative age value for the sample payload.</summary>
+    private const int SampleAge = 36;
+
+    /// <summary>The comma delimiter used when joining a collection value.</summary>
+    private const string CsvDelimiter = ",";
+
+    /// <summary>Settings using the built-in serializer that enables the descriptor path.</summary>
+    private readonly RefitSettings _settings = new(new SystemTextJsonContentSerializer());
+
+    /// <summary>The default form value formatter under test.</summary>
+    private readonly DefaultFormUrlEncodedParameterFormatter _formatter = new();
+
+    /// <summary>A representative collection joined by the collection-joining benchmark.</summary>
+    private readonly List<string> _collection = ["admin", "author", "editor", "reviewer"];
+
+    /// <summary>The payload mapped by each mapping benchmark.</summary>
+    private FormBenchmarkModel _body = null!;
+
+    /// <summary>The compile-time field descriptors mirroring <see cref="FormBenchmarkModel"/>.</summary>
+    private FormField<FormBenchmarkModel>[] _fields = null!;
+
+    /// <summary>Builds the payload and descriptors before the benchmarks run.</summary>
+    [GlobalSetup]
+    public void Setup()
+    {
+        _body = new()
+        {
+            FirstName = "Ada",
+            LastName = "Lovelace",
+            Email = "ada@example.com",
+            Age = SampleAge,
+            Note = null,
+        };
+        _body.Roles.Add("admin");
+        _body.Roles.Add("author");
+
+        _fields =
+        [
+            new(static b => b.FirstName, "FirstName", "first_name", null, null, null, false),
+            new(static b => b.LastName, "LastName", "last_name", null, null, null, false),
+            new(static b => b.Email, "Email", null, null, null, null, false),
+            new(static b => b.Age, "Age", null, null, null, null, false),
+            new(static b => b.Note, "Note", null, null, null, null, true),
+            new(static b => b.Roles, "Roles", null, null, null, CollectionFormat.Multi, false),
+        ];
+    }
+
+    /// <summary>Maps the payload to form entries through the reflection property walk.</summary>
+    /// <returns>The number of mapped entries.</returns>
+    [Benchmark(Baseline = true)]
+    [BenchmarkCategory("Mapping")]
+    public int ReflectionCreate() => Count(FormValueMultimap.Create(_body, _settings));
+
+    /// <summary>Maps the payload to form entries through the source-generated descriptors.</summary>
+    /// <returns>The number of mapped entries.</returns>
+    [Benchmark]
+    [BenchmarkCategory("Mapping")]
+    public int DescriptorCreate() => Count(FormValueMultimap.CreateFromFields(_body, _fields, _settings));
+
+    /// <summary>Joins a collection of values with the comma delimiter through the shared join helper.</summary>
+    /// <returns>The joined value length.</returns>
+    [Benchmark]
+    [BenchmarkCategory("Join")]
+    public int JoinCsvValues() =>
+        FormValueMultimap.JoinFormattedValues(_collection, CsvDelimiter, null, _settings).Length;
+
+    /// <summary>Formats a plain string value.</summary>
+    /// <returns>The formatted value length.</returns>
+    [Benchmark]
+    [BenchmarkCategory("ValueFormat")]
+    public int FormatString() => (_formatter.Format("widgets and gadgets", null) ?? string.Empty).Length;
+
+    /// <summary>Formats an integer value (boxed through the invariant <c>string.Format</c> path).</summary>
+    /// <returns>The formatted value length.</returns>
+    [Benchmark]
+    [BenchmarkCategory("ValueFormat")]
+    public int FormatInt() => (_formatter.Format(SampleAge, null) ?? string.Empty).Length;
+
+    /// <summary>Formats an enum value carrying an <c>[EnumMember]</c> override (exercises the enum-member cache).</summary>
+    /// <returns>The formatted value length.</returns>
+    [Benchmark]
+    [BenchmarkCategory("ValueFormat")]
+    public int FormatEnumMember() => (_formatter.Format(QuerySort.DateDescending, null) ?? string.Empty).Length;
+
+    /// <summary>Counts the entries produced by a form value map, forcing the enumeration.</summary>
+    /// <param name="map">The form value map to count.</param>
+    /// <returns>The number of entries.</returns>
+    private static int Count(IEnumerable map)
+    {
+        var count = 0;
+        foreach (var _ in map)
+        {
+            count++;
+        }
+
+        return count;
+    }
+}

--- a/src/benchmarks/Refit.Benchmarks/HeaderApplicationBenchmarks.cs
+++ b/src/benchmarks/Refit.Benchmarks/HeaderApplicationBenchmarks.cs
@@ -1,0 +1,111 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Diagnosers;
+
+namespace Refit.Benchmarks;
+
+/// <summary>
+/// Allocation micro-benchmarks for the header application path shared by generated and reflection request building:
+/// <c>HttpHeaderApplier.Apply</c> (validated and unvalidated) and the <see cref="GeneratedRequestRunner"/> header
+/// entry points that sanitize, replace, and stamp request and content headers. Each benchmark builds a fresh request
+/// so header state does not accumulate across invocations; the request allocation is part of the measured cost.
+/// </summary>
+[MemoryDiagnoser]
+[EventPipeProfiler(EventPipeProfile.GcVerbose)]
+[ShortRunJob]
+[GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]
+[CategoriesColumn]
+public class HeaderApplicationBenchmarks
+{
+    /// <summary>A representative custom header name applied to a request.</summary>
+    private readonly string _customHeaderName = "X-Correlation-Id";
+
+    /// <summary>A representative custom header value applied to a request.</summary>
+    private readonly string _customHeaderValue = "6f8b2c1e-3a4d-4e5f-8a9b-0c1d2e3f4a5b";
+
+    /// <summary>A header collection stamped onto a request by the collection benchmark.</summary>
+    private readonly Dictionary<string, string> _headerCollection = new()
+    {
+        ["X-Correlation-Id"] = "6f8b2c1e-3a4d-4e5f-8a9b-0c1d2e3f4a5b",
+        ["X-Client-Version"] = "12.3.4",
+        ["Accept-Language"] = "en-AU",
+    };
+
+    /// <summary>Builds a fresh request without applying any header, isolating the per-op request construction cost
+    /// that every other benchmark in this class also pays so the header-application delta can be read directly.</summary>
+    /// <returns>The resulting request header count.</returns>
+    [Benchmark]
+    [BenchmarkCategory("Control")]
+    public int BuildRequestOnly()
+    {
+        // Reading the shared header-name field anchors this control to the instance so BenchmarkDotNet can invoke it
+        // like the header benchmarks, while it still measures only the per-op request construction they all pay.
+        _ = _customHeaderName;
+        using var request = NewRequest();
+        return request.Headers.NonValidated.Count;
+    }
+
+    /// <summary>Sets one custom request header verbatim (unvalidated).</summary>
+    /// <returns>The resulting request header count.</returns>
+    [Benchmark(Baseline = true)]
+    [BenchmarkCategory("SetHeader")]
+    public int SetHeaderUnvalidated()
+    {
+        using var request = NewRequest();
+        GeneratedRequestRunner.SetHeader(request, _customHeaderName, _customHeaderValue, false);
+        return request.Headers.NonValidated.Count;
+    }
+
+    /// <summary>Sets one custom request header with framework validation.</summary>
+    /// <returns>The resulting request header count.</returns>
+    [Benchmark]
+    [BenchmarkCategory("SetHeader")]
+    public int SetHeaderValidated()
+    {
+        using var request = NewRequest();
+        GeneratedRequestRunner.SetHeader(request, _customHeaderName, _customHeaderValue, true);
+        return request.Headers.NonValidated.Count;
+    }
+
+    /// <summary>Stamps a collection of headers onto a request.</summary>
+    /// <returns>The resulting request header count.</returns>
+    [Benchmark]
+    [BenchmarkCategory("Collection")]
+    public int AddHeaderCollection()
+    {
+        using var request = NewRequest();
+        GeneratedRequestRunner.AddHeaderCollection(request, _headerCollection, false);
+        return request.Headers.NonValidated.Count;
+    }
+
+    /// <summary>Applies a validated header directly through the shared applier.</summary>
+    /// <returns>The resulting request header count.</returns>
+    [Benchmark]
+    [BenchmarkCategory("Apply")]
+    public int ApplyValidated()
+    {
+        using var request = NewRequest();
+        HttpHeaderApplier.Apply(request, _customHeaderName, _customHeaderValue, true);
+        return request.Headers.NonValidated.Count;
+    }
+
+    /// <summary>Applies an unvalidated header directly through the shared applier.</summary>
+    /// <returns>The resulting request header count.</returns>
+    [Benchmark]
+    [BenchmarkCategory("Apply")]
+    public int ApplyUnvalidated()
+    {
+        using var request = NewRequest();
+        HttpHeaderApplier.Apply(request, _customHeaderName, _customHeaderValue, false);
+        return request.Headers.NonValidated.Count;
+    }
+
+    /// <summary>Creates a fresh POST request with empty content for header application.</summary>
+    /// <returns>The new request.</returns>
+    private static HttpRequestMessage NewRequest() =>
+        new(HttpMethod.Post, new Uri("/resource", UriKind.Relative)) { Content = new ByteArrayContent([]) };
+}

--- a/src/benchmarks/Refit.Benchmarks/PartiallyReadableModel.cs
+++ b/src/benchmarks/Refit.Benchmarks/PartiallyReadableModel.cs
@@ -1,0 +1,23 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Refit.Benchmarks;
+
+/// <summary>A model with a mix of readable and write-only properties, exercising the reflection property filter's
+/// slow path where the readable count differs from the total property count.</summary>
+public sealed class PartiallyReadableModel
+{
+    /// <summary>Gets or sets a readable identifier.</summary>
+    public int Id { get; set; }
+
+    /// <summary>Gets or sets a readable name.</summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets a value whose getter is non-public, so the readable-property filter skips it.</summary>
+    public string Hidden { private get; set; } = string.Empty;
+
+    /// <summary>Reads the hidden value, keeping the non-public getter observable.</summary>
+    /// <returns>The current hidden value.</returns>
+    public string PeekHidden() => Hidden;
+}

--- a/src/benchmarks/Refit.Benchmarks/PooledBufferWriterBenchmarks.cs
+++ b/src/benchmarks/Refit.Benchmarks/PooledBufferWriterBenchmarks.cs
@@ -1,0 +1,90 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Diagnosers;
+using Refit.Buffers;
+
+namespace Refit.Benchmarks;
+
+/// <summary>
+/// Allocation micro-benchmarks for the pooled <c>PooledBufferWriter</c> and its detached read-only stream: writing
+/// within the default rented buffer, writing past it to force pooled growth, and detaching the buffer into a
+/// <c>PooledMemoryStream</c> that is then read to completion.
+/// </summary>
+[MemoryDiagnoser]
+[EventPipeProfiler(EventPipeProfile.GcVerbose)]
+[ShortRunJob]
+public class PooledBufferWriterBenchmarks
+{
+    /// <summary>A byte count that fits within the writer's default rented buffer.</summary>
+    private const int SmallByteCount = 512;
+
+    /// <summary>A byte count that forces the writer to grow past its default rented buffer.</summary>
+    private const int LargeByteCount = 8192;
+
+    /// <summary>The chunk size requested from the writer on each write.</summary>
+    private const int ChunkSize = 256;
+
+    /// <summary>The fill byte written into the buffer.</summary>
+    private readonly byte _fillByte = (byte)'x';
+
+    /// <summary>A reused destination buffer for draining the detached stream.</summary>
+    private readonly byte[] _readBuffer = new byte[LargeByteCount];
+
+    /// <summary>Writes a payload that fits within the default rented buffer, then returns it to the pool.</summary>
+    /// <returns>The number of bytes written.</returns>
+    [Benchmark(Baseline = true)]
+    public int WriteSmall()
+    {
+        using var writer = new PooledBufferWriter();
+        Fill(writer, SmallByteCount);
+        return SmallByteCount;
+    }
+
+    /// <summary>Writes a payload that overflows the default buffer, forcing pooled growth, then returns it to the pool.</summary>
+    /// <returns>The number of bytes written.</returns>
+    [Benchmark]
+    public int WriteLargeGrowing()
+    {
+        using var writer = new PooledBufferWriter();
+        Fill(writer, LargeByteCount);
+        return LargeByteCount;
+    }
+
+    /// <summary>Writes a payload, detaches it into a stream, and drains the stream to completion.</summary>
+    /// <returns>The number of bytes read back from the detached stream.</returns>
+    [Benchmark]
+    public int WriteDetachAndRead()
+    {
+        using var writer = new PooledBufferWriter();
+        Fill(writer, LargeByteCount);
+        using var stream = writer.DetachStream();
+
+        var total = 0;
+        int read;
+        while ((read = stream.Read(_readBuffer, 0, _readBuffer.Length)) > 0)
+        {
+            total += read;
+        }
+
+        return total;
+    }
+
+    /// <summary>Writes the given number of fill bytes into the writer in fixed-size chunks.</summary>
+    /// <param name="writer">The buffer writer to fill.</param>
+    /// <param name="byteCount">The number of bytes to write.</param>
+    private void Fill(PooledBufferWriter writer, int byteCount)
+    {
+        var remaining = byteCount;
+        while (remaining > 0)
+        {
+            var span = writer.GetSpan(ChunkSize);
+            var take = Math.Min(span.Length, remaining);
+            span[..take].Fill(_fillByte);
+            writer.Advance(take);
+            remaining -= take;
+        }
+    }
+}

--- a/src/benchmarks/Refit.Benchmarks/QueryAddressModel.cs
+++ b/src/benchmarks/Refit.Benchmarks/QueryAddressModel.cs
@@ -1,0 +1,15 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Refit.Benchmarks;
+
+/// <summary>A nested address used by the query-flattening benchmark to exercise the recursive object walk.</summary>
+public sealed class QueryAddressModel
+{
+    /// <summary>Gets or sets the city.</summary>
+    public string City { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the postal code.</summary>
+    public string Zip { get; set; } = string.Empty;
+}

--- a/src/benchmarks/Refit.Benchmarks/QueryFlattenModel.cs
+++ b/src/benchmarks/Refit.Benchmarks/QueryFlattenModel.cs
@@ -1,0 +1,28 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Refit.Benchmarks;
+
+/// <summary>A representative query object flattened into a query string by the query-flattening benchmark: scalars,
+/// a collection, and a nested object.</summary>
+public sealed class QueryFlattenModel
+{
+    /// <summary>Gets or sets the identifier.</summary>
+    public int Id { get; set; }
+
+    /// <summary>Gets or sets the name.</summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets a value indicating whether the record is active.</summary>
+    public bool Active { get; set; }
+
+    /// <summary>Gets or sets the creation timestamp.</summary>
+    public DateTimeOffset CreatedAt { get; set; }
+
+    /// <summary>Gets the tags collection.</summary>
+    public List<string> Tags { get; } = [];
+
+    /// <summary>Gets or sets the nested address.</summary>
+    public QueryAddressModel? Address { get; set; }
+}

--- a/src/benchmarks/Refit.Benchmarks/QueryFlatteningBenchmarks.cs
+++ b/src/benchmarks/Refit.Benchmarks/QueryFlatteningBenchmarks.cs
@@ -1,0 +1,79 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Text.Json;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Diagnosers;
+
+namespace Refit.Benchmarks;
+
+/// <summary>
+/// Allocation micro-benchmarks for the query-object flattening engine <c>SystemTextJsonQueryFlattener</c> and its
+/// public entry point <see cref="SystemTextJsonQueryConverter{T}"/>, which walk a value's JSON metadata and append
+/// each property (scalar, collection, or nested object) to a query string.
+/// </summary>
+[MemoryDiagnoser]
+[EventPipeProfiler(EventPipeProfile.GcVerbose)]
+[ShortRunJob]
+public class QueryFlatteningBenchmarks
+{
+    /// <summary>The base path the flattened query is appended to.</summary>
+    private const string Path = "/search";
+
+    /// <summary>A representative identifier on the flattened payload.</summary>
+    private const int SampleId = 42;
+
+    /// <summary>The Refit settings supplying the URL parameter formatter and collection format.</summary>
+    private RefitSettings _settings = null!;
+
+    /// <summary>The serializer options supplying the JSON type metadata walked during flattening.</summary>
+    private JsonSerializerOptions _options = null!;
+
+    /// <summary>The public converter entry point under test.</summary>
+    private SystemTextJsonQueryConverter<QueryFlattenModel> _converter = null!;
+
+    /// <summary>The representative object flattened by each benchmark.</summary>
+    private QueryFlattenModel _model = null!;
+
+    /// <summary>Builds the settings, options, and payload before the benchmarks run.</summary>
+    [GlobalSetup]
+    public void Setup()
+    {
+        var serializer = new SystemTextJsonContentSerializer();
+        _settings = new(serializer);
+        _options = serializer.SerializerOptions;
+        _converter = new();
+        _model = new()
+        {
+            Id = SampleId,
+            Name = "widgets and gadgets",
+            Active = true,
+            CreatedAt = new(2026, 7, 15, 12, 30, 0, TimeSpan.Zero),
+            Address = new() { City = "Melbourne", Zip = "3000" },
+        };
+        _model.Tags.Add("alpha");
+        _model.Tags.Add("beta");
+        _model.Tags.Add("gamma");
+    }
+
+    /// <summary>Flattens the object graph directly through the flattening engine.</summary>
+    /// <returns>The built path length.</returns>
+    [Benchmark]
+    public int FlattenObject()
+    {
+        var builder = new GeneratedQueryStringBuilder(Path);
+        SystemTextJsonQueryFlattener.FlattenObject(_model, "filter.", ref builder, _settings, _options, 0);
+        return builder.Build().Length;
+    }
+
+    /// <summary>Flattens the object graph through the public converter entry point.</summary>
+    /// <returns>The built path length.</returns>
+    [Benchmark]
+    public int ConverterFlatten()
+    {
+        var builder = new GeneratedQueryStringBuilder(Path);
+        _converter.Flatten(_model, "filter.", ref builder, _settings);
+        return builder.Build().Length;
+    }
+}

--- a/src/benchmarks/Refit.Benchmarks/QueryStringBuildingBenchmarks.cs
+++ b/src/benchmarks/Refit.Benchmarks/QueryStringBuildingBenchmarks.cs
@@ -1,0 +1,119 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Diagnosers;
+
+namespace Refit.Benchmarks;
+
+/// <summary>
+/// Allocation micro-benchmarks for <see cref="GeneratedQueryStringBuilder"/>, the reflection-free ref-struct that
+/// source-generated request construction uses to append query parameters. Each benchmark drives one appender shape
+/// (escaped scalar, pre-escaped key, span-formatted value, joined and multi collections, and a valueless flag) and
+/// materializes the result so the buffer work is not elided.
+/// </summary>
+[MemoryDiagnoser]
+[EventPipeProfiler(EventPipeProfile.GcVerbose)]
+[ShortRunJob]
+public class QueryStringBuildingBenchmarks
+{
+    /// <summary>A representative integer value span-formatted into query strings.</summary>
+    private const int SampleInteger = 1_234_567;
+
+    /// <summary>A representative timestamp whose invariant form contains reserved characters.</summary>
+    private static readonly DateTimeOffset _timestamp = new(2026, 7, 15, 12, 30, 0, TimeSpan.Zero);
+
+    /// <summary>The relative path each benchmark appends its query string to.</summary>
+    private readonly string _path = "/search";
+
+    /// <summary>A scalar query value that requires percent-encoding.</summary>
+    private readonly string _scalarValue = "widgets and gadgets";
+
+    /// <summary>A representative collection of identifiers appended as a query collection.</summary>
+    private readonly int[] _ids = [1, 2, 3, 4, 5, 6, 7, 8];
+
+    /// <summary>Appends several escaped <c>key=value</c> scalar pairs.</summary>
+    /// <returns>The built path length.</returns>
+    [Benchmark]
+    public int ScalarPairs()
+    {
+        var builder = new GeneratedQueryStringBuilder(_path);
+        builder.Add("q", _scalarValue, false);
+        builder.Add("page", "3", false);
+        builder.Add("size", "25", false);
+        return builder.Build().Length;
+    }
+
+    /// <summary>Appends a scalar pair whose key the generator already escaped.</summary>
+    /// <returns>The built path length.</returns>
+    [Benchmark]
+    public int PreEscapedKeyPair()
+    {
+        var builder = new GeneratedQueryStringBuilder(_path);
+        builder.AddPreEscapedKey("q", _scalarValue, false);
+        return builder.Build().Length;
+    }
+
+    /// <summary>Appends an integer value span-formatted straight into the buffer.</summary>
+    /// <returns>The built path length.</returns>
+    [Benchmark]
+    public int FormattedInt()
+    {
+        var builder = new GeneratedQueryStringBuilder(_path);
+        builder.AddFormatted("page", SampleInteger, null, false);
+        return builder.Build().Length;
+    }
+
+    /// <summary>Appends a span-formatted timestamp that requires in-place escaping.</summary>
+    /// <returns>The built path length.</returns>
+    [Benchmark]
+    public int FormattedTimestamp()
+    {
+        var builder = new GeneratedQueryStringBuilder(_path);
+        builder.AddFormatted("at", _timestamp, null, false);
+        return builder.Build().Length;
+    }
+
+    /// <summary>Appends a comma-joined collection parameter.</summary>
+    /// <returns>The built path length.</returns>
+    [Benchmark]
+    public int CsvCollection()
+    {
+        var builder = new GeneratedQueryStringBuilder(_path);
+        builder.BeginCollection("ids", CollectionFormat.Csv, false);
+        foreach (var id in _ids)
+        {
+            builder.AddCollectionValueFormatted(id);
+        }
+
+        builder.EndCollection();
+        return builder.Build().Length;
+    }
+
+    /// <summary>Appends a multi-expanded collection parameter (one pair per element).</summary>
+    /// <returns>The built path length.</returns>
+    [Benchmark]
+    public int MultiCollection()
+    {
+        var builder = new GeneratedQueryStringBuilder(_path);
+        builder.BeginCollection("ids", CollectionFormat.Multi, false);
+        foreach (var id in _ids)
+        {
+            builder.AddCollectionValueFormatted(id);
+        }
+
+        builder.EndCollection();
+        return builder.Build().Length;
+    }
+
+    /// <summary>Appends a valueless query flag.</summary>
+    /// <returns>The built path length.</returns>
+    [Benchmark]
+    public int Flag()
+    {
+        var builder = new GeneratedQueryStringBuilder(_path);
+        builder.AddFlag("ready to ship", false);
+        return builder.Build().Length;
+    }
+}

--- a/src/benchmarks/Refit.Benchmarks/ReflectionMetadataBenchmarks.cs
+++ b/src/benchmarks/Refit.Benchmarks/ReflectionMetadataBenchmarks.cs
@@ -1,0 +1,85 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Diagnosers;
+
+namespace Refit.Benchmarks;
+
+/// <summary>
+/// Allocation micro-benchmarks for the runtime reflection metadata helpers: <c>ReflectionPropertyHelpers</c> readable
+/// property enumeration (all-readable fast path and the filtered slow path) and <see cref="GeneratedParameterAttributeProvider"/>
+/// attribute flattening and lookups (uncached first access, memoized access, and type-filtered access).
+/// </summary>
+[MemoryDiagnoser]
+[EventPipeProfiler(EventPipeProfile.GcVerbose)]
+[ShortRunJob]
+[GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]
+[CategoriesColumn]
+public class ReflectionMetadataBenchmarks
+{
+    /// <summary>The per-type attribute arrays supplied to a parameter attribute provider.</summary>
+    private readonly Dictionary<Type, object[]> _attributes = new()
+    {
+        [typeof(QueryAttribute)] = [new QueryAttribute()],
+        [typeof(EncodedAttribute)] = [new EncodedAttribute()],
+        [typeof(AliasAsAttribute)] = [new AliasAsAttribute("field")],
+    };
+
+    /// <summary>The all-readable type enumerated by the fast-path benchmark.</summary>
+    private readonly Type _allReadableType = typeof(User);
+
+    /// <summary>The mixed-readability type enumerated by the filtered-path benchmark.</summary>
+    private readonly Type _filteredType = typeof(PartiallyReadableModel);
+
+    /// <summary>A pre-built provider whose attributes are already flattened, used by the memoized-access benchmark.</summary>
+    private GeneratedParameterAttributeProvider _cachedProvider = null!;
+
+    /// <summary>Warms the memoized provider before the benchmarks run.</summary>
+    [GlobalSetup]
+    public void Setup()
+    {
+        _cachedProvider = new(_attributes);
+        _ = _cachedProvider.GetCustomAttributes(true);
+    }
+
+    /// <summary>Enumerates the readable public properties of an all-readable type (fast path).</summary>
+    /// <returns>The readable property count.</returns>
+    [Benchmark]
+    [BenchmarkCategory("Properties")]
+    public int GetReadablePropertiesFastPath() =>
+        ReflectionPropertyHelpers.GetReadablePublicInstanceProperties(_allReadableType).Length;
+
+    /// <summary>Enumerates the readable public properties of a mixed-readability type (filtered path).</summary>
+    /// <returns>The readable property count.</returns>
+    [Benchmark]
+    [BenchmarkCategory("Properties")]
+    public int GetReadablePropertiesFiltered() =>
+        ReflectionPropertyHelpers.GetReadablePublicInstanceProperties(_filteredType).Length;
+
+    /// <summary>Flattens the per-type attribute arrays into a single array.</summary>
+    /// <returns>The flattened attribute count.</returns>
+    [Benchmark]
+    [BenchmarkCategory("Attributes")]
+    public int FlattenAttributes() => GeneratedParameterAttributeProvider.FlattenAttributes(_attributes).Length;
+
+    /// <summary>Flattens all attributes on first access through a fresh provider (uncached).</summary>
+    /// <returns>The flattened attribute count.</returns>
+    [Benchmark]
+    [BenchmarkCategory("Attributes")]
+    public int GetAllAttributesUncached() => new GeneratedParameterAttributeProvider(_attributes).GetCustomAttributes(true).Length;
+
+    /// <summary>Returns the memoized flattened attributes on a warmed provider.</summary>
+    /// <returns>The flattened attribute count.</returns>
+    [Benchmark(Baseline = true)]
+    [BenchmarkCategory("Attributes")]
+    public int GetAllAttributesCached() => _cachedProvider.GetCustomAttributes(true).Length;
+
+    /// <summary>Returns the attributes of a single requested type (dictionary lookup).</summary>
+    /// <returns>The matching attribute count.</returns>
+    [Benchmark]
+    [BenchmarkCategory("Attributes")]
+    public int GetAttributesByType() => _cachedProvider.GetCustomAttributes(typeof(QueryAttribute), true).Length;
+}

--- a/src/benchmarks/Refit.Benchmarks/RequestBodyContentBenchmarks.cs
+++ b/src/benchmarks/Refit.Benchmarks/RequestBodyContentBenchmarks.cs
@@ -1,0 +1,95 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Diagnosers;
+
+namespace Refit.Benchmarks;
+
+/// <summary>
+/// Allocation micro-benchmarks for the request body content dispatch in <c>GeneratedRequestRunner.BodyContent</c>:
+/// wrapping a JSON object, a raw string, and a JSON Lines sequence into <see cref="HttpContent"/>. The dispatch and
+/// wrapper allocation are measured; the actual serialization happens later on copy, so it is not part of the signal.
+/// </summary>
+[MemoryDiagnoser]
+[EventPipeProfiler(EventPipeProfile.GcVerbose)]
+[ShortRunJob]
+[GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]
+[CategoriesColumn]
+public class RequestBodyContentBenchmarks
+{
+    /// <summary>The number of items in the JSON Lines payload.</summary>
+    private const int ItemCount = 8;
+
+    /// <summary>The settings supplying the content serializer.</summary>
+    private readonly RefitSettings _settings = new(new SystemTextJsonContentSerializer());
+
+    /// <summary>A raw string body.</summary>
+    private readonly string _stringBody = "a raw request body payload";
+
+    /// <summary>A JSON object body.</summary>
+    private User _user = null!;
+
+    /// <summary>A JSON Lines payload.</summary>
+    private List<FastItem> _items = null!;
+
+    /// <summary>Builds the payloads before the benchmarks run.</summary>
+    [GlobalSetup]
+    public void Setup()
+    {
+        _user = new() { Id = 1, Name = "Ada", Bio = "mathematician", Url = "https://x/y" };
+        _items = new(ItemCount);
+        for (var i = 0; i < ItemCount; i++)
+        {
+            _items.Add(new() { Id = i, Name = "name" });
+        }
+    }
+
+    /// <summary>Serializes the JSON object body straight through the content serializer, isolating the framework
+    /// <see cref="HttpContent"/> construction that the dispatch benchmark also pays so the dispatch delta reads directly.</summary>
+    /// <returns>The content media-type length.</returns>
+    [Benchmark]
+    [BenchmarkCategory("Json")]
+    public int CreateJsonBodyDirect()
+    {
+        using var content = _settings.ContentSerializer.ToHttpContent(_user);
+        return MediaTypeLength(content);
+    }
+
+    /// <summary>Dispatches a JSON object body to serialized HTTP content.</summary>
+    /// <returns>The content media-type length.</returns>
+    [Benchmark]
+    [BenchmarkCategory("Json")]
+    public int CreateJsonBody()
+    {
+        using var content = GeneratedRequestRunner.CreateBodyContent(_settings, _user, BodySerializationMethod.Default, false);
+        return MediaTypeLength(content);
+    }
+
+    /// <summary>Dispatches a raw string body to string HTTP content.</summary>
+    /// <returns>The content media-type length.</returns>
+    [Benchmark]
+    [BenchmarkCategory("String")]
+    public int CreateStringBody()
+    {
+        using var content = GeneratedRequestRunner.CreateBodyContent(_settings, _stringBody, BodySerializationMethod.Default, false);
+        return MediaTypeLength(content);
+    }
+
+    /// <summary>Dispatches a sequence to JSON Lines HTTP content.</summary>
+    /// <returns>The content media-type length.</returns>
+    [Benchmark]
+    [BenchmarkCategory("JsonLines")]
+    public int CreateJsonLinesBody()
+    {
+        using var content = GeneratedRequestRunner.CreateJsonLinesBodyContent(_settings, _items);
+        return MediaTypeLength(content);
+    }
+
+    /// <summary>Returns the length of the content's media type, or zero when none is set.</summary>
+    /// <param name="content">The content to inspect.</param>
+    /// <returns>The media-type length.</returns>
+    private static int MediaTypeLength(HttpContent content) => content.Headers.ContentType?.MediaType?.Length ?? 0;
+}

--- a/src/benchmarks/Refit.Benchmarks/RequestExecutionBenchmarks.cs
+++ b/src/benchmarks/Refit.Benchmarks/RequestExecutionBenchmarks.cs
@@ -1,0 +1,145 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Diagnosers;
+
+namespace Refit.Benchmarks;
+
+/// <summary>
+/// Allocation micro-benchmarks for the request execution scaffolding shared by generated and reflection sends: the
+/// cancellation-token linking in <c>GeneratedRequestRunner</c> and the timeout linking, per-call timeout stashing, and
+/// streaming-format detection in <c>RequestExecutionHelpers</c>. Linked sources allocated by the helpers are disposed
+/// inside each benchmark.
+/// </summary>
+[MemoryDiagnoser]
+[EventPipeProfiler(EventPipeProfile.GcVerbose)]
+[ShortRunJob]
+[GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]
+[CategoriesColumn]
+public class RequestExecutionBenchmarks
+{
+    /// <summary>A representative per-call timeout in milliseconds.</summary>
+    private const int TimeoutMilliseconds = 5_000;
+
+    /// <summary>The per-call timeout stashed onto and read back from a request.</summary>
+    private readonly int _timeoutMilliseconds = TimeoutMilliseconds;
+
+    /// <summary>A cancellable source whose token seeds the linking benchmarks.</summary>
+    private CancellationTokenSource _sourceA = null!;
+
+    /// <summary>A second cancellable source whose token seeds the both-cancellable linking benchmark.</summary>
+    private CancellationTokenSource _sourceB = null!;
+
+    /// <summary>Response content advertising a server-sent-events media type.</summary>
+    private HttpContent _sseContent = null!;
+
+    /// <summary>Response content advertising a JSON Lines media type.</summary>
+    private HttpContent _jsonLinesContent = null!;
+
+    /// <summary>Response content advertising a plain JSON media type.</summary>
+    private HttpContent _jsonContent = null!;
+
+    /// <summary>Builds the cancellation sources and typed response content before the benchmarks run.</summary>
+    [GlobalSetup]
+    public void Setup()
+    {
+        _sourceA = new();
+        _sourceB = new();
+        _sseContent = TypedContent("text/event-stream");
+        _jsonLinesContent = TypedContent("application/jsonl");
+        _jsonContent = TypedContent("application/json");
+    }
+
+    /// <summary>Disposes the cancellation sources and content.</summary>
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        _sourceA.Dispose();
+        _sourceB.Dispose();
+        _sseContent.Dispose();
+        _jsonLinesContent.Dispose();
+        _jsonContent.Dispose();
+    }
+
+    /// <summary>Resolves the effective token when both inputs can cancel (allocates and disposes a linked source).</summary>
+    /// <returns>1 when the resolved token can cancel; otherwise 0.</returns>
+    [Benchmark]
+    [BenchmarkCategory("Cancellation")]
+    public int ResolveTokenBoth()
+    {
+        var (token, linked) = GeneratedRequestRunner.ResolveRequestCancellationToken(_sourceA.Token, _sourceB.Token);
+        linked?.Dispose();
+        return token.CanBeCanceled ? 1 : 0;
+    }
+
+    /// <summary>Resolves the effective token when only one input can cancel (no source allocated).</summary>
+    /// <returns>1 when the resolved token can cancel; otherwise 0.</returns>
+    [Benchmark(Baseline = true)]
+    [BenchmarkCategory("Cancellation")]
+    public int ResolveTokenSingle()
+    {
+        var (token, linked) = GeneratedRequestRunner.ResolveRequestCancellationToken(_sourceA.Token, default);
+        linked?.Dispose();
+        return token.CanBeCanceled ? 1 : 0;
+    }
+
+    /// <summary>Layers a per-call timeout onto the effective token (allocates and disposes a linked source).</summary>
+    /// <returns>1 when the resolved token can cancel; otherwise 0.</returns>
+    [Benchmark]
+    [BenchmarkCategory("Timeout")]
+    public int CreateTimeoutTokenWith()
+    {
+        var (token, timeoutSource) = RequestExecutionHelpers.CreateTimeoutToken(TimeoutMilliseconds, _sourceA.Token);
+        timeoutSource?.Dispose();
+        return token.CanBeCanceled ? 1 : 0;
+    }
+
+    /// <summary>Passes through the effective token when no timeout applies (no source allocated).</summary>
+    /// <returns>1 when the resolved token can cancel; otherwise 0.</returns>
+    [Benchmark]
+    [BenchmarkCategory("Timeout")]
+    public int CreateTimeoutTokenNone()
+    {
+        var (token, timeoutSource) = RequestExecutionHelpers.CreateTimeoutToken(0, _sourceA.Token);
+        timeoutSource?.Dispose();
+        return token.CanBeCanceled ? 1 : 0;
+    }
+
+    /// <summary>Stashes and reads back a per-call timeout on a fresh request's options.</summary>
+    /// <returns>The round-tripped timeout in milliseconds.</returns>
+    [Benchmark]
+    [BenchmarkCategory("Timeout")]
+    public int StashAndReadTimeout()
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, new Uri("/resource", UriKind.Relative));
+        GeneratedRequestRunner.SetRequestTimeout(request, _timeoutMilliseconds);
+        return GeneratedRequestRunner.GetRequestTimeout(request);
+    }
+
+    /// <summary>Detects the streaming frame format of a server-sent-events response.</summary>
+    /// <returns>The detected format as an integer.</returns>
+    [Benchmark]
+    [BenchmarkCategory("StreamingFormat")]
+    public int DetectServerSentEvents() => (int)RequestExecutionHelpers.DetectStreamingFormat(_sseContent);
+
+    /// <summary>Detects the streaming frame format of a JSON Lines response.</summary>
+    /// <returns>The detected format as an integer.</returns>
+    [Benchmark]
+    [BenchmarkCategory("StreamingFormat")]
+    public int DetectJsonLines() => (int)RequestExecutionHelpers.DetectStreamingFormat(_jsonLinesContent);
+
+    /// <summary>Detects the streaming frame format of a plain JSON response (the array default).</summary>
+    /// <returns>The detected format as an integer.</returns>
+    [Benchmark]
+    [BenchmarkCategory("StreamingFormat")]
+    public int DetectJsonArray() => (int)RequestExecutionHelpers.DetectStreamingFormat(_jsonContent);
+
+    /// <summary>Creates empty content advertising the given media type.</summary>
+    /// <param name="mediaType">The media type to advertise.</param>
+    /// <returns>The typed content.</returns>
+    private static ByteArrayContent TypedContent(string mediaType) =>
+        new([]) { Headers = { ContentType = new(mediaType) } };
+}

--- a/src/benchmarks/Refit.Benchmarks/RequestPathBuildingBenchmarks.cs
+++ b/src/benchmarks/Refit.Benchmarks/RequestPathBuildingBenchmarks.cs
@@ -1,0 +1,210 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Diagnosers;
+
+namespace Refit.Benchmarks;
+
+/// <summary>
+/// Allocation micro-benchmarks for the <see cref="GeneratedRequestRunner"/> path and query building helpers shared by
+/// generated and reflection request construction: placeholder substitution (span, integer, and formattable overloads),
+/// catch-all path round-tripping, relative URI assembly, query-key composition, invariant value formatting, absolute
+/// URL validation, and collection expansion.
+/// </summary>
+[MemoryDiagnoser]
+[EventPipeProfiler(EventPipeProfile.GcVerbose)]
+[ShortRunJob]
+[GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]
+[CategoriesColumn]
+public class RequestPathBuildingBenchmarks
+{
+    /// <summary>A representative integer path/query value.</summary>
+    private const int IdValue = 42;
+
+    /// <summary>The base address host used to assemble relative URIs.</summary>
+    private const string Host = "https://api.example.test/";
+
+    /// <summary>An absolute URL validated by the absolute-URL benchmark.</summary>
+    private const string AbsoluteUrl = "https://host.example.test/path/resource";
+
+    /// <summary>A representative timestamp whose invariant form contains reserved characters.</summary>
+    private readonly DateTimeOffset _timestamp = new(2026, 7, 15, 12, 30, 0, TimeSpan.Zero);
+
+    /// <summary>A representative integer value formatted by the invariant-format benchmark.</summary>
+    private readonly int _idValue = IdValue;
+
+    /// <summary>The absolute URL validated by the absolute-URL benchmark.</summary>
+    private readonly string _absoluteUrl = AbsoluteUrl;
+
+    /// <summary>The single-placeholder query template used by the span overload.</summary>
+    private readonly string _spanTemplate = "/search/{q}";
+
+    /// <summary>The single-placeholder template used by the integer overload.</summary>
+    private readonly string _intTemplate = "/users/{id}";
+
+    /// <summary>The single-placeholder template used by the formattable overload.</summary>
+    private readonly string _formattableTemplate = "/events/{at}";
+
+    /// <summary>A catch-all path value round-tripped section by section.</summary>
+    private readonly string _catchAllValue = "reports/2026/q3/summary";
+
+    /// <summary>A scalar value substituted into the span-overload placeholder.</summary>
+    private readonly string _spanValue = "widgets and gadgets";
+
+    /// <summary>A representative collection expanded by the collection benchmarks.</summary>
+    private readonly int[] _ids = [1, 2, 3, 4, 5, 6, 7, 8];
+
+    /// <summary>Settings using the pristine default formatters.</summary>
+    private RefitSettings _settings = null!;
+
+    /// <summary>Settings using a snake_case key formatter, forcing the formatted query-key path.</summary>
+    private RefitSettings _snakeSettings = null!;
+
+    /// <summary>The HTTP client whose base address relative URIs are assembled against.</summary>
+    private HttpClient _client = null!;
+
+    /// <summary>The computed placeholder range for the span template.</summary>
+    private (int StartIdx, int EndIdx) _spanRange;
+
+    /// <summary>The computed placeholder range for the integer template.</summary>
+    private (int StartIdx, int EndIdx) _intRange;
+
+    /// <summary>The computed placeholder range for the formattable template.</summary>
+    private (int StartIdx, int EndIdx) _formattableRange;
+
+    /// <summary>Builds the settings, client, and placeholder ranges before the benchmarks run.</summary>
+    [GlobalSetup]
+    public void Setup()
+    {
+        _settings = new(new SystemTextJsonContentSerializer());
+        _snakeSettings = new(new SystemTextJsonContentSerializer())
+        {
+            UrlParameterKeyFormatter = new SnakeCaseUrlParameterKeyFormatter(),
+        };
+        _client = new() { BaseAddress = new(Host) };
+        _spanRange = FindPlaceholder(_spanTemplate);
+        _intRange = FindPlaceholder(_intTemplate);
+        _formattableRange = FindPlaceholder(_formattableTemplate);
+    }
+
+    /// <summary>Disposes the HTTP client.</summary>
+    [GlobalCleanup]
+    public void Cleanup() => _client.Dispose();
+
+    /// <summary>Substitutes a single escaped placeholder through the span overload.</summary>
+    /// <returns>The built path length.</returns>
+    [Benchmark]
+    [BenchmarkCategory("Path")]
+    public int BuildPathSpan() =>
+        GeneratedRequestRunner.BuildRequestPath(_spanTemplate, false, [(_spanRange, _spanValue)]).Length;
+
+    /// <summary>Substitutes a single integer placeholder span-formatted into the path.</summary>
+    /// <returns>The built path length.</returns>
+    [Benchmark]
+    [BenchmarkCategory("Path")]
+    public int BuildPathInt() =>
+        GeneratedRequestRunner.BuildRequestPath(_intTemplate, false, _intRange, IdValue).Length;
+
+    /// <summary>Substitutes a single formattable placeholder with in-place escaping.</summary>
+    /// <returns>The built path length.</returns>
+    [Benchmark]
+    [BenchmarkCategory("Path")]
+    public int BuildPathFormattable() =>
+        GeneratedRequestRunner.BuildRequestPath(_formattableTemplate, false, _formattableRange, _timestamp, null).Length;
+
+    /// <summary>Round-trips a catch-all path value, escaping each slash-separated section.</summary>
+    /// <returns>The escaped path fragment length.</returns>
+    [Benchmark]
+    [BenchmarkCategory("Path")]
+    public int RoundTripEscapePath() =>
+        GeneratedRequestRunner.RoundTripEscapePath(_catchAllValue, _settings, typeof(string), typeof(string)).Length;
+
+    /// <summary>Assembles a relative URI under RFC 3986 resolution.</summary>
+    /// <returns>The relative URI string length.</returns>
+    [Benchmark]
+    [BenchmarkCategory("Uri")]
+    public int BuildRelativeUriRfc() =>
+        GeneratedRequestRunner.BuildRelativeUri(_client, "/users/42", UrlResolutionMode.Rfc3986).OriginalString.Length;
+
+    /// <summary>Assembles a relative URI under legacy base-address merging.</summary>
+    /// <returns>The relative URI string length.</returns>
+    [Benchmark]
+    [BenchmarkCategory("Uri")]
+    public int BuildRelativeUriLegacy() =>
+        GeneratedRequestRunner.BuildRelativeUri(_client, "/users/42", UrlResolutionMode.RefitLegacy).OriginalString.Length;
+
+    /// <summary>Composes a query key through the pristine default (no key formatter) fast path.</summary>
+    /// <returns>The composed key length.</returns>
+    [Benchmark]
+    [BenchmarkCategory("Key")]
+    public int BuildQueryKeyDefault() => GeneratedRequestRunner.BuildQueryKey(_settings, "FirstName", null, null).Length;
+
+    /// <summary>Composes a query key through the snake_case key formatter.</summary>
+    /// <returns>The composed key length.</returns>
+    [Benchmark]
+    [BenchmarkCategory("Key")]
+    public int BuildQueryKeyFormatted() => GeneratedRequestRunner.BuildQueryKey(_snakeSettings, "FirstName", null, null).Length;
+
+    /// <summary>Formats an integer value with the invariant culture, without boxing.</summary>
+    /// <returns>The formatted value length.</returns>
+    [Benchmark]
+    [BenchmarkCategory("Format")]
+    public int FormatInvariantInt() => GeneratedRequestRunner.FormatInvariant(_idValue, null).Length;
+
+    /// <summary>Formats a timestamp value with the invariant culture, without boxing.</summary>
+    /// <returns>The formatted value length.</returns>
+    [Benchmark]
+    [BenchmarkCategory("Format")]
+    public int FormatInvariantTimestamp() => GeneratedRequestRunner.FormatInvariant(_timestamp, null).Length;
+
+    /// <summary>Validates and returns the string form of an absolute URL.</summary>
+    /// <returns>The absolute URL length.</returns>
+    [Benchmark]
+    [BenchmarkCategory("Format")]
+    public int RequireAbsoluteUrl() => GeneratedRequestRunner.RequireAbsoluteUrl(_absoluteUrl).Length;
+
+    /// <summary>Expands a customized-formatter collection property as a joined value.</summary>
+    /// <returns>The built path length.</returns>
+    [Benchmark]
+    [BenchmarkCategory("Collection")]
+    public int AddFormattedCollectionCsv()
+    {
+        var builder = new GeneratedQueryStringBuilder("/search");
+        GeneratedRequestRunner.AddFormattedCollectionProperty(
+            ref builder,
+            _settings,
+            _ids,
+            "ids",
+            CollectionFormat.Csv,
+            false,
+            (typeof(int[]), typeof(int[]), typeof(int[])));
+        return builder.Build().Length;
+    }
+
+    /// <summary>Expands a customized-formatter collection property as repeated pairs.</summary>
+    /// <returns>The built path length.</returns>
+    [Benchmark]
+    [BenchmarkCategory("Collection")]
+    public int AddFormattedCollectionMulti()
+    {
+        var builder = new GeneratedQueryStringBuilder("/search");
+        GeneratedRequestRunner.AddFormattedCollectionProperty(
+            ref builder,
+            _settings,
+            _ids,
+            "ids",
+            CollectionFormat.Multi,
+            false,
+            (typeof(int[]), typeof(int[]), typeof(int[])));
+        return builder.Build().Length;
+    }
+
+    /// <summary>Locates the single <c>{name}</c> placeholder range in a template.</summary>
+    /// <param name="template">The template to scan.</param>
+    /// <returns>The start and one-past-end indices of the placeholder.</returns>
+    private static (int StartIdx, int EndIdx) FindPlaceholder(string template) =>
+        (template.IndexOf('{'), template.IndexOf('}') + 1);
+}

--- a/src/benchmarks/Refit.Benchmarks/StringSanitizationBenchmarks.cs
+++ b/src/benchmarks/Refit.Benchmarks/StringSanitizationBenchmarks.cs
@@ -1,0 +1,64 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Diagnosers;
+
+namespace Refit.Benchmarks;
+
+/// <summary>
+/// Allocation micro-benchmarks for the shared <c>StringHelpers</c> string routines used on the request path: URI data
+/// escaping (both the whole-string and in-place span variants) and the CR/LF header sanitization that runs on every
+/// generated header name and value.
+/// </summary>
+[MemoryDiagnoser]
+[EventPipeProfiler(EventPipeProfile.GcVerbose)]
+[ShortRunJob]
+public class StringSanitizationBenchmarks
+{
+    /// <summary>The slice start index escaped by the slice benchmark.</summary>
+    private const int SliceStart = 2;
+
+    /// <summary>The slice length escaped by the slice benchmark.</summary>
+    private const int SliceLength = 20;
+
+    /// <summary>A value with reserved characters that must be percent-encoded.</summary>
+    private readonly string _reservedValue = "a value/with spaces & symbols?";
+
+    /// <summary>A header value with no CR or LF, so sanitization returns it unchanged.</summary>
+    private readonly string _cleanHeaderValue = "application/json; charset=utf-8";
+
+    /// <summary>A header value carrying embedded CR/LF that sanitization must strip.</summary>
+    private readonly string _injectedHeaderValue = "application/json\r\nX-Injected: evil";
+
+    /// <summary>Escapes a whole string for a URI data component.</summary>
+    /// <returns>The escaped value length.</returns>
+    [Benchmark]
+    public int EscapeDataString() => StringHelpers.EscapeDataString(_reservedValue).Length;
+
+    /// <summary>Escapes a slice of a string for a URI data component.</summary>
+    /// <returns>The escaped value length.</returns>
+    [Benchmark]
+    public int EscapeDataStringSlice() => StringHelpers.EscapeDataString(_reservedValue, SliceStart, SliceLength).Length;
+
+    /// <summary>Escapes a value into a stack-backed builder in place, with no intermediate escaped string.</summary>
+    /// <returns>The escaped value length.</returns>
+    [Benchmark]
+    public int AppendUriDataEscaped()
+    {
+        var builder = new ValueStringBuilder(stackalloc char[256]);
+        StringHelpers.AppendUriDataEscaped(ref builder, _reservedValue.AsSpan());
+        return builder.ToString().Length;
+    }
+
+    /// <summary>Sanitizes a header value that contains no CR or LF (the returns-unchanged fast path).</summary>
+    /// <returns>The sanitized value length.</returns>
+    [Benchmark(Baseline = true)]
+    public int RemoveCrOrLfClean() => StringHelpers.RemoveCrOrLf(_cleanHeaderValue).Length;
+
+    /// <summary>Sanitizes a header value that contains CR/LF (the builder-copy path).</summary>
+    /// <returns>The sanitized value length.</returns>
+    [Benchmark]
+    public int RemoveCrOrLfInjected() => StringHelpers.RemoveCrOrLf(_injectedHeaderValue).Length;
+}

--- a/src/benchmarks/Refit.Benchmarks/UrlParameterFormattingBenchmarks.cs
+++ b/src/benchmarks/Refit.Benchmarks/UrlParameterFormattingBenchmarks.cs
@@ -1,0 +1,110 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Diagnosers;
+
+namespace Refit.Benchmarks;
+
+/// <summary>
+/// Allocation micro-benchmarks for the URL parameter value and key formatters that turn a bound argument into the
+/// text placed in a route or query string: <see cref="DefaultUrlParameterFormatter"/>, the built-in
+/// <see cref="IUrlParameterKeyFormatter"/> implementations, and the shared <c>SeparatedCaseFormatter</c> behind them.
+/// </summary>
+[MemoryDiagnoser]
+[EventPipeProfiler(EventPipeProfile.GcVerbose)]
+[ShortRunJob]
+[GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]
+[CategoriesColumn]
+public class UrlParameterFormattingBenchmarks
+{
+    /// <summary>A representative integer value formatted into query strings.</summary>
+    private const int SampleInteger = 1_234_567;
+
+    /// <summary>A representative timestamp whose invariant form contains reserved characters.</summary>
+    private static readonly DateTimeOffset _timestamp = new(2026, 7, 15, 12, 30, 0, TimeSpan.Zero);
+
+    /// <summary>A representative identifier value formatted into query strings.</summary>
+    private static readonly Guid _guid = new("1b4e28ba-2fa1-11d2-883f-0016d3cca427");
+
+    /// <summary>The default URL parameter value formatter under test.</summary>
+    private readonly DefaultUrlParameterFormatter _valueFormatter = new();
+
+    /// <summary>The camelCase key formatter under test.</summary>
+    private readonly CamelCaseUrlParameterKeyFormatter _camelCaseKey = new();
+
+    /// <summary>The snake_case key formatter under test.</summary>
+    private readonly SnakeCaseUrlParameterKeyFormatter _snakeCaseKey = new();
+
+    /// <summary>The kebab-case key formatter under test.</summary>
+    private readonly KebabCaseUrlParameterKeyFormatter _kebabCaseKey = new();
+
+    /// <summary>The pass-through key formatter used as a baseline.</summary>
+    private readonly DefaultUrlParameterKeyFormatter _defaultKey = new();
+
+    /// <summary>Gets or sets a representative property name formatted by the key benchmarks.</summary>
+    [Params("FirstName", "HTTPStatusCode")]
+    public string Key { get; set; } = "FirstName";
+
+    /// <summary>Formats a plain string value.</summary>
+    /// <returns>The formatted value length.</returns>
+    [Benchmark]
+    [BenchmarkCategory("Value")]
+    public int FormatString() => (_valueFormatter.Format("widgets and gadgets", typeof(string), typeof(string)) ?? string.Empty).Length;
+
+    /// <summary>Formats an integer value (boxed through the invariant <c>string.Format</c> path).</summary>
+    /// <returns>The formatted value length.</returns>
+    [Benchmark]
+    [BenchmarkCategory("Value")]
+    public int FormatInt() => (_valueFormatter.Format(SampleInteger, typeof(int), typeof(int)) ?? string.Empty).Length;
+
+    /// <summary>Formats an enum value with no <c>[EnumMember]</c> override.</summary>
+    /// <returns>The formatted value length.</returns>
+    [Benchmark]
+    [BenchmarkCategory("Value")]
+    public int FormatEnumPlain() => (_valueFormatter.Format(QuerySort.Name, typeof(QuerySort), typeof(QuerySort)) ?? string.Empty).Length;
+
+    /// <summary>Formats an enum value carrying an <c>[EnumMember]</c> override (exercises the enum-member cache).</summary>
+    /// <returns>The formatted value length.</returns>
+    [Benchmark]
+    [BenchmarkCategory("Value")]
+    public int FormatEnumMember() => (_valueFormatter.Format(QuerySort.DateDescending, typeof(QuerySort), typeof(QuerySort)) ?? string.Empty).Length;
+
+    /// <summary>Formats a <see cref="DateTimeOffset"/> value.</summary>
+    /// <returns>The formatted value length.</returns>
+    [Benchmark]
+    [BenchmarkCategory("Value")]
+    public int FormatDateTimeOffset() => (_valueFormatter.Format(_timestamp, typeof(DateTimeOffset), typeof(DateTimeOffset)) ?? string.Empty).Length;
+
+    /// <summary>Formats a <see cref="Guid"/> value.</summary>
+    /// <returns>The formatted value length.</returns>
+    [Benchmark]
+    [BenchmarkCategory("Value")]
+    public int FormatGuid() => (_valueFormatter.Format(_guid, typeof(Guid), typeof(Guid)) ?? string.Empty).Length;
+
+    /// <summary>Formats a key through the pass-through default key formatter (baseline).</summary>
+    /// <returns>The formatted key length.</returns>
+    [Benchmark(Baseline = true)]
+    [BenchmarkCategory("Key")]
+    public int DefaultKey() => _defaultKey.Format(Key).Length;
+
+    /// <summary>Formats a key into camelCase.</summary>
+    /// <returns>The formatted key length.</returns>
+    [Benchmark]
+    [BenchmarkCategory("Key")]
+    public int CamelCaseKey() => _camelCaseKey.Format(Key).Length;
+
+    /// <summary>Formats a key into snake_case through the shared separated-case formatter.</summary>
+    /// <returns>The formatted key length.</returns>
+    [Benchmark]
+    [BenchmarkCategory("Key")]
+    public int SnakeCaseKey() => _snakeCaseKey.Format(Key).Length;
+
+    /// <summary>Formats a key into kebab-case through the shared separated-case formatter.</summary>
+    /// <returns>The formatted key length.</returns>
+    [Benchmark]
+    [BenchmarkCategory("Key")]
+    public int KebabCaseKey() => _kebabCaseKey.Format(Key).Length;
+}

--- a/src/benchmarks/Refit.Benchmarks/ValueStringBuilderBenchmarks.cs
+++ b/src/benchmarks/Refit.Benchmarks/ValueStringBuilderBenchmarks.cs
@@ -1,0 +1,109 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Diagnosers;
+
+namespace Refit.Benchmarks;
+
+/// <summary>
+/// Allocation micro-benchmarks for the stack-allocated, pool-backed <c>ValueStringBuilder</c> used throughout request
+/// path and query construction: appending characters, strings, and spans (including the pooled-buffer growth path),
+/// reserving a span to fill directly, and inserting a prefix.
+/// </summary>
+[MemoryDiagnoser]
+[EventPipeProfiler(EventPipeProfile.GcVerbose)]
+[ShortRunJob]
+public class ValueStringBuilderBenchmarks
+{
+    /// <summary>The stack buffer size that comfortably holds a small render.</summary>
+    private const int RoomyStackBuffer = 256;
+
+    /// <summary>A small stack buffer that overflows into pooled growth once several words are appended.</summary>
+    private const int TightStackBuffer = 16;
+
+    /// <summary>The words appended to build a larger value.</summary>
+    private readonly string[] _words = ["alpha", "beta", "gamma", "delta", "epsilon", "zeta", "eta", "theta"];
+
+    /// <summary>A representative text whose characters and span are appended.</summary>
+    private readonly string _text = "a-representative-request-path-segment";
+
+    /// <summary>A prefix inserted at the front of a built value.</summary>
+    private readonly string _prefix = "/api/v3";
+
+    /// <summary>Appends several strings within a roomy stack buffer, then materializes the result.</summary>
+    /// <returns>The built string length.</returns>
+    [Benchmark(Baseline = true)]
+    public int AppendStrings()
+    {
+        var builder = new ValueStringBuilder(stackalloc char[RoomyStackBuffer]);
+        foreach (var word in _words)
+        {
+            builder.Append(word);
+        }
+
+        return builder.ToString().Length;
+    }
+
+    /// <summary>Appends several strings into a tight buffer, forcing pooled-buffer growth.</summary>
+    /// <returns>The built string length.</returns>
+    [Benchmark]
+    public int AppendStringsGrowing()
+    {
+        var builder = new ValueStringBuilder(stackalloc char[TightStackBuffer]);
+        foreach (var word in _words)
+        {
+            builder.Append(word);
+            builder.Append('-');
+        }
+
+        return builder.ToString().Length;
+    }
+
+    /// <summary>Appends a text character by character.</summary>
+    /// <returns>The built string length.</returns>
+    [Benchmark]
+    public int AppendChars()
+    {
+        var builder = new ValueStringBuilder(stackalloc char[RoomyStackBuffer]);
+        foreach (var character in _text)
+        {
+            builder.Append(character);
+        }
+
+        return builder.ToString().Length;
+    }
+
+    /// <summary>Appends a text span in one shot.</summary>
+    /// <returns>The built string length.</returns>
+    [Benchmark]
+    public int AppendSpan()
+    {
+        var builder = new ValueStringBuilder(stackalloc char[RoomyStackBuffer]);
+        builder.Append(_text.AsSpan());
+        return builder.ToString().Length;
+    }
+
+    /// <summary>Reserves a span and fills it directly, avoiding an intermediate copy.</summary>
+    /// <returns>The built string length.</returns>
+    [Benchmark]
+    public int ReserveAndFill()
+    {
+        var builder = new ValueStringBuilder(stackalloc char[RoomyStackBuffer]);
+        var span = builder.AppendSpan(_text.Length);
+        _text.AsSpan().CopyTo(span);
+        return builder.ToString().Length;
+    }
+
+    /// <summary>Appends a text then inserts a prefix at the front.</summary>
+    /// <returns>The built string length.</returns>
+    [Benchmark]
+    public int InsertPrefix()
+    {
+        var builder = new ValueStringBuilder(stackalloc char[RoomyStackBuffer]);
+        builder.Append(_text);
+        builder.Insert(0, _prefix);
+        return builder.ToString().Length;
+    }
+}

--- a/src/tests/Refit.Tests/CamelCaseStringEnumConverterTests.cs
+++ b/src/tests/Refit.Tests/CamelCaseStringEnumConverterTests.cs
@@ -1,0 +1,97 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Refit.Tests;
+
+/// <summary>Pins the serialized-name maps the camelCase enum converter builds from an enum's fields, so the build path
+/// stays behavior-preserving under allocation refactoring.</summary>
+public sealed class CamelCaseStringEnumConverterTests
+{
+    /// <summary>The expected names-to-values entry count: two entries each for <c>DateDescending</c> and <c>Name</c>
+    /// (camelCase plus declared name) and one for the already-lowercase <c>plain</c>.</summary>
+    private const int ExpectedNameEntryCount = 5;
+
+    /// <summary>The camelCase preferred name of <see cref="SortOrder.DateDescending"/>.</summary>
+    private const string DateDescendingCamelCase = "dateDescending";
+
+    /// <summary>An enum whose members exercise the camelCase preferred name plus the declared-name fallback.</summary>
+    private enum SortOrder
+    {
+        /// <summary>A multi-word member whose camelCase name ("dateDescending") differs from its declared name.</summary>
+        DateDescending,
+
+        /// <summary>A single-word member whose camelCase name ("name") differs from its declared name.</summary>
+        Name,
+
+        /// <summary>An already-lowercase member whose camelCase name equals its declared name, contributing one entry.</summary>
+        plain,
+    }
+
+    /// <summary>Verifies the names-to-values map carries both the camelCase preferred name and the declared name for a
+    /// member whose two names differ, and a single entry for an already-lowercase member.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task NamesToValuesMapCarriesCamelCaseAndDeclaredNames()
+    {
+        var map = CamelCaseStringEnumConverter.EnumConverter<SortOrder>.BuildNameMaps().NamesToValues;
+
+        await Assert.That(map[DateDescendingCamelCase]).IsEqualTo(SortOrder.DateDescending);
+        await Assert.That(map["DateDescending"]).IsEqualTo(SortOrder.DateDescending);
+        await Assert.That(map["name"]).IsEqualTo(SortOrder.Name);
+        await Assert.That(map["Name"]).IsEqualTo(SortOrder.Name);
+        await Assert.That(map["plain"]).IsEqualTo(SortOrder.plain);
+
+        // "plain" is already lowercase, so its camelCase and declared names coincide and it contributes one entry only.
+        await Assert.That(map.Count).IsEqualTo(ExpectedNameEntryCount);
+    }
+
+    /// <summary>Verifies the ordinal-ignore-case map resolves a name regardless of case, while the ordinal map is
+    /// case-sensitive, matching the two lookups the converter performs.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task NamesToValuesMapsHonorComparerCaseSensitivity()
+    {
+        var maps = CamelCaseStringEnumConverter.EnumConverter<SortOrder>.BuildNameMaps();
+
+        await Assert.That(maps.NamesToValues.ContainsKey("DATEDESCENDING")).IsFalse();
+        await Assert.That(maps.NamesToValuesIgnoreCase["DATEDESCENDING"]).IsEqualTo(SortOrder.DateDescending);
+    }
+
+    /// <summary>Verifies a constructed converter builds its ordinal names-to-values map from the enum's fields, so the
+    /// entry count it exposes matches the map produced by <see cref="CamelCaseStringEnumConverter.EnumConverter{TEnum}.BuildNameMaps"/>.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task ConstructedConverterMapEntryCountMatchesBuiltNameMap()
+    {
+        var converter = new CamelCaseStringEnumConverter.EnumConverter<SortOrder>();
+
+        await Assert.That(converter.MapEntryCount).IsEqualTo(ExpectedNameEntryCount);
+    }
+
+    /// <summary>Verifies the values-to-names map yields each value's camelCase preferred name.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task ValuesToNamesMapYieldsPreferredCamelCaseName()
+    {
+        var map = CamelCaseStringEnumConverter.EnumConverter<SortOrder>.BuildNameMaps().ValuesToNames;
+
+        await Assert.That(map[SortOrder.DateDescending]).IsEqualTo(DateDescendingCamelCase);
+        await Assert.That(map[SortOrder.Name]).IsEqualTo("name");
+        await Assert.That(map[SortOrder.plain]).IsEqualTo("plain");
+    }
+
+    /// <summary>Verifies camelCase conversion lowercases only the first character and returns non-uppercase-leading and
+    /// empty inputs unchanged.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task ToCamelCaseLowercasesOnlyTheFirstCharacter()
+    {
+        await Assert.That(CamelCaseStringEnumConverter.ToCamelCase("DateDescending")).IsEqualTo(DateDescendingCamelCase);
+        await Assert.That(CamelCaseStringEnumConverter.ToCamelCase("A")).IsEqualTo("a");
+        await Assert.That(CamelCaseStringEnumConverter.ToCamelCase("ABC")).IsEqualTo("aBC");
+        await Assert.That(CamelCaseStringEnumConverter.ToCamelCase("already")).IsEqualTo("already");
+        await Assert.That(CamelCaseStringEnumConverter.ToCamelCase("_leading")).IsEqualTo("_leading");
+        await Assert.That(CamelCaseStringEnumConverter.ToCamelCase(string.Empty)).IsEqualTo(string.Empty);
+    }
+}

--- a/src/tests/Refit.Tests/DefaultFormUrlEncodedParameterFormatterTests.cs
+++ b/src/tests/Refit.Tests/DefaultFormUrlEncodedParameterFormatterTests.cs
@@ -12,6 +12,12 @@ public class DefaultFormUrlEncodedParameterFormatterTests
     /// <summary>An enum value that is not defined on <see cref="FormEnum"/>.</summary>
     private const int UndefinedEnumValue = 999;
 
+    /// <summary>A representative string value used to verify verbatim string formatting.</summary>
+    private const string StringValue = "widgets and gadgets";
+
+    /// <summary>A representative integer value used to verify invariant integer formatting.</summary>
+    private const int IntegerValue = 1234;
+
     /// <summary>Enum used to verify enum-member formatting and undefined enum fallback.</summary>
     private enum FormEnum
     {
@@ -43,5 +49,34 @@ public class DefaultFormUrlEncodedParameterFormatterTests
         await Assert.That(formatter.Format(FormEnum.Custom, null)).IsEqualTo("custom-value");
         await Assert.That(formatter.Format(FormEnum.Plain, null)).IsEqualTo("Plain");
         await Assert.That(formatter.Format((FormEnum)UndefinedEnumValue, null)).IsEqualTo("999");
+    }
+
+    /// <summary>Verifies a string value is returned verbatim, ignoring any format string, matching composite formatting.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task FormatReturnsStringValueVerbatimIgnoringFormat()
+    {
+        var formatter = new DefaultFormUrlEncodedParameterFormatter();
+
+        await Assert.That(formatter.Format(StringValue, null)).IsEqualTo(StringValue);
+        await Assert.That(formatter.Format(StringValue, "X")).IsEqualTo(StringValue);
+    }
+
+    /// <summary>Verifies formattable values render with the invariant culture, apply a format string, and treat a
+    /// whitespace-only format string as no format.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task FormatRendersFormattableValuesInvariantlyAndAppliesFormat()
+    {
+        const int sample = 7;
+        const double fraction = 1.5;
+        var formatter = new DefaultFormUrlEncodedParameterFormatter();
+
+        await Assert.That(formatter.Format(IntegerValue, null)).IsEqualTo("1234");
+        await Assert.That(formatter.Format(sample, "D3")).IsEqualTo("007");
+        await Assert.That(formatter.Format(sample, "  ")).IsEqualTo("7");
+        await Assert.That(formatter.Format(fraction, null)).IsEqualTo("1.5");
+        await Assert.That(formatter.Format(true, null)).IsEqualTo("True");
+        await Assert.That(formatter.Format('a', null)).IsEqualTo("a");
     }
 }

--- a/src/tests/Refit.Tests/DefaultUrlParameterFormatterTests.ValueFormatting.cs
+++ b/src/tests/Refit.Tests/DefaultUrlParameterFormatterTests.ValueFormatting.cs
@@ -1,0 +1,55 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Refit.Tests;
+
+/// <summary>Tests pinning the scalar value rendering of <see cref="DefaultUrlParameterFormatter"/>: a string passes
+/// through verbatim and a formattable value renders with the invariant culture.</summary>
+public partial class DefaultUrlParameterFormatterTests
+{
+    /// <summary>Verifies a string value is returned verbatim and a formattable value renders invariantly.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task FormatReturnsStringVerbatimAndRendersFormattableInvariantly()
+    {
+        const int sample = 1234;
+        var formatter = new DefaultUrlParameterFormatter();
+
+        await Assert.That(formatter.Format("widgets and gadgets", typeof(string), typeof(string)))
+            .IsEqualTo("widgets and gadgets");
+        await Assert.That(formatter.Format(sample, typeof(int), typeof(int)))
+            .IsEqualTo("1234");
+    }
+
+    /// <summary>Verifies a non-formattable value falls back to its <see cref="object.ToString"/>, and a value whose
+    /// <see cref="object.ToString"/> returns null renders as the empty string, matching composite formatting.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task FormatFallsBackToToStringForNonFormattableValues()
+    {
+        var formatter = new DefaultUrlParameterFormatter();
+
+        await Assert.That(formatter.Format(new NonFormattableValue(), typeof(NonFormattableValue), typeof(NonFormattableValue)))
+            .IsEqualTo("custom-text");
+        await Assert.That(formatter.Format(new NullToStringValue(), typeof(NullToStringValue), typeof(NullToStringValue)))
+            .IsEqualTo(string.Empty);
+    }
+
+    /// <summary>A non-formattable value whose <see cref="ToString"/> supplies the rendered text.</summary>
+    private sealed class NonFormattableValue
+    {
+        /// <inheritdoc/>
+        public override string ToString() => "custom-text";
+    }
+
+    /// <summary>A non-formattable value whose <see cref="ToString"/> returns null, exercising the empty fallback.</summary>
+    private sealed class NullToStringValue
+    {
+        /// <summary>Gets the backing text, left null so <see cref="ToString"/> yields the empty-string fallback.</summary>
+        public string? Text { get; init; }
+
+        /// <inheritdoc/>
+        public override string? ToString() => Text;
+    }
+}

--- a/src/tests/Refit.Tests/DefaultUrlParameterFormatterTests.cs
+++ b/src/tests/Refit.Tests/DefaultUrlParameterFormatterTests.cs
@@ -5,7 +5,7 @@
 namespace Refit.Tests;
 
 /// <summary>Tests for <see cref="DefaultUrlParameterFormatter"/> date, collection and enum formatting behaviour.</summary>
-public class DefaultUrlParameterFormatterTests
+public partial class DefaultUrlParameterFormatterTests
 {
     /// <summary>A general date format registered for the DateTime formatter tests.</summary>
     private const string GeneralDateFormat = "yyyy-MM-dd";

--- a/src/tests/Refit.Tests/FormValueMultimapTests.KeyFormatting.cs
+++ b/src/tests/Refit.Tests/FormValueMultimapTests.KeyFormatting.cs
@@ -1,0 +1,40 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+using System.Linq;
+
+namespace Refit.Tests;
+
+/// <summary>Tests pinning that field-name resolution stays sensitive to the per-call key formatter even though
+/// attribute metadata is cached by source type.</summary>
+public partial class FormValueMultimapTests
+{
+    /// <summary>Verifies field-name resolution honors the per-call key formatter for the same source type across
+    /// repeated construction, so caching attribute metadata by type never freezes settings-dependent key formatting.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task KeyFormattingHonorsSettingsAcrossRepeatedConstructionForSameType()
+    {
+        var source = new MultiWordNameForm { FirstName = "Ada" };
+        var snakeSettings = new RefitSettings
+        {
+            UrlParameterKeyFormatter = new SnakeCaseUrlParameterKeyFormatter()
+        };
+
+        var defaultFirst = new FormValueMultimap(source, _settings).Keys.ToArray();
+        var snake = new FormValueMultimap(source, snakeSettings).Keys.ToArray();
+        var defaultSecond = new FormValueMultimap(source, _settings).Keys.ToArray();
+
+        await Assert.That(defaultFirst).Contains("FirstName");
+        await Assert.That(snake).Contains("first_name");
+        await Assert.That(defaultSecond).Contains("FirstName");
+    }
+
+    /// <summary>Test fixture with a multi-word property name that a key formatter rewrites, used to verify
+    /// settings-dependent key formatting is applied per call rather than cached by type.</summary>
+    public class MultiWordNameForm
+    {
+        /// <summary>Gets or sets the multi-word property whose key differs under a snake_case formatter.</summary>
+        public string? FirstName { get; set; }
+    }
+}

--- a/src/tests/Refit.Tests/FormValueMultimapTests.cs
+++ b/src/tests/Refit.Tests/FormValueMultimapTests.cs
@@ -12,7 +12,7 @@ using System.Text.Json.Serialization;
 namespace Refit.Tests;
 
 /// <summary>Tests for <see cref="FormValueMultimap"/> source loading and serialization behavior.</summary>
-public class FormValueMultimapTests
+public partial class FormValueMultimapTests
 {
     /// <summary>The second element shared by the sample integer collections.</summary>
     private const int SecondSampleInt = 2;

--- a/src/tests/Refit.Tests/GeneratedRequestRunnerTests.RoundTripEscaping.cs
+++ b/src/tests/Refit.Tests/GeneratedRequestRunnerTests.RoundTripEscaping.cs
@@ -1,0 +1,43 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Refit.Tests;
+
+/// <summary>Tests pinning the byte output of the catch-all path escaper under the pristine default formatter.</summary>
+public partial class GeneratedRequestRunnerTests
+{
+    /// <summary>Verifies each slash-separated section is percent-encoded independently under the default formatter,
+    /// with the separators preserved and only the default-formatter fast path exercised.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task RoundTripEscapePathEscapesEachSectionUnderDefaultFormatter()
+    {
+        var settings = new RefitSettings();
+
+        var result = GeneratedRequestRunner.RoundTripEscapePath(
+            "aa a/bb-b/c%d/e",
+            settings,
+            typeof(string),
+            typeof(string));
+
+        await Assert.That(result).IsEqualTo("aa%20a/bb-b/c%25d/e");
+    }
+
+    /// <summary>Verifies a null catch-all value escapes the default-formatter rendering of a null value (the empty
+    /// string), exercising the null-value branch of the escaper.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task RoundTripEscapePathRendersNullValueAsEmptyUnderDefaultFormatter()
+    {
+        var settings = new RefitSettings();
+
+        var result = GeneratedRequestRunner.RoundTripEscapePath(
+            null,
+            settings,
+            typeof(string),
+            typeof(string));
+
+        await Assert.That(result).IsEqualTo(string.Empty);
+    }
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Performance / refactor of the runtime Refit library. No behavioural change and no public API change.

## What is the new behavior?

Reduced memory allocations across the runtime request/response/serialization hot paths, guided by a new GcVerbose micro-benchmark suite and verified behaviour-identical:

- Reflection form mapping caches per-type attribute metadata (`FormValueMultimap.Create` 2736 -> 776 B).
- Path building escapes catch-all sections inline from the source span under the default formatter (`RoundTripEscapePath` 1416 -> 72 B).
- Parameter formatting renders values without a composite `string.Format` and skips the query-attribute array when none is defined (string values 328 -> 0 B; the int/date/guid/enum paths drop sharply).
- Enum handling builds the camelCase name in a single allocation, builds the serialized-name map without a per-field iterator, and scans the enum's fields once for all three converter maps (`ToCamelCase` 104 -> 56 B; converter construction 1624 -> 1178 B).
- Adds a `Refit.Benchmarks` GcVerbose micro-benchmark suite (97 benchmarks across 10 components) covering the hot path, plus guard tests pinning each optimised method's functional contract; the relevant private members are widened to internal (fields stay private) so the benchmarks can reach them.

## What is the current behavior?

The runtime paths above materialised more short-lived allocations than necessary - composite-format boxing, per-section substrings, repeated reflection reads, and intermediate strings in the enum converter build.

## What might this PR break?

None. Behaviour and serialised output are unchanged, verified by the full `Refit.Tests` suite (1161 passing) plus new guard tests pinning each optimised method's contract. No public API changes; the widened members are `internal`.

## Checklist
- [x] I have read the Contribute guide
- [x] Tests have been added or updated (for bug fixes / features)
- [ ] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the `main` branch
- [x] PR title follows Conventional Commits

## Additional information

Allocation measured with BenchmarkDotNet (`Allocated`, deterministic) plus EventPipe GcVerbose traces. Selected per-method reductions (bytes/op, net10):

| Method | Before | After |
| --- | --- | --- |
| FormValueMultimap.Create | 2736 | 776 |
| RoundTripEscapePath | 1416 | 72 |
| DefaultUrlParameterFormatter.Format (string) | 328 | 0 |
| DefaultUrlParameterFormatter.Format (Guid) | 440 | 128 |
| ToCamelCase | 104 | 56 |
| Enum converter construction | 1624 | 1178 |

A reflection census confirmed the runtime library is source-gen-first (the generated System.Text.Json path is reflection-free); the residual reflection is confined to dynamic by-Type entry points and deliberate fallbacks and is cached to zero allocation per request. Remaining allocations were each measured and left only where irreducible (for example a value-type box forced by the object-returning reflection API on the fallback path, or framework HttpHeaders value storage).
