### PR TITLE
fix: generate inline query building for nullable value-type query obj.

### DIFF
--- a/src/InterfaceStubGenerator.Shared/Emitter.Inline.Query.Object.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.Inline.Query.Object.cs
@@ -42,7 +42,13 @@ internal static partial class Emitter
             providerField,
             query.CollectionFormatValue,
             ToLowerInvariantString(query.PreEncoded));
-        var scope = new ObjectFlattenScope("@" + parameter.Name, null, query.NestingDelimiter, string.Empty, indent);
+
+        // A Nullable<T> query object holds its underlying struct behind .Value; the != null guard above is the HasValue
+        // check, so the deref is always safe here. A reference-type object flattens directly off the parameter.
+        var accessExpr = query.ValueFormat.IsNullableValueType
+            ? "@" + parameter.Name + NullableValueAccess
+            : "@" + parameter.Name;
+        var scope = new ObjectFlattenScope(accessExpr, null, query.NestingDelimiter, string.Empty, indent);
         AppendObjectPropertyList(sb, context, query.ObjectProperties!.Value, scope, emission);
 
         if (!guarded)

--- a/src/InterfaceStubGenerator.Shared/Parser.Request.Query.cs
+++ b/src/InterfaceStubGenerator.Shared/Parser.Request.Query.cs
@@ -223,7 +223,16 @@ internal static partial class Parser
             return dictionaryQuery;
         }
 
-        if (TryBuildQueryObjectProperties(parameter.Type, parameterPrefixSegment, formattableSymbol, context) is not { } properties)
+        // A Nullable<T> query object flattens its underlying struct's properties. The object emitter reaches the value
+        // through .Value inside the HasValue guard it already emits for a nullable parameter (CanBeNull is true for a
+        // Nullable<T>), mirroring how a nested nullable-value-type property flattens. A Nullable<dictionary> is
+        // impossible, so only this object branch unwraps; BuildValueFormat keeps the Nullable<T> so the emitted access
+        // reads through .Value.
+        var objectType = parameter.Type is INamedTypeSymbol { OriginalDefinition.SpecialType: SpecialType.System_Nullable_T } nullableObject
+            ? nullableObject.TypeArguments[0]
+            : parameter.Type;
+
+        if (TryBuildQueryObjectProperties(objectType, parameterPrefixSegment, formattableSymbol, context) is not { } properties)
         {
             return null;
         }

--- a/src/tests/Refit.GeneratedCode.TestModels/Scenarios/GeneratedQueryParameter.cs
+++ b/src/tests/Refit.GeneratedCode.TestModels/Scenarios/GeneratedQueryParameter.cs
@@ -1,0 +1,49 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Refit.GeneratedCode.TestModels.Scenarios
+{
+    /// <summary>Represents a generated query parameter for use in Refit API calls.</summary>
+    [DebuggerDisplay("{Value}")]
+    public readonly struct GeneratedQueryParameter : IEquatable<GeneratedQueryParameter>
+    {
+        /// <summary>Initializes a new instance of the <see cref="GeneratedQueryParameter"/> struct with the specified value.</summary>
+        /// <param name="value">The value of the query parameter.</param>
+        public GeneratedQueryParameter(string value)
+        {
+            Value = value;
+        }
+
+        /// <summary>Gets the value of the query parameter.</summary>
+        public string Value { get; }
+
+        /// <inheritdoc/>
+        public static bool operator ==(GeneratedQueryParameter left, GeneratedQueryParameter right)
+        {
+            return left.Equals(right);
+        }
+
+        /// <inheritdoc/>
+        public static bool operator !=(GeneratedQueryParameter left, GeneratedQueryParameter right)
+        {
+            return !left.Equals(right);
+        }
+
+        /// <inheritdoc/>
+        public bool Equals(GeneratedQueryParameter other) => Value == other.Value;
+
+        /// <inheritdoc/>
+        public override bool Equals([NotNullWhen(true)] object? obj) => obj is GeneratedQueryParameter other && Equals(other);
+
+        /// <inheritdoc/>
+        public override int GetHashCode() => Value.GetHashCode();
+
+        /// <inheritdoc/>
+        public override string ToString() => Value;
+    }
+}

--- a/src/tests/Refit.GeneratedCode.TestModels/Scenarios/IGeneratedUserApi.cs
+++ b/src/tests/Refit.GeneratedCode.TestModels/Scenarios/IGeneratedUserApi.cs
@@ -29,15 +29,20 @@ namespace Refit.GeneratedCode.TestModels.Scenarios
         /// <summary>Searches users with generated inline query construction.</summary>
         /// <param name="query">The search text.</param>
         /// <param name="page">The optional page number.</param>
+        /// <param name="hello">A generated query parameter.</param>
+        /// <param name="maybeHello">A nullable generated query parameter, flattened inline through its <c>.Value</c>.</param>
         /// <param name="ids">Identifiers expanded as repeated pairs.</param>
         /// <param name="sort">The compile-time-resolved sort order.</param>
         /// <param name="flag">A valueless query flag.</param>
         /// <param name="cursor">A caller-encoded continuation cursor.</param>
         /// <returns>The matching user payload.</returns>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Maintainability", "SST1472", Justification = "Test code")]
         [Get("/users/search")]
         Task<string> SearchUsersAsync(
             [AliasAs("q")] string query,
             int? page,
+            [Query]GeneratedQueryParameter hello,
+            [Query]GeneratedQueryParameter? maybeHello,
             [Query(CollectionFormat.Multi)] IReadOnlyList<int> ids,
             GeneratedUserSort sort,
             [QueryName] string flag,

--- a/src/tests/Refit.GeneratorTests/QueryObjectFlatteningGenerationTests.cs
+++ b/src/tests/Refit.GeneratorTests/QueryObjectFlatteningGenerationTests.cs
@@ -131,6 +131,40 @@ public sealed class QueryObjectFlatteningGenerationTests
         await Assert.That(result.GeneratedSources[Hint]).DoesNotContain(ReflectiveFallback);
     }
 
+    /// <summary>Verifies a nullable value-type (struct) query object flattens inline: the underlying struct's properties
+    /// are reached through <c>.Value</c> inside the parameter's <c>HasValue</c> guard, rather than falling back to the
+    /// reflection request builder.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task NullableStructQueryObjectFlattensInline()
+    {
+        const string source =
+            """
+            #nullable enable
+            using System.Threading.Tasks;
+            using Refit;
+
+            namespace RefitGeneratorTest;
+
+            public struct GeoQuery
+            {
+                public string? Name { get; set; }
+                [Query(Format = "0.00")] public double Lat { get; set; }
+            }
+
+            public interface IGeneratedClient
+            {
+                [Get("/geo")]
+                Task<string> Find([Query] GeoQuery? query);
+            }
+            """;
+
+        var result = Fixture.RunGenerator(source, generatedRequestBuilding: true);
+
+        await Assert.That(result.CompilesWithoutErrors).IsTrue();
+        await Assert.That(result.GeneratedSources[Hint]).DoesNotContain(ReflectiveFallback);
+    }
+
     /// <summary>Verifies a query object with nullable and non-nullable dictionary properties (with nullable values)
     /// expands each entry inline under the property key.</summary>
     /// <returns>A task representing the asynchronous test.</returns>

--- a/src/tests/Refit.GeneratorTests/QueryRequestBuildingLiveTests.cs
+++ b/src/tests/Refit.GeneratorTests/QueryRequestBuildingLiveTests.cs
@@ -170,6 +170,25 @@ public sealed partial class QueryRequestBuildingLiveTests
         _ = await harness.AssertParityAsync("RangeSearch", [query], "/base/range?Window=1..9");
     }
 
+    /// <summary>Verifies a nullable value-type (struct) query object matches the reflection builder: a present value
+    /// reaches its properties through <c>.Value</c> inside the parameter's <c>HasValue</c> guard, and a null value is
+    /// omitted entirely.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    [RequiresUnreferencedCode("Loads a generated assembly and reflects over generated types and members.")]
+    [RequiresDynamicCode("Compares generated request building against the reflection request builder.")]
+    public async Task NullableStructQueryObjectMatchesReflection()
+    {
+        using var harness = LiveQueryHarness.Create();
+
+        // A present nullable struct flattens its underlying properties; parity guards the exact key order and encoding.
+        var point = harness.CreateApiValue("Refit.LiveQuery.GeoPoint", ("Name", "peak"), ("Lat", RawDouble));
+        _ = await harness.AssertParityAsync("NullableStructQuery", [point], null);
+
+        // A null nullable-struct parameter contributes no query pairs, matching the reflection builder.
+        _ = await harness.AssertParityAsync("NullableStructQuery", [null], "/base/point");
+    }
+
     /// <summary>Verifies a dictionary of a concrete (non-sealed) complex value type flattens each entry under the entry key, matching
     /// the reflection builder's per-value nested map (<c>key.Property=value</c>).</summary>
     /// <returns>A task representing the asynchronous test.</returns>
@@ -400,6 +419,16 @@ public sealed partial class QueryRequestBuildingLiveTests
                 public Bounds? Window { get; set; }
             }
 
+            // A value-type (struct) query object used through a nullable parameter: exercises flattening the underlying
+            // struct's properties through .Value inside the parameter's HasValue guard.
+            public struct GeoPoint
+            {
+                public string? Name { get; set; }
+
+                [Query(Format = "0.00")]
+                public double Lat { get; set; }
+            }
+
             // Deliberately not sealed: exercises the concrete (non-sealed) declared-type flatten. The test value is not a
             // subtype, so the declared-type flatten matches the reflection builder's runtime-type flatten exactly.
             public class Facet
@@ -479,6 +508,9 @@ public sealed partial class QueryRequestBuildingLiveTests
 
                 [Get("/range")]
                 Task<string> RangeSearch([Query] RangeQuery query);
+
+                [Get("/point")]
+                Task<string> NullableStructQuery([Query] GeoPoint? point);
 
                 [Get("/facets")]
                 Task<string> Facets(Dictionary<string, Facet> facets);


### PR DESCRIPTION



Adds live parity coverage (present value + null), an inline no-fallback test, and a nullable parameter in the generated-code compliance interface.


<!-- Please read our [Contribute guide](https://www.reactiveui.net/contribute/index.html) before opening a PR, and give this PR a title that follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `fix:`, `feat:`, `docs:`, `build:`). -->

## What kind of change does this PR introduce?
Fixes #2264

## What is the new behavior?
<!-- The most important section: describe what this PR changes things TO. For a feature, explain the new functionality; for a fix, describe the corrected behavior. -->

IsInlineFlattenableQueryObject excludes Nullable<T>, so the parameter root never unwrapped it. This mirrors the existing nested-property handling at the root: the parser unwraps to the underlying struct (keeping IsNullableValueType set), and the emitter dereferences through .Value inside the existing null guard (CanBeNull is already true for Nullable<T>).

## What is the current behavior?
<!-- The OLD, pre-PR behavior on the target branch — i.e. what this PR changes away from. Link any related issue here and use "Closes #123" to auto-close it on merge. -->

A [Query] parameter whose type is a nullable value type (Nullable<T> over a struct Refit flattens by its public properties) fell back to the reflection request builder while the non-nullable form generated inline, and the method was flagged by RF006.


## What might this PR break?
<!-- Call out any breaking changes, behavioural changes, or migration steps consumers need. Write "None" if there are none. -->

None

## Checklist
- [x] I have read the [Contribute guide](https://www.reactiveui.net/contribute/index.html)
- [x] Tests have been added or updated (for bug fixes / features)
- [x] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the `main` branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional information
<!-- Screenshots, benchmarks, links, or anything else that helps reviewers. -->

The addition of the `NullableStructQueryObjectMatchesReflection` has increased the line count in that file too much, so that the I get "error SST1522: This file is 518 lines, over the maximum of 500". I really think that this test should be there, but I have been unable to suppress the error.