### PR TITLE
perf: reduce Refit.Reflection memory allocations

### DIFF
--- a/src/Refit.Reflection/CachedAttributeProvider.cs
+++ b/src/Refit.Reflection/CachedAttributeProvider.cs
@@ -1,0 +1,33 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Reflection;
+
+namespace Refit;
+
+/// <summary>Wraps an <see cref="ICustomAttributeProvider"/> and materializes its <see cref="QueryAttribute"/> lookup once
+/// so the URL parameter formatter, which re-reads the attribute for every formatted value, never re-materializes it from
+/// metadata.</summary>
+/// <param name="inner">The underlying provider (a parameter, property or type) to read attributes from.</param>
+/// <remarks>Only the <c>(typeof(QueryAttribute), inherit: true)</c> lookup the default formatter performs is cached; every
+/// other query delegates to <paramref name="inner"/>, so a custom formatter that reads other attributes sees exactly the
+/// same values it would from the original provider. The cached array holds immutable metadata attributes, so sharing it
+/// across format calls is behaviourally identical to re-reading it.</remarks>
+internal sealed class CachedAttributeProvider(ICustomAttributeProvider inner) : ICustomAttributeProvider
+{
+    /// <summary>The materialized <see cref="QueryAttribute"/> lookup, cached on first read.</summary>
+    private object[]? _queryAttributes;
+
+    /// <inheritdoc/>
+    public object[] GetCustomAttributes(bool inherit) => inner.GetCustomAttributes(inherit);
+
+    /// <inheritdoc/>
+    public object[] GetCustomAttributes(Type attributeType, bool inherit) =>
+        inherit && attributeType == typeof(QueryAttribute)
+            ? _queryAttributes ??= inner.GetCustomAttributes(typeof(QueryAttribute), true)
+            : inner.GetCustomAttributes(attributeType, inherit);
+
+    /// <inheritdoc/>
+    public bool IsDefined(Type attributeType, bool inherit) => inner.IsDefined(attributeType, inherit);
+}

--- a/src/Refit.Reflection/IQueryValueSink.cs
+++ b/src/Refit.Reflection/IQueryValueSink.cs
@@ -1,0 +1,14 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Refit;
+
+/// <summary>Receives formatted enumerable query values so they can be appended in place without an intermediate sequence
+/// or iterator state machine.</summary>
+internal interface IQueryValueSink
+{
+    /// <summary>Appends one formatted value.</summary>
+    /// <param name="value">The formatted value, or <see langword="null"/>.</param>
+    void Add(string? value);
+}

--- a/src/Refit.Reflection/MethodTableKey.cs
+++ b/src/Refit.Reflection/MethodTableKey.cs
@@ -18,13 +18,13 @@ internal readonly struct MethodTableKey : IEquatable<MethodTableKey>
     }
 
     /// <summary>Gets the methods name.</summary>
-    private string MethodName { get; }
+    internal string MethodName { get; }
 
     /// <summary>Gets the Array containing the methods parameters.</summary>
-    private Type[] Parameters { get; }
+    internal Type[] Parameters { get; }
 
     /// <summary>Gets the Array containing the methods generic arguments.</summary>
-    private Type[] GenericArguments { get; }
+    internal Type[] GenericArguments { get; }
 
     /// <inheritdoc/>
     public override int GetHashCode()

--- a/src/Refit.Reflection/ParameterAttributeSet.cs
+++ b/src/Refit.Reflection/ParameterAttributeSet.cs
@@ -1,0 +1,25 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Refit;
+
+/// <summary>The request-shaping attributes read from a single method parameter in one metadata pass, so the request
+/// builder's construction classifies each parameter without re-enumerating its attribute records per lookup.</summary>
+/// <param name="Query">The parameter's <see cref="QueryAttribute"/>, or null.</param>
+/// <param name="Header">The parameter's <see cref="HeaderAttribute"/>, or null.</param>
+/// <param name="HeaderCollection">The parameter's <see cref="HeaderCollectionAttribute"/>, or null.</param>
+/// <param name="Property">The parameter's <see cref="PropertyAttribute"/>, or null.</param>
+/// <param name="Authorize">The parameter's <see cref="AuthorizeAttribute"/>, or null.</param>
+/// <param name="Body">The parameter's <see cref="BodyAttribute"/>, or null.</param>
+/// <param name="Url">The parameter's <see cref="UrlAttribute"/>, or null.</param>
+/// <param name="FormObject">The parameter's <see cref="FormObjectAttribute"/>, or null.</param>
+internal readonly record struct ParameterAttributeSet(
+    QueryAttribute? Query,
+    HeaderAttribute? Header,
+    HeaderCollectionAttribute? HeaderCollection,
+    PropertyAttribute? Property,
+    AuthorizeAttribute? Authorize,
+    BodyAttribute? Body,
+    UrlAttribute? Url,
+    FormObjectAttribute? FormObject);

--- a/src/Refit.Reflection/QueryMapEntrySink.cs
+++ b/src/Refit.Reflection/QueryMapEntrySink.cs
@@ -1,0 +1,14 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Refit;
+
+/// <summary>Appends formatted enumerable values as <see cref="QueryMapEntry"/> items under a fixed key.</summary>
+/// <param name="Entries">The list receiving the entries.</param>
+/// <param name="Key">The query key applied to every appended value.</param>
+internal readonly record struct QueryMapEntrySink(List<QueryMapEntry> Entries, string Key) : IQueryValueSink
+{
+    /// <inheritdoc/>
+    public void Add(string? value) => Entries.Add(new(Key, value));
+}

--- a/src/Refit.Reflection/QueryParameterEntrySink.cs
+++ b/src/Refit.Reflection/QueryParameterEntrySink.cs
@@ -1,0 +1,14 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Refit;
+
+/// <summary>Appends formatted enumerable values as <see cref="QueryParameterEntry"/> items under a fixed key.</summary>
+/// <param name="Entries">The list receiving the entries.</param>
+/// <param name="Key">The query key applied to every appended value.</param>
+internal readonly record struct QueryParameterEntrySink(List<QueryParameterEntry> Entries, string Key) : IQueryValueSink
+{
+    /// <inheritdoc/>
+    public void Add(string? value) => Entries.Add(new(Key, value));
+}

--- a/src/Refit.Reflection/QueryPropertyMetadata.cs
+++ b/src/Refit.Reflection/QueryPropertyMetadata.cs
@@ -1,0 +1,19 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Reflection;
+
+namespace Refit;
+
+/// <summary>One readable public property of a query object, together with the attribute-derived facts the reflection
+/// request builder would otherwise re-read from metadata on every request.</summary>
+/// <param name="Property">The readable public instance property.</param>
+/// <param name="IsIgnored">Whether the property carries a serialization-ignore attribute and is always skipped.</param>
+/// <param name="QueryAttribute">The property's <see cref="Refit.QueryAttribute"/>, or <see langword="null"/> when absent.</param>
+/// <param name="AliasAttribute">The property's <see cref="AliasAsAttribute"/>, or <see langword="null"/> when absent.</param>
+internal readonly record struct QueryPropertyMetadata(
+    PropertyInfo Property,
+    bool IsIgnored,
+    QueryAttribute? QueryAttribute,
+    AliasAsAttribute? AliasAttribute);

--- a/src/Refit.Reflection/Refit.Reflection.csproj
+++ b/src/Refit.Reflection/Refit.Reflection.csproj
@@ -12,6 +12,8 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="Refit.Tests"/>
+    <InternalsVisibleTo Include="Refit.Reflection.Tests"/>
+    <InternalsVisibleTo Include="Refit.Reflection.Benchmarks"/>
     <ProjectReference Include="..\Refit\Refit.csproj" PrivateAssets="Analyzers"/>
   </ItemGroup>
 

--- a/src/Refit.Reflection/RequestBuilderImplementation.Execution.cs
+++ b/src/Refit.Reflection/RequestBuilderImplementation.Execution.cs
@@ -9,6 +9,26 @@ namespace Refit;
 /// <summary>Reflection-based request builder that turns Refit interface calls into HTTP requests.</summary>
 internal partial class RequestBuilderImplementation
 {
+    /// <summary>Gets the cancellation token declared by the interface method, if any.</summary>
+    /// <param name="restMethod">The rest method being invoked.</param>
+    /// <param name="paramList">The argument values for the call.</param>
+    /// <returns>The method's cancellation token, or <see cref="CancellationToken.None"/>.</returns>
+    internal static CancellationToken GetMethodCancellationToken(
+        RestMethodInfoInternal restMethod,
+        object[] paramList) =>
+        restMethod.CancellationToken is not null
+            ? GetCancellationToken(paramList)
+            : CancellationToken.None;
+
+    /// <summary>Determines whether the request body should be buffered before sending.</summary>
+    /// <param name="restMethod">The rest method being invoked.</param>
+    /// <param name="request">The built request message.</param>
+    /// <returns><see langword="true"/> if the body should be buffered; otherwise <see langword="false"/>.</returns>
+    internal static bool IsBodyBuffered(
+        RestMethodInfoInternal restMethod,
+        HttpRequestMessage request) =>
+        (restMethod.BodyParameterInfo?.Item2 ?? false) && request.Content is not null;
+
     /// <summary>Builds and streams the response for a method returning an asynchronous sequence.</summary>
     /// <typeparam name="T">The element type yielded to the caller.</typeparam>
     /// <param name="client">The HTTP client to send with.</param>
@@ -53,31 +73,11 @@ internal partial class RequestBuilderImplementation
         }
     }
 
-    /// <summary>Gets the cancellation token declared by the interface method, if any.</summary>
-    /// <param name="restMethod">The rest method being invoked.</param>
-    /// <param name="paramList">The argument values for the call.</param>
-    /// <returns>The method's cancellation token, or <see cref="CancellationToken.None"/>.</returns>
-    private static CancellationToken GetMethodCancellationToken(
-        RestMethodInfoInternal restMethod,
-        object[] paramList) =>
-        restMethod.CancellationToken is not null
-            ? GetCancellationToken(paramList)
-            : CancellationToken.None;
-
-    /// <summary>Determines whether the request body should be buffered before sending.</summary>
-    /// <param name="restMethod">The rest method being invoked.</param>
-    /// <param name="request">The built request message.</param>
-    /// <returns><see langword="true"/> if the body should be buffered; otherwise <see langword="false"/>.</returns>
-    private static bool IsBodyBuffered(
-        RestMethodInfoInternal restMethod,
-        HttpRequestMessage request) =>
-        (restMethod.BodyParameterInfo?.Item2 ?? false) && request.Content is not null;
-
     /// <summary>Builds a delegate that constructs and returns the request for a <c>Task&lt;HttpRequestMessage&gt;</c> method.</summary>
     /// <param name="restMethod">The rest method to build a delegate for.</param>
     /// <returns>A delegate that returns a task producing the built request without sending it.</returns>
     [RequiresDynamicCode("Serializing a body by runtime Type requires runtime generic method instantiation.")]
-    private Func<HttpClient, object[], object?> BuildRequestMessageFuncForMethod(
+    internal Func<HttpClient, object[], object?> BuildRequestMessageFuncForMethod(
         RestMethodInfoInternal restMethod) =>
         (client, paramList) => BuildRequestMessageWithoutSendingAsync(client, restMethod, paramList);
 
@@ -90,7 +90,7 @@ internal partial class RequestBuilderImplementation
     /// logging, or manual dispatch. Any configured async authorization token getter runs at dispatch time and is
     /// therefore not applied to a request obtained this way.</remarks>
     [RequiresDynamicCode("Serializing a body by runtime Type requires runtime generic method instantiation.")]
-    private Task<HttpRequestMessage> BuildRequestMessageWithoutSendingAsync(
+    internal Task<HttpRequestMessage> BuildRequestMessageWithoutSendingAsync(
         HttpClient client,
         RestMethodInfoInternal restMethod,
         object[] paramList)
@@ -113,7 +113,7 @@ internal partial class RequestBuilderImplementation
     /// <param name="cancellationToken">A token to cancel the request.</param>
     /// <returns>A task that completes when the request finishes.</returns>
     [RequiresDynamicCode("Serializing a body by runtime Type requires runtime generic method instantiation.")]
-    private async Task ExecuteVoidRequestAsync(
+    internal async Task ExecuteVoidRequestAsync(
         HttpClient client,
         RestMethodInfoInternal restMethod,
         object[] paramList,
@@ -154,7 +154,7 @@ internal partial class RequestBuilderImplementation
         "SST2307:Generic method type parameters should be inferable from the parameters",
         Justification = "Type parameter intentionally specified explicitly by callers.")]
     [RequiresDynamicCode("Serializing a body by runtime Type requires runtime generic method instantiation.")]
-    private async Task<T?> ExecuteRequestAsync<T, TBody>(
+    internal async Task<T?> ExecuteRequestAsync<T, TBody>(
         HttpClient client,
         RestMethodInfoInternal restMethod,
         object[] paramList,
@@ -192,7 +192,7 @@ internal partial class RequestBuilderImplementation
         Justification = "Type parameter intentionally specified explicitly by callers.")]
     [RequiresDynamicCode("Serializing a body by runtime Type requires runtime generic method instantiation.")]
     [ExcludeFromCodeCoverage]
-    private async IAsyncEnumerable<T?> ExecuteAsyncEnumerableRequestAsync<T>(
+    internal async IAsyncEnumerable<T?> ExecuteAsyncEnumerableRequestAsync<T>(
         HttpClient client,
         RestMethodInfoInternal restMethod,
         object[] paramList,
@@ -218,7 +218,7 @@ internal partial class RequestBuilderImplementation
         "SST2307:Generic method type parameters should be inferable from the parameters",
         Justification = "Type parameter intentionally specified explicitly by callers.")]
     [RequiresDynamicCode("Serializing a body by runtime Type requires runtime generic method instantiation.")]
-    private Func<HttpClient, CancellationToken, object[], Task<T?>> BuildCancellableTaskFuncForMethod<T, TBody>(
+    internal Func<HttpClient, CancellationToken, object[], Task<T?>> BuildCancellableTaskFuncForMethod<T, TBody>(
         RestMethodInfoInternal restMethod) =>
         async (client, ct, paramList) =>
         {
@@ -254,7 +254,7 @@ internal partial class RequestBuilderImplementation
         "Design",
         "SST2307:Generic method type parameters should be inferable from the parameters",
         Justification = "Type parameter intentionally specified explicitly by callers.")]
-    private Task<T?> SendAndProcessResponseAsync<T, TBody>(
+    internal Task<T?> SendAndProcessResponseAsync<T, TBody>(
         HttpClient client,
         RestMethodInfoInternal restMethod,
         HttpRequestMessage request,

--- a/src/Refit.Reflection/RequestBuilderImplementation.Payload.cs
+++ b/src/Refit.Reflection/RequestBuilderImplementation.Payload.cs
@@ -17,7 +17,7 @@ internal partial class RequestBuilderImplementation
     /// <param name="param">The body argument value.</param>
     /// <param name="ret">The request message to populate.</param>
     [RequiresDynamicCode("Serializing a body by runtime Type requires runtime generic method instantiation.")]
-    private void AddBodyToRequest(RestMethodInfoInternal restMethod, object param, HttpRequestMessage ret)
+    internal void AddBodyToRequest(RestMethodInfoInternal restMethod, object param, HttpRequestMessage ret)
     {
         if (param is HttpContent httpContentParam)
         {
@@ -86,7 +86,7 @@ internal partial class RequestBuilderImplementation
     /// <param name="param">The body argument value.</param>
     /// <param name="ret">The request message to populate.</param>
     [RequiresDynamicCode("Serializing a body by runtime Type requires runtime generic method instantiation.")]
-    private void AddSerializedBodyToRequest(RestMethodInfoInternal restMethod, object param, HttpRequestMessage ret)
+    internal void AddSerializedBodyToRequest(RestMethodInfoInternal restMethod, object param, HttpRequestMessage ret)
     {
         var declaredBodyType = restMethod.ParameterInfoArray[
             restMethod.BodyParameterInfo!.Item3].ParameterType;
@@ -134,7 +134,7 @@ internal partial class RequestBuilderImplementation
     /// <param name="queryParamsToAdd">The list of query parameters being built.</param>
     /// <param name="i">The index of the parameter.</param>
     /// <param name="parameterInfo">Optional parameter info for property-bound parameters.</param>
-    private void AddQueryParameters(
+    internal void AddQueryParameters(
         RestMethodInfoInternal restMethod,
         QueryAttribute? queryAttribute,
         object param,
@@ -192,7 +192,7 @@ internal partial class RequestBuilderImplementation
     /// <param name="i">The index of the parameter.</param>
     /// <param name="param">The argument value, which may be a single item or an enumerable.</param>
     /// <param name="multiPartContent">The multipart content to add to.</param>
-    private void AddMultiPart(
+    internal void AddMultiPart(
         RestMethodInfoInternal restMethod,
         int i,
         object param,
@@ -205,7 +205,7 @@ internal partial class RequestBuilderImplementation
 
         // An opt-in [FormObject] parameter is flattened into one text form-data part per property (resolved field name +
         // formatted value) so server-side form model binding sees individual fields instead of a single serialized part.
-        if (restMethod.ParameterInfoArray[i].GetCustomAttribute<FormObjectAttribute>(true) is not null)
+        if (restMethod.ParameterFormObjectFlags[i])
         {
             AddFlattenedFormObject(multiPartContent!, param);
             return;
@@ -242,7 +242,7 @@ internal partial class RequestBuilderImplementation
     /// <remarks>Reuses <see cref="FormValueMultimap"/> so field-name resolution (alias, serializer, key formatter),
     /// value formatting, collection handling and nested <c>parent.child</c> composition match url-encoded body
     /// flattening. Each entry is added as its own text <see cref="StringContent"/> under the resolved field name.</remarks>
-    private void AddFlattenedFormObject(MultipartFormDataContent multiPartContent, object param)
+    internal void AddFlattenedFormObject(MultipartFormDataContent multiPartContent, object param)
     {
         foreach (var field in new FormValueMultimap(param, _settings))
         {
@@ -262,7 +262,7 @@ internal partial class RequestBuilderImplementation
     /// <param name="fileName">The file name to use for file-like parts.</param>
     /// <param name="parameterName">The form field name for the part.</param>
     /// <param name="itemValue">The value to add.</param>
-    private void AddMultipartItem(
+    internal void AddMultipartItem(
         MultipartFormDataContent multiPartContent,
         string fileName,
         string parameterName,
@@ -320,7 +320,7 @@ internal partial class RequestBuilderImplementation
     /// <param name="fileName">The file name used in the error message.</param>
     /// <param name="parameterName">The form field name for the part.</param>
     /// <param name="itemValue">The value to serialize and add.</param>
-    private void AddSerializedMultipartItem(
+    internal void AddSerializedMultipartItem(
         MultipartFormDataContent multiPartContent,
         string fileName,
         string parameterName,
@@ -369,7 +369,7 @@ internal partial class RequestBuilderImplementation
     /// <param name="parameterInfo">Reflection info for the parameter.</param>
     /// <param name="queryPath">The query key path for the parameter.</param>
     /// <param name="queryAttribute">The query attribute governing formatting.</param>
-    private void AppendQueryParameter(
+    internal void AppendQueryParameter(
         List<QueryParameterEntry> queryParamsToAdd,
         object? param,
         ParameterInfo parameterInfo,
@@ -378,15 +378,13 @@ internal partial class RequestBuilderImplementation
     {
         if (param is not string and IEnumerable paramValues)
         {
-            foreach (var value in ParseEnumerableQueryParameterValue(
-                         paramValues,
-                         parameterInfo,
-                         parameterInfo.ParameterType,
-                         queryAttribute))
-            {
-                queryParamsToAdd.Add(new(queryPath, value));
-            }
-
+            AppendFormattedEnumerableValues(
+                paramValues,
+                parameterInfo,
+                parameterInfo.ParameterType,
+                queryAttribute,
+                null,
+                new QueryParameterEntrySink(queryParamsToAdd, queryPath));
             return;
         }
 
@@ -396,23 +394,27 @@ internal partial class RequestBuilderImplementation
                 GeneratedRequestRunner.FormatUrlParameter(
                     _settings,
                     param,
-                    parameterInfo,
+                    GetCachedAttributeProvider(parameterInfo),
                     parameterInfo.ParameterType)));
     }
 
-    /// <summary>Formats an enumerable parameter value according to the effective collection format.</summary>
+    /// <summary>Formats an enumerable value according to the effective collection format and appends each result to a
+    /// sink, without allocating an intermediate sequence or iterator state machine.</summary>
+    /// <typeparam name="TSink">The sink that receives each formatted value.</typeparam>
     /// <param name="paramValues">The enumerable values to format.</param>
     /// <param name="customAttributeProvider">The attribute provider for the parameter or property.</param>
     /// <param name="type">The element type used for formatting.</param>
     /// <param name="queryAttribute">The query attribute governing the collection format, if any.</param>
     /// <param name="fallbackCollectionFormat">The collection format to use when none is specified.</param>
-    /// <returns>The formatted query values.</returns>
-    private IEnumerable<string?> ParseEnumerableQueryParameterValue(
+    /// <param name="sink">The sink receiving each formatted value.</param>
+    internal void AppendFormattedEnumerableValues<TSink>(
         IEnumerable paramValues,
         ICustomAttributeProvider customAttributeProvider,
         Type type,
         QueryAttribute? queryAttribute,
-        CollectionFormat? fallbackCollectionFormat = null)
+        CollectionFormat? fallbackCollectionFormat,
+        TSink sink)
+        where TSink : struct, IQueryValueSink
     {
         // Precedence: the property's own [Query] format wins; otherwise the format
         // supplied by the enclosing parameter's [Query] attribute (if any); finally
@@ -424,16 +426,18 @@ internal partial class RequestBuilderImplementation
 
         if (collectionFormat == CollectionFormat.Multi)
         {
+            var cachedProvider = GetCachedAttributeProvider(customAttributeProvider);
             foreach (var paramValue in paramValues)
             {
-                yield return GeneratedRequestRunner.FormatUrlParameter(
-                    _settings,
-                    paramValue,
-                    customAttributeProvider,
-                    type);
+                sink.Add(
+                    GeneratedRequestRunner.FormatUrlParameter(
+                        _settings,
+                        paramValue,
+                        cachedProvider,
+                        type));
             }
 
-            yield break;
+            return;
         }
 
         var delimiter =
@@ -445,8 +449,8 @@ internal partial class RequestBuilderImplementation
                 _ => ","
             };
 
-        // Missing a "default" clause was preventing the collection from serializing at all, as it was hitting "continue" thus causing an off-by-one error
-        yield return JoinFormattedQueryValues(paramValues, customAttributeProvider, type, delimiter);
+        // A single joined value is emitted; a missing default arm here previously dropped the collection entirely.
+        sink.Add(JoinFormattedQueryValues(paramValues, customAttributeProvider, type, delimiter));
     }
 
     /// <summary>Formats and joins an enumerable query value without LINQ adapters.</summary>
@@ -459,7 +463,7 @@ internal partial class RequestBuilderImplementation
         "Correctness",
         "SST2410:A created disposable is never disposed",
         Justification = "ValueStringBuilder.ToString() disposes the builder and returns its pooled buffer; Dispose is idempotent.")]
-    private string JoinFormattedQueryValues(
+    internal string JoinFormattedQueryValues(
         IEnumerable paramValues,
         ICustomAttributeProvider customAttributeProvider,
         Type type,
@@ -473,12 +477,13 @@ internal partial class RequestBuilderImplementation
                 return string.Empty;
             }
 
+            var cachedProvider = GetCachedAttributeProvider(customAttributeProvider);
             var builder = new ValueStringBuilder(stackalloc char[StackallocThreshold]);
             builder.Append(
                 GeneratedRequestRunner.FormatUrlParameter(
                     _settings,
                     enumerator.Current,
-                    customAttributeProvider,
+                    cachedProvider,
                     type));
 
             while (enumerator.MoveNext())
@@ -488,7 +493,7 @@ internal partial class RequestBuilderImplementation
                     GeneratedRequestRunner.FormatUrlParameter(
                         _settings,
                         enumerator.Current,
-                        customAttributeProvider,
+                        cachedProvider,
                         type));
             }
 

--- a/src/Refit.Reflection/RequestBuilderImplementation.QueryAndHeaders.Helpers.cs
+++ b/src/Refit.Reflection/RequestBuilderImplementation.QueryAndHeaders.Helpers.cs
@@ -6,34 +6,55 @@ using System.Collections;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 
 namespace Refit;
 
 /// <summary>Internal query and header helpers exposed to focused tests.</summary>
 internal partial class RequestBuilderImplementation
 {
+    /// <summary>Caches, per enumerable type, whether its element type is emitted directly, so the interface scan runs
+    /// once per type without keeping collectible types alive.</summary>
+    private static readonly ConditionalWeakTable<Type, StrongBox<bool>> EnumerableEmitsDirectlyCache = new();
+
+    /// <summary>Reuses one delegate for the classification factory so classifying never allocates a callback.</summary>
+    private static readonly ConditionalWeakTable<Type, StrongBox<bool>>.CreateValueCallback EnumerableEmitsDirectlyFactory =
+        ClassifyEnumerableElement;
+
+    /// <summary>The shared "emit directly" classification result.</summary>
+    private static readonly StrongBox<bool> EmitDirectly = new(true);
+
+    /// <summary>The shared "expand into a query map" classification result.</summary>
+    private static readonly StrongBox<bool> ExpandIntoQueryMap = new(false);
+
     /// <summary>Determines whether a value should be emitted directly rather than expanded into a query map.</summary>
     /// <param name="value">The value to inspect.</param>
     /// <returns><see langword="true"/> if the value is a simple/formattable type; otherwise <see langword="false"/>.</returns>
-    [UnconditionalSuppressMessage(
-        "Trimming",
-        "IL2075:UnrecognizedReflectionPattern",
-        Justification = "Query-map formatting only checks implemented enumerable interfaces on the runtime value.")]
     internal static bool DoNotConvertToQueryMap(object value)
     {
         var type = value.GetType();
 
-        // Bail out early & match string
-        if (ShouldReturn(type))
-        {
-            return true;
-        }
+        // Scalars and non-enumerable objects are the common case and stay allocation-free and cache-free (matching a
+        // string or any IFormattable early); only enumerables reach the cached interface scan.
+        return ShouldReturn(type)
+            || (value is IEnumerable
+                && EnumerableEmitsDirectlyCache.GetValue(type, EnumerableEmitsDirectlyFactory).Value);
+    }
 
-        if (value is not IEnumerable)
-        {
-            return false;
-        }
-
+    /// <summary>Classifies an enumerable type by whether its <see cref="IEnumerable{T}"/> element type is emitted
+    /// directly, reading its interfaces once so the per-request path never re-scans them.</summary>
+    /// <param name="type">The runtime enumerable type to classify.</param>
+    /// <returns>The shared classification result.</returns>
+    [UnconditionalSuppressMessage(
+        "Trimming",
+        "IL2070:UnrecognizedReflectionPattern",
+        Justification = "Query-map formatting only checks implemented enumerable interfaces on the runtime value.")]
+    [UnconditionalSuppressMessage(
+        "Trimming",
+        "IL2075:UnrecognizedReflectionPattern",
+        Justification = "Query-map formatting only checks implemented enumerable interfaces on the runtime value.")]
+    internal static StrongBox<bool> ClassifyEnumerableElement(Type type)
+    {
         // Get the element type for enumerables
         var ienu = typeof(IEnumerable<>);
 
@@ -53,11 +74,10 @@ internal partial class RequestBuilderImplementation
 
         if (intType is null)
         {
-            return false;
+            return ExpandIntoQueryMap;
         }
 
-        type = intType.GetGenericArguments()[0];
-        return ShouldReturn(type);
+        return ShouldReturn(intType.GetGenericArguments()[0]) ? EmitDirectly : ExpandIntoQueryMap;
     }
 
     /// <summary>Sets or replaces a header on the request or its content, with CRLF-injection protection.</summary>
@@ -105,7 +125,7 @@ internal partial class RequestBuilderImplementation
     /// <param name="type">The type to inspect; a nullable value type is unwrapped first.</param>
     /// <returns><see langword="true"/> if the type formats directly into a query value.</returns>
     [ExcludeFromCodeCoverage] // The CultureInfo query-value arm needs a settable-collection value that SST2305 forbids, so the branch cannot be covered by a test.
-    private static bool ShouldReturn(Type type) =>
+    internal static bool ShouldReturn(Type type) =>
         Nullable.GetUnderlyingType(type) is { } underlyingType
             ? ShouldReturn(underlyingType)
             : type == typeof(string)

--- a/src/Refit.Reflection/RequestBuilderImplementation.QueryAndHeaders.cs
+++ b/src/Refit.Reflection/RequestBuilderImplementation.QueryAndHeaders.cs
@@ -13,27 +13,58 @@ namespace Refit;
 /// <summary>Reflection-based request builder that turns Refit interface calls into HTTP requests.</summary>
 internal partial class RequestBuilderImplementation
 {
-    /// <summary>Caches query-map properties by type without keeping collectible types alive.</summary>
-    private static readonly ConditionalWeakTable<Type, PropertyInfo[]> QueryPropertyCache = new();
+    /// <summary>Caches per-type query-property metadata without keeping collectible types alive.</summary>
+    internal static readonly ConditionalWeakTable<Type, QueryPropertyMetadata[]> QueryPropertyCache = new();
+
+    /// <summary>Caches an attribute provider per parameter/property/type that materializes the <see cref="QueryAttribute"/>
+    /// lookup once, so repeated formatting never re-reads it from metadata.</summary>
+    internal static readonly ConditionalWeakTable<ICustomAttributeProvider, CachedAttributeProvider> AttributeProviderCache = new();
+
+    /// <summary>Reuses one delegate for the cache factory so the flattening path never allocates a callback.</summary>
+    [UnconditionalSuppressMessage(
+        "Trimming",
+        "IL2111:Method with DynamicallyAccessedMembersAttribute is accessed via reflection",
+        Justification = "The cache callback receives the same Type key that carries the public property metadata requirement.")]
+    private static readonly ConditionalWeakTable<Type, QueryPropertyMetadata[]>.CreateValueCallback QueryPropertyFactory =
+        BuildQueryPropertyMetadata;
 
     /// <summary>Determines whether a property should be skipped when building the query map.</summary>
-    /// <param name="propertyInfo">The property to inspect.</param>
+    /// <param name="metadata">The cached metadata for the property to inspect.</param>
     /// <param name="parameterInfo">Optional parameter info used to skip path-bound properties.</param>
     /// <returns><see langword="true"/> when the property is ignored or already bound to the path.</returns>
-    private static bool ShouldSkipQueryProperty(PropertyInfo propertyInfo, RestMethodParameterInfo? parameterInfo)
+    internal static bool ShouldSkipQueryProperty(in QueryPropertyMetadata metadata, RestMethodParameterInfo? parameterInfo)
     {
+        if (metadata.IsIgnored)
+        {
+            return true;
+        }
+
+        if (parameterInfo is not { IsObjectPropertyParameter: true })
+        {
+            return false;
+        }
+
         // Compare by name rather than PropertyInfo reference: for a derived runtime
         // type the inherited property is a different PropertyInfo instance, which
         // would otherwise be wrongly emitted as a duplicate query parameter.
-        return ShouldIgnorePropertyInQueryMap(propertyInfo)
-            || (parameterInfo is { IsObjectPropertyParameter: true }
-                && parameterInfo.ParameterProperties.Exists(x => x.PropertyChain[0].Name == propertyInfo.Name));
+        // A manual scan avoids the per-call predicate closure a List.Exists lambda would allocate.
+        var propertyName = metadata.Property.Name;
+        var properties = parameterInfo.ParameterProperties;
+        for (var i = 0; i < properties.Count; i++)
+        {
+            if (properties[i].PropertyChain[0].Name == propertyName)
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /// <summary>Determines whether a property is marked to be ignored during serialization.</summary>
     /// <param name="propertyInfo">The property to inspect.</param>
     /// <returns><see langword="true"/> if the property carries an ignore attribute; otherwise <see langword="false"/>.</returns>
-    private static bool ShouldIgnorePropertyInQueryMap(PropertyInfo propertyInfo)
+    internal static bool ShouldIgnorePropertyInQueryMap(PropertyInfo propertyInfo)
     {
         foreach (var attributeData in propertyInfo.GetCustomAttributesData())
         {
@@ -53,7 +84,7 @@ internal partial class RequestBuilderImplementation
     /// <param name="headersToAdd">The headers to apply, or null.</param>
     /// <param name="ret">The request message to populate.</param>
     /// <param name="validateHeaders">Whether header values are validated as they are applied; see <see cref="SetHeader"/>.</param>
-    private static void AddHeadersToRequest(Dictionary<string, string?>? headersToAdd, HttpRequestMessage ret, bool validateHeaders)
+    internal static void AddHeadersToRequest(Dictionary<string, string?>? headersToAdd, HttpRequestMessage ret, bool validateHeaders)
     {
         // NB: We defer setting headers until the body has been
         // added so any custom content headers don't get left out.
@@ -79,7 +110,7 @@ internal partial class RequestBuilderImplementation
     /// <summary>Extracts any query parameters already present on the URI into the pending list.</summary>
     /// <param name="uri">The URI builder whose query is read.</param>
     /// <param name="queryParamsToAdd">The pending query parameter list, created if needed.</param>
-    private static void ParseExistingQueryString(UriBuilder uri, ref List<QueryParameterEntry>? queryParamsToAdd) =>
+    internal static void ParseExistingQueryString(UriBuilder uri, ref List<QueryParameterEntry>? queryParamsToAdd) =>
         ParseQueryStringInto(uri.Query, ref queryParamsToAdd);
 
     /// <summary>Assigns the request URI as a bare relative reference so the <see cref="HttpClient"/> merges it
@@ -87,7 +118,7 @@ internal partial class RequestBuilderImplementation
     /// <param name="ret">The request message being populated.</param>
     /// <param name="urlTarget">The expanded relative path, with dynamic segments already escaped.</param>
     /// <param name="queryParamsToAdd">The query parameters collected for the request, if any.</param>
-    private static void AssignRequestUriRfc3986(
+    internal static void AssignRequestUriRfc3986(
         HttpRequestMessage ret,
         string urlTarget,
         List<QueryParameterEntry>? queryParamsToAdd)
@@ -113,7 +144,7 @@ internal partial class RequestBuilderImplementation
     /// <param name="ret">The request message being populated.</param>
     /// <param name="paramList">The argument values for the call.</param>
     /// <param name="queryParamsToAdd">The query parameters collected for the request, if any.</param>
-    private static void AssignAbsoluteRequestUri(
+    internal static void AssignAbsoluteRequestUri(
         RestMethodInfoInternal restMethod,
         HttpRequestMessage ret,
         object[] paramList,
@@ -131,31 +162,72 @@ internal partial class RequestBuilderImplementation
         ret.RequestUri = builder.Uri;
     }
 
-    /// <summary>Parses a raw query string into the pending query parameter list.</summary>
+    /// <summary>Parses a raw query string into the pending query parameter list, ahead of any already-collected entries.</summary>
     /// <param name="queryString">The raw query string, with or without a leading '?'.</param>
     /// <param name="queryParamsToAdd">The pending query parameter list, created if needed.</param>
-    private static void ParseQueryStringInto(string? queryString, ref List<QueryParameterEntry>? queryParamsToAdd)
+    /// <remarks>Mirrors the reference query-string parser without materializing a name/value collection: a single leading
+    /// '?' is dropped, keys and values are URL-decoded (<c>+</c> to space, percent escapes), a segment with no '=' or a
+    /// blank key is skipped, and keys that match case-insensitively are joined with commas under the first-seen key.</remarks>
+    internal static void ParseQueryStringInto(string? queryString, ref List<QueryParameterEntry>? queryParamsToAdd)
     {
         if (string.IsNullOrEmpty(queryString))
         {
             return;
         }
 
-        queryParamsToAdd ??= [];
-        var query = HttpUtility.ParseQueryString(queryString);
-        var index = 0;
-        var keys = query.AllKeys;
-        for (var i = 0; i < keys.Length; i++)
+        // Assign to a non-null local; the older reference assemblies' string.IsNullOrEmpty lacks a nullable-flow annotation.
+        var query = queryString!;
+        var position = query[0] == '?' ? 1 : 0;
+        List<QueryParameterEntry>? parsed = null;
+        while (position < query.Length)
         {
-            var key = keys[i];
-            if (!string.IsNullOrWhiteSpace(key))
+            var ampersand = query.IndexOf('&', position);
+            var segmentEnd = ampersand < 0 ? query.Length : ampersand;
+            var equals = query.IndexOf('=', position, segmentEnd - position);
+
+            // A segment with no '=' has a null name in the reference parser and is dropped, as is a blank key.
+            if (equals >= 0)
             {
-                queryParamsToAdd.Insert(
-                    index,
-                    new(key, query[key]));
-                index++;
+                var key = HttpUtility.UrlDecode(query.Substring(position, equals - position));
+                if (!string.IsNullOrWhiteSpace(key))
+                {
+                    var value = HttpUtility.UrlDecode(query.Substring(equals + 1, segmentEnd - equals - 1));
+                    AppendOrJoinQueryValue(ref parsed, key, value);
+                }
+            }
+
+            position = segmentEnd + 1;
+        }
+
+        if (parsed is null)
+        {
+            return;
+        }
+
+        queryParamsToAdd ??= [];
+        for (var i = 0; i < parsed.Count; i++)
+        {
+            queryParamsToAdd.Insert(i, parsed[i]);
+        }
+    }
+
+    /// <summary>Adds a parsed query key/value, joining the value under an existing case-insensitively equal key.</summary>
+    /// <param name="parsed">The accumulating parsed entries, created on first use.</param>
+    /// <param name="key">The decoded query key.</param>
+    /// <param name="value">The decoded query value.</param>
+    internal static void AppendOrJoinQueryValue(ref List<QueryParameterEntry>? parsed, string key, string? value)
+    {
+        parsed ??= [];
+        for (var i = 0; i < parsed.Count; i++)
+        {
+            if (string.Equals(parsed[i].Key, key, StringComparison.InvariantCultureIgnoreCase))
+            {
+                parsed[i] = new(parsed[i].Key, parsed[i].Value + "," + value);
+                return;
             }
         }
+
+        parsed.Add(new(key, value));
     }
 
     /// <summary>Builds an escaped query string from the collected key/value pairs.</summary>
@@ -165,7 +237,7 @@ internal partial class RequestBuilderImplementation
         "Correctness",
         "SST2410:A created disposable is never disposed",
         Justification = "ValueStringBuilder.ToString() disposes the builder and returns its pooled buffer; Dispose is idempotent.")]
-    private static string CreateQueryString(List<QueryParameterEntry> queryParamsToAdd)
+    internal static string CreateQueryString(List<QueryParameterEntry> queryParamsToAdd)
     {
         var vsb = new ValueStringBuilder(stackalloc char[StackallocThreshold]);
         var firstQuery = true;
@@ -209,18 +281,18 @@ internal partial class RequestBuilderImplementation
     /// <summary>Strips CR and LF characters from a header value to prevent header injection.</summary>
     /// <param name="value">The value to sanitize.</param>
     /// <returns>The value with carriage-return and line-feed characters removed.</returns>
-    private static string EnsureSafe(string value) => StringHelpers.RemoveCrOrLf(value);
+    internal static string EnsureSafe(string value) => StringHelpers.RemoveCrOrLf(value);
 
     /// <summary>Determines whether the HTTP method must not carry a request body.</summary>
     /// <param name="method">The HTTP method to check.</param>
     /// <returns><see langword="true"/> for GET and HEAD; otherwise <see langword="false"/>.</returns>
-    private static bool IsBodyless(HttpMethod method) => method == HttpMethod.Get || method == HttpMethod.Head;
+    internal static bool IsBodyless(HttpMethod method) => method == HttpMethod.Get || method == HttpMethod.Head;
 
     /// <summary>Checks whether a header collection contains a key without throwing for unsupported header types.</summary>
     /// <param name="headers">The header collection to inspect.</param>
     /// <param name="name">The header name.</param>
     /// <returns><see langword="true"/> when the header key exists; otherwise <see langword="false"/>.</returns>
-    private static bool ContainsHeader(System.Net.Http.Headers.HttpHeaders headers, string name)
+    internal static bool ContainsHeader(System.Net.Http.Headers.HttpHeaders headers, string name)
     {
         foreach (var header in headers)
         {
@@ -233,21 +305,47 @@ internal partial class RequestBuilderImplementation
         return false;
     }
 
-    /// <summary>Gets cached query-map properties for the given type.</summary>
+    /// <summary>Gets the cached query-property metadata for the given type.</summary>
     /// <param name="type">The object type to inspect.</param>
-    /// <returns>The readable public instance properties.</returns>
-    [UnconditionalSuppressMessage(
-        "Trimming",
-        "IL2111:Method with DynamicallyAccessedMembersAttribute is accessed via reflection",
-        Justification = "The cache callback receives the same Type key that carries the public property metadata requirement.")]
-    private static PropertyInfo[] GetCachedQueryProperties(Type type) =>
-        QueryPropertyCache.GetValue(type, ReflectionPropertyHelpers.GetReadablePublicInstanceProperties);
+    /// <returns>The readable public instance properties with their attribute-derived facts.</returns>
+    internal static QueryPropertyMetadata[] GetCachedQueryProperties(Type type) =>
+        QueryPropertyCache.GetValue(type, QueryPropertyFactory);
+
+    /// <summary>Gets an attribute provider for a parameter, property or type whose <see cref="QueryAttribute"/> lookup is
+    /// materialized once and reused for every formatted value.</summary>
+    /// <param name="provider">The underlying attribute provider.</param>
+    /// <returns>The cached attribute provider.</returns>
+    internal static ICustomAttributeProvider GetCachedAttributeProvider(ICustomAttributeProvider provider) =>
+        AttributeProviderCache.GetValue(provider, static p => new CachedAttributeProvider(p));
+
+    /// <summary>Builds the per-type query-property metadata, reading each property's serialization-ignore, query and
+    /// alias attributes once so the per-request flattening path never touches attribute metadata.</summary>
+    /// <param name="type">The object type to inspect.</param>
+    /// <returns>The metadata for each readable public instance property.</returns>
+    internal static QueryPropertyMetadata[] BuildQueryPropertyMetadata(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)]
+        Type type)
+    {
+        var properties = ReflectionPropertyHelpers.GetReadablePublicInstanceProperties(type);
+        var metadata = new QueryPropertyMetadata[properties.Length];
+        for (var i = 0; i < properties.Length; i++)
+        {
+            var property = properties[i];
+            metadata[i] = new(
+                property,
+                ShouldIgnorePropertyInQueryMap(property),
+                property.GetCustomAttribute<QueryAttribute>(),
+                property.GetCustomAttribute<AliasAsAttribute>());
+        }
+
+        return metadata;
+    }
 
     /// <summary>Populates the Authorization header from the configured token getter when present.</summary>
     /// <param name="request">The request to add the header to.</param>
     /// <param name="cancellationToken">A token to cancel the getter.</param>
     /// <returns>A task that completes when the header has been set.</returns>
-    private Task AddAuthorizationHeadersFromGetterAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+    internal Task AddAuthorizationHeadersFromGetterAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
         RequestExecutionHelpers.AddAuthorizationHeaderFromGetterAsync(request, _settings, cancellationToken);
 
     /// <summary>Adds configured options/properties and Refit metadata to the request.</summary>
@@ -255,7 +353,7 @@ internal partial class RequestBuilderImplementation
     /// <param name="ret">The request message to populate.</param>
     /// <param name="paramList">The argument values for the call, with cancellation tokens removed.</param>
     /// <param name="declaredArguments">The full declared-order argument values, including any cancellation token.</param>
-    private void AddPropertiesToRequest(
+    internal void AddPropertiesToRequest(
         RestMethodInfoInternal restMethod,
         HttpRequestMessage ret,
         object[] paramList,
@@ -330,7 +428,7 @@ internal partial class RequestBuilderImplementation
 #if NET6_0_OR_GREATER
     /// <summary>Applies the configured HTTP version and version policy to the request.</summary>
     /// <param name="ret">The request message to populate.</param>
-    private void AddVersionToRequest(HttpRequestMessage ret)
+    internal void AddVersionToRequest(HttpRequestMessage ret)
     {
         ret.Version = _settings.Version;
         ret.VersionPolicy = _settings.VersionPolicy;
@@ -343,7 +441,7 @@ internal partial class RequestBuilderImplementation
     /// <param name="parameterInfo">Optional parameter info used to skip path-bound properties.</param>
     /// <param name="collectionFormat">The collection format for enumerable values.</param>
     /// <returns>The query-string key/value pairs.</returns>
-    private List<QueryMapEntry> BuildQueryMap(
+    internal List<QueryMapEntry> BuildQueryMap(
         object @object,
         string? delimiter = null,
         RestMethodParameterInfo? parameterInfo = null,
@@ -354,13 +452,11 @@ internal partial class RequestBuilderImplementation
             return BuildQueryMap(idictionary, delimiter, collectionFormat);
         }
 
-        var kvps = new List<QueryMapEntry>();
-
         var props = GetCachedQueryProperties(@object.GetType());
+        var kvps = new List<QueryMapEntry>(props.Length);
         for (var i = 0; i < props.Length; i++)
         {
-            var propertyInfo = props[i];
-            AppendPropertyToQueryMap(@object, propertyInfo, kvps, delimiter, parameterInfo, collectionFormat);
+            AppendPropertyToQueryMap(@object, in props[i], kvps, delimiter, parameterInfo, collectionFormat);
         }
 
         return kvps;
@@ -371,7 +467,7 @@ internal partial class RequestBuilderImplementation
     /// <param name="delimiter">The delimiter used between nested keys.</param>
     /// <param name="collectionFormat">The collection format for enumerable values.</param>
     /// <returns>The query-string key/value pairs.</returns>
-    private List<QueryMapEntry> BuildQueryMap(
+    internal List<QueryMapEntry> BuildQueryMap(
         IDictionary dictionary,
         string? delimiter = null,
         CollectionFormat? collectionFormat = null)
@@ -387,7 +483,7 @@ internal partial class RequestBuilderImplementation
             }
 
             var keyType = key.GetType();
-            var formattedKey = GeneratedRequestRunner.FormatUrlParameter(_settings, key, keyType, keyType);
+            var formattedKey = GeneratedRequestRunner.FormatUrlParameter(_settings, key, GetCachedAttributeProvider(keyType), keyType);
 
             if (string.IsNullOrWhiteSpace(formattedKey)) // blank keys can't be put in the query string
             {
@@ -417,27 +513,28 @@ internal partial class RequestBuilderImplementation
 
     /// <summary>Appends a single property's query-string key/value pairs to the accumulating list.</summary>
     /// <param name="object">The object the property belongs to.</param>
-    /// <param name="propertyInfo">The property to flatten.</param>
+    /// <param name="metadata">The cached metadata for the property to flatten.</param>
     /// <param name="kvps">The accumulating list of query pairs.</param>
     /// <param name="delimiter">The delimiter used between nested property names.</param>
     /// <param name="parameterInfo">Optional parameter info used to skip path-bound properties.</param>
     /// <param name="collectionFormat">The collection format for enumerable values.</param>
-    private void AppendPropertyToQueryMap(
+    internal void AppendPropertyToQueryMap(
         object @object,
-        PropertyInfo propertyInfo,
+        in QueryPropertyMetadata metadata,
         List<QueryMapEntry> kvps,
         string? delimiter,
         RestMethodParameterInfo? parameterInfo,
         CollectionFormat? collectionFormat)
     {
+        var propertyInfo = metadata.Property;
         var obj = propertyInfo.GetValue(@object);
-        if (ShouldSkipQueryProperty(propertyInfo, parameterInfo))
+        if (ShouldSkipQueryProperty(in metadata, parameterInfo))
         {
             return;
         }
 
-        var queryAttribute = propertyInfo.GetCustomAttribute<QueryAttribute>();
-        var key = BuildPropertyQueryKey(propertyInfo, queryAttribute);
+        var queryAttribute = metadata.QueryAttribute;
+        var key = BuildPropertyQueryKey(propertyInfo, metadata.AliasAttribute, queryAttribute);
 
         if (obj is null)
         {
@@ -475,12 +572,11 @@ internal partial class RequestBuilderImplementation
 
     /// <summary>Builds the query key for a property, honoring its alias and any query prefix/delimiter.</summary>
     /// <param name="propertyInfo">The property being flattened.</param>
+    /// <param name="aliasAttribute">The property's alias attribute, if any.</param>
     /// <param name="queryAttribute">The property's query attribute, if any.</param>
     /// <returns>The query key for the property.</returns>
-    private string BuildPropertyQueryKey(PropertyInfo propertyInfo, QueryAttribute? queryAttribute)
+    internal string BuildPropertyQueryKey(PropertyInfo propertyInfo, AliasAsAttribute? aliasAttribute, QueryAttribute? queryAttribute)
     {
-        var aliasAttribute = propertyInfo.GetCustomAttribute<AliasAsAttribute>();
-
         // Match the form-encoded field-naming precedence (FormValueMultimap.GetFieldNameForProperty): an [AliasAs]
         // wins, then the configured content serializer's field name ([JsonPropertyName] for System.Text.Json,
         // [JsonProperty] for Newtonsoft.Json) unless disabled, then the URL parameter key formatter over the CLR name.
@@ -502,7 +598,7 @@ internal partial class RequestBuilderImplementation
     /// <param name="value">The value to format.</param>
     /// <param name="formattedValue">Receives the formatted value.</param>
     /// <returns><see langword="true"/> when a non-null value remains.</returns>
-    private bool TryFormatQueryPropertyValue<T>(
+    internal bool TryFormatQueryPropertyValue<T>(
         QueryAttribute? queryAttribute,
         T value,
         [NotNullWhen(true)] out object? formattedValue)
@@ -533,24 +629,20 @@ internal partial class RequestBuilderImplementation
     /// <param name="kvps">The accumulating list of query pairs.</param>
     /// <param name="queryAttribute">The property's query attribute, if any.</param>
     /// <param name="collectionFormat">The collection format for enumerable values.</param>
-    private void AppendEnumerablePropertyValues(
+    internal void AppendEnumerablePropertyValues(
         IEnumerable values,
         PropertyInfo propertyInfo,
         string key,
         List<QueryMapEntry> kvps,
         QueryAttribute? queryAttribute,
-        CollectionFormat? collectionFormat)
-    {
-        foreach (var value in ParseEnumerableQueryParameterValue(
-                     values,
-                     propertyInfo,
-                     propertyInfo.PropertyType,
-                     queryAttribute,
-                     collectionFormat))
-        {
-            kvps.Add(new(key, value));
-        }
-    }
+        CollectionFormat? collectionFormat) =>
+        AppendFormattedEnumerableValues(
+            values,
+            propertyInfo,
+            propertyInfo.PropertyType,
+            queryAttribute,
+            collectionFormat,
+            new QueryMapEntrySink(kvps, key));
 
     /// <summary>Flattens a nested object or dictionary value into prefixed query-string key/value pairs.</summary>
     /// <param name="obj">The nested value to flatten.</param>
@@ -558,7 +650,7 @@ internal partial class RequestBuilderImplementation
     /// <param name="kvps">The accumulating list of query pairs.</param>
     /// <param name="delimiter">The delimiter used between nested keys.</param>
     /// <param name="collectionFormat">The collection format for enumerable values.</param>
-    private void AppendNestedQueryMap(
+    internal void AppendNestedQueryMap(
         object obj,
         string key,
         List<QueryMapEntry> kvps,

--- a/src/Refit.Reflection/RequestBuilderImplementation.RequestBuilding.cs
+++ b/src/Refit.Reflection/RequestBuilderImplementation.RequestBuilding.cs
@@ -17,7 +17,7 @@ internal partial class RequestBuilderImplementation
         "Trimming",
         "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' may break when trimming",
         Justification = "The cached method handle points to a local generic serialization helper used through runtime generic method closure.")]
-    private static readonly MethodInfo SerializeBodyMethod =
+    internal static readonly MethodInfo SerializeBodyMethod =
         FindDeclaredMethod(nameof(SerializeBodyGeneric));
 
     /// <summary>Cached reflection handle to the generic synchronous body-serialization method.</summary>
@@ -25,7 +25,7 @@ internal partial class RequestBuilderImplementation
         "Trimming",
         "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' may break when trimming",
         Justification = "The cached method handle points to a local generic serialization helper used through runtime generic method closure.")]
-    private static readonly MethodInfo SerializeBodySynchronouslyMethod =
+    internal static readonly MethodInfo SerializeBodySynchronouslyMethod =
         FindDeclaredMethod(nameof(SerializeBodySynchronouslyGeneric));
 
     /// <summary>Cached reflection handle to the generic streaming body-serialization method.</summary>
@@ -33,7 +33,7 @@ internal partial class RequestBuilderImplementation
         "Trimming",
         "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' may break when trimming",
         Justification = "The cached method handle points to a local generic serialization helper used through runtime generic method closure.")]
-    private static readonly MethodInfo SerializeBodyStreamingMethod =
+    internal static readonly MethodInfo SerializeBodyStreamingMethod =
         FindDeclaredMethod(nameof(SerializeBodyStreamingGeneric));
 
     /// <summary>Maps a single header, header-collection or authorization parameter into the pending headers.</summary>
@@ -42,7 +42,7 @@ internal partial class RequestBuilderImplementation
     /// <param name="param">The argument value.</param>
     /// <param name="headersToAdd">The pending header collection, created as needed.</param>
     /// <returns><see langword="true"/> when the parameter contributed a header.</returns>
-    private static bool MapHeaderParameters(
+    internal static bool MapHeaderParameters(
         RestMethodInfoInternal restMethod,
         int i,
         object? param,
@@ -77,7 +77,7 @@ internal partial class RequestBuilderImplementation
     /// <summary>Adds each entry of a header-collection argument to the pending header dictionary.</summary>
     /// <param name="param">The header-collection argument value.</param>
     /// <param name="headersToAdd">The pending header collection, created as needed.</param>
-    private static void AddHeaderCollection(object? param, ref Dictionary<string, string?>? headersToAdd)
+    internal static void AddHeaderCollection(object? param, ref Dictionary<string, string?>? headersToAdd)
     {
         if (param is not IDictionary<string, string> headerCollection)
         {
@@ -95,14 +95,14 @@ internal partial class RequestBuilderImplementation
     /// <param name="restMethod">The rest method being invoked.</param>
     /// <param name="i">The index of the parameter.</param>
     /// <returns><see langword="true"/> when the parameter is property-only and should not also feed the query string.</returns>
-    private static bool IsPropertyOnlyParameter(RestMethodInfoInternal restMethod, int i) =>
+    internal static bool IsPropertyOnlyParameter(RestMethodInfoInternal restMethod, int i) =>
         restMethod.PropertyParameterMap.ContainsKey(i)
-        && restMethod.ParameterInfoArray[i].GetCustomAttribute<QueryAttribute>() is null;
+        && restMethod.ParameterQueryAttributes[i] is null;
 
     /// <summary>Reduces a round-tripping parameter value to its string form, using <c>ToString</c> for non-strings.</summary>
     /// <param name="param">The parameter value.</param>
     /// <returns>The value's string form, or null.</returns>
-    private static string? RoundTripStringValue(object? param) => (param as string) ?? param?.ToString();
+    internal static string? RoundTripStringValue(object? param) => (param as string) ?? param?.ToString();
 
     /// <summary>Serializes a request body using the declared body type.</summary>
     /// <param name="serializer">The content serializer to use.</param>
@@ -114,7 +114,7 @@ internal partial class RequestBuilderImplementation
         "IL2060:MakeGenericMethod",
         Justification = "The reflection request builder intentionally closes the serializer method over the runtime body type.")]
     [RequiresDynamicCode("Serializing a body by runtime Type requires runtime generic method instantiation.")]
-    private static HttpContent SerializeBody(
+    internal static HttpContent SerializeBody(
         IHttpContentSerializer serializer,
         object? body,
         Type declaredBodyType)
@@ -132,7 +132,7 @@ internal partial class RequestBuilderImplementation
         "Design",
         "SST2307:Generic method type parameters should be inferable from the parameters",
         Justification = "Type parameter intentionally specified explicitly by callers.")]
-    private static HttpContent SerializeBodyGeneric<T>(IHttpContentSerializer serializer, object? body) =>
+    internal static HttpContent SerializeBodyGeneric<T>(IHttpContentSerializer serializer, object? body) =>
         serializer.ToHttpContent((T)body!);
 
     /// <summary>Serializes a request body synchronously as the given type.</summary>
@@ -145,7 +145,7 @@ internal partial class RequestBuilderImplementation
         "IL2060:MakeGenericMethod",
         Justification = "The reflection request builder intentionally closes the serializer method over the runtime body type.")]
     [RequiresDynamicCode("Serializing a body by runtime Type requires runtime generic method instantiation.")]
-    private static HttpContent SerializeBodySynchronously(
+    internal static HttpContent SerializeBodySynchronously(
         ISynchronousContentSerializer serializer,
         object? body,
         Type declaredBodyType)
@@ -163,7 +163,7 @@ internal partial class RequestBuilderImplementation
         "Design",
         "SST2307:Generic method type parameters should be inferable from the parameters",
         Justification = "Type parameter intentionally specified explicitly by callers.")]
-    private static HttpContent SerializeBodySynchronouslyGeneric<T>(ISynchronousContentSerializer serializer, object? body) =>
+    internal static HttpContent SerializeBodySynchronouslyGeneric<T>(ISynchronousContentSerializer serializer, object? body) =>
         serializer.ToHttpContentSynchronous((T)body!);
 
     /// <summary>Serializes a request body as a streaming content for the given type.</summary>
@@ -176,7 +176,7 @@ internal partial class RequestBuilderImplementation
         "IL2060:MakeGenericMethod",
         Justification = "The reflection request builder intentionally closes the serializer method over the runtime body type.")]
     [RequiresDynamicCode("Serializing a body by runtime Type requires runtime generic method instantiation.")]
-    private static HttpContent SerializeBodyStreaming(
+    internal static HttpContent SerializeBodyStreaming(
         ISynchronousContentSerializer serializer,
         object? body,
         Type declaredBodyType)
@@ -194,13 +194,13 @@ internal partial class RequestBuilderImplementation
         "Design",
         "SST2307:Generic method type parameters should be inferable from the parameters",
         Justification = "Type parameter intentionally specified explicitly by callers.")]
-    private static HttpContent SerializeBodyStreamingGeneric<T>(ISynchronousContentSerializer serializer, object? body) =>
+    internal static HttpContent SerializeBodyStreamingGeneric<T>(ISynchronousContentSerializer serializer, object? body) =>
         serializer.ToStreamingHttpContent((T)body!);
 
     /// <summary>Coerces a JSON Lines body argument into the sequence of values to serialize line by line.</summary>
     /// <param name="param">The body argument value.</param>
     /// <returns>The sequence of values; a non-enumerable value becomes a single line.</returns>
-    private static IEnumerable AsJsonLinesSequence(object param) =>
+    internal static IEnumerable AsJsonLinesSequence(object param) =>
         param is IEnumerable enumerable and not string
             ? enumerable
             : new[] { param };
@@ -208,7 +208,7 @@ internal partial class RequestBuilderImplementation
     /// <summary>Returns a copy of an argument array with cancellation tokens removed.</summary>
     /// <param name="paramList">The original argument values.</param>
     /// <returns>The argument values used for request mapping.</returns>
-    private static object[] RemoveCancellationTokens(object[] paramList)
+    internal static object[] RemoveCancellationTokens(object[] paramList)
     {
         var count = 0;
         for (var i = 0; i < paramList.Length; i++)
@@ -240,7 +240,7 @@ internal partial class RequestBuilderImplementation
 
     /// <summary>Removes the '/' separator that precedes a dropped optional segment, if one was already appended.</summary>
     /// <param name="vsb">The path builder to trim.</param>
-    private static void DropOptionalSegmentSeparator(ref ValueStringBuilder vsb)
+    internal static void DropOptionalSegmentSeparator(ref ValueStringBuilder vsb)
     {
         if (vsb.Length == 0 || vsb[vsb.Length - 1] != '/')
         {
@@ -259,7 +259,7 @@ internal partial class RequestBuilderImplementation
     /// dispatch-time step skipped when the request is built only to be handed back to the caller.</param>
     /// <returns>The constructed request message.</returns>
     [RequiresDynamicCode("Serializing a body by runtime Type requires runtime generic method instantiation.")]
-    private async Task<HttpRequestMessage> BuildRequestMessageForMethodAsync(
+    internal async Task<HttpRequestMessage> BuildRequestMessageForMethodAsync(
         RestMethodInfoInternal restMethod,
         string basePath,
         bool paramsContainsCancellationToken,
@@ -289,9 +289,16 @@ internal partial class RequestBuilderImplementation
             }
 
             List<QueryParameterEntry>? queryParamsToAdd = null;
-            var headersToAdd = restMethod.Headers.Count > 0
-                ? new Dictionary<string, string?>(restMethod.Headers)
-                : null;
+
+            // The static headers only need a per-request mutable copy when an argument can add, override or remove a
+            // header; otherwise the parsed set is emitted directly (it is read, never mutated, on this path).
+            Dictionary<string, string?>? headersToAdd = null;
+            if (restMethod.Headers.Count > 0)
+            {
+                headersToAdd = restMethod.ContributesDynamicHeaders
+                    ? new Dictionary<string, string?>(restMethod.Headers)
+                    : restMethod.Headers;
+            }
 
             MapParametersToRequest(restMethod, paramList, ret, multiPartContent, ref headersToAdd, ref queryParamsToAdd);
 
@@ -324,7 +331,7 @@ internal partial class RequestBuilderImplementation
     /// <param name="headersToAdd">The pending header collection, created as needed.</param>
     /// <param name="queryParamsToAdd">The pending query parameter collection, created as needed.</param>
     [RequiresDynamicCode("Serializing a body by runtime Type requires runtime generic method instantiation.")]
-    private void MapParametersToRequest(
+    internal void MapParametersToRequest(
         RestMethodInfoInternal restMethod,
         object[] paramList,
         HttpRequestMessage ret,
@@ -354,9 +361,7 @@ internal partial class RequestBuilderImplementation
                 continue;
             }
 
-            var queryAttribute = restMethod
-                .ParameterInfoArray[i]
-                .GetCustomAttribute<QueryAttribute>();
+            var queryAttribute = restMethod.ParameterQueryAttributes[i];
             if (!restMethod.IsMultipart
                 || (restMethod.ParameterMap.TryGetValue(i, out var mapValue) && mapValue.IsObjectPropertyParameter)
                 || queryAttribute is not null)
@@ -384,7 +389,7 @@ internal partial class RequestBuilderImplementation
     /// <param name="headersToAdd">The pending header collection, created as needed.</param>
     /// <returns><see langword="true"/> when the parameter was fully mapped and needs no further handling.</returns>
     [RequiresDynamicCode("Serializing a body by runtime Type requires runtime generic method instantiation.")]
-    private bool MapSingleParameterToRequest(
+    internal bool MapSingleParameterToRequest(
         RestMethodInfoInternal restMethod,
         int i,
         object? param,
@@ -428,7 +433,7 @@ internal partial class RequestBuilderImplementation
     /// <param name="basePath">The base path from the client's base address.</param>
     /// <param name="paramList">The argument values for the call.</param>
     /// <param name="queryParamsToAdd">The query parameters collected for the request, if any.</param>
-    private void AssignRequestUri(
+    internal void AssignRequestUri(
         RestMethodInfoInternal restMethod,
         HttpRequestMessage ret,
         string basePath,
@@ -467,7 +472,7 @@ internal partial class RequestBuilderImplementation
     /// <param name="restMethod">The rest method being invoked.</param>
     /// <param name="paramList">The argument values used to resolve dynamic fragments.</param>
     /// <returns>The fully expanded relative path.</returns>
-    private string BuildRelativePath(string basePath, RestMethodInfoInternal restMethod, object[] paramList)
+    internal string BuildRelativePath(string basePath, RestMethodInfoInternal restMethod, object[] paramList)
     {
         // Under RFC 3986 resolution the HttpClient merges the base address with the relative path itself,
         // so emit only the declared relative path (preserving any leading slash) and prepend nothing.
@@ -506,7 +511,7 @@ internal partial class RequestBuilderImplementation
     /// <param name="restMethod">The rest method being invoked.</param>
     /// <param name="paramList">The argument values used to resolve the fragment.</param>
     /// <param name="fragment">The path fragment to append.</param>
-    private void AppendPathFragmentValue(
+    internal void AppendPathFragmentValue(
         ref ValueStringBuilder vsb,
         RestMethodInfoInternal restMethod,
         object[] paramList,
@@ -538,7 +543,7 @@ internal partial class RequestBuilderImplementation
     /// <param name="paramList">The argument values used to resolve the fragment.</param>
     /// <param name="fragment">The path fragment to append.</param>
     /// <param name="parameterMapValue">The parameter info for the fragment.</param>
-    private void AppendObjectPropertyFragment(
+    internal void AppendObjectPropertyFragment(
         ref ValueStringBuilder vsb,
         object[] paramList,
         ParameterFragment fragment,
@@ -582,7 +587,7 @@ internal partial class RequestBuilderImplementation
     /// <param name="paramList">The argument values used to resolve the fragment.</param>
     /// <param name="fragment">The path fragment to append.</param>
     /// <param name="parameterMapValue">The parameter info for the fragment.</param>
-    private void AppendDynamicRouteFragment(
+    internal void AppendDynamicRouteFragment(
         ref ValueStringBuilder vsb,
         RestMethodInfoInternal restMethod,
         object[] paramList,
@@ -645,7 +650,7 @@ internal partial class RequestBuilderImplementation
     /// <param name="param">The bound argument value.</param>
     /// <param name="parameterInfo">The parameter supplying the value.</param>
     /// <param name="isOptional">Whether the placeholder was declared optional with the <c>{name?}</c> syntax.</param>
-    private void AppendNormalRouteFragment(
+    internal void AppendNormalRouteFragment(
         ref ValueStringBuilder vsb,
         object? param,
         ParameterInfo parameterInfo,

--- a/src/Refit.Reflection/RequestBuilderImplementation.cs
+++ b/src/Refit.Reflection/RequestBuilderImplementation.cs
@@ -16,18 +16,26 @@ namespace Refit;
 internal partial class RequestBuilderImplementation : IRequestBuilder
 {
     /// <summary>Maximum stack-allocated buffer size, in characters, used when building paths and query strings.</summary>
-    private const int StackallocThreshold = 512;
+    internal const int StackallocThreshold = 512;
 
     /// <summary>The name of the <see cref="IReturnTypeAdapter{TReturn, TResult}.Adapt"/> method, resolved reflectively.</summary>
-    private const string AdaptMethodName = "Adapt";
+    internal const string AdaptMethodName = "Adapt";
 
     /// <summary>The default query attribute applied when a parameter has none.</summary>
-    private static readonly QueryAttribute DefaultQueryAttribute = new();
+    internal static readonly QueryAttribute DefaultQueryAttribute = new();
 
     /// <summary>A placeholder base URI used while building relative request URIs. Its scheme and host are
     /// discarded — only the combined path and query are kept (see <c>AssignRequestUri</c>), so it never
     /// reaches the network.</summary>
-    private static readonly Uri BaseUri = new("https://api");
+    internal static readonly Uri BaseUri = new("https://api");
+
+    /// <summary>Caches this type's private delegate-factory methods by name, so resolving one never re-materializes the
+    /// full <see cref="TypeInfo.DeclaredMethods"/> array — a fresh reflection allocation on every lookup — for the small
+    /// fixed set of names the builder repeatedly asks for.</summary>
+    private static readonly ConcurrentDictionary<string, MethodInfo> DeclaredMethodCache = new();
+
+    /// <summary>Reuses one delegate for the declared-method resolver so a cache miss never allocates a callback.</summary>
+    private static readonly Func<string, MethodInfo> DeclaredMethodFactory = ResolveDeclaredMethod;
 
     /// <summary>Lookup of HTTP methods keyed by method name.</summary>
     private readonly Dictionary<string, List<RestMethodInfoInternal>> _interfaceHttpMethods;
@@ -149,34 +157,16 @@ internal partial class RequestBuilderImplementation : IRequestBuilder
             : BuildGeneratedSyncFuncForMethod(restMethod);
     }
 
-    /// <summary>Finds a method declared on this implementation type by name.</summary>
+    /// <summary>Finds a method declared on this implementation type by name, caching the resolved metadata by name.</summary>
     /// <param name="name">The method name.</param>
     /// <returns>The declared method.</returns>
-    [UnconditionalSuppressMessage(
-        "Trimming",
-        "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' may break when trimming",
-        Justification = "This resolves Refit's own private generic delegate factory methods by known method name.")]
-    [UnconditionalSuppressMessage(
-        "Trimming",
-        "IL2111:Reflection access to methods with DynamicallyAccessedMembersAttribute",
-        Justification = "This helper filters by known method names and does not invoke methods with dynamic-access requirements.")]
-    internal static MethodInfo FindDeclaredMethod(string name)
-    {
-        foreach (var method in typeof(RequestBuilderImplementation).GetTypeInfo().DeclaredMethods)
-        {
-            if (method.Name == name)
-            {
-                return method;
-            }
-        }
-
-        throw new MissingMethodException(typeof(RequestBuilderImplementation).FullName, name);
-    }
+    internal static MethodInfo FindDeclaredMethod(string name) =>
+        DeclaredMethodCache.GetOrAdd(name, DeclaredMethodFactory);
 
     /// <summary>Gets the lookup key for a method, stripping any explicit-interface prefix from the name.</summary>
     /// <param name="methodInfo">The method to derive a key for.</param>
     /// <returns>The simple method name used as a lookup key.</returns>
-    private static string GetLookupKeyForMethod(MethodInfo methodInfo)
+    internal static string GetLookupKeyForMethod(MethodInfo methodInfo)
     {
         var name = methodInfo.Name;
         var lastDot = name.LastIndexOf('.');
@@ -187,14 +177,14 @@ internal partial class RequestBuilderImplementation : IRequestBuilder
     /// <param name="restMethod">The rest method to inspect.</param>
     /// <param name="openGenericType">The open generic type definition to match.</param>
     /// <returns><see langword="true"/> if the return type closes <paramref name="openGenericType"/>; otherwise <see langword="false"/>.</returns>
-    private static bool IsGenericReturnType(RestMethodInfoInternal restMethod, Type openGenericType) =>
+    internal static bool IsGenericReturnType(RestMethodInfoInternal restMethod, Type openGenericType) =>
         restMethod.ReturnType.GetTypeInfo().IsGenericType
         && restMethod.ReturnType.GetGenericTypeDefinition() == openGenericType;
 
     /// <summary>Determines whether the method returns <see cref="Task{TResult}"/> of <see cref="HttpRequestMessage"/>.</summary>
     /// <param name="restMethod">The rest method to inspect.</param>
     /// <returns><see langword="true"/> when the method builds and returns its request without sending it.</returns>
-    private static bool IsRequestMessageReturnType(RestMethodInfoInternal restMethod) =>
+    internal static bool IsRequestMessageReturnType(RestMethodInfoInternal restMethod) =>
         IsGenericReturnType(restMethod, typeof(Task<>))
         && restMethod.ReturnResultType == typeof(HttpRequestMessage);
 
@@ -203,7 +193,7 @@ internal partial class RequestBuilderImplementation : IRequestBuilder
     /// <param name="parameterTypes">The parameter types to match.</param>
     /// <param name="genericArgumentTypes">The generic argument types, or null.</param>
     /// <returns>The matching candidate methods.</returns>
-    private static RestMethodInfoInternal[] FilterPossibleMethods(
+    internal static RestMethodInfoInternal[] FilterPossibleMethods(
         List<RestMethodInfoInternal> httpMethods,
         Type[] parameterTypes,
         Type[]? genericArgumentTypes)
@@ -249,7 +239,7 @@ internal partial class RequestBuilderImplementation : IRequestBuilder
         "Performance",
         "PSH1315:A blocking wait on an awaitable that may not be done",
         Justification = "Deliberate sync-over-async bridge for synchronous (void/non-Task) interface methods that have no async caller; the work is offloaded via Task.Run to avoid deadlocks.")]
-    private static void RunSynchronous(Func<Task> taskFactory) =>
+    internal static void RunSynchronous(Func<Task> taskFactory) =>
         Task.Run(taskFactory).GetAwaiter().GetResult();
 
     /// <summary>Runs an asynchronous task factory synchronously and returns its result.</summary>
@@ -264,7 +254,7 @@ internal partial class RequestBuilderImplementation : IRequestBuilder
         "Performance",
         "PSH1315:A blocking wait on an awaitable that may not be done",
         Justification = "Deliberate sync-over-async bridge for synchronous (non-Task) interface methods that have no async caller; the work is offloaded via Task.Run to avoid deadlocks.")]
-    private static T? RunSynchronous<T>(Func<Task<T?>> taskFactory) =>
+    internal static T? RunSynchronous<T>(Func<Task<T?>> taskFactory) =>
         Task.Run(taskFactory).GetAwaiter().GetResult();
 
     /// <summary>Awaits the request task and disposes the linked cancellation source once it completes.</summary>
@@ -276,7 +266,7 @@ internal partial class RequestBuilderImplementation : IRequestBuilder
         "Usage",
         "VSTHRD003:Avoid awaiting foreign Tasks",
         Justification = "The task is the request just launched by the caller; awaiting it here only scopes disposal of the linked cancellation source.")]
-    private static async Task<T?> DisposeWhenDoneAsync<T>(Task<T?> task, CancellationTokenSource cts)
+    internal static async Task<T?> DisposeWhenDoneAsync<T>(Task<T?> task, CancellationTokenSource cts)
     {
         try
         {
@@ -292,7 +282,7 @@ internal partial class RequestBuilderImplementation : IRequestBuilder
     /// <param name="parameters">The reflected method parameters.</param>
     /// <param name="parameterTypes">The requested parameter types.</param>
     /// <returns><see langword="true"/> when the parameter types match.</returns>
-    private static bool ParametersMatch(ParameterInfo[] parameters, Type[] parameterTypes)
+    internal static bool ParametersMatch(ParameterInfo[] parameters, Type[] parameterTypes)
     {
         for (var i = 0; i < parameters.Length; i++)
         {
@@ -308,7 +298,7 @@ internal partial class RequestBuilderImplementation : IRequestBuilder
     /// <summary>Finds the first cancellation token in an argument array.</summary>
     /// <param name="paramList">The argument values.</param>
     /// <returns>The first cancellation token, or <see cref="CancellationToken.None"/>.</returns>
-    private static CancellationToken GetCancellationToken(object[] paramList)
+    internal static CancellationToken GetCancellationToken(object[] paramList)
     {
         for (var i = 0; i < paramList.Length; i++)
         {
@@ -325,7 +315,7 @@ internal partial class RequestBuilderImplementation : IRequestBuilder
     /// <param name="interfaceType">The interface to scan for HTTP methods.</param>
     /// <param name="methods">The dictionary to populate with discovered methods.</param>
     [RequiresUnreferencedCode("Reading reflected interface methods requires interface and request object metadata to be available at runtime.")]
-    private void AddInterfaceHttpMethods(
+    internal void AddInterfaceHttpMethods(
         [DynamicallyAccessedMembers(
             DynamicallyAccessedMemberTypes.Interfaces
             | DynamicallyAccessedMemberTypes.PublicMethods
@@ -366,7 +356,7 @@ internal partial class RequestBuilderImplementation : IRequestBuilder
     /// <returns>The matching rest method info.</returns>
     [RequiresUnreferencedCode("Resolving generic Refit methods from reflected metadata requires generic method metadata to be available at runtime.")]
     [RequiresDynamicCode("Resolving generic Refit methods from reflected metadata requires runtime generic method instantiation.")]
-    private RestMethodInfoInternal FindMatchingRestMethodInfo(
+    internal RestMethodInfoInternal FindMatchingRestMethodInfo(
         string key,
         Type[]? parameterTypes,
         Type[]? genericArgumentTypes)
@@ -419,7 +409,7 @@ internal partial class RequestBuilderImplementation : IRequestBuilder
     /// <returns>The closed rest method info, or the original when no generic arguments are supplied.</returns>
     [RequiresUnreferencedCode("Closing generic Refit methods requires generic method metadata to be available at runtime.")]
     [RequiresDynamicCode("Closing generic Refit methods requires runtime generic method instantiation.")]
-    private RestMethodInfoInternal CloseGenericMethodIfNeeded(
+    internal RestMethodInfoInternal CloseGenericMethodIfNeeded(
         RestMethodInfoInternal restMethodInfo,
         Type[]? genericArgumentTypes) =>
         genericArgumentTypes is { } genericArguments
@@ -440,7 +430,7 @@ internal partial class RequestBuilderImplementation : IRequestBuilder
     /// <returns>A delegate that invokes the method.</returns>
     [RequiresUnreferencedCode("Building generic result delegates requires generic method metadata to be available at runtime.")]
     [RequiresDynamicCode("Building generic result delegates requires runtime generic method instantiation.")]
-    private Func<HttpClient, object[], object?> BuildResultFuncForMethod(
+    internal Func<HttpClient, object[], object?> BuildResultFuncForMethod(
         RestMethodInfoInternal restMethod,
         string builderMethodName)
     {
@@ -461,7 +451,7 @@ internal partial class RequestBuilderImplementation : IRequestBuilder
     /// <returns>A delegate that adapts the deferred HTTP call into the surfaced return type.</returns>
     [RequiresUnreferencedCode("Building return-type adapter delegates requires generic method metadata to be available at runtime.")]
     [RequiresDynamicCode("Building return-type adapter delegates requires runtime generic method instantiation.")]
-    private Func<HttpClient, object[], object?> BuildAdapterFuncForMethod(RestMethodInfoInternal restMethod)
+    internal Func<HttpClient, object[], object?> BuildAdapterFuncForMethod(RestMethodInfoInternal restMethod)
     {
         var builderMethodInfo = FindDeclaredMethod(nameof(BuildAdapterFuncForMethodGeneric));
         return (Func<HttpClient, object[], object?>)
@@ -482,7 +472,7 @@ internal partial class RequestBuilderImplementation : IRequestBuilder
         Justification = "Type parameter intentionally specified explicitly by callers.")]
     [RequiresUnreferencedCode("Instantiating the adapter and resolving its interface method requires adapter metadata to be available at runtime.")]
     [RequiresDynamicCode("Instantiating the adapter and closing its interface method requires runtime generic type instantiation.")]
-    private Func<HttpClient, object[], object?> BuildAdapterFuncForMethodGeneric<T, TBody>(
+    internal Func<HttpClient, object[], object?> BuildAdapterFuncForMethodGeneric<T, TBody>(
         RestMethodInfoInternal restMethod)
     {
         var taskFunc = BuildCancellableTaskFuncForMethod<T, TBody>(restMethod);
@@ -524,7 +514,7 @@ internal partial class RequestBuilderImplementation : IRequestBuilder
     /// <returns>A delegate that invokes the method synchronously.</returns>
     [RequiresUnreferencedCode("Building synchronous result delegates requires generic method metadata to be available at runtime.")]
     [RequiresDynamicCode("Building synchronous result delegates requires runtime generic method instantiation.")]
-    private Func<HttpClient, object[], object?> BuildGeneratedSyncFuncForMethod(
+    internal Func<HttpClient, object[], object?> BuildGeneratedSyncFuncForMethod(
         RestMethodInfoInternal restMethod)
     {
         if (restMethod.ReturnResultType == typeof(void))
@@ -562,7 +552,7 @@ internal partial class RequestBuilderImplementation : IRequestBuilder
         "SST2307:Generic method type parameters should be inferable from the parameters",
         Justification = "Type parameter intentionally specified explicitly by callers.")]
     [RequiresDynamicCode("Serializing a body by runtime Type requires runtime generic method instantiation.")]
-    private Func<HttpClient, object[], object?> BuildGeneratedSyncFuncForMethodGeneric<T, TBody>(
+    internal Func<HttpClient, object[], object?> BuildGeneratedSyncFuncForMethodGeneric<T, TBody>(
         RestMethodInfoInternal restMethod) =>
         (client, paramList) =>
             RunSynchronous(() =>
@@ -583,7 +573,7 @@ internal partial class RequestBuilderImplementation : IRequestBuilder
         "SST2307:Generic method type parameters should be inferable from the parameters",
         Justification = "Type parameter intentionally specified explicitly by callers.")]
     [RequiresDynamicCode("Serializing a body by runtime Type requires runtime generic method instantiation.")]
-    private Func<HttpClient, object[], IObservable<T?>> BuildRxFuncForMethod<T, TBody>(
+    internal Func<HttpClient, object[], IObservable<T?>> BuildRxFuncForMethod<T, TBody>(
         RestMethodInfoInternal restMethod)
     {
         var taskFunc = BuildCancellableTaskFuncForMethod<T, TBody>(restMethod);
@@ -621,7 +611,7 @@ internal partial class RequestBuilderImplementation : IRequestBuilder
         "SST1452:Unused type parameters should be removed",
         Justification = "The second type parameter is required so this factory matches the two-type-argument shape invoked reflectively by BuildResultFuncForMethod.")]
     [RequiresDynamicCode("Serializing a body by runtime Type requires runtime generic method instantiation.")]
-    private Func<HttpClient, object[], IAsyncEnumerable<T?>> BuildAsyncEnumerableFuncForMethod<T, TBody>(
+    internal Func<HttpClient, object[], IAsyncEnumerable<T?>> BuildAsyncEnumerableFuncForMethod<T, TBody>(
         RestMethodInfoInternal restMethod) =>
         (client, paramList) => ExecuteAsyncEnumerableRequestAsync<T>(client, restMethod, paramList);
 
@@ -635,7 +625,7 @@ internal partial class RequestBuilderImplementation : IRequestBuilder
         "SST2307:Generic method type parameters should be inferable from the parameters",
         Justification = "Type parameter intentionally specified explicitly by callers.")]
     [RequiresDynamicCode("Serializing a body by runtime Type requires runtime generic method instantiation.")]
-    private Func<HttpClient, object[], Task<T?>> BuildTaskFuncForMethod<T, TBody>(
+    internal Func<HttpClient, object[], Task<T?>> BuildTaskFuncForMethod<T, TBody>(
         RestMethodInfoInternal restMethod)
     {
         var ret = BuildCancellableTaskFuncForMethod<T, TBody>(restMethod);
@@ -656,7 +646,7 @@ internal partial class RequestBuilderImplementation : IRequestBuilder
         "SST2307:Generic method type parameters should be inferable from the parameters",
         Justification = "Type parameter intentionally specified explicitly by callers.")]
     [RequiresDynamicCode("Serializing a body by runtime Type requires runtime generic method instantiation.")]
-    private Func<HttpClient, object[], ValueTask<T?>> BuildValueTaskFuncForMethod<T, TBody>(
+    internal Func<HttpClient, object[], ValueTask<T?>> BuildValueTaskFuncForMethod<T, TBody>(
         RestMethodInfoInternal restMethod)
     {
         var ret = BuildTaskFuncForMethod<T, TBody>(restMethod);
@@ -668,7 +658,7 @@ internal partial class RequestBuilderImplementation : IRequestBuilder
     /// <param name="restMethod">The rest method to build a delegate for.</param>
     /// <returns>A delegate that returns a task with no result.</returns>
     [RequiresDynamicCode("Serializing a body by runtime Type requires runtime generic method instantiation.")]
-    private Func<HttpClient, object[], Task> BuildVoidTaskFuncForMethod(
+    internal Func<HttpClient, object[], Task> BuildVoidTaskFuncForMethod(
         RestMethodInfoInternal restMethod) =>
         (client, paramList) =>
         {
@@ -686,4 +676,30 @@ internal partial class RequestBuilderImplementation : IRequestBuilder
                 restMethod.CancellationToken is not null,
                 ct);
         };
+
+    /// <summary>Resolves a method declared on this implementation type by name, on a declared-method-cache miss.</summary>
+    /// <param name="name">The method name.</param>
+    /// <returns>The declared method.</returns>
+    /// <exception cref="MissingMethodException">No method with the given name is declared on the type. The miss is not
+    /// cached, so an unknown name keeps throwing rather than poisoning the cache.</exception>
+    [UnconditionalSuppressMessage(
+        "Trimming",
+        "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' may break when trimming",
+        Justification = "This resolves Refit's own private generic delegate factory methods by known method name.")]
+    [UnconditionalSuppressMessage(
+        "Trimming",
+        "IL2111:Reflection access to methods with DynamicallyAccessedMembersAttribute",
+        Justification = "This helper filters by known method names and does not invoke methods with dynamic-access requirements.")]
+    private static MethodInfo ResolveDeclaredMethod(string name)
+    {
+        foreach (var method in typeof(RequestBuilderImplementation).GetTypeInfo().DeclaredMethods)
+        {
+            if (method.Name == name)
+            {
+                return method;
+            }
+        }
+
+        throw new MissingMethodException(typeof(RequestBuilderImplementation).FullName, name);
+    }
 }

--- a/src/Refit.Reflection/RestMethodInfoInternal.AttributeReading.cs
+++ b/src/Refit.Reflection/RestMethodInfoInternal.AttributeReading.cs
@@ -1,0 +1,243 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Reflection;
+
+namespace Refit;
+
+/// <summary>Per-parameter attribute reading for <see cref="RestMethodInfoInternal"/>. Reads each parameter's
+/// request-shaping attributes once into a classified set so the constructor never re-enumerates a parameter's attribute
+/// records for each distinct lookup.</summary>
+internal partial class RestMethodInfoInternal
+{
+    /// <summary>Reads every parameter's request-shaping attributes in a single metadata pass.</summary>
+    /// <param name="parameterArray">The parameters excluding cancellation tokens.</param>
+    /// <returns>The classified attribute set for each parameter, indexed to match <paramref name="parameterArray"/>.</returns>
+    /// <remarks>Each parameter's attributes are enumerated once and sorted by type; a per-request-shaping <c>GetCustomAttribute</c>
+    /// call would otherwise re-scan the same attribute records once per lookup, allocating a scratch array each time.</remarks>
+    internal static ParameterAttributeSet[] BuildParameterAttributeSets(ParameterInfo[] parameterArray)
+    {
+        if (parameterArray.Length == 0)
+        {
+            return [];
+        }
+
+        var sets = new ParameterAttributeSet[parameterArray.Length];
+        for (var i = 0; i < parameterArray.Length; i++)
+        {
+            sets[i] = ClassifyParameterAttributes(parameterArray[i]);
+        }
+
+        return sets;
+    }
+
+    /// <summary>Reads and classifies a single parameter's request-shaping attributes in one metadata pass.</summary>
+    /// <param name="parameter">The parameter whose attributes are read.</param>
+    /// <returns>The classified attribute set for the parameter.</returns>
+    internal static ParameterAttributeSet ClassifyParameterAttributes(ParameterInfo parameter)
+    {
+        QueryAttribute? query = null;
+        HeaderAttribute? header = null;
+        HeaderCollectionAttribute? headerCollection = null;
+        PropertyAttribute? property = null;
+        AuthorizeAttribute? authorize = null;
+        BodyAttribute? body = null;
+        UrlAttribute? url = null;
+        FormObjectAttribute? formObject = null;
+
+        // Each of these attributes is single-per-parameter, so classifying with a null-coalescing assignment keeps the
+        // first (only) match of each type without the line or branch cost of a braced type switch.
+        foreach (var attribute in parameter.GetCustomAttributes(true))
+        {
+            query ??= attribute as QueryAttribute;
+            header ??= attribute as HeaderAttribute;
+            headerCollection ??= attribute as HeaderCollectionAttribute;
+            property ??= attribute as PropertyAttribute;
+            authorize ??= attribute as AuthorizeAttribute;
+            body ??= attribute as BodyAttribute;
+            url ??= attribute as UrlAttribute;
+            formObject ??= attribute as FormObjectAttribute;
+        }
+
+        return new(query, header, headerCollection, property, authorize, body, url, formObject);
+    }
+
+    /// <summary>Materializes each parameter's <see cref="QueryAttribute"/> so the per-request mapping path can look it up
+    /// from an array instead of re-reading it from metadata on every call.</summary>
+    /// <param name="sets">The classified attribute set for each parameter.</param>
+    /// <returns>The query attribute for each parameter, or null where absent, indexed to match <paramref name="sets"/>.</returns>
+    internal static QueryAttribute?[] BuildParameterQueryAttributes(ParameterAttributeSet[] sets)
+    {
+        if (sets.Length == 0)
+        {
+            return [];
+        }
+
+        var attributes = new QueryAttribute?[sets.Length];
+        for (var i = 0; i < sets.Length; i++)
+        {
+            attributes[i] = sets[i].Query;
+        }
+
+        return attributes;
+    }
+
+    /// <summary>Records which parameters carry <see cref="FormObjectAttribute"/> so the per-part multipart path looks the
+    /// fact up from an array instead of re-reading it from metadata on every part.</summary>
+    /// <param name="sets">The classified attribute set for each parameter.</param>
+    /// <param name="isMultipart">Whether the method is multipart; only then is the form-object fact ever consulted.</param>
+    /// <returns>A flag per parameter for a multipart method, or a shared empty array otherwise.</returns>
+    internal static bool[] BuildFormObjectFlags(ParameterAttributeSet[] sets, bool isMultipart)
+    {
+        if (!isMultipart)
+        {
+            return [];
+        }
+
+        var flags = new bool[sets.Length];
+        for (var i = 0; i < sets.Length; i++)
+        {
+            flags[i] = sets[i].FormObject is not null;
+        }
+
+        return flags;
+    }
+
+    /// <summary>Finds the index of the header collection parameter in the parameter array.</summary>
+    /// <param name="parameterArray">The array of method parameters.</param>
+    /// <param name="sets">The classified attribute set for each parameter.</param>
+    /// <returns>The index of the header collection parameter, or a negative value when none exists.</returns>
+    internal static int GetHeaderCollectionParameterIndex(ParameterInfo[] parameterArray, ParameterAttributeSet[] sets)
+    {
+        var headerIndex = -1;
+
+        for (var i = 0; i < parameterArray.Length; i++)
+        {
+            if (sets[i].HeaderCollection is null)
+            {
+                continue;
+            }
+
+            // Opted for IDictionary<string, string> semantics here as opposed to the looser
+            // IEnumerable<KeyValuePair<string, string>> because IDictionary enforces unique keys.
+            if (!parameterArray[i].ParameterType.IsAssignableFrom(typeof(IDictionary<string, string>)))
+            {
+                throw new ArgumentException(
+                    $"HeaderCollection parameter of type {parameterArray[i].ParameterType.Name} is not assignable from IDictionary<string, string>");
+            }
+
+            // Throw if there is already a HeaderCollection parameter.
+            if (headerIndex >= 0)
+            {
+                throw new ArgumentException("Only one parameter can be a HeaderCollection parameter");
+            }
+
+            headerIndex = i;
+        }
+
+        return headerIndex;
+    }
+
+    /// <summary>Builds the map of parameter indexes to request property keys.</summary>
+    /// <param name="parameterArray">The array of method parameters.</param>
+    /// <param name="sets">The classified attribute set for each parameter.</param>
+    /// <returns>A map of parameter indexes to property keys.</returns>
+    internal static Dictionary<int, string> BuildRequestPropertyMap(ParameterInfo[] parameterArray, ParameterAttributeSet[] sets)
+    {
+        Dictionary<int, string>? propertyMap = null;
+
+        for (var i = 0; i < parameterArray.Length; i++)
+        {
+            var propertyAttribute = sets[i].Property;
+            if (propertyAttribute is not null)
+            {
+                var propertyKey = !string.IsNullOrEmpty(propertyAttribute.Key)
+                    ? propertyAttribute.Key
+                    : parameterArray[i].Name!;
+                propertyMap ??= [];
+                propertyMap[i] = propertyKey!;
+            }
+        }
+
+        return propertyMap ?? EmptyDictionary<int, string>.Get();
+    }
+
+    /// <summary>Builds the map of parameter indexes to header names.</summary>
+    /// <param name="sets">The classified attribute set for each parameter.</param>
+    /// <returns>A map of parameter indexes to header names.</returns>
+    internal static Dictionary<int, string> BuildHeaderParameterMap(ParameterAttributeSet[] sets)
+    {
+        Dictionary<int, string>? ret = null;
+
+        for (var i = 0; i < sets.Length; i++)
+        {
+            var header = sets[i].Header?.Header;
+
+            if (!string.IsNullOrWhiteSpace(header))
+            {
+                ret ??= [];
+                ret[i] = header!.Trim();
+            }
+        }
+
+        return ret ?? EmptyDictionary<int, string>.Get();
+    }
+
+    /// <summary>Scans the parameters for an explicit <see cref="BodyAttribute"/>.</summary>
+    /// <param name="sets">The classified attribute set for each parameter.</param>
+    /// <returns>The first body attribute and its index, and whether more than one parameter carries one.</returns>
+    internal static (BodyAttribute? Attribute, int Index, bool HasMultiple) FindBodyAttribute(ParameterAttributeSet[] sets)
+    {
+        BodyAttribute? bodyAttribute = null;
+        var bodyParameterIndex = -1;
+        for (var i = 0; i < sets.Length; i++)
+        {
+            var attribute = sets[i].Body;
+            if (attribute is null)
+            {
+                continue;
+            }
+
+            if (bodyAttribute is not null)
+            {
+                return (bodyAttribute, bodyParameterIndex, true);
+            }
+
+            bodyAttribute = attribute;
+            bodyParameterIndex = i;
+        }
+
+        return (bodyAttribute, bodyParameterIndex, false);
+    }
+
+    /// <summary>Finds the parameter that carries the authorization value.</summary>
+    /// <param name="sets">The classified attribute set for each parameter.</param>
+    /// <returns>The authorization parameter information, or null when there is no authorize parameter.</returns>
+    internal static Tuple<string, int>? FindAuthorizationParameter(ParameterAttributeSet[] sets)
+    {
+        AuthorizeAttribute? authorizeAttribute = null;
+        var authorizeIndex = -1;
+
+        for (var i = 0; i < sets.Length; i++)
+        {
+            var attribute = sets[i].Authorize;
+            if (attribute is null)
+            {
+                continue;
+            }
+
+            if (authorizeAttribute is not null)
+            {
+                throw new ArgumentException("Only one parameter can be an Authorize parameter");
+            }
+
+            authorizeAttribute = attribute;
+            authorizeIndex = i;
+        }
+
+        return authorizeAttribute is null
+            ? null
+            : Tuple.Create(authorizeAttribute.Scheme, authorizeIndex);
+    }
+}

--- a/src/Refit.Reflection/RestMethodInfoInternal.ParameterBinding.cs
+++ b/src/Refit.Reflection/RestMethodInfoInternal.ParameterBinding.cs
@@ -17,7 +17,7 @@ internal partial class RestMethodInfoInternal
     /// <param name="allowUnmatchedRouteParameters">When true, a placeholder with no matching argument is left in the path verbatim instead of throwing.</param>
     /// <returns>A tuple containing the parameter map and the ordered list of URL fragments.</returns>
     [RequiresUnreferencedCode("Binding route parameters from request object properties requires public property metadata to be available at runtime.")]
-    private static (Dictionary<int, RestMethodParameterInfo> Map, List<ParameterFragment> Fragments)
+    internal static (Dictionary<int, RestMethodParameterInfo> Map, List<ParameterFragment> Fragments)
         BuildParameterMap(
             string relativePath,
             ParameterInfo[] parameterInfo,
@@ -35,7 +35,11 @@ internal partial class RestMethodInfoInternal
         }
 
         var paramValidationDict = BuildParamValidationDict(parameterInfo);
-        var objectParamValidationDict = BuildObjectParamValidationDict(parameterInfo);
+
+        // The object-property lookup is only needed for a {obj.prop} placeholder that no direct parameter matches, so it
+        // is built on first such use. A template whose placeholders all bind direct parameters never builds it.
+        (Dictionary<string, ParameterInfo> Param, Dictionary<string, (ParameterInfo Parameter, PropertyInfo Property)>? Object) validation =
+            (paramValidationDict, null);
 
         var fragmentList = new List<ParameterFragment>();
         var index = 0;
@@ -57,7 +61,7 @@ internal partial class RestMethodInfoInternal
                 parameterInfo,
                 ret,
                 fragmentList,
-                (paramValidationDict, objectParamValidationDict),
+                ref validation,
                 match,
                 allowUnmatchedRouteParameters);
         }
@@ -77,7 +81,7 @@ internal partial class RestMethodInfoInternal
     /// <summary>Builds a lookup of lower-cased URL parameter names to their declaring method parameter.</summary>
     /// <param name="parameterInfo">The array of method parameters.</param>
     /// <returns>A map of URL parameter names to method parameters.</returns>
-    private static Dictionary<string, ParameterInfo> BuildParamValidationDict(ParameterInfo[] parameterInfo)
+    internal static Dictionary<string, ParameterInfo> BuildParamValidationDict(ParameterInfo[] parameterInfo)
     {
         var paramValidationDict = new Dictionary<string, ParameterInfo>(parameterInfo.Length);
         for (var i = 0; i < parameterInfo.Length; i++)
@@ -92,11 +96,11 @@ internal partial class RestMethodInfoInternal
     /// <param name="parameterInfo">The array of method parameters.</param>
     /// <returns>A map of nested property names to their parameter/property pair.</returns>
     [RequiresUnreferencedCode("Binding route parameters from request object properties requires public property metadata to be available at runtime.")]
-    private static Dictionary<string, Tuple<ParameterInfo, PropertyInfo>> BuildObjectParamValidationDict(
+    internal static Dictionary<string, (ParameterInfo Parameter, PropertyInfo Property)> BuildObjectParamValidationDict(
         ParameterInfo[] parameterInfo)
     {
         // If the parameter is a class, build a dictionary for all of its potential bound properties.
-        var objectParamValidationDict = new Dictionary<string, Tuple<ParameterInfo, PropertyInfo>>();
+        var objectParamValidationDict = new Dictionary<string, (ParameterInfo Parameter, PropertyInfo Property)>();
         for (var i = 0; i < parameterInfo.Length; i++)
         {
             var parameter = parameterInfo[i];
@@ -109,7 +113,7 @@ internal partial class RestMethodInfoInternal
             for (var j = 0; j < properties.Length; j++)
             {
                 var key = $"{parameter.Name}.{GetUrlNameForProperty(properties[j])}".ToLowerInvariant();
-                _ = objectParamValidationDict.TryAdd(key, Tuple.Create(parameter, properties[j]));
+                _ = objectParamValidationDict.TryAdd(key, (parameter, properties[j]));
             }
         }
 
@@ -121,16 +125,18 @@ internal partial class RestMethodInfoInternal
     /// <param name="parameterInfo">The array of method parameters.</param>
     /// <param name="ret">The parameter map being built.</param>
     /// <param name="fragmentList">The fragment list being built.</param>
-    /// <param name="validation">The lookups of directly matched parameter names and nested object-property names.</param>
+    /// <param name="validation">The lookup of directly matched parameter names, and the single-level object-property
+    /// lookup built on first use and reused across the template's placeholders; its object entry is null until a
+    /// placeholder needs it.</param>
     /// <param name="match">The parameterized URL match being resolved.</param>
     /// <param name="allowUnmatchedRouteParameters">When true, an unmatched placeholder is left in the path verbatim instead of throwing.</param>
     [RequiresUnreferencedCode("Binding route parameters from request object properties requires public property metadata to be available at runtime.")]
-    private static void AddFragmentForMatch(
+    internal static void AddFragmentForMatch(
         string relativePath,
         ParameterInfo[] parameterInfo,
         Dictionary<int, RestMethodParameterInfo> ret,
         List<ParameterFragment> fragmentList,
-        (Dictionary<string, ParameterInfo> Param, Dictionary<string, Tuple<ParameterInfo, PropertyInfo>> Object) validation,
+        ref (Dictionary<string, ParameterInfo> Param, Dictionary<string, (ParameterInfo Parameter, PropertyInfo Property)>? Object) validation,
         Match match,
         bool allowUnmatchedRouteParameters)
     {
@@ -152,9 +158,10 @@ internal partial class RestMethodInfoInternal
                 value,
                 isOptional);
         }
-        else if (validation.Object.TryGetValue(name, out var value1) && !isRoundTripping)
+        else if (!isRoundTripping
+            && (validation.Object ??= BuildObjectParamValidationDict(parameterInfo)).TryGetValue(name, out var value1))
         {
-            AddObjectPropertyParameter(parameterInfo, ret, fragmentList, name, value1.Item1, [value1.Item2], isOptional);
+            AddObjectPropertyParameter(parameterInfo, ret, fragmentList, name, value1.Parameter, [value1.Property], isOptional);
         }
         else if (TryResolveNestedPropertyChain(parameterInfo, name) is { } nested)
         {
@@ -182,7 +189,7 @@ internal partial class RestMethodInfoInternal
     /// <param name="parsedName">The parsed parameter name details from the URL template.</param>
     /// <param name="value">The matched method parameter.</param>
     /// <param name="isOptional">Whether the placeholder was declared optional with the <c>{name?}</c> syntax.</param>
-    private static void AddStandardParameter(
+    internal static void AddStandardParameter(
         ParameterInfo[] parameterInfo,
         Dictionary<int, RestMethodParameterInfo> ret,
         List<ParameterFragment> fragmentList,
@@ -219,7 +226,7 @@ internal partial class RestMethodInfoInternal
     /// <param name="owner">The parameter whose property chain binds the placeholder.</param>
     /// <param name="propertyChain">The ordered property navigation from the parameter to the bound value.</param>
     /// <param name="isOptional">Whether the placeholder was declared optional with the <c>{name?}</c> syntax.</param>
-    private static void AddObjectPropertyParameter(
+    internal static void AddObjectPropertyParameter(
         ParameterInfo[] parameterInfo,
         Dictionary<int, RestMethodParameterInfo> ret,
         List<ParameterFragment> fragmentList,
@@ -267,7 +274,7 @@ internal partial class RestMethodInfoInternal
     /// <param name="name">The normalized (lower-cased) placeholder name.</param>
     /// <returns>The parameter and its property chain, or null when the placeholder is not a resolvable nested chain.</returns>
     [RequiresUnreferencedCode("Binding route parameters from request object properties requires public property metadata to be available at runtime.")]
-    private static (ParameterInfo Parameter, IReadOnlyList<PropertyInfo> Chain)? TryResolveNestedPropertyChain(
+    internal static (ParameterInfo Parameter, IReadOnlyList<PropertyInfo> Chain)? TryResolveNestedPropertyChain(
         ParameterInfo[] parameterInfo,
         string name)
     {
@@ -310,7 +317,7 @@ internal partial class RestMethodInfoInternal
     /// <param name="urlName">The URL name segment to match.</param>
     /// <returns>The matching property, or null when none matches.</returns>
     [RequiresUnreferencedCode("Binding route parameters from request object properties requires public property metadata to be available at runtime.")]
-    private static PropertyInfo? FindPropertyByUrlName(Type type, string urlName)
+    internal static PropertyInfo? FindPropertyByUrlName(Type type, string urlName)
     {
         foreach (var property in ReflectionPropertyHelpers.GetReadablePublicInstanceProperties(type))
         {
@@ -326,7 +333,7 @@ internal partial class RestMethodInfoInternal
     /// <summary>Gets the URL name to use for a parameter, honoring any alias attribute.</summary>
     /// <param name="paramInfo">The parameter whose URL name is resolved.</param>
     /// <returns>The aliased or declared parameter name.</returns>
-    private static string GetUrlNameForParameter(ParameterInfo paramInfo)
+    internal static string GetUrlNameForParameter(ParameterInfo paramInfo)
     {
         var aliasAttr = paramInfo.GetCustomAttribute<AliasAsAttribute>(true);
         return aliasAttr is not null ? aliasAttr.Name : paramInfo.Name!;
@@ -335,7 +342,7 @@ internal partial class RestMethodInfoInternal
     /// <summary>Gets the URL name to use for a property, honoring any alias attribute.</summary>
     /// <param name="propInfo">The property whose URL name is resolved.</param>
     /// <returns>The aliased or declared property name.</returns>
-    private static string GetUrlNameForProperty(PropertyInfo propInfo)
+    internal static string GetUrlNameForProperty(PropertyInfo propInfo)
     {
         var aliasAttr = propInfo.GetCustomAttribute<AliasAsAttribute>(true);
         return aliasAttr is not null ? aliasAttr.Name : propInfo.Name;
@@ -345,7 +352,7 @@ internal partial class RestMethodInfoInternal
     /// <param name="paramInfo">The parameter whose attachment name is resolved.</param>
     /// <returns>The attachment name, or null when none is specified.</returns>
     [ExcludeFromCodeCoverage] // The AttachmentName arm needs the [Obsolete] AttachmentNameAttribute, which CS0618 forbids a test from applying, so the branch cannot be covered.
-    private static string GetAttachmentNameForParameter(ParameterInfo paramInfo)
+    internal static string GetAttachmentNameForParameter(ParameterInfo paramInfo)
     {
 #pragma warning disable CS0618 // Type or member is obsolete
         var nameAttr = paramInfo.GetCustomAttribute<AttachmentNameAttribute>(true);
@@ -355,40 +362,10 @@ internal partial class RestMethodInfoInternal
         return nameAttr?.Name ?? paramInfo.GetCustomAttribute<AliasAsAttribute>(true)?.Name!;
     }
 
-    /// <summary>Finds the parameter that carries the authorization value.</summary>
-    /// <param name="parameterArray">The array of method parameters.</param>
-    /// <returns>The authorization parameter information, or null when there is no authorize parameter.</returns>
-    private static Tuple<string, int>? FindAuthorizationParameter(ParameterInfo[] parameterArray)
-    {
-        AuthorizeAttribute? authorizeAttribute = null;
-        var authorizeIndex = -1;
-
-        for (var i = 0; i < parameterArray.Length; i++)
-        {
-            var attribute = parameterArray[i].GetCustomAttribute<AuthorizeAttribute>(true);
-            if (attribute is null)
-            {
-                continue;
-            }
-
-            if (authorizeAttribute is not null)
-            {
-                throw new ArgumentException("Only one parameter can be an Authorize parameter");
-            }
-
-            authorizeAttribute = attribute;
-            authorizeIndex = i;
-        }
-
-        return authorizeAttribute is null
-            ? null
-            : Tuple.Create(authorizeAttribute.Scheme, authorizeIndex);
-    }
-
     /// <summary>Finds the single cancellation token parameter for the method.</summary>
     /// <param name="methodInfo">The reflected method information.</param>
     /// <returns>The cancellation token parameter, or null when none is present.</returns>
-    private static ParameterInfo? FindCancellationTokenParameter(MethodInfo methodInfo)
+    internal static ParameterInfo? FindCancellationTokenParameter(MethodInfo methodInfo)
     {
         var parameters = methodInfo.GetParameters();
         ParameterInfo? cancellationTokenParam = null;
@@ -414,14 +391,15 @@ internal partial class RestMethodInfoInternal
     /// <summary>Finds and validates the <c>[Url]</c> parameter that supplies the absolute request URI, ensuring the
     /// method does not also declare a path template.</summary>
     /// <param name="parameterArray">The array of method parameters.</param>
+    /// <param name="sets">The classified attribute set for each parameter.</param>
     /// <param name="relativePath">The method's relative path template.</param>
     /// <returns>The index of the <c>[Url]</c> parameter, or a negative value when none is present.</returns>
     /// <exception cref="ArgumentException">More than one parameter carries <c>[Url]</c>, the parameter is not a
     /// <see cref="string"/> or <see cref="Uri"/>, or a <c>[Url]</c> parameter is combined with a non-empty path
     /// template.</exception>
-    private static int ResolveUrlParameter(ParameterInfo[] parameterArray, string relativePath)
+    internal static int ResolveUrlParameter(ParameterInfo[] parameterArray, ParameterAttributeSet[] sets, string relativePath)
     {
-        var urlIndex = FindUrlParameter(parameterArray);
+        var urlIndex = FindUrlParameter(parameterArray, sets);
         if (urlIndex >= 0
             && !string.IsNullOrEmpty(relativePath)
             && relativePath != "/")
@@ -435,17 +413,18 @@ internal partial class RestMethodInfoInternal
 
     /// <summary>Finds the index of the <c>[Url]</c> parameter that supplies the absolute request URI.</summary>
     /// <param name="parameterArray">The array of method parameters.</param>
+    /// <param name="sets">The classified attribute set for each parameter.</param>
     /// <returns>The index of the <c>[Url]</c> parameter, or a negative value when none is present.</returns>
     /// <exception cref="ArgumentException">More than one parameter carries <c>[Url]</c>, or the parameter is not a
     /// <see cref="string"/> or <see cref="Uri"/>.</exception>
-    private static int FindUrlParameter(ParameterInfo[] parameterArray)
+    internal static int FindUrlParameter(ParameterInfo[] parameterArray, ParameterAttributeSet[] sets)
     {
         var urlIndex = -1;
 
         for (var i = 0; i < parameterArray.Length; i++)
         {
             var param = parameterArray[i];
-            if (param.GetCustomAttribute<UrlAttribute>(true) is null)
+            if (sets[i].Url is null)
             {
                 continue;
             }

--- a/src/Refit.Reflection/RestMethodInfoInternal.cs
+++ b/src/Refit.Reflection/RestMethodInfoInternal.cs
@@ -14,11 +14,11 @@ namespace Refit;
 internal partial class RestMethodInfoInternal
 {
     /// <summary>The HTTP PATCH method instance.</summary>
-    private static readonly HttpMethod _patchMethod = new("PATCH");
+    internal static readonly HttpMethod _patchMethod = new("PATCH");
 
 #if !NET7_0_OR_GREATER
     /// <summary>The compiled regular expression that matches URL path parameters, including an optional <c>?</c> marker.</summary>
-    private static readonly Regex _parameterRegexValue = new(
+    internal static readonly Regex _parameterRegexValue = new(
         "{(([^/?\\r\\n])*?)(\\?)?}",
         RegexOptions.Compiled,
         TimeSpan.FromSeconds(1));
@@ -73,9 +73,22 @@ internal partial class RestMethodInfoInternal
         // Exclude cancellation token parameters from this list
         ParameterInfoArray = GetNonCancellationTokenParameters(methodInfo.GetParameters());
 
+        // Read every parameter's request-shaping attributes once. Each classifier below then consults this set instead
+        // of issuing its own GetCustomAttribute call, which would re-enumerate the same attribute records (allocating a
+        // scratch array each time) once per parameter per lookup.
+        var parameterAttributeSets = BuildParameterAttributeSets(ParameterInfoArray);
+
+        // Materialize each parameter's [Query] attribute once so the per-request mapping path never re-reads it from
+        // metadata (each reflected read allocates the attribute-record and candidate-type scratch arrays).
+        ParameterQueryAttributes = BuildParameterQueryAttributes(parameterAttributeSets);
+
+        // Record which parameters carry [FormObject] once, so the per-part multipart path never re-reads it. Only
+        // multipart methods reach that path, so non-multipart methods keep the shared empty array.
+        ParameterFormObjectFlags = BuildFormObjectFlags(parameterAttributeSets, IsMultipart);
+
         // A [Url] parameter supplies the complete absolute request URI, bypassing the base address. It provides the
         // full URL, so the method's path template must be empty; a non-empty template is an invalid combination.
-        UrlParameterInfo = ResolveUrlParameter(ParameterInfoArray, RelativePath);
+        UrlParameterInfo = ResolveUrlParameter(ParameterInfoArray, parameterAttributeSets, RelativePath);
 
         // An open generic method definition cannot resolve dotted {obj.Prop} placeholders yet — the generic parameter
         // has no properties until the method is closed over a concrete type. This RestMethodInfo is only used for
@@ -83,13 +96,13 @@ internal partial class RestMethodInfoInternal
         // unmatched placeholder in place here instead of throwing.
         var allowUnmatched = RefitSettings.AllowUnmatchedRouteParameters || methodInfo.IsGenericMethodDefinition;
         (ParameterMap, FragmentPath) = BuildParameterMap(RelativePath, ParameterInfoArray, allowUnmatched);
-        BodyParameterInfo = FindBodyParameter(ParameterInfoArray, IsMultipart, hma.Method);
-        AuthorizeParameterInfo = FindAuthorizationParameter(ParameterInfoArray);
+        BodyParameterInfo = FindBodyParameter(ParameterInfoArray, parameterAttributeSets, IsMultipart, hma.Method);
+        AuthorizeParameterInfo = FindAuthorizationParameter(parameterAttributeSets);
 
         Headers = ParseHeaders(targetInterface, methodInfo);
-        HeaderParameterMap = BuildHeaderParameterMap(ParameterInfoArray);
-        _headerCollectionParameterIndex = GetHeaderCollectionParameterIndex(ParameterInfoArray);
-        PropertyParameterMap = BuildRequestPropertyMap(ParameterInfoArray);
+        HeaderParameterMap = BuildHeaderParameterMap(parameterAttributeSets);
+        _headerCollectionParameterIndex = GetHeaderCollectionParameterIndex(ParameterInfoArray, parameterAttributeSets);
+        PropertyParameterMap = BuildRequestPropertyMap(ParameterInfoArray, parameterAttributeSets);
 
         AttachmentNameMap = BuildAttachmentNameMap();
         QueryParameterMap = BuildQueryParameterMap();
@@ -198,7 +211,21 @@ internal partial class RestMethodInfoInternal
     public bool HasHeaderCollection => _headerCollectionParameterIndex >= 0;
 
     /// <summary>Gets the name of the method.</summary>
-    private string Name => MethodInfo.Name;
+    internal string Name => MethodInfo.Name;
+
+    /// <summary>Gets each parameter's <see cref="QueryAttribute"/> (or null), indexed to match <see cref="ParameterInfoArray"/>,
+    /// materialized once so the per-request path never re-reads it from metadata.</summary>
+    internal QueryAttribute?[] ParameterQueryAttributes { get; }
+
+    /// <summary>Gets a value indicating whether any argument can add, override or remove a header at call time (a header
+    /// parameter, a header collection or an authorization parameter). When false the per-call path can emit the method's
+    /// static headers without first copying them into a mutable per-request dictionary.</summary>
+    internal bool ContributesDynamicHeaders =>
+        HeaderParameterMap.Count > 0 || HasHeaderCollection || AuthorizeParameterInfo is not null;
+
+    /// <summary>Gets a flag per parameter indicating whether it carries <see cref="FormObjectAttribute"/> on a multipart
+    /// method, indexed to match <see cref="ParameterInfoArray"/>; a shared empty array for non-multipart methods.</summary>
+    internal bool[] ParameterFormObjectFlags { get; }
 
     /// <summary>Determines whether the parameter at the given index is the header collection parameter.</summary>
     /// <param name="index">The parameter index to test.</param>
@@ -209,7 +236,7 @@ internal partial class RestMethodInfoInternal
     /// <summary>Removes cancellation-token parameters from a reflected parameter array.</summary>
     /// <param name="parameters">The reflected method parameters.</param>
     /// <returns>The parameters used for request mapping.</returns>
-    private static ParameterInfo[] GetNonCancellationTokenParameters(ParameterInfo[] parameters)
+    internal static ParameterInfo[] GetNonCancellationTokenParameters(ParameterInfo[] parameters)
     {
         var count = 0;
         for (var i = 0; i < parameters.Length; i++)
@@ -242,7 +269,7 @@ internal partial class RestMethodInfoInternal
     /// <summary>Determines whether a parameter is a cancellation token.</summary>
     /// <param name="parameter">The parameter to inspect.</param>
     /// <returns><see langword="true"/> for cancellation-token parameters.</returns>
-    private static bool IsCancellationTokenParameter(ParameterInfo parameter) =>
+    internal static bool IsCancellationTokenParameter(ParameterInfo parameter) =>
         parameter.ParameterType == typeof(CancellationToken)
         || parameter.ParameterType == typeof(CancellationToken?);
 
@@ -250,7 +277,7 @@ internal partial class RestMethodInfoInternal
     /// <param name="methodInfo">The reflected method information.</param>
     /// <param name="isMultipart">A value indicating whether the request is multipart.</param>
     /// <returns>The multipart boundary text, or an empty string for non-multipart requests.</returns>
-    private static string GetMultipartBoundary(MethodInfo methodInfo, bool isMultipart) =>
+    internal static string GetMultipartBoundary(MethodInfo methodInfo, bool isMultipart) =>
         isMultipart
             ? methodInfo.GetCustomAttribute<MultipartAttribute>(true)!.BoundaryText // [Multipart] is present whenever isMultipart is true, and its BoundaryText is never null.
             : string.Empty;
@@ -258,7 +285,7 @@ internal partial class RestMethodInfoInternal
     /// <summary>Determines whether the result type is one of the supported API response wrappers.</summary>
     /// <param name="returnResultType">The result type wrapped by the method's return type.</param>
     /// <returns><see langword="true"/> when the result type is an API response wrapper; otherwise <see langword="false"/>.</returns>
-    private static bool DetermineIsApiResponse(Type returnResultType)
+    internal static bool DetermineIsApiResponse(Type returnResultType)
     {
         if (returnResultType == typeof(IApiResponse))
         {
@@ -275,79 +302,17 @@ internal partial class RestMethodInfoInternal
                || genericDefinition == typeof(IApiResponse<>);
     }
 
-    /// <summary>Finds the index of the header collection parameter in the parameter array.</summary>
-    /// <param name="parameterArray">The array of method parameters.</param>
-    /// <returns>The index of the header collection parameter, or a negative value when none exists.</returns>
-    private static int GetHeaderCollectionParameterIndex(ParameterInfo[] parameterArray)
-    {
-        var headerIndex = -1;
-
-        for (var i = 0; i < parameterArray.Length; i++)
-        {
-            var param = parameterArray[i];
-            var headerCollection = param.GetCustomAttribute<HeaderCollectionAttribute>(true);
-
-            if (headerCollection is null)
-            {
-                continue;
-            }
-
-            // Opted for IDictionary<string, string> semantics here as opposed to the looser
-            // IEnumerable<KeyValuePair<string, string>> because IDictionary enforces unique keys.
-            if (!param.ParameterType.IsAssignableFrom(typeof(IDictionary<string, string>)))
-            {
-                throw new ArgumentException(
-                    $"HeaderCollection parameter of type {param.ParameterType.Name} is not assignable from IDictionary<string, string>");
-            }
-
-            // Throw if there is already a HeaderCollection parameter.
-            if (headerIndex >= 0)
-            {
-                throw new ArgumentException("Only one parameter can be a HeaderCollection parameter");
-            }
-
-            headerIndex = i;
-        }
-
-        return headerIndex;
-    }
-
-    /// <summary>Builds the map of parameter indexes to request property keys.</summary>
-    /// <param name="parameterArray">The array of method parameters.</param>
-    /// <returns>A map of parameter indexes to property keys.</returns>
-    private static Dictionary<int, string> BuildRequestPropertyMap(ParameterInfo[] parameterArray)
-    {
-        Dictionary<int, string>? propertyMap = null;
-
-        for (var i = 0; i < parameterArray.Length; i++)
-        {
-            var param = parameterArray[i];
-            var propertyAttribute = param.GetCustomAttribute<PropertyAttribute>(true);
-
-            if (propertyAttribute is not null)
-            {
-                var propertyKey = !string.IsNullOrEmpty(propertyAttribute.Key)
-                    ? propertyAttribute.Key
-                    : param.Name!;
-                propertyMap ??= [];
-                propertyMap[i] = propertyKey!;
-            }
-        }
-
-        return propertyMap ?? EmptyDictionary<int, string>.Get();
-    }
-
     /// <summary>Gets the readable public instance properties of a parameter type.</summary>
     /// <param name="parameter">The parameter whose properties are enumerated.</param>
     /// <returns>The readable public instance properties.</returns>
     [RequiresUnreferencedCode("Reading request object properties requires public property metadata to be available at runtime.")]
-    private static PropertyInfo[] GetParameterProperties(ParameterInfo parameter) =>
+    internal static PropertyInfo[] GetParameterProperties(ParameterInfo parameter) =>
         ReflectionPropertyHelpers.GetReadablePublicInstanceProperties(parameter.ParameterType);
 
     /// <summary>Verifies that the relative URL path is well formed and free of injection characters.</summary>
     /// <param name="relativePath">The relative URL path to validate.</param>
     /// <param name="urlResolution">The URL resolution mode; the leading-slash requirement is relaxed under <see cref="UrlResolutionMode.Rfc3986"/>.</param>
-    private static void VerifyUrlPathIsSane(string relativePath, UrlResolutionMode urlResolution)
+    internal static void VerifyUrlPathIsSane(string relativePath, UrlResolutionMode urlResolution)
     {
         if (string.IsNullOrEmpty(relativePath))
         {
@@ -374,7 +339,7 @@ internal partial class RestMethodInfoInternal
     /// <summary>Adds headers from a <see cref="HeadersAttribute"/> into the accumulated map.</summary>
     /// <param name="headersAttribute">The header attribute to process.</param>
     /// <param name="ret">The accumulated map, created as needed.</param>
-    private static void AddHeaders(HeadersAttribute headersAttribute, ref Dictionary<string, string?>? ret)
+    internal static void AddHeaders(HeadersAttribute headersAttribute, ref Dictionary<string, string?>? ret)
     {
         var headers = headersAttribute.Headers;
         for (var i = 0; i < headers.Length; i++)
@@ -401,7 +366,7 @@ internal partial class RestMethodInfoInternal
     /// <param name="targetInterface">The interface type that declares the method.</param>
     /// <param name="methodInfo">The reflected method information.</param>
     /// <returns>A map of header names to header values.</returns>
-    private static Dictionary<string, string?> ParseHeaders(
+    internal static Dictionary<string, string?> ParseHeaders(
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] Type targetInterface,
         MethodInfo methodInfo)
     {
@@ -427,7 +392,7 @@ internal partial class RestMethodInfoInternal
     /// <param name="attributes">The attributes to scan.</param>
     /// <param name="reverse">When true, scans the attributes from last to first so earlier declarations take precedence.</param>
     /// <param name="ret">The header map being built, created lazily on first use.</param>
-    private static void AddHeadersFromAttributes(object[] attributes, bool reverse, ref Dictionary<string, string?>? ret)
+    internal static void AddHeadersFromAttributes(object[] attributes, bool reverse, ref Dictionary<string, string?>? ret)
     {
         if (reverse)
         {
@@ -451,33 +416,12 @@ internal partial class RestMethodInfoInternal
         }
     }
 
-    /// <summary>Builds the map of parameter indexes to header names.</summary>
-    /// <param name="parameterArray">The array of method parameters.</param>
-    /// <returns>A map of parameter indexes to header names.</returns>
-    private static Dictionary<int, string> BuildHeaderParameterMap(ParameterInfo[] parameterArray)
-    {
-        Dictionary<int, string>? ret = null;
-
-        for (var i = 0; i < parameterArray.Length; i++)
-        {
-            var header = parameterArray[i].GetCustomAttribute<HeaderAttribute>(true)?.Header;
-
-            if (!string.IsNullOrWhiteSpace(header))
-            {
-                ret ??= [];
-                ret[i] = header!.Trim();
-            }
-        }
-
-        return ret ?? EmptyDictionary<int, string>.Get();
-    }
-
     /// <summary>Determines the return type, result type, and deserialized result type for the method.</summary>
     /// <param name="methodInfo">The reflected method whose return type is classified.</param>
     /// <param name="adapterResultType">The wrapped result type of a matched return-type adapter, or
     /// <see langword="null"/> when the return type is a built-in shape or unadapted.</param>
     /// <returns>A tuple of the return type, result type, and deserialized result type.</returns>
-    private static (Type ReturnType, Type ReturnResultType, Type DeserializedResultType) DetermineReturnTypeInfo(
+    internal static (Type ReturnType, Type ReturnResultType, Type DeserializedResultType) DetermineReturnTypeInfo(
         MethodInfo methodInfo,
         Type? adapterResultType)
     {
@@ -531,7 +475,7 @@ internal partial class RestMethodInfoInternal
     /// <summary>Determines the type that response content is deserialized into for the given result type.</summary>
     /// <param name="returnResultType">The result type wrapped by the return type.</param>
     /// <returns>The type to deserialize response content into.</returns>
-    private static Type DetermineDeserializedResultType(Type returnResultType)
+    internal static Type DetermineDeserializedResultType(Type returnResultType)
     {
         if (
             returnResultType.IsGenericType
@@ -552,7 +496,7 @@ internal partial class RestMethodInfoInternal
     /// <summary>Determines whether the response must be disposed based on the deserialized result type.</summary>
     /// <param name="deserializedResultType">The type the response content is deserialized into.</param>
     /// <returns><see langword="true"/> when the caller must dispose the response; otherwise <see langword="false"/>.</returns>
-    private static bool DetermineIfResponseMustBeDisposed(Type deserializedResultType) =>
+    internal static bool DetermineIfResponseMustBeDisposed(Type deserializedResultType) =>
 
         // Rest method caller will have to dispose if it's one of those 3
         deserializedResultType != typeof(HttpResponseMessage)
@@ -563,44 +507,16 @@ internal partial class RestMethodInfoInternal
     /// <summary>Gets the compiled regular expression that matches URL path parameters, including an optional <c>?</c> marker.</summary>
     /// <returns>The parameter matching regular expression.</returns>
     [GeneratedRegex("{(([^/?\\r\\n])*?)(\\?)?}", RegexOptions.None, matchTimeoutMilliseconds: 1000)]
-    private static partial Regex ParameterRegex();
+    internal static partial Regex ParameterRegex();
 #else
     /// <summary>Gets the compiled regular expression that matches URL path parameters.</summary>
     /// <returns>The parameter matching regular expression.</returns>
-    private static Regex ParameterRegex() => _parameterRegexValue;
+    internal static Regex ParameterRegex() => _parameterRegexValue;
 #endif
-
-    /// <summary>Scans the parameters for an explicit <see cref="BodyAttribute"/>.</summary>
-    /// <param name="parameterArray">The array of method parameters.</param>
-    /// <returns>The first body attribute and its index, and whether more than one parameter carries one.</returns>
-    private static (BodyAttribute? Attribute, int Index, bool HasMultiple) FindBodyAttribute(
-        ParameterInfo[] parameterArray)
-    {
-        BodyAttribute? bodyAttribute = null;
-        var bodyParameterIndex = -1;
-        for (var i = 0; i < parameterArray.Length; i++)
-        {
-            var attribute = parameterArray[i].GetCustomAttribute<BodyAttribute>(true);
-            if (attribute is null)
-            {
-                continue;
-            }
-
-            if (bodyAttribute is not null)
-            {
-                return (bodyAttribute, bodyParameterIndex, true);
-            }
-
-            bodyAttribute = attribute;
-            bodyParameterIndex = i;
-        }
-
-        return (bodyAttribute, bodyParameterIndex, false);
-    }
 
     /// <summary>Builds the map of parameter indexes to multipart attachment names.</summary>
     /// <returns>A map of parameter indexes to attachment name pairs.</returns>
-    private Dictionary<int, Tuple<string, string>> BuildAttachmentNameMap()
+    internal Dictionary<int, Tuple<string, string>> BuildAttachmentNameMap()
     {
         if (!IsMultipart)
         {
@@ -635,7 +551,7 @@ internal partial class RestMethodInfoInternal
 
     /// <summary>Builds the map of parameter indexes to query string names.</summary>
     /// <returns>A map of parameter indexes to query string names.</returns>
-    private Dictionary<int, string> BuildQueryParameterMap()
+    internal Dictionary<int, string> BuildQueryParameterMap()
     {
         Dictionary<int, string>? queryDict = null;
         for (var i = 0; i < ParameterInfoArray.Length; i++)
@@ -655,14 +571,14 @@ internal partial class RestMethodInfoInternal
     /// <summary>Determines whether the parameter at the given index should be excluded from the query map.</summary>
     /// <param name="index">The parameter index to test.</param>
     /// <returns><see langword="true"/> when the parameter is not a query parameter; otherwise <see langword="false"/>.</returns>
-    private bool IsExcludedFromQueryMap(int index) =>
+    internal bool IsExcludedFromQueryMap(int index) =>
         ParameterMap.ContainsKey(index)
         || HeaderParameterMap.ContainsKey(index)
 
         // A parameter can carry both [Property] and [Query]; only exclude it from the
         // query map when it is a property AND does not also opt into the query string.
         || (PropertyParameterMap.ContainsKey(index)
-            && ParameterInfoArray[index].GetCustomAttribute<QueryAttribute>() is null)
+            && ParameterQueryAttributes[index] is null)
         || HeaderCollectionAt(index)
         || (BodyParameterInfo is not null && BodyParameterInfo.Item3 == index)
         || (AuthorizeParameterInfo is not null && AuthorizeParameterInfo.Item2 == index)
@@ -672,11 +588,13 @@ internal partial class RestMethodInfoInternal
 
     /// <summary>Finds the parameter that carries the request body.</summary>
     /// <param name="parameterArray">The array of method parameters.</param>
+    /// <param name="sets">The classified attribute set for each parameter.</param>
     /// <param name="isMultipart">A value indicating whether the request is multipart.</param>
     /// <param name="method">The HTTP method of the request.</param>
     /// <returns>The body parameter information, or null when there is no body parameter.</returns>
-    private Tuple<BodySerializationMethod, bool, int>? FindBodyParameter(
+    internal Tuple<BodySerializationMethod, bool, int>? FindBodyParameter(
         ParameterInfo[] parameterArray,
+        ParameterAttributeSet[] sets,
         bool isMultipart,
         HttpMethod method)
     {
@@ -684,7 +602,7 @@ internal partial class RestMethodInfoInternal
         // 1) [Body] attribute
         // 2) POST/PUT/PATCH: Reference type other than string
         // 3) If there are two reference types other than string, without the body attribute, throw
-        var (bodyAttribute, bodyParameterIndex, hasMultipleBodyParameters) = FindBodyAttribute(parameterArray);
+        var (bodyAttribute, bodyParameterIndex, hasMultipleBodyParameters) = FindBodyAttribute(sets);
 
         // multipart requests may not contain a body, implicit or explicit
         if (isMultipart)
@@ -716,14 +634,17 @@ internal partial class RestMethodInfoInternal
         return method.Equals(HttpMethod.Post)
             || method.Equals(HttpMethod.Put)
             || method.Equals(_patchMethod)
-            ? FindImplicitBodyParameter(parameterArray)
+            ? FindImplicitBodyParameter(parameterArray, sets)
             : null;
     }
 
     /// <summary>Finds an implicit body parameter for POST/PUT/PATCH requests.</summary>
     /// <param name="parameterArray">The array of method parameters.</param>
+    /// <param name="sets">The classified attribute set for each parameter.</param>
     /// <returns>The body parameter information, or null when there is no implicit body parameter.</returns>
-    private Tuple<BodySerializationMethod, bool, int>? FindImplicitBodyParameter(ParameterInfo[] parameterArray)
+    internal Tuple<BodySerializationMethod, bool, int>? FindImplicitBodyParameter(
+        ParameterInfo[] parameterArray,
+        ParameterAttributeSet[] sets)
     {
         // see if we're a post/put/patch
         // explicitly skip [Query], [HeaderCollection], and [Property]-denoted params
@@ -734,12 +655,12 @@ internal partial class RestMethodInfoInternal
             var parameter = parameterArray[i];
             if (parameter.ParameterType.GetTypeInfo().IsValueType
                 || parameter.ParameterType == typeof(string)
-                || parameter.GetCustomAttribute<QueryAttribute>() is not null
-                || parameter.GetCustomAttribute<HeaderCollectionAttribute>() is not null
-                || parameter.GetCustomAttribute<PropertyAttribute>() is not null
+                || sets[i].Query is not null
+                || sets[i].HeaderCollection is not null
+                || sets[i].Property is not null
 
                 // A [Url] Uri parameter supplies the request URI, never the implicit body.
-                || parameter.GetCustomAttribute<UrlAttribute>() is not null)
+                || sets[i].Url is not null)
             {
                 continue;
             }
@@ -766,5 +687,5 @@ internal partial class RestMethodInfoInternal
     /// <param name="RawName">The raw parameter name from the URL template.</param>
     /// <param name="Name">The normalized parameter name with any round-tripping prefix removed.</param>
     /// <param name="IsRoundTripping">A value indicating whether the parameter is round-tripping.</param>
-    private readonly record struct ParsedParameterName(string RawName, string Name, bool IsRoundTripping);
+    internal readonly record struct ParsedParameterName(string RawName, string Name, bool IsRoundTripping);
 }

--- a/src/Refit.Reflection/ReturnTypeAdapterResolver.cs
+++ b/src/Refit.Reflection/ReturnTypeAdapterResolver.cs
@@ -65,7 +65,7 @@ internal static class ReturnTypeAdapterResolver
     /// <param name="resultType">The result type the adapter wraps (its <c>TResult</c>) when matched.</param>
     /// <returns><see langword="true"/> when the adapter surfaces the return type; otherwise <see langword="false"/>.</returns>
     [RequiresUnreferencedCode("Resolving return-type adapters inspects adapter interface metadata that trimming may remove.")]
-    private static bool TryMatch(
+    internal static bool TryMatch(
         Type returnType,
         Type adapter,
         out Type[] typeArguments,
@@ -90,7 +90,7 @@ internal static class ReturnTypeAdapterResolver
     /// <param name="resultType">The adapter's <c>TResult</c> when matched.</param>
     /// <returns><see langword="true"/> when the adapter surfaces the return type; otherwise <see langword="false"/>.</returns>
     [RequiresUnreferencedCode("Resolving return-type adapters inspects adapter interface metadata that trimming may remove.")]
-    private static bool TryMatchClosed(Type returnType, Type adapter, [NotNullWhen(true)] out Type? resultType)
+    internal static bool TryMatchClosed(Type returnType, Type adapter, [NotNullWhen(true)] out Type? resultType)
     {
         foreach (var implemented in adapter.GetInterfaces())
         {
@@ -117,7 +117,7 @@ internal static class ReturnTypeAdapterResolver
     /// generic definition matches the return type's, so <c>Wrapper&lt;X&gt;</c> closes the adapter over <c>X</c>.
     /// </remarks>
     [RequiresUnreferencedCode("Resolving return-type adapters inspects adapter interface metadata that trimming may remove.")]
-    private static bool TryMatchGenericDefinition(
+    internal static bool TryMatchGenericDefinition(
         Type returnType,
         Type adapter,
         out Type[] typeArguments,
@@ -167,7 +167,7 @@ internal static class ReturnTypeAdapterResolver
     /// <summary>Determines whether an implemented interface is a closed <see cref="IReturnTypeAdapter{TReturn, TResult}"/>.</summary>
     /// <param name="implemented">The implemented interface to test.</param>
     /// <returns><see langword="true"/> when the interface is a return-type adapter.</returns>
-    private static bool IsAdapterInterface(Type implemented) =>
+    internal static bool IsAdapterInterface(Type implemented) =>
         implemented.IsGenericType && implemented.GetGenericTypeDefinition() == typeof(IReturnTypeAdapter<,>);
 
     /// <summary>Maps a wrapper return type's arguments onto the adapter's type parameters, in adapter declaration order.</summary>
@@ -181,7 +181,7 @@ internal static class ReturnTypeAdapterResolver
     /// return type's argument, so <c>Adapter&lt;T1, T2&gt; : IReturnTypeAdapter&lt;Wrapper&lt;T2, T1&gt;, …&gt;</c> closes over a
     /// <c>Wrapper&lt;A, B&gt;</c> return as <c>Adapter&lt;B, A&gt;</c>. Mirrors the generator's <c>TryMapAdapterTypeArguments</c>.
     /// </remarks>
-    private static bool TryMapTypeArguments(Type templateReturn, Type returnType, out Type[] adapterOrdered)
+    internal static bool TryMapTypeArguments(Type templateReturn, Type returnType, out Type[] adapterOrdered)
     {
         adapterOrdered = [];
         if (!templateReturn.IsGenericType
@@ -215,7 +215,7 @@ internal static class ReturnTypeAdapterResolver
     /// <param name="returnArgument">The return type's argument at the same position.</param>
     /// <param name="mapped">The per-type-parameter binding slots, filled by position.</param>
     /// <returns><see langword="true"/> when the argument binds consistently.</returns>
-    private static bool TryBindArgument(Type templateArgument, Type returnArgument, Type?[] mapped)
+    internal static bool TryBindArgument(Type templateArgument, Type returnArgument, Type?[] mapped)
     {
         if (!templateArgument.IsGenericParameter)
         {
@@ -238,7 +238,7 @@ internal static class ReturnTypeAdapterResolver
     /// <param name="templateResult">The adapter's declared <c>TResult</c>.</param>
     /// <param name="returnArguments">The return type's type arguments, ordered by the adapter's type parameters.</param>
     /// <returns>The concrete result type, or <see langword="null"/> when it needs runtime generic instantiation.</returns>
-    private static Type? ResolveTemplateResult(Type templateResult, Type[] returnArguments) =>
+    internal static Type? ResolveTemplateResult(Type templateResult, Type[] returnArguments) =>
         templateResult switch
         {
             { IsGenericParameter: true } => returnArguments[templateResult.GenericParameterPosition],

--- a/src/Refit.slnx
+++ b/src/Refit.slnx
@@ -26,6 +26,7 @@
     <Folder Name="/Benchmarks/">
         <Project Path="benchmarks/Refit.Benchmarks/Refit.Benchmarks.csproj" />
         <Project Path="benchmarks/Refit.Generator.Benchmarks/Refit.Generator.Benchmarks.csproj" />
+        <Project Path="benchmarks/Refit.Reflection.Benchmarks/Refit.Reflection.Benchmarks.csproj" />
     </Folder>
     <Folder Name="/Solution Items/workflows/">
         <File Path="../.github/workflows/ci-build.yml" />
@@ -41,6 +42,7 @@
         <Project Path="tests/Refit.GeneratorTests/Refit.GeneratorTests.csproj" />
         <Project Path="tests/Refit.MockInterop.Tests/Refit.MockInterop.Tests.csproj" />
         <Project Path="tests/Refit.Newtonsoft.Json.Tests/Refit.Newtonsoft.Json.Tests.csproj" />
+        <Project Path="tests/Refit.Reflection.Tests/Refit.Reflection.Tests.csproj" />
         <Project Path="tests/Refit.Testing.Tests/Refit.Testing.Tests.csproj" />
         <Project Path="tests/Refit.Tests/Refit.Tests.csproj" />
     </Folder>

--- a/src/benchmarks/Refit.Reflection.Benchmarks/CachedRequestBuilderBenchmarks.cs
+++ b/src/benchmarks/Refit.Reflection.Benchmarks/CachedRequestBuilderBenchmarks.cs
@@ -1,0 +1,63 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Diagnosers;
+
+namespace Refit.Reflection.Benchmarks;
+
+/// <summary>
+/// EventPipe GC-verbose allocation profile of the caching request-builder wrapper's cache-hit path: forming the
+/// method-table key and returning the already-built delegate for a parameterless, a parameter-typed, and a generic
+/// method lookup.
+/// </summary>
+[ShortRunJob]
+[MemoryDiagnoser]
+[EventPipeProfiler(EventPipeProfile.GcVerbose)]
+public class CachedRequestBuilderBenchmarks
+{
+    /// <summary>The parameter types of the dynamic-route method.</summary>
+    private static readonly Type[] _intParameters = [typeof(int)];
+
+    /// <summary>The parameter types of the closed generic method.</summary>
+    private static readonly Type[] _stringParameters = [typeof(string)];
+
+    /// <summary>The generic argument types closing the generic method.</summary>
+    private static readonly Type[] _genericArguments = [typeof(string)];
+
+    /// <summary>The caching request builder with a primed cache.</summary>
+    private CachedRequestBuilderImplementation _cached = null!;
+
+    /// <summary>Builds the caching wrapper and primes its cache before the benchmarks run.</summary>
+    [GlobalSetup]
+    public void Setup()
+    {
+        var settings = ReflectionBenchmarkFixtures.CreateSettings();
+        var inner = new RequestBuilderImplementation(typeof(IReflectionRequestService), settings);
+        _cached = new(inner);
+
+        // Prime the cache so the benchmarks exercise the cache-hit path rather than the first-build path.
+        _ = _cached.BuildRestResultFuncForMethod(nameof(IReflectionRequestService.ConstantRouteAsync));
+        _ = _cached.BuildRestResultFuncForMethod(nameof(IReflectionRequestService.UserByIdAsync), _intParameters);
+        _ = _cached.BuildRestResultFuncForMethod(nameof(IReflectionRequestService.TypedItemAsync), _stringParameters, _genericArguments);
+    }
+
+    /// <summary>Returns the cached delegate for a parameterless method.</summary>
+    /// <returns>The cached result delegate.</returns>
+    [Benchmark]
+    public Func<HttpClient, object[], object?> CacheHitParameterless() =>
+        _cached.BuildRestResultFuncForMethod(nameof(IReflectionRequestService.ConstantRouteAsync));
+
+    /// <summary>Returns the cached delegate for a method keyed by parameter types.</summary>
+    /// <returns>The cached result delegate.</returns>
+    [Benchmark]
+    public Func<HttpClient, object[], object?> CacheHitParameterTypes() =>
+        _cached.BuildRestResultFuncForMethod(nameof(IReflectionRequestService.UserByIdAsync), _intParameters);
+
+    /// <summary>Returns the cached delegate for a generic method keyed by parameter and generic argument types.</summary>
+    /// <returns>The cached result delegate.</returns>
+    [Benchmark]
+    public Func<HttpClient, object[], object?> CacheHitGeneric() =>
+        _cached.BuildRestResultFuncForMethod(nameof(IReflectionRequestService.TypedItemAsync), _stringParameters, _genericArguments);
+}

--- a/src/benchmarks/Refit.Reflection.Benchmarks/IReflectionRequestService.cs
+++ b/src/benchmarks/Refit.Reflection.Benchmarks/IReflectionRequestService.cs
@@ -1,0 +1,121 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Refit.Reflection.Benchmarks;
+
+/// <summary>
+/// A representative Refit interface exercising the full binding surface of the reflection request builder:
+/// constant and dynamic routes, object and nested-object path binding, scalar/collection/object query parameters,
+/// static and per-parameter headers, a header collection, an authorization parameter, a request property, a JSON
+/// body, a multipart upload, a generic method, an absolute <c>[Url]</c> parameter, and a cancellation token.
+/// </summary>
+[Headers("User-Agent: RefitBench")]
+public interface IReflectionRequestService
+{
+    /// <summary>A request against a constant route with no parameters.</summary>
+    /// <returns>The HTTP response message.</returns>
+    [Get("/users")]
+    Task<HttpResponseMessage> ConstantRouteAsync();
+
+    /// <summary>A request against a route with one dynamic path segment.</summary>
+    /// <param name="id">The user identifier.</param>
+    /// <returns>The HTTP response message.</returns>
+    [Get("/users/{id}")]
+    Task<HttpResponseMessage> UserByIdAsync(int id);
+
+    /// <summary>A request against a route with several dynamic path segments.</summary>
+    /// <param name="id">The user identifier.</param>
+    /// <param name="group">The group name.</param>
+    /// <param name="status">The status.</param>
+    /// <returns>The HTTP response message.</returns>
+    [Get("/users/{id}/{group}/{status}")]
+    Task<HttpResponseMessage> MultiSegmentAsync(int id, string group, string status);
+
+    /// <summary>A request with several scalar query parameters.</summary>
+    /// <param name="q">The query text.</param>
+    /// <param name="page">The page number.</param>
+    /// <param name="includeArchived">Whether archived entries are included.</param>
+    /// <returns>The HTTP response message.</returns>
+    [Get("/search")]
+    Task<HttpResponseMessage> ScalarQueryAsync(string q, int page, bool includeArchived);
+
+    /// <summary>A request with a multi-expanded collection query parameter.</summary>
+    /// <param name="tags">The tag identifiers.</param>
+    /// <returns>The HTTP response message.</returns>
+    [Get("/search/tags")]
+    Task<HttpResponseMessage> CollectionQueryAsync([Query(CollectionFormat.Multi)] int[] tags);
+
+    /// <summary>A request whose object argument is flattened into the query string.</summary>
+    /// <param name="query">The query object.</param>
+    /// <returns>The HTTP response message.</returns>
+    [Get("/list")]
+    Task<HttpResponseMessage> ObjectQueryAsync(ReflectionQueryModel query);
+
+    /// <summary>A request whose route is bound to an object property.</summary>
+    /// <param name="request">The request object.</param>
+    /// <returns>The HTTP response message.</returns>
+    [Get("/users/{request.id}/detail")]
+    Task<HttpResponseMessage> ObjectPathAsync(ReflectionQueryModel request);
+
+    /// <summary>A request whose route is bound to a nested object property chain.</summary>
+    /// <param name="request">The request object.</param>
+    /// <returns>The HTTP response message.</returns>
+    [Get("/orgs/{request.inner.code}/audit")]
+    Task<HttpResponseMessage> NestedPathAsync(ReflectionQueryModel request);
+
+    /// <summary>A request with a static method header, a header parameter, a header collection and an authorization parameter.</summary>
+    /// <param name="apiKey">The API key header value.</param>
+    /// <param name="headers">The dynamic header collection.</param>
+    /// <param name="token">The bearer token.</param>
+    /// <returns>The HTTP response message.</returns>
+    [Headers("X-Feature: on")]
+    [Get("/traced")]
+    Task<HttpResponseMessage> HeaderAsync(
+        [Header("X-Api-Key")] string apiKey,
+        [HeaderCollection] IDictionary<string, string> headers,
+        [Authorize("Bearer")] string token);
+
+    /// <summary>A request that carries a request property alongside a dynamic route.</summary>
+    /// <param name="id">The user identifier.</param>
+    /// <param name="traceId">The trace identifier stored as a request property.</param>
+    /// <returns>The HTTP response message.</returns>
+    [Get("/props/{id}")]
+    Task<HttpResponseMessage> PropertyAsync(int id, [Property("trace-id")] string traceId);
+
+    /// <summary>A request that serializes an object argument as the JSON body.</summary>
+    /// <param name="user">The user body.</param>
+    /// <returns>The HTTP response message.</returns>
+    [Post("/users")]
+    Task<HttpResponseMessage> CreateUserAsync([Body] ReflectionUserModel user);
+
+    /// <summary>A multipart request with a text field, a byte array and a stream.</summary>
+    /// <param name="title">The title text field.</param>
+    /// <param name="payload">The byte-array part.</param>
+    /// <param name="content">The stream part.</param>
+    /// <returns>The HTTP response message.</returns>
+    [Multipart]
+    [Post("/upload")]
+    Task<HttpResponseMessage> UploadAsync(string title, byte[] payload, Stream content);
+
+    /// <summary>A generic method whose type argument is closed at call time.</summary>
+    /// <typeparam name="T">The probe type used to close the method.</typeparam>
+    /// <param name="probe">The probe argument supplying the type parameter.</param>
+    /// <returns>The HTTP response message.</returns>
+    [Get("/items")]
+    Task<HttpResponseMessage> TypedItemAsync<T>(T probe);
+
+    /// <summary>A request whose absolute URI is supplied by a <c>[Url]</c> parameter, with an extra query parameter.</summary>
+    /// <param name="url">The absolute request URL.</param>
+    /// <param name="page">The page number appended as a query parameter.</param>
+    /// <returns>The HTTP response message.</returns>
+    [Get("")]
+    Task<HttpResponseMessage> AbsoluteUrlAsync([Url] string url, int page);
+
+    /// <summary>A request against a dynamic route that also accepts a cancellation token.</summary>
+    /// <param name="id">The user identifier.</param>
+    /// <param name="cancellationToken">A token to cancel the request.</param>
+    /// <returns>The HTTP response message.</returns>
+    [Get("/cancelable/{id}")]
+    Task<HttpResponseMessage> CancelableAsync(int id, CancellationToken cancellationToken);
+}

--- a/src/benchmarks/Refit.Reflection.Benchmarks/MethodKeyEqualityBenchmarks.cs
+++ b/src/benchmarks/Refit.Reflection.Benchmarks/MethodKeyEqualityBenchmarks.cs
@@ -1,0 +1,163 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Diagnosers;
+
+namespace Refit.Reflection.Benchmarks;
+
+/// <summary>
+/// EventPipe GC-verbose allocation profile of the value equality and hashing of the internal cache-key and
+/// request-shape structs: <c>CloseGenericMethodKey</c>, <c>MethodTableKey</c>, <c>ParameterFragment</c>,
+/// <c>QueryMapEntry</c>, and <c>QueryParameterEntry</c>, plus the parameter-fragment factories.
+/// </summary>
+[ShortRunJob]
+[MemoryDiagnoser]
+[EventPipeProfiler(EventPipeProfile.GcVerbose)]
+public class MethodKeyEqualityBenchmarks
+{
+    /// <summary>The argument index used to build a dynamic parameter fragment.</summary>
+    private const int ArgumentIndex = 1;
+
+    /// <summary>The property index used to build an object-property parameter fragment.</summary>
+    private const int PropertyIndex = 2;
+
+    /// <summary>The first type-argument array of the closed-generic key.</summary>
+    private static readonly Type[] _closeTypesA = [typeof(int)];
+
+    /// <summary>The second, equal-valued type-argument array of the closed-generic key.</summary>
+    private static readonly Type[] _closeTypesB = [typeof(int)];
+
+    /// <summary>The first parameter-type array of the method-table key.</summary>
+    private static readonly Type[] _methodParametersA = [typeof(int), typeof(string)];
+
+    /// <summary>The second, equal-valued parameter-type array of the method-table key.</summary>
+    private static readonly Type[] _methodParametersB = [typeof(int), typeof(string)];
+
+    /// <summary>The empty generic-argument array of the method-table key.</summary>
+    private static readonly Type[] _methodGenerics = [];
+
+    /// <summary>The argument index supplied to the parameter-fragment factories.</summary>
+    private int _argumentIndex;
+
+    /// <summary>The property index supplied to the parameter-fragment factories.</summary>
+    private int _propertyIndex;
+
+    /// <summary>The first closed-generic key.</summary>
+    private CloseGenericMethodKey _closeKeyA;
+
+    /// <summary>The second, equal closed-generic key.</summary>
+    private CloseGenericMethodKey _closeKeyB;
+
+    /// <summary>The first method-table key.</summary>
+    private MethodTableKey _methodKeyA;
+
+    /// <summary>The second, equal method-table key.</summary>
+    private MethodTableKey _methodKeyB;
+
+    /// <summary>The first parameter fragment.</summary>
+    private ParameterFragment _fragmentA;
+
+    /// <summary>The second, equal parameter fragment.</summary>
+    private ParameterFragment _fragmentB;
+
+    /// <summary>The first query-map entry.</summary>
+    private QueryMapEntry _mapEntryA;
+
+    /// <summary>The second, equal query-map entry.</summary>
+    private QueryMapEntry _mapEntryB;
+
+    /// <summary>The first query-parameter entry.</summary>
+    private QueryParameterEntry _paramEntryA;
+
+    /// <summary>The second, equal query-parameter entry.</summary>
+    private QueryParameterEntry _paramEntryB;
+
+    /// <summary>Builds the key and request-shape structs before the benchmarks run.</summary>
+    [GlobalSetup]
+    public void Setup()
+    {
+        var method = ReflectionBenchmarkFixtures.Method(nameof(IReflectionRequestService.UserByIdAsync));
+        _closeKeyA = new(method, _closeTypesA);
+        _closeKeyB = new(method, _closeTypesB);
+
+        _methodKeyA = new(nameof(IReflectionRequestService.UserByIdAsync), _methodParametersA, _methodGenerics);
+        _methodKeyB = new(nameof(IReflectionRequestService.UserByIdAsync), _methodParametersB, _methodGenerics);
+
+        _fragmentA = ParameterFragment.DynamicObject(ArgumentIndex, PropertyIndex);
+        _fragmentB = ParameterFragment.DynamicObject(ArgumentIndex, PropertyIndex);
+
+        _mapEntryA = new("category", "widgets");
+        _mapEntryB = new("category", "widgets");
+
+        _paramEntryA = new("page", "recent");
+        _paramEntryB = new("page", "recent");
+
+        _argumentIndex = ArgumentIndex;
+        _propertyIndex = PropertyIndex;
+    }
+
+    /// <summary>Compares two closed-generic keys for equality.</summary>
+    /// <returns><see langword="true"/> when the keys are equal.</returns>
+    [Benchmark]
+    public bool CloseGenericMethodKeyEquals() => _closeKeyA.Equals(_closeKeyB);
+
+    /// <summary>Hashes a closed-generic key.</summary>
+    /// <returns>The hash code.</returns>
+    [Benchmark]
+    public int CloseGenericMethodKeyGetHashCode() => _closeKeyA.GetHashCode();
+
+    /// <summary>Compares two method-table keys for equality.</summary>
+    /// <returns><see langword="true"/> when the keys are equal.</returns>
+    [Benchmark]
+    public bool MethodTableKeyEquals() => _methodKeyA.Equals(_methodKeyB);
+
+    /// <summary>Hashes a method-table key.</summary>
+    /// <returns>The hash code.</returns>
+    [Benchmark]
+    public int MethodTableKeyGetHashCode() => _methodKeyA.GetHashCode();
+
+    /// <summary>Compares two parameter fragments for equality.</summary>
+    /// <returns><see langword="true"/> when the fragments are equal.</returns>
+    [Benchmark]
+    public bool ParameterFragmentEquals() => _fragmentA.Equals(_fragmentB);
+
+    /// <summary>Hashes a parameter fragment.</summary>
+    /// <returns>The hash code.</returns>
+    [Benchmark]
+    public int ParameterFragmentGetHashCode() => _fragmentA.GetHashCode();
+
+    /// <summary>Builds the three parameter-fragment shapes and reads their classification.</summary>
+    /// <returns>The number of correctly classified fragment shapes.</returns>
+    [Benchmark]
+    public int ParameterFragmentFactories()
+    {
+        var constant = ParameterFragment.Constant("segment");
+        var dynamic = ParameterFragment.Dynamic(_argumentIndex);
+        var objectProperty = ParameterFragment.DynamicObject(_argumentIndex, _propertyIndex);
+        return (constant.IsConstant ? 1 : 0)
+            + (dynamic.IsDynamicRoute ? 1 : 0)
+            + (objectProperty.IsObjectProperty ? 1 : 0);
+    }
+
+    /// <summary>Compares two query-map entries for equality.</summary>
+    /// <returns><see langword="true"/> when the entries are equal.</returns>
+    [Benchmark]
+    public bool QueryMapEntryEquals() => _mapEntryA.Equals(_mapEntryB);
+
+    /// <summary>Hashes a query-map entry.</summary>
+    /// <returns>The hash code.</returns>
+    [Benchmark]
+    public int QueryMapEntryGetHashCode() => _mapEntryA.GetHashCode();
+
+    /// <summary>Compares two query-parameter entries for equality.</summary>
+    /// <returns><see langword="true"/> when the entries are equal.</returns>
+    [Benchmark]
+    public bool QueryParameterEntryEquals() => _paramEntryA.Equals(_paramEntryB);
+
+    /// <summary>Hashes a query-parameter entry.</summary>
+    /// <returns>The hash code.</returns>
+    [Benchmark]
+    public int QueryParameterEntryGetHashCode() => _paramEntryA.GetHashCode();
+}

--- a/src/benchmarks/Refit.Reflection.Benchmarks/Program.cs
+++ b/src/benchmarks/Refit.Reflection.Benchmarks/Program.cs
@@ -1,0 +1,26 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+using BenchmarkDotNet.Running;
+using Refit.Reflection.Benchmarks;
+
+if (args is { Length: > 0 })
+{
+    _ = BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+}
+else
+{
+    _ = BenchmarkRunner.Run<RestMethodInfoParseBenchmarks>();
+
+    // To run a different suite by default, swap the type above for another reflection benchmark class
+    // (or pass a filter such as --filter *ReflectionRequestBuilding* on the command line).
+}
+
+/// <summary>The generated top-level program's declaring type, sealed so the JIT can devirtualize its members.</summary>
+internal sealed partial class Program
+{
+    /// <summary>Initializes a new instance of the <see cref="Program"/> class. Unused; the entry point is the generated top-level <c>Main</c>.</summary>
+    private Program()
+    {
+    }
+}

--- a/src/benchmarks/Refit.Reflection.Benchmarks/Refit.Reflection.Benchmarks.csproj
+++ b/src/benchmarks/Refit.Reflection.Benchmarks/Refit.Reflection.Benchmarks.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>$(RefitBenchmarkTargets)</TargetFrameworks>
+    <IsPackable>false</IsPackable>
+    <IsAotCompatible>false</IsAotCompatible>
+    <EnableAotAnalyzer>false</EnableAotAnalyzer>
+    <EnableTrimAnalyzer>false</EnableTrimAnalyzer>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Refit\Refit.csproj" />
+    <ProjectReference Include="..\..\Refit.Reflection\Refit.Reflection.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" />
+  </ItemGroup>
+</Project>

--- a/src/benchmarks/Refit.Reflection.Benchmarks/ReflectionBenchmarkFixtures.cs
+++ b/src/benchmarks/Refit.Reflection.Benchmarks/ReflectionBenchmarkFixtures.cs
@@ -1,0 +1,57 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Reflection;
+
+namespace Refit.Reflection.Benchmarks;
+
+/// <summary>
+/// Shared fixtures for the reflection request-builder micro-benchmarks: default settings and helpers that resolve
+/// method metadata on <see cref="IReflectionRequestService"/> and build parsed <see cref="RestMethodInfoInternal"/>
+/// instances for the request-building benchmarks.
+/// </summary>
+internal static class ReflectionBenchmarkFixtures
+{
+    /// <summary>The base host address used by the reflection request-builder benchmarks.</summary>
+    internal const string Host = "https://api.example.test";
+
+    /// <summary>A sample user identifier used as a path/query argument.</summary>
+    internal const int SampleUserId = 42;
+
+    /// <summary>A sample model identifier used for object path/query binding.</summary>
+    internal const int SampleModelId = 101;
+
+    /// <summary>A sample page number used as a scalar query argument.</summary>
+    internal const int SamplePage = 3;
+
+    /// <summary>A sample identifier used for the JSON body model.</summary>
+    internal const int SampleBodyUserId = 7;
+
+    /// <summary>A sample trace identifier stored as a request property.</summary>
+    internal const string SampleTraceId = "trace-123";
+
+    /// <summary>Creates the default settings used across the reflection benchmarks.</summary>
+    /// <returns>The Refit settings.</returns>
+    internal static RefitSettings CreateSettings() => new(new SystemTextJsonContentSerializer());
+
+    /// <summary>Resolves a declared method on the sample interface by name.</summary>
+    /// <param name="name">The method name.</param>
+    /// <returns>The reflected method information.</returns>
+    internal static MethodInfo Method(string name) =>
+        typeof(IReflectionRequestService).GetMethod(name)
+        ?? throw new MissingMethodException(nameof(IReflectionRequestService), name);
+
+    /// <summary>Gets the reflected parameters of a sample interface method, excluding cancellation tokens.</summary>
+    /// <param name="name">The method name.</param>
+    /// <returns>The parameters used for request mapping.</returns>
+    internal static ParameterInfo[] MappedParameters(string name) =>
+        RestMethodInfoInternal.GetNonCancellationTokenParameters(Method(name).GetParameters());
+
+    /// <summary>Builds the parsed metadata for a sample interface method.</summary>
+    /// <param name="name">The method name.</param>
+    /// <param name="settings">The settings to use.</param>
+    /// <returns>The parsed method metadata.</returns>
+    internal static RestMethodInfoInternal Build(string name, RefitSettings settings) =>
+        new(typeof(IReflectionRequestService), Method(name), settings);
+}

--- a/src/benchmarks/Refit.Reflection.Benchmarks/ReflectionClosedResultAdapter.cs
+++ b/src/benchmarks/Refit.Reflection.Benchmarks/ReflectionClosedResultAdapter.cs
@@ -1,0 +1,12 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Refit.Reflection.Benchmarks;
+
+/// <summary>A closed return-type adapter surfacing <see cref="ReflectionResult{T}"/> of <see cref="string"/>, matched via the closed-adapter path.</summary>
+public sealed class ReflectionClosedResultAdapter : IReturnTypeAdapter<ReflectionResult<string>, string>
+{
+    /// <inheritdoc/>
+    public ReflectionResult<string> Adapt(Func<CancellationToken, Task<string>> invoke) => new();
+}

--- a/src/benchmarks/Refit.Reflection.Benchmarks/ReflectionHeaderAssemblyBenchmarks.cs
+++ b/src/benchmarks/Refit.Reflection.Benchmarks/ReflectionHeaderAssemblyBenchmarks.cs
@@ -1,0 +1,143 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Diagnosers;
+
+namespace Refit.Reflection.Benchmarks;
+
+/// <summary>
+/// EventPipe GC-verbose allocation profile of header and request-property assembly: mapping a header, header
+/// collection and authorization parameter; expanding a header collection; applying collected headers to a request;
+/// setting a single header; and writing request options and Refit metadata.
+/// </summary>
+[ShortRunJob]
+[MemoryDiagnoser]
+[EventPipeProfiler(EventPipeProfile.GcVerbose)]
+public class ReflectionHeaderAssemblyBenchmarks
+{
+    /// <summary>The parameter index of the single header parameter.</summary>
+    private const int HeaderParameterIndex = 0;
+
+    /// <summary>The parameter index of the header-collection parameter.</summary>
+    private const int HeaderCollectionParameterIndex = 1;
+
+    /// <summary>The parameter index of the authorization parameter.</summary>
+    private const int AuthorizeParameterIndex = 2;
+
+    /// <summary>The parsed header method.</summary>
+    private RestMethodInfoInternal _headerMethod = null!;
+
+    /// <summary>The request builder used by the request-property benchmark.</summary>
+    private RequestBuilderImplementation _builder = null!;
+
+    /// <summary>The parsed request-property method.</summary>
+    private RestMethodInfoInternal _propertyMethod = null!;
+
+    /// <summary>The boxed header-parameter value.</summary>
+    private object _apiKeyValue = null!;
+
+    /// <summary>The boxed header-collection value.</summary>
+    private object _headerCollectionValue = null!;
+
+    /// <summary>The boxed authorization-parameter value.</summary>
+    private object _tokenValue = null!;
+
+    /// <summary>A prebuilt header map applied to a request.</summary>
+    private Dictionary<string, string?> _prebuiltHeaders = null!;
+
+    /// <summary>The request-property method arguments.</summary>
+    private object[] _propertyArgs = null!;
+
+    /// <summary>The name of the header set by the single-header benchmark.</summary>
+    private string _customHeaderName = null!;
+
+    /// <summary>The value of the header set by the single-header benchmark.</summary>
+    private string _customHeaderValue = null!;
+
+    /// <summary>Prepares the parsed methods, values and header map before the benchmarks run.</summary>
+    [GlobalSetup]
+    public void Setup()
+    {
+        var settings = ReflectionBenchmarkFixtures.CreateSettings();
+        _builder = new(typeof(IReflectionRequestService), settings);
+        _headerMethod = ReflectionBenchmarkFixtures.Build(nameof(IReflectionRequestService.HeaderAsync), settings);
+        _propertyMethod = ReflectionBenchmarkFixtures.Build(nameof(IReflectionRequestService.PropertyAsync), settings);
+
+        _apiKeyValue = "secret-key";
+        _headerCollectionValue = new Dictionary<string, string> { ["X-One"] = "one", ["X-Two"] = "two", ["X-Three"] = "three" };
+        _tokenValue = "jwt-token";
+        _prebuiltHeaders = new() { ["X-Trace"] = "on", ["X-Region"] = "eu", ["Accept"] = "application/json" };
+        _propertyArgs = [ReflectionBenchmarkFixtures.SampleUserId, ReflectionBenchmarkFixtures.SampleTraceId];
+        _customHeaderName = "X-Custom";
+        _customHeaderValue = "value";
+    }
+
+    /// <summary>Maps a single header parameter into the pending headers.</summary>
+    /// <returns><see langword="true"/> when the parameter contributed a header.</returns>
+    [Benchmark]
+    public bool MapHeaderParameterSingle()
+    {
+        Dictionary<string, string?>? headers = null;
+        return RequestBuilderImplementation.MapHeaderParameters(_headerMethod, HeaderParameterIndex, _apiKeyValue, ref headers);
+    }
+
+    /// <summary>Maps a header-collection parameter into the pending headers.</summary>
+    /// <returns><see langword="true"/> when the parameter contributed a header.</returns>
+    [Benchmark]
+    public bool MapHeaderParameterCollection()
+    {
+        Dictionary<string, string?>? headers = null;
+        return RequestBuilderImplementation.MapHeaderParameters(_headerMethod, HeaderCollectionParameterIndex, _headerCollectionValue, ref headers);
+    }
+
+    /// <summary>Maps an authorization parameter into the pending headers.</summary>
+    /// <returns><see langword="true"/> when the parameter contributed a header.</returns>
+    [Benchmark]
+    public bool MapHeaderParameterAuthorize()
+    {
+        Dictionary<string, string?>? headers = null;
+        return RequestBuilderImplementation.MapHeaderParameters(_headerMethod, AuthorizeParameterIndex, _tokenValue, ref headers);
+    }
+
+    /// <summary>Expands a header-collection argument into the pending headers.</summary>
+    /// <returns>The number of headers added.</returns>
+    [Benchmark]
+    public int AddHeaderCollection()
+    {
+        Dictionary<string, string?>? headers = null;
+        RequestBuilderImplementation.AddHeaderCollection(_headerCollectionValue, ref headers);
+        return headers?.Count ?? 0;
+    }
+
+    /// <summary>Applies the collected headers to a request.</summary>
+    /// <returns>The request the headers were applied to.</returns>
+    [Benchmark]
+    public HttpRequestMessage AddHeadersToRequest()
+    {
+        var request = new HttpRequestMessage { Method = HttpMethod.Get };
+        RequestBuilderImplementation.AddHeadersToRequest(_prebuiltHeaders, request, true);
+        return request;
+    }
+
+    /// <summary>Sets a single header on a request, clearing any existing value.</summary>
+    /// <returns>The request the header was set on.</returns>
+    [Benchmark]
+    public HttpRequestMessage SetHeader()
+    {
+        var request = new HttpRequestMessage { Method = HttpMethod.Get };
+        RequestBuilderImplementation.SetHeader(request, _customHeaderName, _customHeaderValue, true);
+        return request;
+    }
+
+    /// <summary>Writes request options and Refit metadata to a request.</summary>
+    /// <returns>The request the options were written to.</returns>
+    [Benchmark]
+    public HttpRequestMessage AddPropertiesToRequest()
+    {
+        var request = new HttpRequestMessage { Method = HttpMethod.Get };
+        _builder.AddPropertiesToRequest(_propertyMethod, request, _propertyArgs, _propertyArgs);
+        return request;
+    }
+}

--- a/src/benchmarks/Refit.Reflection.Benchmarks/ReflectionInnerModel.cs
+++ b/src/benchmarks/Refit.Reflection.Benchmarks/ReflectionInnerModel.cs
@@ -1,0 +1,15 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Refit.Reflection.Benchmarks;
+
+/// <summary>A nested request model exercised by the nested-property path binding and recursive query-flattening benchmarks.</summary>
+public sealed class ReflectionInnerModel
+{
+    /// <summary>Gets or sets the code, bound to <c>{request.inner.code}</c> path placeholders.</summary>
+    public string? Code { get; set; }
+
+    /// <summary>Gets or sets the label flattened into the query string.</summary>
+    public string? Label { get; set; }
+}

--- a/src/benchmarks/Refit.Reflection.Benchmarks/ReflectionPayloadBenchmarks.cs
+++ b/src/benchmarks/Refit.Reflection.Benchmarks/ReflectionPayloadBenchmarks.cs
@@ -1,0 +1,119 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Diagnosers;
+
+namespace Refit.Reflection.Benchmarks;
+
+/// <summary>
+/// EventPipe GC-verbose allocation profile of body and multipart payload assembly: setting a serialized JSON body,
+/// serializing a body by runtime type, and adding text, byte-array and stream multipart parts.
+/// </summary>
+[ShortRunJob]
+[MemoryDiagnoser]
+[EventPipeProfiler(EventPipeProfile.GcVerbose)]
+public class ReflectionPayloadBenchmarks
+{
+    /// <summary>The multipart parameter index of the text part.</summary>
+    private const int TitlePartIndex = 0;
+
+    /// <summary>The multipart parameter index of the byte-array part.</summary>
+    private const int PayloadPartIndex = 1;
+
+    /// <summary>The multipart parameter index of the stream part.</summary>
+    private const int StreamPartIndex = 2;
+
+    /// <summary>The sample byte-array multipart payload.</summary>
+    private static readonly byte[] _payloadBytes = [1, 2, 3, 4, 5, 6, 7, 8];
+
+    /// <summary>The sample bytes backing the stream multipart part.</summary>
+    private static readonly byte[] _streamBytes = [9, 8, 7, 6, 5, 4, 3, 2, 1];
+
+    /// <summary>The request builder under test.</summary>
+    private RequestBuilderImplementation _builder = null!;
+
+    /// <summary>The parsed JSON-body method.</summary>
+    private RestMethodInfoInternal _bodyMethod = null!;
+
+    /// <summary>The parsed multipart method.</summary>
+    private RestMethodInfoInternal _multipartMethod = null!;
+
+    /// <summary>The content serializer used to serialize the body.</summary>
+    private IHttpContentSerializer _serializer = null!;
+
+    /// <summary>The boxed JSON-body value.</summary>
+    private object _userValue = null!;
+
+    /// <summary>The boxed multipart text value.</summary>
+    private object _titleValue = null!;
+
+    /// <summary>The boxed multipart byte-array value.</summary>
+    private object _payloadValue = null!;
+
+    /// <summary>The boxed multipart stream value.</summary>
+    private object _streamValue = null!;
+
+    /// <summary>Prepares the builder, parsed methods, serializer and payload values before the benchmarks run.</summary>
+    [GlobalSetup]
+    public void Setup()
+    {
+        var settings = ReflectionBenchmarkFixtures.CreateSettings();
+        _builder = new(typeof(IReflectionRequestService), settings);
+        _serializer = settings.ContentSerializer;
+        _bodyMethod = ReflectionBenchmarkFixtures.Build(nameof(IReflectionRequestService.CreateUserAsync), settings);
+        _multipartMethod = ReflectionBenchmarkFixtures.Build(nameof(IReflectionRequestService.UploadAsync), settings);
+
+        _userValue = new ReflectionUserModel { Id = ReflectionBenchmarkFixtures.SampleBodyUserId, Name = "octocat", Email = "octo@example.test" };
+        _titleValue = "quarterly report";
+        _payloadValue = _payloadBytes;
+        _streamValue = new MemoryStream(_streamBytes);
+    }
+
+    /// <summary>Sets a serialized JSON body on a request.</summary>
+    /// <returns>The serialized body content.</returns>
+    [Benchmark]
+    public HttpContent? AddBodyToRequest()
+    {
+        var request = new HttpRequestMessage { Method = HttpMethod.Post };
+        _builder.AddBodyToRequest(_bodyMethod, _userValue, request);
+        return request.Content;
+    }
+
+    /// <summary>Serializes a body by its runtime type.</summary>
+    /// <returns>The serialized body content.</returns>
+    [Benchmark]
+    public HttpContent SerializeBody() =>
+        RequestBuilderImplementation.SerializeBody(_serializer, _userValue, typeof(ReflectionUserModel));
+
+    /// <summary>Adds a text multipart part.</summary>
+    /// <returns>The multipart content.</returns>
+    [Benchmark]
+    public MultipartFormDataContent AddMultiPartText()
+    {
+        var content = new MultipartFormDataContent();
+        _builder.AddMultiPart(_multipartMethod, TitlePartIndex, _titleValue, content);
+        return content;
+    }
+
+    /// <summary>Adds a byte-array multipart part.</summary>
+    /// <returns>The multipart content.</returns>
+    [Benchmark]
+    public MultipartFormDataContent AddMultiPartBytes()
+    {
+        var content = new MultipartFormDataContent();
+        _builder.AddMultiPart(_multipartMethod, PayloadPartIndex, _payloadValue, content);
+        return content;
+    }
+
+    /// <summary>Adds a stream multipart part.</summary>
+    /// <returns>The multipart content.</returns>
+    [Benchmark]
+    public MultipartFormDataContent AddMultiPartStream()
+    {
+        var content = new MultipartFormDataContent();
+        _builder.AddMultiPart(_multipartMethod, StreamPartIndex, _streamValue, content);
+        return content;
+    }
+}

--- a/src/benchmarks/Refit.Reflection.Benchmarks/ReflectionQueryBuildingBenchmarks.cs
+++ b/src/benchmarks/Refit.Reflection.Benchmarks/ReflectionQueryBuildingBenchmarks.cs
@@ -1,0 +1,208 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Collections;
+using System.Reflection;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Diagnosers;
+
+namespace Refit.Reflection.Benchmarks;
+
+/// <summary>
+/// EventPipe GC-verbose allocation profile of query-string assembly: flattening objects and dictionaries into query
+/// maps, adding scalar/collection/object query parameters, encoding and parsing query strings, joining collection
+/// values, building a property query key, and classifying values for flattening.
+/// </summary>
+[ShortRunJob]
+[MemoryDiagnoser]
+[EventPipeProfiler(EventPipeProfile.GcVerbose)]
+public class ReflectionQueryBuildingBenchmarks
+{
+    /// <summary>The delimiter used to join collection query values.</summary>
+    private const string CsvDelimiter = ",";
+
+    /// <summary>The parameter index of the single mapped query parameter.</summary>
+    private const int QueryParameterIndex = 0;
+
+    /// <summary>The sample tag values flattened from the model into the query string.</summary>
+    private static readonly int[] _sampleTags = [1, 2, 3, 4];
+
+    /// <summary>The sample collection joined into a delimited query value.</summary>
+    private static readonly int[] _sampleCollectionElements = [1, 2, 3, 4, 5];
+
+    /// <summary>The request builder under test.</summary>
+    private RequestBuilderImplementation _builder = null!;
+
+    /// <summary>A populated model flattened into a query map.</summary>
+    private ReflectionQueryModel _queryModel = null!;
+
+    /// <summary>The boxed model reused across the object-flattening benchmarks.</summary>
+    private object _queryModelBoxed = null!;
+
+    /// <summary>A dictionary flattened into a query map.</summary>
+    private IDictionary _dictionary = null!;
+
+    /// <summary>The parsed scalar-query method.</summary>
+    private RestMethodInfoInternal _scalarQuery = null!;
+
+    /// <summary>The parsed collection-query method.</summary>
+    private RestMethodInfoInternal _collectionQuery = null!;
+
+    /// <summary>The parsed object-query method.</summary>
+    private RestMethodInfoInternal _objectQuery = null!;
+
+    /// <summary>The boxed scalar query value.</summary>
+    private object _scalarValue = null!;
+
+    /// <summary>The boxed collection query value.</summary>
+    private object _collectionValue = null!;
+
+    /// <summary>The query attribute declared on the collection-query parameter.</summary>
+    private QueryAttribute _collectionQueryAttribute = null!;
+
+    /// <summary>A prebuilt list of query entries encoded into a query string.</summary>
+    private List<QueryParameterEntry> _queryEntries = null!;
+
+    /// <summary>A raw query string parsed into query entries.</summary>
+    private string _rawQueryString = null!;
+
+    /// <summary>An integer collection joined into a delimited query value.</summary>
+    private int[] _collectionElements = null!;
+
+    /// <summary>The collection-query parameter's reflected information.</summary>
+    private ParameterInfo _collectionParameter = null!;
+
+    /// <summary>A property flattened into a query key.</summary>
+    private PropertyInfo _nameProperty = null!;
+
+    /// <summary>A property probed for serialization-ignore attributes.</summary>
+    private PropertyInfo _idProperty = null!;
+
+    /// <summary>A boxed simple value classified for query flattening.</summary>
+    private object _simpleValue = null!;
+
+    /// <summary>Prepares the builder, models, methods and reflected metadata before the benchmarks run.</summary>
+    [GlobalSetup]
+    public void Setup()
+    {
+        var settings = ReflectionBenchmarkFixtures.CreateSettings();
+        _builder = new(typeof(IReflectionRequestService), settings);
+
+        _queryModel = new()
+        {
+            Id = ReflectionBenchmarkFixtures.SampleModelId,
+            Name = "widgets & gadgets",
+            Page = ReflectionBenchmarkFixtures.SamplePage,
+            Tags = _sampleTags,
+            Inner = new() { Code = "abc", Label = "primary" },
+        };
+        _queryModelBoxed = _queryModel;
+        _dictionary = new Dictionary<string, string> { ["status"] = "open", ["sort"] = "desc", ["page"] = "recent" };
+
+        _scalarQuery = ReflectionBenchmarkFixtures.Build(nameof(IReflectionRequestService.ScalarQueryAsync), settings);
+        _collectionQuery = ReflectionBenchmarkFixtures.Build(nameof(IReflectionRequestService.CollectionQueryAsync), settings);
+        _objectQuery = ReflectionBenchmarkFixtures.Build(nameof(IReflectionRequestService.ObjectQueryAsync), settings);
+
+        _scalarValue = "widgets";
+        _collectionElements = _sampleCollectionElements;
+        _collectionValue = _collectionElements;
+
+        _collectionParameter = _collectionQuery.ParameterInfoArray[0];
+        _collectionQueryAttribute = _collectionParameter.GetCustomAttribute<QueryAttribute>()!;
+
+        _queryEntries =
+        [
+            new("q", "widgets and gadgets"),
+            new("page", "3"),
+            new("size", "25"),
+            new("sort", "desc"),
+        ];
+        _rawQueryString = "?status=open&sort=desc&page=2";
+
+        _nameProperty = typeof(ReflectionQueryModel).GetProperty(nameof(ReflectionQueryModel.Name))!;
+        _idProperty = typeof(ReflectionQueryModel).GetProperty(nameof(ReflectionQueryModel.Id))!;
+        _simpleValue = ReflectionBenchmarkFixtures.SampleUserId;
+    }
+
+    /// <summary>Flattens a populated object into query-map entries.</summary>
+    /// <returns>The number of query-map entries.</returns>
+    [Benchmark]
+    public int BuildQueryMapObject() => _builder.BuildQueryMap(_queryModelBoxed).Count;
+
+    /// <summary>Flattens a dictionary into query-map entries.</summary>
+    /// <returns>The number of query-map entries.</returns>
+    [Benchmark]
+    public int BuildQueryMapDictionary() => _builder.BuildQueryMap(_dictionary).Count;
+
+    /// <summary>Adds a scalar query parameter.</summary>
+    /// <returns>The number of query entries added.</returns>
+    [Benchmark]
+    public int AddQueryParametersScalar()
+    {
+        var entries = new List<QueryParameterEntry>();
+        _builder.AddQueryParameters(_scalarQuery, null, _scalarValue, entries, QueryParameterIndex, null);
+        return entries.Count;
+    }
+
+    /// <summary>Adds a multi-expanded collection query parameter.</summary>
+    /// <returns>The number of query entries added.</returns>
+    [Benchmark]
+    public int AddQueryParametersCollection()
+    {
+        var entries = new List<QueryParameterEntry>();
+        _builder.AddQueryParameters(_collectionQuery, _collectionQueryAttribute, _collectionValue, entries, QueryParameterIndex, null);
+        return entries.Count;
+    }
+
+    /// <summary>Adds an object query parameter, flattening it into the query string.</summary>
+    /// <returns>The number of query entries added.</returns>
+    [Benchmark]
+    public int AddQueryParametersObject()
+    {
+        var entries = new List<QueryParameterEntry>();
+        _builder.AddQueryParameters(_objectQuery, null, _queryModelBoxed, entries, QueryParameterIndex, null);
+        return entries.Count;
+    }
+
+    /// <summary>Encodes the collected query entries into a query string.</summary>
+    /// <returns>The encoded query string.</returns>
+    [Benchmark]
+    public string CreateQueryString() => RequestBuilderImplementation.CreateQueryString(_queryEntries);
+
+    /// <summary>Parses a raw query string into query entries.</summary>
+    /// <returns>The number of parsed query entries.</returns>
+    [Benchmark]
+    public int ParseQueryStringInto()
+    {
+        List<QueryParameterEntry>? entries = null;
+        RequestBuilderImplementation.ParseQueryStringInto(_rawQueryString, ref entries);
+        return entries?.Count ?? 0;
+    }
+
+    /// <summary>Formats and joins a collection into a delimited query value.</summary>
+    /// <returns>The joined query value.</returns>
+    [Benchmark]
+    public string JoinFormattedQueryValues() =>
+        _builder.JoinFormattedQueryValues(_collectionElements, _collectionParameter, _collectionParameter.ParameterType, CsvDelimiter);
+
+    /// <summary>Builds the query key for a property.</summary>
+    /// <returns>The property query key.</returns>
+    [Benchmark]
+    public string BuildPropertyQueryKey() => _builder.BuildPropertyQueryKey(_nameProperty, null, null);
+
+    /// <summary>Classifies a simple value that is emitted directly.</summary>
+    /// <returns><see langword="true"/> when the value is emitted directly.</returns>
+    [Benchmark]
+    public bool DoNotConvertToQueryMapSimple() => RequestBuilderImplementation.DoNotConvertToQueryMap(_simpleValue);
+
+    /// <summary>Classifies a complex value that must be flattened, scanning its interfaces.</summary>
+    /// <returns><see langword="true"/> when the value is emitted directly.</returns>
+    [Benchmark]
+    public bool DoNotConvertToQueryMapComplex() => RequestBuilderImplementation.DoNotConvertToQueryMap(_queryModelBoxed);
+
+    /// <summary>Scans a property's attribute data for a serialization-ignore marker.</summary>
+    /// <returns><see langword="true"/> when the property is ignored.</returns>
+    [Benchmark]
+    public bool ShouldIgnorePropertyInQueryMap() => RequestBuilderImplementation.ShouldIgnorePropertyInQueryMap(_idProperty);
+}

--- a/src/benchmarks/Refit.Reflection.Benchmarks/ReflectionQueryModel.cs
+++ b/src/benchmarks/Refit.Reflection.Benchmarks/ReflectionQueryModel.cs
@@ -1,0 +1,25 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Refit.Reflection.Benchmarks;
+
+/// <summary>A request model exercised by the reflection query-flattening and object-path benchmarks.</summary>
+public sealed class ReflectionQueryModel
+{
+    /// <summary>Gets or sets the identifier, bound to <c>{request.id}</c> path placeholders.</summary>
+    public int Id { get; set; }
+
+    /// <summary>Gets or sets the display name flattened into the query string.</summary>
+    public string? Name { get; set; }
+
+    /// <summary>Gets or sets the page number flattened into the query string.</summary>
+    public int Page { get; set; }
+
+    /// <summary>Gets or sets the multi-expanded tag collection flattened into the query string.</summary>
+    [Query(CollectionFormat.Multi)]
+    public int[]? Tags { get; set; }
+
+    /// <summary>Gets or sets the nested model bound to <c>{request.inner.code}</c> path placeholders and flattened recursively.</summary>
+    public ReflectionInnerModel? Inner { get; set; }
+}

--- a/src/benchmarks/Refit.Reflection.Benchmarks/ReflectionRequestBuilderConstructionBenchmarks.cs
+++ b/src/benchmarks/Refit.Reflection.Benchmarks/ReflectionRequestBuilderConstructionBenchmarks.cs
@@ -1,0 +1,86 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Diagnosers;
+
+namespace Refit.Reflection.Benchmarks;
+
+/// <summary>
+/// EventPipe GC-verbose allocation profile of building the reflection request builder and its per-method delegates:
+/// discovering every interface method (constructor), resolving a method by name and parameter types, filtering
+/// overload candidates, closing a generic method, resolving a private delegate factory, and building a result delegate.
+/// </summary>
+[ShortRunJob]
+[MemoryDiagnoser]
+[EventPipeProfiler(EventPipeProfile.GcVerbose)]
+public class ReflectionRequestBuilderConstructionBenchmarks
+{
+    /// <summary>The single-parameter types used to resolve and filter the dynamic-route method.</summary>
+    private static readonly Type[] _singleIntParameter = [typeof(int)];
+
+    /// <summary>The generic argument types used to close the generic method.</summary>
+    private static readonly Type[] _genericArguments = [typeof(string)];
+
+    /// <summary>The settings used across the benchmarks.</summary>
+    private RefitSettings _settings = null!;
+
+    /// <summary>A prebuilt request builder used by the per-method resolution and delegate benchmarks.</summary>
+    private RequestBuilderImplementation _builder = null!;
+
+    /// <summary>The open generic method metadata closed by the generic-closing benchmark.</summary>
+    private RestMethodInfoInternal _genericMethod = null!;
+
+    /// <summary>The candidate method list filtered by the overload-filtering benchmark.</summary>
+    private List<RestMethodInfoInternal> _candidateMethods = null!;
+
+    /// <summary>Prepares the settings, builder and method metadata before the benchmarks run.</summary>
+    [GlobalSetup]
+    public void Setup()
+    {
+        _settings = ReflectionBenchmarkFixtures.CreateSettings();
+        _builder = new(typeof(IReflectionRequestService), _settings);
+        _genericMethod = ReflectionBenchmarkFixtures.Build(nameof(IReflectionRequestService.TypedItemAsync), _settings);
+        _candidateMethods =
+        [
+            ReflectionBenchmarkFixtures.Build(nameof(IReflectionRequestService.UserByIdAsync), _settings),
+            ReflectionBenchmarkFixtures.Build(nameof(IReflectionRequestService.ScalarQueryAsync), _settings),
+        ];
+    }
+
+    /// <summary>Constructs the request builder, parsing metadata for every interface method.</summary>
+    /// <returns>The constructed request builder.</returns>
+    [Benchmark]
+    public object ConstructBuilder() => new RequestBuilderImplementation(typeof(IReflectionRequestService), _settings);
+
+    /// <summary>Resolves a method by name and parameter types.</summary>
+    /// <returns>The resolved method metadata.</returns>
+    [Benchmark]
+    public object FindMatchingRestMethodInfo() =>
+        _builder.FindMatchingRestMethodInfo(nameof(IReflectionRequestService.UserByIdAsync), _singleIntParameter, null);
+
+    /// <summary>Filters the candidate methods by parameter count and generic arity.</summary>
+    /// <returns>The number of matching candidates, returned to retain the filtered array.</returns>
+    [Benchmark]
+    public int FilterPossibleMethods() =>
+        RequestBuilderImplementation.FilterPossibleMethods(_candidateMethods, _singleIntParameter, null).Length;
+
+    /// <summary>Closes the generic method over a concrete type argument.</summary>
+    /// <returns>The closed method metadata.</returns>
+    [Benchmark]
+    public object CloseGenericMethodIfNeeded() =>
+        _builder.CloseGenericMethodIfNeeded(_genericMethod, _genericArguments);
+
+    /// <summary>Resolves a private delegate factory method by name.</summary>
+    /// <returns>The resolved factory method.</returns>
+    [Benchmark]
+    public object FindDeclaredMethod() =>
+        RequestBuilderImplementation.FindDeclaredMethod(nameof(RequestBuilderImplementation.BuildTaskFuncForMethod));
+
+    /// <summary>Builds a result delegate for a dynamic-route method.</summary>
+    /// <returns>The built result delegate.</returns>
+    [Benchmark]
+    public Func<HttpClient, object[], object?> BuildRestResultFuncForMethod() =>
+        _builder.BuildRestResultFuncForMethod(nameof(IReflectionRequestService.UserByIdAsync));
+}

--- a/src/benchmarks/Refit.Reflection.Benchmarks/ReflectionRequestBuildingBenchmarks.cs
+++ b/src/benchmarks/Refit.Reflection.Benchmarks/ReflectionRequestBuildingBenchmarks.cs
@@ -1,0 +1,159 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Diagnosers;
+
+namespace Refit.Reflection.Benchmarks;
+
+/// <summary>
+/// EventPipe GC-verbose allocation profile of the per-call request assembly: building the full
+/// <see cref="HttpRequestMessage"/> (path, query, headers, body, options) and expanding the relative path across
+/// route shapes (constant, dynamic segment, multiple segments, and object-property binding).
+/// </summary>
+[ShortRunJob]
+[MemoryDiagnoser]
+[EventPipeProfiler(EventPipeProfile.GcVerbose)]
+public class ReflectionRequestBuildingBenchmarks
+{
+    /// <summary>The base path used when assembling the relative request URI.</summary>
+    private const string BasePath = "/";
+
+    /// <summary>The empty argument list for the constant-route method.</summary>
+    private static readonly object[] _constantArgs = [];
+
+    /// <summary>The request builder under test.</summary>
+    private RequestBuilderImplementation _builder = null!;
+
+    /// <summary>The parsed constant-route method.</summary>
+    private RestMethodInfoInternal _constant = null!;
+
+    /// <summary>The parsed dynamic-route method.</summary>
+    private RestMethodInfoInternal _dynamicRoute = null!;
+
+    /// <summary>The parsed multi-segment method.</summary>
+    private RestMethodInfoInternal _multiSegment = null!;
+
+    /// <summary>The parsed object-property path method.</summary>
+    private RestMethodInfoInternal _objectPath = null!;
+
+    /// <summary>The parsed scalar-query method.</summary>
+    private RestMethodInfoInternal _scalarQuery = null!;
+
+    /// <summary>The parsed JSON-body method.</summary>
+    private RestMethodInfoInternal _body = null!;
+
+    /// <summary>The dynamic-route arguments.</summary>
+    private object[] _dynamicRouteArgs = null!;
+
+    /// <summary>The multi-segment arguments.</summary>
+    private object[] _multiSegmentArgs = null!;
+
+    /// <summary>The object-property path arguments.</summary>
+    private object[] _objectPathArgs = null!;
+
+    /// <summary>The scalar-query arguments.</summary>
+    private object[] _scalarQueryArgs = null!;
+
+    /// <summary>The JSON-body arguments.</summary>
+    private object[] _bodyArgs = null!;
+
+    /// <summary>Prepares the builder, parsed methods and argument lists before the benchmarks run.</summary>
+    [GlobalSetup]
+    public void Setup()
+    {
+        var settings = ReflectionBenchmarkFixtures.CreateSettings();
+        _builder = new(typeof(IReflectionRequestService), settings);
+
+        _constant = ReflectionBenchmarkFixtures.Build(nameof(IReflectionRequestService.ConstantRouteAsync), settings);
+        _dynamicRoute = ReflectionBenchmarkFixtures.Build(nameof(IReflectionRequestService.UserByIdAsync), settings);
+        _multiSegment = ReflectionBenchmarkFixtures.Build(nameof(IReflectionRequestService.MultiSegmentAsync), settings);
+        _objectPath = ReflectionBenchmarkFixtures.Build(nameof(IReflectionRequestService.ObjectPathAsync), settings);
+        _scalarQuery = ReflectionBenchmarkFixtures.Build(nameof(IReflectionRequestService.ScalarQueryAsync), settings);
+        _body = ReflectionBenchmarkFixtures.Build(nameof(IReflectionRequestService.CreateUserAsync), settings);
+
+        _dynamicRouteArgs = [ReflectionBenchmarkFixtures.SampleUserId];
+        _multiSegmentArgs = [ReflectionBenchmarkFixtures.SampleUserId, "admins", "active"];
+        _objectPathArgs =
+        [
+            new ReflectionQueryModel
+            {
+                Id = ReflectionBenchmarkFixtures.SampleModelId,
+                Name = "widgets",
+                Page = ReflectionBenchmarkFixtures.SamplePage,
+                Inner = new() { Code = "abc", Label = "l" },
+            },
+        ];
+        _scalarQueryArgs = ["widgets", ReflectionBenchmarkFixtures.SamplePage, true];
+        _bodyArgs =
+        [
+            new ReflectionUserModel
+            {
+                Id = ReflectionBenchmarkFixtures.SampleBodyUserId,
+                Name = "octocat",
+                Email = "octo@example.test",
+            },
+        ];
+    }
+
+    /// <summary>Builds the full request message for a constant route.</summary>
+    /// <returns>The constructed request message.</returns>
+    [Benchmark]
+    public Task<HttpRequestMessage> BuildRequestMessageConstantAsync() =>
+        _builder.BuildRequestMessageForMethodAsync(_constant, BasePath, false, _constantArgs);
+
+    /// <summary>Builds the full request message for a dynamic route.</summary>
+    /// <returns>The constructed request message.</returns>
+    [Benchmark]
+    public Task<HttpRequestMessage> BuildRequestMessageDynamicRouteAsync() =>
+        _builder.BuildRequestMessageForMethodAsync(_dynamicRoute, BasePath, false, _dynamicRouteArgs);
+
+    /// <summary>Builds the full request message for a multi-segment route.</summary>
+    /// <returns>The constructed request message.</returns>
+    [Benchmark]
+    public Task<HttpRequestMessage> BuildRequestMessageMultiSegmentAsync() =>
+        _builder.BuildRequestMessageForMethodAsync(_multiSegment, BasePath, false, _multiSegmentArgs);
+
+    /// <summary>Builds the full request message for an object-property route.</summary>
+    /// <returns>The constructed request message.</returns>
+    [Benchmark]
+    public Task<HttpRequestMessage> BuildRequestMessageObjectPathAsync() =>
+        _builder.BuildRequestMessageForMethodAsync(_objectPath, BasePath, false, _objectPathArgs);
+
+    /// <summary>Builds the full request message for a scalar-query route.</summary>
+    /// <returns>The constructed request message.</returns>
+    [Benchmark]
+    public Task<HttpRequestMessage> BuildRequestMessageScalarQueryAsync() =>
+        _builder.BuildRequestMessageForMethodAsync(_scalarQuery, BasePath, false, _scalarQueryArgs);
+
+    /// <summary>Builds the full request message for a JSON-body route.</summary>
+    /// <returns>The constructed request message.</returns>
+    [Benchmark]
+    public Task<HttpRequestMessage> BuildRequestMessageBodyAsync() =>
+        _builder.BuildRequestMessageForMethodAsync(_body, BasePath, false, _bodyArgs);
+
+    /// <summary>Expands the relative path for a constant route.</summary>
+    /// <returns>The expanded relative path.</returns>
+    [Benchmark]
+    public string BuildRelativePathConstant() =>
+        _builder.BuildRelativePath(BasePath, _constant, _constantArgs);
+
+    /// <summary>Expands the relative path for a dynamic route.</summary>
+    /// <returns>The expanded relative path.</returns>
+    [Benchmark]
+    public string BuildRelativePathDynamicRoute() =>
+        _builder.BuildRelativePath(BasePath, _dynamicRoute, _dynamicRouteArgs);
+
+    /// <summary>Expands the relative path for a multi-segment route.</summary>
+    /// <returns>The expanded relative path.</returns>
+    [Benchmark]
+    public string BuildRelativePathMultiSegment() =>
+        _builder.BuildRelativePath(BasePath, _multiSegment, _multiSegmentArgs);
+
+    /// <summary>Expands the relative path for an object-property route.</summary>
+    /// <returns>The expanded relative path.</returns>
+    [Benchmark]
+    public string BuildRelativePathObjectPath() =>
+        _builder.BuildRelativePath(BasePath, _objectPath, _objectPathArgs);
+}

--- a/src/benchmarks/Refit.Reflection.Benchmarks/ReflectionResult.cs
+++ b/src/benchmarks/Refit.Reflection.Benchmarks/ReflectionResult.cs
@@ -1,0 +1,13 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Refit.Reflection.Benchmarks;
+
+/// <summary>A sample return-wrapper type surfaced by the return-type adapters under benchmark.</summary>
+/// <typeparam name="T">The wrapped result type.</typeparam>
+public sealed class ReflectionResult<T>
+{
+    /// <summary>Gets or sets the wrapped value.</summary>
+    public T? Value { get; set; }
+}

--- a/src/benchmarks/Refit.Reflection.Benchmarks/ReflectionResultAdapter.cs
+++ b/src/benchmarks/Refit.Reflection.Benchmarks/ReflectionResultAdapter.cs
@@ -1,0 +1,13 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Refit.Reflection.Benchmarks;
+
+/// <summary>An open generic return-type adapter surfacing <see cref="ReflectionResult{T}"/>, matched via the generic-definition path.</summary>
+/// <typeparam name="T">The wrapped result type.</typeparam>
+public sealed class ReflectionResultAdapter<T> : IReturnTypeAdapter<ReflectionResult<T>, T>
+{
+    /// <inheritdoc/>
+    public ReflectionResult<T> Adapt(Func<CancellationToken, Task<T>> invoke) => new();
+}

--- a/src/benchmarks/Refit.Reflection.Benchmarks/ReflectionUserModel.cs
+++ b/src/benchmarks/Refit.Reflection.Benchmarks/ReflectionUserModel.cs
@@ -1,0 +1,18 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Refit.Reflection.Benchmarks;
+
+/// <summary>A request body model exercised by the reflection body-serialization benchmarks.</summary>
+public sealed class ReflectionUserModel
+{
+    /// <summary>Gets or sets the identifier.</summary>
+    public int Id { get; set; }
+
+    /// <summary>Gets or sets the name.</summary>
+    public string? Name { get; set; }
+
+    /// <summary>Gets or sets the email address.</summary>
+    public string? Email { get; set; }
+}

--- a/src/benchmarks/Refit.Reflection.Benchmarks/RestMethodInfoParseBenchmarks.cs
+++ b/src/benchmarks/Refit.Reflection.Benchmarks/RestMethodInfoParseBenchmarks.cs
@@ -1,0 +1,68 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Diagnosers;
+
+namespace Refit.Reflection.Benchmarks;
+
+/// <summary>
+/// EventPipe GC-verbose allocation profile of the one-time-per-method reflective metadata parse
+/// (<see cref="RestMethodInfoInternal"/> construction) across representative interface method shapes: dynamic
+/// route, scalar query, object query, headers, JSON body, multipart, and nested-object path binding.
+/// </summary>
+[ShortRunJob]
+[MemoryDiagnoser]
+[EventPipeProfiler(EventPipeProfile.GcVerbose)]
+public class RestMethodInfoParseBenchmarks
+{
+    /// <summary>The settings used when parsing method metadata.</summary>
+    private RefitSettings _settings = null!;
+
+    /// <summary>Initializes the settings before the benchmarks run.</summary>
+    [GlobalSetup]
+    public void Setup() => _settings = ReflectionBenchmarkFixtures.CreateSettings();
+
+    /// <summary>Parses a method with a single dynamic route segment.</summary>
+    /// <returns>The parsed method metadata.</returns>
+    [Benchmark]
+    public object ParseDynamicRoute() =>
+        ReflectionBenchmarkFixtures.Build(nameof(IReflectionRequestService.UserByIdAsync), _settings);
+
+    /// <summary>Parses a method with several scalar query parameters.</summary>
+    /// <returns>The parsed method metadata.</returns>
+    [Benchmark]
+    public object ParseScalarQuery() =>
+        ReflectionBenchmarkFixtures.Build(nameof(IReflectionRequestService.ScalarQueryAsync), _settings);
+
+    /// <summary>Parses a method whose object argument is flattened into the query string.</summary>
+    /// <returns>The parsed method metadata.</returns>
+    [Benchmark]
+    public object ParseObjectQuery() =>
+        ReflectionBenchmarkFixtures.Build(nameof(IReflectionRequestService.ObjectQueryAsync), _settings);
+
+    /// <summary>Parses a method with static, per-parameter, collection and authorization headers.</summary>
+    /// <returns>The parsed method metadata.</returns>
+    [Benchmark]
+    public object ParseHeaderMethod() =>
+        ReflectionBenchmarkFixtures.Build(nameof(IReflectionRequestService.HeaderAsync), _settings);
+
+    /// <summary>Parses a method that serializes an object body.</summary>
+    /// <returns>The parsed method metadata.</returns>
+    [Benchmark]
+    public object ParseBodyMethod() =>
+        ReflectionBenchmarkFixtures.Build(nameof(IReflectionRequestService.CreateUserAsync), _settings);
+
+    /// <summary>Parses a multipart upload method.</summary>
+    /// <returns>The parsed method metadata.</returns>
+    [Benchmark]
+    public object ParseMultipartMethod() =>
+        ReflectionBenchmarkFixtures.Build(nameof(IReflectionRequestService.UploadAsync), _settings);
+
+    /// <summary>Parses a method whose route is bound to a nested object property chain.</summary>
+    /// <returns>The parsed method metadata.</returns>
+    [Benchmark]
+    public object ParseNestedObjectPath() =>
+        ReflectionBenchmarkFixtures.Build(nameof(IReflectionRequestService.NestedPathAsync), _settings);
+}

--- a/src/benchmarks/Refit.Reflection.Benchmarks/RestMethodMetadataParsingBenchmarks.cs
+++ b/src/benchmarks/Refit.Reflection.Benchmarks/RestMethodMetadataParsingBenchmarks.cs
@@ -1,0 +1,212 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Reflection;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Diagnosers;
+
+namespace Refit.Reflection.Benchmarks;
+
+/// <summary>
+/// EventPipe GC-verbose allocation profile of the individual reflective metadata sub-parsers used while
+/// constructing a <see cref="RestMethodInfoInternal"/>: header parsing, parameter/property/query map building,
+/// body/authorization/URL/cancellation-token discovery, and return-type classification.
+/// </summary>
+[ShortRunJob]
+[MemoryDiagnoser]
+[EventPipeProfiler(EventPipeProfile.GcVerbose)]
+public class RestMethodMetadataParsingBenchmarks
+{
+    /// <summary>The mapped parameters of the header method.</summary>
+    private ParameterInfo[] _headerParameters = null!;
+
+    /// <summary>The mapped parameters of the request-property method.</summary>
+    private ParameterInfo[] _propertyParameters = null!;
+
+    /// <summary>The mapped parameters of the body method.</summary>
+    private ParameterInfo[] _bodyParameters = null!;
+
+    /// <summary>The mapped parameters of the absolute-URL method.</summary>
+    private ParameterInfo[] _urlParameters = null!;
+
+    /// <summary>The raw parameters of the cancellation-token method, including the token.</summary>
+    private ParameterInfo[] _cancelableRawParameters = null!;
+
+    /// <summary>The header method's reflected information.</summary>
+    private MethodInfo _headerMethod = null!;
+
+    /// <summary>The cancellation-token method's reflected information.</summary>
+    private MethodInfo _cancelableMethod = null!;
+
+    /// <summary>The dynamic-route method's reflected information, used to classify the return type.</summary>
+    private MethodInfo _returnTypeMethod = null!;
+
+    /// <summary>A representative multi-header attribute to parse into a header map.</summary>
+    private HeadersAttribute _headersAttribute = null!;
+
+    /// <summary>The parsed body method used for the instance body-discovery benchmarks.</summary>
+    private RestMethodInfoInternal _bodyMethodInfo = null!;
+
+    /// <summary>The parsed scalar-query method used for the query-map benchmark.</summary>
+    private RestMethodInfoInternal _scalarQueryMethodInfo = null!;
+
+    /// <summary>The parsed multipart method used for the attachment-name-map benchmark.</summary>
+    private RestMethodInfoInternal _multipartMethodInfo = null!;
+
+    /// <summary>Prepares reflected metadata and parsed methods before the benchmarks run.</summary>
+    [GlobalSetup]
+    public void Setup()
+    {
+        var settings = ReflectionBenchmarkFixtures.CreateSettings();
+
+        _headerParameters = ReflectionBenchmarkFixtures.MappedParameters(nameof(IReflectionRequestService.HeaderAsync));
+        _propertyParameters = ReflectionBenchmarkFixtures.MappedParameters(nameof(IReflectionRequestService.PropertyAsync));
+        _bodyParameters = ReflectionBenchmarkFixtures.MappedParameters(nameof(IReflectionRequestService.CreateUserAsync));
+        _urlParameters = ReflectionBenchmarkFixtures.MappedParameters(nameof(IReflectionRequestService.AbsoluteUrlAsync));
+        _cancelableRawParameters = ReflectionBenchmarkFixtures.Method(nameof(IReflectionRequestService.CancelableAsync)).GetParameters();
+
+        _headerMethod = ReflectionBenchmarkFixtures.Method(nameof(IReflectionRequestService.HeaderAsync));
+        _cancelableMethod = ReflectionBenchmarkFixtures.Method(nameof(IReflectionRequestService.CancelableAsync));
+        _returnTypeMethod = ReflectionBenchmarkFixtures.Method(nameof(IReflectionRequestService.UserByIdAsync));
+
+        _headersAttribute = new("Authorization: Bearer token", "X-Trace: enabled", "X-Blank");
+
+        _bodyMethodInfo = ReflectionBenchmarkFixtures.Build(nameof(IReflectionRequestService.CreateUserAsync), settings);
+        _scalarQueryMethodInfo = ReflectionBenchmarkFixtures.Build(nameof(IReflectionRequestService.ScalarQueryAsync), settings);
+        _multipartMethodInfo = ReflectionBenchmarkFixtures.Build(nameof(IReflectionRequestService.UploadAsync), settings);
+    }
+
+    /// <summary>Reads every parameter's request-shaping attributes in a single metadata pass.</summary>
+    /// <returns>The classified attribute set per parameter, returned as an object to keep the internal type off the public benchmark surface.</returns>
+    [Benchmark]
+    public object BuildParameterAttributeSets() =>
+        RestMethodInfoInternal.BuildParameterAttributeSets(_headerParameters);
+
+    /// <summary>Parses the static headers declared across the interface hierarchy and the method.</summary>
+    /// <returns>The parsed header map.</returns>
+    [Benchmark]
+    public Dictionary<string, string?> ParseHeaders() =>
+        RestMethodInfoInternal.ParseHeaders(typeof(IReflectionRequestService), _headerMethod);
+
+    /// <summary>Parses a multi-entry header attribute into a header map.</summary>
+    /// <returns>The accumulated header map.</returns>
+    [Benchmark]
+    public Dictionary<string, string?> AddHeaders()
+    {
+        Dictionary<string, string?>? result = null;
+        RestMethodInfoInternal.AddHeaders(_headersAttribute, ref result);
+        return result!;
+    }
+
+    /// <summary>Reads the attribute sets and builds the map of parameter indexes to header names, measuring the classifier's
+    /// true per-call cost including the single attribute pass a real parse performs first.</summary>
+    /// <returns>The header parameter map.</returns>
+    [Benchmark]
+    public Dictionary<int, string> BuildHeaderParameterMap() =>
+        RestMethodInfoInternal.BuildHeaderParameterMap(
+            RestMethodInfoInternal.BuildParameterAttributeSets(_headerParameters));
+
+    /// <summary>Reads the attribute sets and builds the map of parameter indexes to request property keys, measuring the
+    /// classifier's true per-call cost including the single attribute pass a real parse performs first.</summary>
+    /// <returns>The request property map.</returns>
+    [Benchmark]
+    public Dictionary<int, string> BuildRequestPropertyMap() =>
+        RestMethodInfoInternal.BuildRequestPropertyMap(
+            _propertyParameters,
+            RestMethodInfoInternal.BuildParameterAttributeSets(_propertyParameters));
+
+    /// <summary>Strips cancellation-token parameters, exercising the array-copy path.</summary>
+    /// <returns>The parameters used for request mapping.</returns>
+    [Benchmark]
+    public ParameterInfo[] GetNonCancellationTokenParameters() =>
+        RestMethodInfoInternal.GetNonCancellationTokenParameters(_cancelableRawParameters);
+
+    /// <summary>Reads the attribute sets and finds the header-collection parameter index, measuring the classifier's true
+    /// per-call cost including the single attribute pass a real parse performs first.</summary>
+    /// <returns>The index of the header-collection parameter.</returns>
+    [Benchmark]
+    public int GetHeaderCollectionParameterIndex() =>
+        RestMethodInfoInternal.GetHeaderCollectionParameterIndex(
+            _headerParameters,
+            RestMethodInfoInternal.BuildParameterAttributeSets(_headerParameters));
+
+    /// <summary>Classifies the method's return, result, and deserialized result types.</summary>
+    /// <returns>The classified return type tuple.</returns>
+    [Benchmark]
+    public (Type ReturnType, Type ReturnResultType, Type DeserializedResultType) DetermineReturnTypeInfo() =>
+        RestMethodInfoInternal.DetermineReturnTypeInfo(_returnTypeMethod, null);
+
+    /// <summary>Reads the attribute sets and scans the body method's parameters for an explicit body attribute, measuring
+    /// the classifier's true per-call cost including the single attribute pass a real parse performs first.</summary>
+    /// <returns>The body attribute match tuple.</returns>
+    [Benchmark]
+    public (BodyAttribute? Attribute, int Index, bool HasMultiple) FindBodyAttribute() =>
+        RestMethodInfoInternal.FindBodyAttribute(
+            RestMethodInfoInternal.BuildParameterAttributeSets(_bodyParameters));
+
+    /// <summary>Reads the attribute sets and finds the body parameter for a POST method, measuring the classifier's true
+    /// per-call cost including the single attribute pass a real parse performs first.</summary>
+    /// <returns>The body parameter information.</returns>
+    [Benchmark]
+    public Tuple<BodySerializationMethod, bool, int>? FindBodyParameter() =>
+        _bodyMethodInfo.FindBodyParameter(
+            _bodyParameters,
+            RestMethodInfoInternal.BuildParameterAttributeSets(_bodyParameters),
+            false,
+            HttpMethod.Post);
+
+    /// <summary>Reads the attribute sets and finds the implicit body parameter for a POST method, measuring the classifier's
+    /// true per-call cost including the single attribute pass a real parse performs first.</summary>
+    /// <returns>The body parameter information.</returns>
+    [Benchmark]
+    public Tuple<BodySerializationMethod, bool, int>? FindImplicitBodyParameter() =>
+        _bodyMethodInfo.FindImplicitBodyParameter(
+            _bodyParameters,
+            RestMethodInfoInternal.BuildParameterAttributeSets(_bodyParameters));
+
+    /// <summary>Reads the attribute sets and finds the authorization parameter, measuring the classifier's true per-call
+    /// cost including the single attribute pass a real parse performs first.</summary>
+    /// <returns>The authorization parameter information.</returns>
+    [Benchmark]
+    public Tuple<string, int>? FindAuthorizationParameter() =>
+        RestMethodInfoInternal.FindAuthorizationParameter(
+            RestMethodInfoInternal.BuildParameterAttributeSets(_headerParameters));
+
+    /// <summary>Finds the single cancellation-token parameter.</summary>
+    /// <returns>The cancellation-token parameter.</returns>
+    [Benchmark]
+    public ParameterInfo? FindCancellationTokenParameter() =>
+        RestMethodInfoInternal.FindCancellationTokenParameter(_cancelableMethod);
+
+    /// <summary>Reads the attribute sets and finds the <c>[Url]</c> parameter index, measuring the classifier's true per-call
+    /// cost including the single attribute pass a real parse performs first.</summary>
+    /// <returns>The URL parameter index.</returns>
+    [Benchmark]
+    public int FindUrlParameter() =>
+        RestMethodInfoInternal.FindUrlParameter(
+            _urlParameters,
+            RestMethodInfoInternal.BuildParameterAttributeSets(_urlParameters));
+
+    /// <summary>Reads the attribute sets and resolves the <c>[Url]</c> parameter against an empty path template, measuring
+    /// the classifier's true per-call cost including the single attribute pass a real parse performs first.</summary>
+    /// <returns>The URL parameter index.</returns>
+    [Benchmark]
+    public int ResolveUrlParameter() =>
+        RestMethodInfoInternal.ResolveUrlParameter(
+            _urlParameters,
+            RestMethodInfoInternal.BuildParameterAttributeSets(_urlParameters),
+            string.Empty);
+
+    /// <summary>Builds the map of parameter indexes to query-string names.</summary>
+    /// <returns>The query parameter map.</returns>
+    [Benchmark]
+    public Dictionary<int, string> BuildQueryParameterMap() =>
+        _scalarQueryMethodInfo.BuildQueryParameterMap();
+
+    /// <summary>Builds the map of parameter indexes to multipart attachment names.</summary>
+    /// <returns>The attachment name map.</returns>
+    [Benchmark]
+    public Dictionary<int, Tuple<string, string>> BuildAttachmentNameMap() =>
+        _multipartMethodInfo.BuildAttachmentNameMap();
+}

--- a/src/benchmarks/Refit.Reflection.Benchmarks/ReturnTypeAdapterResolverBenchmarks.cs
+++ b/src/benchmarks/Refit.Reflection.Benchmarks/ReturnTypeAdapterResolverBenchmarks.cs
@@ -1,0 +1,83 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Diagnosers;
+
+namespace Refit.Reflection.Benchmarks;
+
+/// <summary>
+/// EventPipe GC-verbose allocation profile of return-type adapter resolution: matching a return type against
+/// registered adapters (closed, generic-definition, and no-match), resolving the closed adapter type to instantiate,
+/// and mapping a wrapper's type arguments onto the adapter's type parameters.
+/// </summary>
+[ShortRunJob]
+[MemoryDiagnoser]
+[EventPipeProfiler(EventPipeProfile.GcVerbose)]
+public class ReturnTypeAdapterResolverBenchmarks
+{
+    /// <summary>The registered open generic adapter definitions.</summary>
+    private readonly List<Type> _genericAdapters = [typeof(ReflectionResultAdapter<>)];
+
+    /// <summary>The registered closed adapter types.</summary>
+    private readonly List<Type> _closedAdapters = [typeof(ReflectionClosedResultAdapter)];
+
+    /// <summary>The return type a registered adapter surfaces.</summary>
+    private readonly Type _matchingReturnType = typeof(ReflectionResult<string>);
+
+    /// <summary>A return type no registered adapter surfaces.</summary>
+    private readonly Type _nonMatchingReturnType = typeof(Task<string>);
+
+    /// <summary>The open generic adapter definition matched directly.</summary>
+    private readonly Type _genericAdapterDefinition = typeof(ReflectionResultAdapter<>);
+
+    /// <summary>The adapter's declared open-constructed wrapper return type.</summary>
+    private Type _templateReturn = null!;
+
+    /// <summary>Resolves the adapter's template return type before the benchmarks run.</summary>
+    [GlobalSetup]
+    public void Setup()
+    {
+        var adapterInterface = Array.Find(
+            _genericAdapterDefinition.GetInterfaces(),
+            static i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IReturnTypeAdapter<,>))!;
+        _templateReturn = adapterInterface.GetGenericArguments()[0];
+    }
+
+    /// <summary>Resolves the result type through a registered generic adapter definition.</summary>
+    /// <returns><see langword="true"/> when a registered adapter surfaces the return type.</returns>
+    [Benchmark]
+    public bool TryResolveResultTypeGeneric() =>
+        ReturnTypeAdapterResolver.TryResolveResultType(_matchingReturnType, _genericAdapters, out _);
+
+    /// <summary>Resolves the result type through a registered closed adapter.</summary>
+    /// <returns><see langword="true"/> when a registered adapter surfaces the return type.</returns>
+    [Benchmark]
+    public bool TryResolveResultTypeClosed() =>
+        ReturnTypeAdapterResolver.TryResolveResultType(_matchingReturnType, _closedAdapters, out _);
+
+    /// <summary>Scans the registered adapters for a return type none surface.</summary>
+    /// <returns><see langword="true"/> when a registered adapter surfaces the return type.</returns>
+    [Benchmark]
+    public bool TryResolveResultTypeNoMatch() =>
+        ReturnTypeAdapterResolver.TryResolveResultType(_nonMatchingReturnType, _genericAdapters, out _);
+
+    /// <summary>Resolves the closed adapter type to instantiate, closing the generic definition.</summary>
+    /// <returns>The closed adapter type.</returns>
+    [Benchmark]
+    public Type? ResolveClosedAdapterTypeGeneric() =>
+        ReturnTypeAdapterResolver.ResolveClosedAdapterType(_matchingReturnType, _genericAdapters);
+
+    /// <summary>Matches an open generic adapter definition against the return type.</summary>
+    /// <returns><see langword="true"/> when the adapter surfaces the return type.</returns>
+    [Benchmark]
+    public bool TryMatchGenericDefinition() =>
+        ReturnTypeAdapterResolver.TryMatchGenericDefinition(_matchingReturnType, _genericAdapterDefinition, out _, out _);
+
+    /// <summary>Maps the wrapper return type's arguments onto the adapter's type parameters.</summary>
+    /// <returns><see langword="true"/> when every adapter type parameter binds consistently.</returns>
+    [Benchmark]
+    public bool TryMapTypeArguments() =>
+        ReturnTypeAdapterResolver.TryMapTypeArguments(_templateReturn, _matchingReturnType, out _);
+}

--- a/src/benchmarks/Refit.Reflection.Benchmarks/RouteTemplateBindingBenchmarks.cs
+++ b/src/benchmarks/Refit.Reflection.Benchmarks/RouteTemplateBindingBenchmarks.cs
@@ -1,0 +1,122 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Reflection;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Diagnosers;
+
+namespace Refit.Reflection.Benchmarks;
+
+/// <summary>
+/// EventPipe GC-verbose allocation profile of route-template binding: expanding a path template into the parameter
+/// map and ordered URL fragments across route shapes, building the direct and nested-object validation lookups,
+/// resolving a dotted <c>{a.b.c}</c> chain, and combining a client path prefix.
+/// </summary>
+[ShortRunJob]
+[MemoryDiagnoser]
+[EventPipeProfiler(EventPipeProfile.GcVerbose)]
+public class RouteTemplateBindingBenchmarks
+{
+    /// <summary>The path template for a single dynamic segment.</summary>
+    private const string SingleSegmentPath = "/users/{id}";
+
+    /// <summary>The path template for several dynamic segments.</summary>
+    private const string MultiSegmentPath = "/users/{id}/{group}/{status}";
+
+    /// <summary>The path template for an object-property segment.</summary>
+    private const string ObjectPropertyPath = "/users/{request.id}/detail";
+
+    /// <summary>The path template for a nested object-property chain.</summary>
+    private const string NestedPropertyPath = "/orgs/{request.inner.code}/audit";
+
+    /// <summary>The mapped parameters of the single-segment method.</summary>
+    private ParameterInfo[] _singleSegmentParameters = null!;
+
+    /// <summary>The mapped parameters of the multi-segment method.</summary>
+    private ParameterInfo[] _multiSegmentParameters = null!;
+
+    /// <summary>The mapped parameters of the object-property method.</summary>
+    private ParameterInfo[] _objectPropertyParameters = null!;
+
+    /// <summary>The mapped parameters of the nested-property method.</summary>
+    private ParameterInfo[] _nestedPropertyParameters = null!;
+
+    /// <summary>The client path prefix combined with a method path template.</summary>
+    private string _clientPathPrefix = null!;
+
+    /// <summary>The method path template combined with the client path prefix.</summary>
+    private string _methodPathTemplate = null!;
+
+    /// <summary>Prepares the mapped parameters before the benchmarks run.</summary>
+    [GlobalSetup]
+    public void Setup()
+    {
+        _singleSegmentParameters = ReflectionBenchmarkFixtures.MappedParameters(nameof(IReflectionRequestService.UserByIdAsync));
+        _multiSegmentParameters = ReflectionBenchmarkFixtures.MappedParameters(nameof(IReflectionRequestService.MultiSegmentAsync));
+        _objectPropertyParameters = ReflectionBenchmarkFixtures.MappedParameters(nameof(IReflectionRequestService.ObjectPathAsync));
+        _nestedPropertyParameters = ReflectionBenchmarkFixtures.MappedParameters(nameof(IReflectionRequestService.NestedPathAsync));
+        _clientPathPrefix = "/api/v2/";
+        _methodPathTemplate = "/users/{id}";
+    }
+
+    /// <summary>Binds a single dynamic route segment.</summary>
+    /// <returns>The combined map and fragment count, returned to retain the built result.</returns>
+    [Benchmark]
+    public int BuildParameterMapSingleSegment()
+    {
+        var (map, fragments) = RestMethodInfoInternal.BuildParameterMap(SingleSegmentPath, _singleSegmentParameters, false);
+        return map.Count + fragments.Count;
+    }
+
+    /// <summary>Binds several dynamic route segments.</summary>
+    /// <returns>The combined map and fragment count, returned to retain the built result.</returns>
+    [Benchmark]
+    public int BuildParameterMapMultiSegment()
+    {
+        var (map, fragments) = RestMethodInfoInternal.BuildParameterMap(MultiSegmentPath, _multiSegmentParameters, false);
+        return map.Count + fragments.Count;
+    }
+
+    /// <summary>Binds an object-property route segment.</summary>
+    /// <returns>The combined map and fragment count, returned to retain the built result.</returns>
+    [Benchmark]
+    public int BuildParameterMapObjectProperty()
+    {
+        var (map, fragments) = RestMethodInfoInternal.BuildParameterMap(ObjectPropertyPath, _objectPropertyParameters, false);
+        return map.Count + fragments.Count;
+    }
+
+    /// <summary>Binds a nested object-property route chain.</summary>
+    /// <returns>The combined map and fragment count, returned to retain the built result.</returns>
+    [Benchmark]
+    public int BuildParameterMapNestedProperty()
+    {
+        var (map, fragments) = RestMethodInfoInternal.BuildParameterMap(NestedPropertyPath, _nestedPropertyParameters, false);
+        return map.Count + fragments.Count;
+    }
+
+    /// <summary>Builds the direct URL-name-to-parameter validation lookup.</summary>
+    /// <returns>The parameter validation lookup.</returns>
+    [Benchmark]
+    public Dictionary<string, ParameterInfo> BuildParamValidationDict() =>
+        RestMethodInfoInternal.BuildParamValidationDict(_multiSegmentParameters);
+
+    /// <summary>Builds the nested object-property validation lookup.</summary>
+    /// <returns>The object-property validation lookup.</returns>
+    [Benchmark]
+    public Dictionary<string, (ParameterInfo Parameter, PropertyInfo Property)> BuildObjectParamValidationDict() =>
+        RestMethodInfoInternal.BuildObjectParamValidationDict(_objectPropertyParameters);
+
+    /// <summary>Resolves a dotted <c>{a.b.c}</c> placeholder into its parameter and property chain.</summary>
+    /// <returns>The resolved parameter and property chain.</returns>
+    [Benchmark]
+    public (ParameterInfo Parameter, IReadOnlyList<PropertyInfo> Chain)? TryResolveNestedPropertyChain() =>
+        RestMethodInfoInternal.TryResolveNestedPropertyChain(_nestedPropertyParameters, "request.inner.code");
+
+    /// <summary>Combines a client path prefix with a method path template.</summary>
+    /// <returns>The combined path.</returns>
+    [Benchmark]
+    public string CombineWithPathPrefix() =>
+        RestMethodInfoInternal.CombineWithPathPrefix(_clientPathPrefix, _methodPathTemplate);
+}

--- a/src/tests/Refit.Reflection.Tests/AotSafeAssertionExtensions.cs
+++ b/src/tests/Refit.Reflection.Tests/AotSafeAssertionExtensions.cs
@@ -1,0 +1,31 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using TUnit.Assertions.Conditions;
+using TUnit.Assertions.Core;
+
+namespace Refit.Reflection.Tests;
+
+/// <summary>AOT-safe collection-equality helpers.</summary>
+internal static class AotSafeAssertionExtensions
+{
+    /// <summary>Provides collection-equality assertions for assertion sources.</summary>
+    /// <param name="source">The assertion source.</param>
+    /// <typeparam name="TCollection">The collection type being asserted.</typeparam>
+    /// <typeparam name="TItem">The element type.</typeparam>
+    extension<TCollection, TItem>(IAssertionSource<TCollection> source)
+        where TCollection : IEnumerable<TItem>
+    {
+        /// <summary>
+        /// Asserts the collection is equivalent to <paramref name="expected"/>
+        /// using the element type's default <see cref="EqualityComparer{T}"/>
+        /// (mirroring <c>IsEquivalentTo</c>) without the reflection-based structural
+        /// comparison that triggers trim/AOT warnings.
+        /// </summary>
+        /// <param name="expected">The expected element sequence.</param>
+        /// <returns>The chained collection-equivalency assertion.</returns>
+        public IsEquivalentToAssertion<TCollection, TItem> IsCollectionEqualTo(IEnumerable<TItem> expected) =>
+            source.IsEquivalentTo(expected, EqualityComparer<TItem>.Default);
+    }
+}

--- a/src/tests/Refit.Reflection.Tests/BodyPayload.cs
+++ b/src/tests/Refit.Reflection.Tests/BodyPayload.cs
@@ -1,0 +1,12 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Refit.Reflection.Tests;
+
+/// <summary>A serializable body payload for the reflection body-serialization tests.</summary>
+public sealed class BodyPayload
+{
+    /// <summary>Gets or sets the payload name.</summary>
+    public string? Name { get; set; }
+}

--- a/src/tests/Refit.Reflection.Tests/IAuthorizeHeaderApi.cs
+++ b/src/tests/Refit.Reflection.Tests/IAuthorizeHeaderApi.cs
@@ -2,7 +2,7 @@
 // ReactiveUI and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-namespace Refit.Tests;
+namespace Refit.Reflection.Tests;
 
 /// <summary>A Refit interface with an authorization parameter, exercised through the reflection builder.</summary>
 public interface IAuthorizeHeaderApi

--- a/src/tests/Refit.Reflection.Tests/IBodySerializationApi.cs
+++ b/src/tests/Refit.Reflection.Tests/IBodySerializationApi.cs
@@ -2,14 +2,14 @@
 // ReactiveUI and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-namespace Refit.Tests;
+namespace Refit.Reflection.Tests;
 
-/// <summary>A Refit interface with a buffered body parameter, exercised through the reflection builder.</summary>
-public interface IBufferedBodyApi
+/// <summary>A Refit interface with a serialized body parameter, exercised through the reflection builder.</summary>
+public interface IBodySerializationApi
 {
-    /// <summary>Posts a buffered serialized body.</summary>
+    /// <summary>Posts a serialized body.</summary>
     /// <param name="payload">The body payload.</param>
     /// <returns>A task that completes when the request finishes.</returns>
-    [Post("/buffered")]
-    Task Post([Body(true)] BodyPayload payload);
+    [Post("/upload")]
+    Task Post([Body] BodyPayload payload);
 }

--- a/src/tests/Refit.Reflection.Tests/IBufferedBodyApi.cs
+++ b/src/tests/Refit.Reflection.Tests/IBufferedBodyApi.cs
@@ -2,14 +2,14 @@
 // ReactiveUI and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-namespace Refit.Tests;
+namespace Refit.Reflection.Tests;
 
-/// <summary>A Refit interface with a serialized body parameter, exercised through the reflection builder.</summary>
-public interface IBodySerializationApi
+/// <summary>A Refit interface with a buffered body parameter, exercised through the reflection builder.</summary>
+public interface IBufferedBodyApi
 {
-    /// <summary>Posts a serialized body.</summary>
+    /// <summary>Posts a buffered serialized body.</summary>
     /// <param name="payload">The body payload.</param>
     /// <returns>A task that completes when the request finishes.</returns>
-    [Post("/upload")]
-    Task Post([Body] BodyPayload payload);
+    [Post("/buffered")]
+    Task Post([Body(true)] BodyPayload payload);
 }

--- a/src/tests/Refit.Reflection.Tests/IHeaderBearingBase.cs
+++ b/src/tests/Refit.Reflection.Tests/IHeaderBearingBase.cs
@@ -2,7 +2,7 @@
 // ReactiveUI and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-namespace Refit.Tests;
+namespace Refit.Reflection.Tests;
 
 /// <summary>A base interface carrying static headers, including a blank entry the parser must ignore.</summary>
 [Headers("", "X-Base: base")]

--- a/src/tests/Refit.Reflection.Tests/IInheritedHeadersApi.cs
+++ b/src/tests/Refit.Reflection.Tests/IInheritedHeadersApi.cs
@@ -2,7 +2,7 @@
 // ReactiveUI and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-namespace Refit.Tests;
+namespace Refit.Reflection.Tests;
 
 /// <summary>A Refit interface inheriting static headers from a base interface.</summary>
 public interface IInheritedHeadersApi : IHeaderBearingBase

--- a/src/tests/Refit.Reflection.Tests/IReflectionAbsoluteUrlApi.cs
+++ b/src/tests/Refit.Reflection.Tests/IReflectionAbsoluteUrlApi.cs
@@ -1,0 +1,17 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Refit.Reflection.Tests;
+
+/// <summary>A Refit interface that dispatches to an absolute URL supplied by a <c>[Url]</c> parameter and appends a
+/// <c>[Query]</c> parameter to it.</summary>
+public interface IReflectionAbsoluteUrlApi
+{
+    /// <summary>Dispatches to an absolute URL and appends a query parameter to it.</summary>
+    /// <param name="url">The absolute request URL.</param>
+    /// <param name="token">A query value appended to the absolute URL.</param>
+    /// <returns>The response body.</returns>
+    [Get("")]
+    Task<string> GetAbsoluteWithQuery([Url] string url, [Query] string token);
+}

--- a/src/tests/Refit.Reflection.Tests/IReflectionCachingQueryApi.cs
+++ b/src/tests/Refit.Reflection.Tests/IReflectionCachingQueryApi.cs
@@ -1,0 +1,15 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Refit.Reflection.Tests;
+
+/// <summary>An API whose query object is flattened by both the generator and the reflection request builder.</summary>
+public interface IReflectionCachingQueryApi
+{
+    /// <summary>Flattens the combined query object into the query string.</summary>
+    /// <param name="query">The query object.</param>
+    /// <returns>The response body.</returns>
+    [Get("/list")]
+    Task<string> Flatten([Query] ReflectionCachingQueryModel query);
+}

--- a/src/tests/Refit.Reflection.Tests/IReflectionMultipartFormObjectApi.cs
+++ b/src/tests/Refit.Reflection.Tests/IReflectionMultipartFormObjectApi.cs
@@ -1,0 +1,18 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Refit.Reflection.Tests;
+
+/// <summary>A multipart API with a plain text part and a <see cref="FormObjectAttribute"/> parameter that flattens into one
+/// text part per property, pinning the reflection builder's per-parameter form-object classification.</summary>
+public interface IReflectionMultipartFormObjectApi
+{
+    /// <summary>Uploads a title text part alongside a flattened address object.</summary>
+    /// <param name="title">A plain text part.</param>
+    /// <param name="address">An object flattened into one text part per property.</param>
+    /// <returns>The response body.</returns>
+    [Multipart]
+    [Post("/upload")]
+    Task<string> Upload(string title, [FormObject] MultipartAddress address);
+}

--- a/src/tests/Refit.Reflection.Tests/IReflectionObjectPathApi.cs
+++ b/src/tests/Refit.Reflection.Tests/IReflectionObjectPathApi.cs
@@ -1,0 +1,16 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Refit.Reflection.Tests;
+
+/// <summary>An API whose route is bound to a property of an object argument that is also flattened into the query string,
+/// exercising the reflection builder's path-bound-property skip when flattening the same object.</summary>
+public interface IReflectionObjectPathApi
+{
+    /// <summary>Binds the object's identifier to a path segment while flattening its remaining properties into the query.</summary>
+    /// <param name="request">The request object supplying both the path segment and the query values.</param>
+    /// <returns>The response body.</returns>
+    [Get("/users/{request.Id}/detail")]
+    Task<string> Detail(ReflectionCachingQueryModel request);
+}

--- a/src/tests/Refit.Reflection.Tests/IReflectionParseShapeApi.cs
+++ b/src/tests/Refit.Reflection.Tests/IReflectionParseShapeApi.cs
@@ -1,0 +1,98 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Refit.Reflection.Tests;
+
+/// <summary>An interface whose methods span the full attribute surface the reflection request builder parses per method:
+/// static headers on the interface and method, an aliased dynamic path segment, a nested-object path chain, scalar and
+/// multi-expanded collection queries, a header parameter, a header collection, an authorization parameter, a request
+/// property, a serialized body, a multipart upload, an absolute <c>[Url]</c> parameter, a cancellation token and a generic
+/// method. It pins the parsed metadata (and the requests built from it) so the per-parameter attribute classification the
+/// constructor performs cannot silently regress.</summary>
+[Headers("X-Interface: iface")]
+public interface IReflectionParseShapeApi
+{
+    /// <summary>A constant route with no parameters, carrying a method-level static header.</summary>
+    /// <returns>The HTTP response message.</returns>
+    [Headers("X-Method: method")]
+    [Get("/constant")]
+    Task<HttpResponseMessage> Constant();
+
+    /// <summary>A dynamic route whose segment is bound by an aliased parameter.</summary>
+    /// <param name="key">The identifier bound to the <c>{id}</c> segment through its alias.</param>
+    /// <returns>The HTTP response message.</returns>
+    [Get("/users/{id}")]
+    Task<HttpResponseMessage> AliasedSegment([AliasAs("id")] int key);
+
+    /// <summary>A route bound to a nested object property chain, with the remaining property flattened into the query.</summary>
+    /// <param name="request">The request object supplying the path chain and query values.</param>
+    /// <returns>The HTTP response message.</returns>
+    [Get("/orgs/{request.Inner.Code}/audit")]
+    Task<HttpResponseMessage> NestedPath(ReflectionParseShapeModel request);
+
+    /// <summary>A route carrying several scalar query parameters.</summary>
+    /// <param name="q">The query text.</param>
+    /// <param name="page">The page number.</param>
+    /// <returns>The HTTP response message.</returns>
+    [Get("/search")]
+    Task<HttpResponseMessage> ScalarQuery(string q, int page);
+
+    /// <summary>A route carrying a multi-expanded collection query parameter.</summary>
+    /// <param name="tags">The tag identifiers expanded one key per element.</param>
+    /// <returns>The HTTP response message.</returns>
+    [Get("/tags")]
+    Task<HttpResponseMessage> CollectionQuery([Query(CollectionFormat.Multi)] int[] tags);
+
+    /// <summary>A route whose parameters each carry a distinct request-shaping attribute, exercising the per-parameter
+    /// attribute classification the constructor performs.</summary>
+    /// <param name="apiKey">The API key emitted as a header.</param>
+    /// <param name="headers">The dynamic header collection.</param>
+    /// <param name="token">The bearer token emitted as the authorization header.</param>
+    /// <param name="traceId">The trace identifier stored as a request property.</param>
+    /// <param name="filter">A scalar query parameter.</param>
+    /// <returns>The HTTP response message.</returns>
+    [Headers("X-Method: dense")]
+    [Get("/dense")]
+    Task<HttpResponseMessage> DenseAttributes(
+        [Header("X-Api-Key")] string apiKey,
+        [HeaderCollection] IDictionary<string, string> headers,
+        [Authorize("Bearer")] string token,
+        [Property("trace-id")] string traceId,
+        string filter);
+
+    /// <summary>A route that serializes an object argument as the JSON body.</summary>
+    /// <param name="payload">The body payload.</param>
+    /// <returns>The HTTP response message.</returns>
+    [Post("/body")]
+    Task<HttpResponseMessage> SerializedBody([Body] BodyPayload payload);
+
+    /// <summary>A multipart route with a text field, a byte-array part and a stream part.</summary>
+    /// <param name="title">The text field.</param>
+    /// <param name="payload">The byte-array part.</param>
+    /// <param name="content">The stream part.</param>
+    /// <returns>The HTTP response message.</returns>
+    [Multipart]
+    [Post("/upload")]
+    Task<HttpResponseMessage> Upload(string title, byte[] payload, Stream content);
+
+    /// <summary>A route whose absolute URI is supplied by a <c>[Url]</c> parameter.</summary>
+    /// <param name="url">The absolute request URL.</param>
+    /// <returns>The HTTP response message.</returns>
+    [Get("")]
+    Task<HttpResponseMessage> AbsoluteUrl([Url] string url);
+
+    /// <summary>A dynamic route that also accepts a cancellation token.</summary>
+    /// <param name="id">The identifier bound to the path segment.</param>
+    /// <param name="cancellationToken">A token to cancel the request.</param>
+    /// <returns>The HTTP response message.</returns>
+    [Get("/cancelable/{id}")]
+    Task<HttpResponseMessage> Cancelable(int id, CancellationToken cancellationToken);
+
+    /// <summary>A generic method whose type argument is closed at call time.</summary>
+    /// <typeparam name="T">The probe type used to close the method.</typeparam>
+    /// <param name="probe">The probe argument supplying the type parameter.</param>
+    /// <returns>The HTTP response message.</returns>
+    [Get("/items")]
+    Task<HttpResponseMessage> TypedItem<T>(T probe);
+}

--- a/src/tests/Refit.Reflection.Tests/IReflectionPropertyQueryApi.cs
+++ b/src/tests/Refit.Reflection.Tests/IReflectionPropertyQueryApi.cs
@@ -1,0 +1,22 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Refit.Reflection.Tests;
+
+/// <summary>An API mixing a plain query parameter, a request-property-only parameter (excluded from the query) and a
+/// parameter carrying both <see cref="PropertyAttribute"/> and <see cref="QueryAttribute"/> (kept in the query), pinning the
+/// reflection builder's per-parameter query-attribute classification.</summary>
+public interface IReflectionPropertyQueryApi
+{
+    /// <summary>Sends a request whose parameters exercise each query/property classification branch.</summary>
+    /// <param name="q">A plain query parameter.</param>
+    /// <param name="trace">A request-property-only parameter that must not appear in the query.</param>
+    /// <param name="tag">A parameter that is both a request property and a query parameter.</param>
+    /// <returns>The response body.</returns>
+    [Get("/search")]
+    Task<string> Search(
+        string q,
+        [Property("trace-id")] string trace,
+        [Property("tag-prop")][Query] string tag);
+}

--- a/src/tests/Refit.Reflection.Tests/IReflectionQueryFormatApi.cs
+++ b/src/tests/Refit.Reflection.Tests/IReflectionQueryFormatApi.cs
@@ -1,0 +1,15 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Refit.Reflection.Tests;
+
+/// <summary>A Refit interface whose path parameter is formatted through its <c>[Query(Format = ...)]</c> attribute.</summary>
+public interface IReflectionQueryFormatApi
+{
+    /// <summary>Fetches a resource whose identifier is formatted into the path.</summary>
+    /// <param name="id">The identifier, formatted with one decimal place.</param>
+    /// <returns>A task whose result is the fetched string.</returns>
+    [Get("/foo/bar/{id}")]
+    Task<string> FetchSomeStuffWithQueryFormat([Query(Format = "0.0")] int id);
+}

--- a/src/tests/Refit.Reflection.Tests/IReflectionStaticHeaderApi.cs
+++ b/src/tests/Refit.Reflection.Tests/IReflectionStaticHeaderApi.cs
@@ -1,0 +1,23 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Refit.Reflection.Tests;
+
+/// <summary>An API carrying class-level static headers, with one method that only emits them and another that also carries a
+/// dynamic <see cref="HeaderAttribute"/> parameter overriding one of them, pinning that the shared static headers are never
+/// mutated across calls.</summary>
+[Headers("X-Static: static-value", "X-Override: original")]
+public interface IReflectionStaticHeaderApi
+{
+    /// <summary>Emits only the class-level static headers.</summary>
+    /// <returns>The response body.</returns>
+    [Get("/static-only")]
+    Task<string> StaticOnly();
+
+    /// <summary>Emits the static headers while overriding one of them from a dynamic header parameter.</summary>
+    /// <param name="overrideValue">The value overriding the static <c>X-Override</c> header.</param>
+    /// <returns>The response body.</returns>
+    [Get("/with-dynamic")]
+    Task<string> WithDynamic([Header("X-Override")] string overrideValue);
+}

--- a/src/tests/Refit.Reflection.Tests/IRfcUrlResolutionApi.cs
+++ b/src/tests/Refit.Reflection.Tests/IRfcUrlResolutionApi.cs
@@ -1,0 +1,31 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Refit.Reflection.Tests;
+
+/// <summary>Fixture used to verify <see cref="UrlResolutionMode.Rfc3986"/> base-address resolution.</summary>
+public interface IRfcUrlResolutionApi
+{
+    /// <summary>Relative path without a leading slash: appended to the base address path under RFC 3986.</summary>
+    /// <returns>The response body.</returns>
+    [Get("values")]
+    Task<string> GetValuesRelative();
+
+    /// <summary>Relative path with a dynamic segment and no leading slash.</summary>
+    /// <param name="id">The identifier substituted into the path.</param>
+    /// <returns>The response body.</returns>
+    [Get("users/{id}")]
+    Task<string> GetUser(int id);
+
+    /// <summary>Relative path with a leading slash: replaces the base address path under RFC 3986.</summary>
+    /// <returns>The response body.</returns>
+    [Get("/values")]
+    Task<string> GetValuesAbsolute();
+
+    /// <summary>Relative path without a leading slash that also carries a query string.</summary>
+    /// <param name="page">The page number added as a query parameter.</param>
+    /// <returns>The response body.</returns>
+    [Get("values?active=true")]
+    Task<string> GetValuesWithQuery(int page);
+}

--- a/src/tests/Refit.Reflection.Tests/IRoundTrippingNullString.cs
+++ b/src/tests/Refit.Reflection.Tests/IRoundTrippingNullString.cs
@@ -1,0 +1,15 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Refit.Reflection.Tests;
+
+/// <summary>Fixture whose round-tripping parameter is nullable, used to verify ignores it.</summary>
+public interface IRoundTrippingNullString
+{
+    /// <summary>Endpoint with a round-tripping parameter name followed by whitespace.</summary>
+    /// <param name="path">The nullable path value.</param>
+    /// <returns>The response body.</returns>
+    [Get("/{**path}")]
+    Task<string> GetValue(string? path);
+}

--- a/src/tests/Refit.Reflection.Tests/MultipartAddress.cs
+++ b/src/tests/Refit.Reflection.Tests/MultipartAddress.cs
@@ -1,0 +1,15 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Refit.Reflection.Tests;
+
+/// <summary>An address flattened into individual multipart form-data parts by a <see cref="FormObjectAttribute"/> parameter.</summary>
+public sealed class MultipartAddress
+{
+    /// <summary>Gets or sets the city, emitted as its own form-data part.</summary>
+    public string? City { get; set; }
+
+    /// <summary>Gets or sets the postal code, emitted as its own form-data part.</summary>
+    public string? PostalCode { get; set; }
+}

--- a/src/tests/Refit.Reflection.Tests/Refit.Reflection.Tests.csproj
+++ b/src/tests/Refit.Reflection.Tests/Refit.Reflection.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>$(RefitTestTargets)</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <JsonSerializerIsReflectionEnabledByDefault>true</JsonSerializerIsReflectionEnabledByDefault>
+    <NoWarn>$(NoWarn);IL2026;IL2046;IL2067;IL2072;IL2075;IL2091;IL2109;IL3050;IL3051;RF003;RF004;RF005</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
+    <PackageReference Include="TUnit" />
+    <ProjectReference Include="..\..\InterfaceStubGenerator.Roslyn48\InterfaceStubGenerator.Roslyn48.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\Refit\Refit.csproj" />
+    <ProjectReference Include="..\..\Refit.Reflection\Refit.Reflection.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/tests/Refit.Reflection.Tests/ReflectionCachedAttributeProviderTests.cs
+++ b/src/tests/Refit.Reflection.Tests/ReflectionCachedAttributeProviderTests.cs
@@ -1,0 +1,66 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Refit.Reflection.Tests;
+
+/// <summary>Pins that formatting which reads a parameter's <c>[Query(Format = ...)]</c> attribute stays correct when the
+/// reflection request builder reuses its cached attribute provider across separate builder instances.</summary>
+public sealed class ReflectionCachedAttributeProviderTests
+{
+    /// <summary>The base address used when building request URIs.</summary>
+    private const string BaseUrl = "http://api/";
+
+    /// <summary>The identifier formatted through the parameter's <c>[Query(Format = "0.0")]</c> attribute.</summary>
+    private const int SampleId = 6;
+
+    /// <summary>Verifies a parameter's query format attribute is applied on both a cold builder (materializing the cached
+    /// attribute provider) and a second builder (reusing it).</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task QueryFormatAttributeAppliesAcrossCachedProviderReuse()
+    {
+        var first = await new RequestBuilderImplementation<IReflectionQueryFormatApi>()
+            .BuildRequestFactoryForMethod(nameof(IReflectionQueryFormatApi.FetchSomeStuffWithQueryFormat))([SampleId]);
+        var second = await new RequestBuilderImplementation<IReflectionQueryFormatApi>()
+            .BuildRequestFactoryForMethod(nameof(IReflectionQueryFormatApi.FetchSomeStuffWithQueryFormat))([SampleId]);
+
+        await Assert.That(new Uri(new(BaseUrl), first.RequestUri!).PathAndQuery).IsEqualTo("/foo/bar/6.0");
+        await Assert.That(new Uri(new(BaseUrl), second.RequestUri!).PathAndQuery).IsEqualTo("/foo/bar/6.0");
+    }
+
+    /// <summary>Verifies the provider materializes the inherited <see cref="QueryAttribute"/> lookup once and reuses it,
+    /// while every other lookup (a non-inherited read, a different attribute type, and the untyped/IsDefined members)
+    /// delegates straight to the wrapped provider.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task CachesInheritedQueryLookupAndDelegatesEverythingElse()
+    {
+        var inner = typeof(FormattedModel).GetProperty(nameof(FormattedModel.Amount))!;
+        var provider = new CachedAttributeProvider(inner);
+
+        // Inherited QueryAttribute read: the first materializes the cache, the second returns the same array.
+        var firstQuery = provider.GetCustomAttributes(typeof(QueryAttribute), true);
+        var secondQuery = provider.GetCustomAttributes(typeof(QueryAttribute), true);
+        await Assert.That(firstQuery.Length).IsEqualTo(1);
+        await Assert.That(ReferenceEquals(firstQuery, secondQuery)).IsTrue();
+
+        // A non-inherited read short-circuits the cache and delegates to the wrapped provider.
+        await Assert.That(provider.GetCustomAttributes(typeof(QueryAttribute), false).Length).IsEqualTo(1);
+
+        // A different attribute type is never cached; it delegates to the wrapped provider.
+        await Assert.That(provider.GetCustomAttributes(typeof(ObsoleteAttribute), true).Length).IsEqualTo(0);
+
+        // The untyped and IsDefined members delegate straight through.
+        await Assert.That(provider.GetCustomAttributes(true).Length).IsEqualTo(1);
+        await Assert.That(provider.IsDefined(typeof(QueryAttribute), true)).IsTrue();
+    }
+
+    /// <summary>A model whose property carries a single <see cref="QueryAttribute"/> for the cached-provider assertions.</summary>
+    private sealed class FormattedModel
+    {
+        /// <summary>Gets or sets a value formatted through a query attribute.</summary>
+        [Query(Format = "0.0")]
+        public int Amount { get; set; }
+    }
+}

--- a/src/tests/Refit.Reflection.Tests/ReflectionCachingInnerModel.cs
+++ b/src/tests/Refit.Reflection.Tests/ReflectionCachingInnerModel.cs
@@ -1,0 +1,15 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Refit.Reflection.Tests;
+
+/// <summary>A nested query model flattened recursively under a dotted key.</summary>
+public sealed class ReflectionCachingInnerModel
+{
+    /// <summary>Gets or sets the nested code.</summary>
+    public string? Code { get; set; }
+
+    /// <summary>Gets or sets the nested label.</summary>
+    public string? Label { get; set; }
+}

--- a/src/tests/Refit.Reflection.Tests/ReflectionCachingQueryModel.cs
+++ b/src/tests/Refit.Reflection.Tests/ReflectionCachingQueryModel.cs
@@ -1,0 +1,33 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Runtime.Serialization;
+
+namespace Refit.Reflection.Tests;
+
+/// <summary>A query model combining a scalar, an aliased scalar, an ignored property, a multi-expanded collection and a
+/// nested object, exercising every branch of the reflection request builder's per-type query-property metadata.</summary>
+public sealed class ReflectionCachingQueryModel
+{
+    /// <summary>Gets or sets a plain scalar rendered under its CLR name.</summary>
+    public int Id { get; set; }
+
+    /// <summary>Gets or sets a scalar renamed by an alias, which bypasses the key formatter.</summary>
+    [AliasAs("handle")]
+    public string? Name { get; set; }
+
+    /// <summary>Gets or sets a second plain scalar.</summary>
+    public int Page { get; set; }
+
+    /// <summary>Gets or sets a property excluded from the query string by an ignore attribute.</summary>
+    [IgnoreDataMember]
+    public string? Ignored { get; set; }
+
+    /// <summary>Gets or sets a multi-expanded collection flattened to one repeated key per element.</summary>
+    [Query(CollectionFormat.Multi)]
+    public int[]? Tags { get; set; }
+
+    /// <summary>Gets or sets the nested model flattened recursively under a dotted key.</summary>
+    public ReflectionCachingInnerModel? Inner { get; set; }
+}

--- a/src/tests/Refit.Reflection.Tests/ReflectionConstructorParseShapeTests.cs
+++ b/src/tests/Refit.Reflection.Tests/ReflectionConstructorParseShapeTests.cs
@@ -1,0 +1,236 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Refit.Reflection.Tests;
+
+/// <summary>Pins the parsed <see cref="RestMethodInfoInternal"/> shape the reflection request-builder constructor produces
+/// for every attribute shape on <see cref="IReflectionParseShapeApi"/>. Constructing the metadata reads each parameter's
+/// request-shaping attributes; these assertions guard that per-parameter classification (path binding, headers, header
+/// collection, authorization, request property, body, multipart and absolute URL) against silent regressions when the
+/// constructor's attribute reads are restructured for allocation.</summary>
+public sealed class ReflectionConstructorParseShapeTests
+{
+    /// <summary>The count of static headers a constant route inherits from the interface plus its method.</summary>
+    private const int StaticHeaderCount = 2;
+
+    /// <summary>The length of the property chain a two-level nested path placeholder resolves.</summary>
+    private const int NestedChainLength = 2;
+
+    /// <summary>The mapped parameter count of the scalar-query method.</summary>
+    private const int ScalarParameterCount = 2;
+
+    /// <summary>The mapped parameter count of the densely attributed method.</summary>
+    private const int DenseParameterCount = 5;
+
+    /// <summary>The parameter index of the authorization argument on the densely attributed method.</summary>
+    private const int AuthorizeParameterIndex = 2;
+
+    /// <summary>The parameter index of the request-property argument on the densely attributed method.</summary>
+    private const int PropertyParameterIndex = 3;
+
+    /// <summary>The parameter index of the scalar-query argument on the densely attributed method.</summary>
+    private const int QueryParameterIndex = 4;
+
+    /// <summary>The part count of the multipart upload method.</summary>
+    private const int MultipartPartCount = 3;
+
+    /// <summary>The parameter index of the stream part on the multipart upload method.</summary>
+    private const int StreamPartIndex = 2;
+
+    /// <summary>A constant route carries both the interface and method static headers and no parameters.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task ConstantRouteParsesStaticHeadersAndNoParameters()
+    {
+        var info = Parse(nameof(IReflectionParseShapeApi.Constant));
+
+        await Assert.That(info.RelativePath).IsEqualTo("/constant");
+        await Assert.That(info.IsMultipart).IsFalse();
+        await Assert.That(info.ParameterInfoArray.Length).IsEqualTo(0);
+        await Assert.That(info.ParameterMap.Count).IsEqualTo(0);
+        await Assert.That(info.QueryParameterMap.Count).IsEqualTo(0);
+        await Assert.That(info.BodyParameterInfo).IsNull();
+        await Assert.That(info.AuthorizeParameterInfo).IsNull();
+        await Assert.That(info.UrlParameterInfo).IsLessThan(0);
+        await Assert.That(info.CancellationToken).IsNull();
+        await Assert.That(info.Headers.Count).IsEqualTo(StaticHeaderCount);
+        await Assert.That(info.Headers["X-Interface"]).IsEqualTo("iface");
+        await Assert.That(info.Headers["X-Method"]).IsEqualTo("method");
+    }
+
+    /// <summary>An aliased path parameter binds the segment under its alias and never enters the query map.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task AliasedSegmentParsesAsNormalPathParameter()
+    {
+        var info = Parse(nameof(IReflectionParseShapeApi.AliasedSegment));
+
+        await Assert.That(info.RelativePath).IsEqualTo("/users/{id}");
+        await Assert.That(info.ParameterInfoArray.Length).IsEqualTo(1);
+        await Assert.That(info.ParameterMap.Count).IsEqualTo(1);
+        await Assert.That(info.ParameterMap[0].IsObjectPropertyParameter).IsFalse();
+        await Assert.That(info.ParameterMap[0].Type).IsEqualTo(ParameterType.Normal);
+        await Assert.That(info.ParameterMap[0].Name).IsEqualTo("id");
+        await Assert.That(info.QueryParameterMap.Count).IsEqualTo(0);
+        await Assert.That(info.Headers.Count).IsEqualTo(1);
+        await Assert.That(info.Headers["X-Interface"]).IsEqualTo("iface");
+    }
+
+    /// <summary>A nested-object path placeholder resolves the full property chain in declared order.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task NestedObjectPathParsesFullPropertyChain()
+    {
+        var info = Parse(nameof(IReflectionParseShapeApi.NestedPath));
+
+        await Assert.That(info.RelativePath).IsEqualTo("/orgs/{request.Inner.Code}/audit");
+        await Assert.That(info.ParameterMap.Count).IsEqualTo(1);
+        await Assert.That(info.ParameterMap[0].IsObjectPropertyParameter).IsTrue();
+        await Assert.That(info.ParameterMap[0].ParameterProperties.Count).IsEqualTo(1);
+
+        var chain = info.ParameterMap[0].ParameterProperties[0].PropertyChain;
+        await Assert.That(chain.Count).IsEqualTo(NestedChainLength);
+        await Assert.That(chain[0].Name).IsEqualTo("Inner");
+        await Assert.That(chain[1].Name).IsEqualTo("Code");
+    }
+
+    /// <summary>Scalar query parameters populate the query map under their CLR names and are not path parameters.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task ScalarQueryParametersPopulateQueryMap()
+    {
+        var info = Parse(nameof(IReflectionParseShapeApi.ScalarQuery));
+
+        await Assert.That(info.RelativePath).IsEqualTo("/search");
+        await Assert.That(info.ParameterInfoArray.Length).IsEqualTo(ScalarParameterCount);
+        await Assert.That(info.ParameterMap.Count).IsEqualTo(0);
+        await Assert.That(info.BodyParameterInfo).IsNull();
+        await Assert.That(info.QueryParameterMap[0]).IsEqualTo("q");
+        await Assert.That(info.QueryParameterMap[1]).IsEqualTo("page");
+    }
+
+    /// <summary>A collection query parameter carries its <see cref="QueryAttribute"/> in the materialized array.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task CollectionQueryParameterCachesQueryAttribute()
+    {
+        var info = Parse(nameof(IReflectionParseShapeApi.CollectionQuery));
+
+        await Assert.That(info.QueryParameterMap[0]).IsEqualTo("tags");
+        await Assert.That(info.ParameterQueryAttributes[0]).IsNotNull();
+        await Assert.That(info.ParameterQueryAttributes[0]!.CollectionFormat).IsEqualTo(CollectionFormat.Multi);
+    }
+
+    /// <summary>Each distinctly attributed parameter is classified into its own map: header, header collection,
+    /// authorization, request property, and a plain scalar query.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task DenseAttributesClassifyEachParameterIntoItsOwnMap()
+    {
+        var info = Parse(nameof(IReflectionParseShapeApi.DenseAttributes));
+
+        await Assert.That(info.ParameterInfoArray.Length).IsEqualTo(DenseParameterCount);
+
+        await Assert.That(info.HeaderParameterMap.Count).IsEqualTo(1);
+        await Assert.That(info.HeaderParameterMap[0]).IsEqualTo("X-Api-Key");
+
+        await Assert.That(info.HasHeaderCollection).IsTrue();
+        await Assert.That(info.HeaderCollectionAt(1)).IsTrue();
+
+        await Assert.That(info.AuthorizeParameterInfo).IsNotNull();
+        await Assert.That(info.AuthorizeParameterInfo!.Item1).IsEqualTo("Bearer");
+        await Assert.That(info.AuthorizeParameterInfo.Item2).IsEqualTo(AuthorizeParameterIndex);
+
+        await Assert.That(info.PropertyParameterMap.Count).IsEqualTo(1);
+        await Assert.That(info.PropertyParameterMap[PropertyParameterIndex]).IsEqualTo("trace-id");
+
+        await Assert.That(info.QueryParameterMap.Count).IsEqualTo(1);
+        await Assert.That(info.QueryParameterMap[QueryParameterIndex]).IsEqualTo("filter");
+
+        await Assert.That(info.BodyParameterInfo).IsNull();
+        await Assert.That(info.Headers["X-Method"]).IsEqualTo("dense");
+    }
+
+    /// <summary>An implicit reference-type argument on a POST is parsed as the serialized body parameter.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task SerializedBodyParsesImplicitBodyParameter()
+    {
+        var info = Parse(nameof(IReflectionParseShapeApi.SerializedBody));
+
+        await Assert.That(info.RelativePath).IsEqualTo("/body");
+        await Assert.That(info.IsMultipart).IsFalse();
+        await Assert.That(info.BodyParameterInfo).IsNotNull();
+        await Assert.That(info.BodyParameterInfo!.Item3).IsEqualTo(0);
+        await Assert.That(info.BodyParameterInfo.Item1).IsEqualTo(BodySerializationMethod.Default);
+    }
+
+    /// <summary>A multipart method has no body parameter and exposes each part as a query-map name.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task MultipartMethodParsesPartsWithoutBody()
+    {
+        var info = Parse(nameof(IReflectionParseShapeApi.Upload));
+
+        await Assert.That(info.IsMultipart).IsTrue();
+        await Assert.That(info.MultipartBoundary).IsNotEmpty();
+        await Assert.That(info.ParameterInfoArray.Length).IsEqualTo(MultipartPartCount);
+        await Assert.That(info.BodyParameterInfo).IsNull();
+        await Assert.That(info.AttachmentNameMap.Count).IsEqualTo(0);
+        await Assert.That(info.QueryParameterMap.Count).IsEqualTo(MultipartPartCount);
+        await Assert.That(info.QueryParameterMap[0]).IsEqualTo("title");
+        await Assert.That(info.QueryParameterMap[1]).IsEqualTo("payload");
+        await Assert.That(info.QueryParameterMap[StreamPartIndex]).IsEqualTo("content");
+    }
+
+    /// <summary>A <c>[Url]</c> parameter is recorded as the absolute-URI source and excluded from the query map.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task AbsoluteUrlParameterIsRecordedAndExcludedFromQuery()
+    {
+        var info = Parse(nameof(IReflectionParseShapeApi.AbsoluteUrl));
+
+        await Assert.That(info.RelativePath).IsEqualTo(string.Empty);
+        await Assert.That(info.UrlParameterInfo).IsEqualTo(0);
+        await Assert.That(info.ParameterInfoArray.Length).IsEqualTo(1);
+        await Assert.That(info.QueryParameterMap.Count).IsEqualTo(0);
+    }
+
+    /// <summary>A cancellation-token argument is stripped from the mapped parameters but recorded on the method.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task CancellationTokenParameterIsStrippedButRecorded()
+    {
+        var info = Parse(nameof(IReflectionParseShapeApi.Cancelable));
+
+        await Assert.That(info.RelativePath).IsEqualTo("/cancelable/{id}");
+        await Assert.That(info.ParameterInfoArray.Length).IsEqualTo(1);
+        await Assert.That(info.CancellationToken).IsNotNull();
+        await Assert.That(info.ParameterMap.Count).IsEqualTo(1);
+        await Assert.That(info.ParameterMap[0].Type).IsEqualTo(ParameterType.Normal);
+    }
+
+    /// <summary>An open generic method is parsed for selection with its single mapped parameter and no route binding.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task GenericMethodParsesForSelection()
+    {
+        var info = Parse(nameof(IReflectionParseShapeApi.TypedItem));
+
+        await Assert.That(info.RelativePath).IsEqualTo("/items");
+        await Assert.That(info.ParameterInfoArray.Length).IsEqualTo(1);
+        await Assert.That(info.ParameterMap.Count).IsEqualTo(0);
+        await Assert.That(info.QueryParameterMap[0]).IsEqualTo("probe");
+    }
+
+    /// <summary>Builds the parsed metadata for a method on the shape interface.</summary>
+    /// <param name="name">The method name to parse.</param>
+    /// <returns>The parsed method metadata.</returns>
+    private static RestMethodInfoInternal Parse(string name) =>
+        new(
+            typeof(IReflectionParseShapeApi),
+            typeof(IReflectionParseShapeApi).GetMethod(name)
+                ?? throw new MissingMethodException(nameof(IReflectionParseShapeApi), name),
+            new RefitSettings());
+}

--- a/src/tests/Refit.Reflection.Tests/ReflectionDeclaredMethodLookupTests.cs
+++ b/src/tests/Refit.Reflection.Tests/ReflectionDeclaredMethodLookupTests.cs
@@ -1,0 +1,43 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Refit.Reflection.Tests;
+
+/// <summary>Pins that the reflection request builder resolves each of its private delegate-factory methods to the method
+/// of that exact name, so the by-name declared-method cache keys correctly, and that an unknown name throws rather than
+/// poisoning the cache.</summary>
+public sealed class ReflectionDeclaredMethodLookupTests
+{
+    /// <summary>Verifies a known factory name resolves to a method of that name declared on the builder type, across
+    /// repeated lookups that exercise both the cache miss and the cache hit.</summary>
+    /// <param name="name">The declared factory-method name to resolve.</param>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    [Arguments(nameof(RequestBuilderImplementation.BuildTaskFuncForMethod))]
+    [Arguments(nameof(RequestBuilderImplementation.BuildVoidTaskFuncForMethod))]
+    [Arguments(nameof(RequestBuilderImplementation.BuildRxFuncForMethod))]
+    public async Task ResolvesEachFactoryMethodToItsOwnName(string name)
+    {
+        var first = RequestBuilderImplementation.FindDeclaredMethod(name);
+        var second = RequestBuilderImplementation.FindDeclaredMethod(name);
+
+        await Assert.That(first.Name).IsEqualTo(name);
+        await Assert.That(first.DeclaringType).IsEqualTo(typeof(RequestBuilderImplementation));
+        await Assert.That(second).IsSameReferenceAs(first);
+    }
+
+    /// <summary>Verifies an unknown method name throws and is not cached, so a later valid lookup still succeeds.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task UnknownMethodNameThrowsWithoutPoisoningTheCache()
+    {
+        await Assert.That(static () => RequestBuilderImplementation.FindDeclaredMethod("NoSuchFactoryMethod"))
+            .ThrowsExactly<MissingMethodException>();
+
+        var resolved = RequestBuilderImplementation.FindDeclaredMethod(
+            nameof(RequestBuilderImplementation.BuildTaskFuncForMethod));
+
+        await Assert.That(resolved.Name).IsEqualTo(nameof(RequestBuilderImplementation.BuildTaskFuncForMethod));
+    }
+}

--- a/src/tests/Refit.Reflection.Tests/ReflectionExistingQueryMergeTests.cs
+++ b/src/tests/Refit.Reflection.Tests/ReflectionExistingQueryMergeTests.cs
@@ -1,0 +1,79 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Refit.Reflection.Tests;
+
+/// <summary>Pins how the reflection request builder merges an absolute <c>[Url]</c>'s existing query string with an
+/// appended <c>[Query]</c> parameter: existing entries come first, values are URL-decoded (<c>+</c> to space, percent
+/// escapes), duplicate keys are comma-joined, and blank or valueless keys are dropped.</summary>
+public sealed class ReflectionExistingQueryMergeTests
+{
+    /// <summary>Verifies an existing single query parameter is preserved before the appended one.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public Task ExistingParameterPrecedesAppended() =>
+        AssertMergeAsync(
+            "https://cdn.example.com/f?existing=1",
+            "https://cdn.example.com/f?existing=1&token=abc");
+
+    /// <summary>Verifies duplicate keys in the existing query are comma-joined (then percent-escaped).</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public Task DuplicateExistingKeysAreCommaJoined() =>
+        AssertMergeAsync(
+            "https://cdn.example.com/f?a=1&a=2",
+            "https://cdn.example.com/f?a=1%2C2&token=abc");
+
+    /// <summary>Verifies existing query values are URL-decoded: <c>+</c> becomes a space, percent escapes are decoded.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public Task ExistingValuesAreUrlDecoded() =>
+        AssertMergeAsync(
+            "https://cdn.example.com/f?x=a+b&y=%41",
+            "https://cdn.example.com/f?x=a%20b&y=A&token=abc");
+
+    /// <summary>Verifies a blank key and a valueless key in the existing query are dropped.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public Task BlankAndValuelessKeysAreDropped() =>
+        AssertMergeAsync(
+            "https://cdn.example.com/f?=v&k",
+            "https://cdn.example.com/f?token=abc");
+
+    /// <summary>Verifies duplicate keys are joined while an interleaved distinct key keeps its first-seen position.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public Task InterleavedDuplicateKeysJoinInFirstSeenOrder() =>
+        AssertMergeAsync(
+            "https://cdn.example.com/f?dup=1&other=z&dup=2",
+            "https://cdn.example.com/f?dup=1%2C2&other=z&token=abc");
+
+    /// <summary>Verifies keys that differ only by case are treated as duplicates and joined under the first casing.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public Task CaseDifferingKeysAreJoinedUnderFirstCasing() =>
+        AssertMergeAsync(
+            "https://cdn.example.com/f?Mix=1&mix=2&MIX=3",
+            "https://cdn.example.com/f?Mix=1%2C2%2C3&token=abc");
+
+    /// <summary>Verifies an absolute URL with no existing query still receives the appended parameter.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public Task NoExistingQueryStillAppends() =>
+        AssertMergeAsync(
+            "https://cdn.example.com/f",
+            "https://cdn.example.com/f?token=abc");
+
+    /// <summary>Builds a request for the absolute URL with an appended token and asserts the merged absolute URI.</summary>
+    /// <param name="url">The absolute URL, possibly already carrying a query string.</param>
+    /// <param name="expectedAbsoluteUri">The expected merged absolute URI.</param>
+    /// <returns>A task representing the asynchronous test.</returns>
+    private static async Task AssertMergeAsync(string url, string expectedAbsoluteUri)
+    {
+        var reflected = await new RequestBuilderImplementation<IReflectionAbsoluteUrlApi>()
+            .BuildRequestFactoryForMethod(nameof(IReflectionAbsoluteUrlApi.GetAbsoluteWithQuery))([url, "abc"]);
+
+        await Assert.That(reflected.RequestUri!.AbsoluteUri).IsEqualTo(expectedAbsoluteUri);
+    }
+}

--- a/src/tests/Refit.Reflection.Tests/ReflectionMultipartFormObjectTests.cs
+++ b/src/tests/Refit.Reflection.Tests/ReflectionMultipartFormObjectTests.cs
@@ -1,0 +1,47 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Linq;
+
+namespace Refit.Reflection.Tests;
+
+/// <summary>Pins that the reflection request builder flattens a <see cref="FormObjectAttribute"/> parameter into one part
+/// per property while a plain parameter stays a single multipart part.</summary>
+public sealed class ReflectionMultipartFormObjectTests
+{
+    /// <summary>The multipart parameter index of the plain text part.</summary>
+    private const int TitlePartIndex = 0;
+
+    /// <summary>The multipart parameter index of the flattened form-object part.</summary>
+    private const int AddressPartIndex = 1;
+
+    /// <summary>The number of parts a two-property form object flattens into.</summary>
+    private const int FlattenedAddressPartCount = 2;
+
+    /// <summary>Verifies a plain parameter yields a single part while a form-object parameter yields one part per property.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task FormObjectParameterFlattensToOnePartPerProperty()
+    {
+        var settings = new RefitSettings();
+        var builder = new RequestBuilderImplementation(typeof(IReflectionMultipartFormObjectApi), settings);
+        var method = new RestMethodInfoInternal(
+            typeof(IReflectionMultipartFormObjectApi),
+            typeof(IReflectionMultipartFormObjectApi).GetMethod(nameof(IReflectionMultipartFormObjectApi.Upload))!,
+            settings);
+
+        using var titleContent = new MultipartFormDataContent();
+        builder.AddMultiPart(method, TitlePartIndex, "quarterly report", titleContent);
+
+        using var addressContent = new MultipartFormDataContent();
+        builder.AddMultiPart(
+            method,
+            AddressPartIndex,
+            new MultipartAddress { City = "Springfield", PostalCode = "12345" },
+            addressContent);
+
+        await Assert.That(titleContent.Count()).IsEqualTo(1);
+        await Assert.That(addressContent.Count()).IsEqualTo(FlattenedAddressPartCount);
+    }
+}

--- a/src/tests/Refit.Reflection.Tests/ReflectionObjectPathBindingTests.cs
+++ b/src/tests/Refit.Reflection.Tests/ReflectionObjectPathBindingTests.cs
@@ -1,0 +1,50 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Refit.Reflection.Tests;
+
+/// <summary>Pins the exact relative URI the reflection request builder produces when an object argument binds a path
+/// segment and is simultaneously flattened into the query string: the path-bound property is dropped from the query while
+/// every remaining property is flattened, and the contract holds on the second call that reuses the cached metadata.</summary>
+public sealed class ReflectionObjectPathBindingTests
+{
+    /// <summary>The exact relative URI the builder must produce: the identifier renders as a path segment and is omitted
+    /// from the query, while the remaining properties flatten in declared order.</summary>
+    private const string ExpectedPathAndQuery =
+        "/users/101/detail?handle=widgets%20%26%20gadgets&Page=3&Tags=1&Tags=2&Tags=3&Inner.Code=abc&Inner.Label=primary";
+
+    /// <summary>The scalar identifier bound to the path segment and omitted from the query.</summary>
+    private const int ModelId = 101;
+
+    /// <summary>The page number flattened into the query under its CLR name.</summary>
+    private const int ModelPage = 3;
+
+    /// <summary>The multi-expanded tag collection flattened to one repeated key per element.</summary>
+    private static readonly int[] _modelTags = [1, 2, 3];
+
+    /// <summary>Verifies the path-bound identifier is dropped from the flattened query and the rest of the object flattens
+    /// identically across two builders, the second reusing the cached per-type query-property metadata.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task ObjectPathBindingDropsBoundPropertyFromFlattenedQuery()
+    {
+        var request = new ReflectionCachingQueryModel
+        {
+            Id = ModelId,
+            Name = "widgets & gadgets",
+            Page = ModelPage,
+            Ignored = "secret",
+            Tags = _modelTags,
+            Inner = new() { Code = "abc", Label = "primary" },
+        };
+
+        var first = await new RequestBuilderImplementation<IReflectionObjectPathApi>()
+            .BuildRequestFactoryForMethod(nameof(IReflectionObjectPathApi.Detail))([request]);
+        var second = await new RequestBuilderImplementation<IReflectionObjectPathApi>()
+            .BuildRequestFactoryForMethod(nameof(IReflectionObjectPathApi.Detail))([request]);
+
+        await Assert.That(first.RequestUri!.PathAndQuery).IsEqualTo(ExpectedPathAndQuery);
+        await Assert.That(second.RequestUri!.PathAndQuery).IsEqualTo(ExpectedPathAndQuery);
+    }
+}

--- a/src/tests/Refit.Reflection.Tests/ReflectionParseShapeModel.cs
+++ b/src/tests/Refit.Reflection.Tests/ReflectionParseShapeModel.cs
@@ -1,0 +1,15 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Refit.Reflection.Tests;
+
+/// <summary>A request object supplying a nested property chain for path binding and remaining properties for the query.</summary>
+public sealed class ReflectionParseShapeModel
+{
+    /// <summary>Gets or sets the scalar identifier flattened into the query.</summary>
+    public int Id { get; set; }
+
+    /// <summary>Gets or sets the nested object whose <see cref="ReflectionCachingInnerModel.Code"/> binds the path chain.</summary>
+    public ReflectionCachingInnerModel? Inner { get; set; }
+}

--- a/src/tests/Refit.Reflection.Tests/ReflectionParseShapeRequestTests.cs
+++ b/src/tests/Refit.Reflection.Tests/ReflectionParseShapeRequestTests.cs
@@ -1,0 +1,104 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Refit.Reflection.Tests;
+
+/// <summary>Drives real requests through the reflection request builder for the attribute shapes on
+/// <see cref="IReflectionParseShapeApi"/> and pins the resulting URI, headers, request options, JSON body and multipart
+/// parts. These end-to-end assertions guard the whole per-call build against regressions in the constructor's
+/// per-parameter attribute classification.</summary>
+public sealed class ReflectionParseShapeRequestTests
+{
+    /// <summary>The serialized JSON body produced for the body payload fixture.</summary>
+    private const string SerializedBody = "{\"name\":\"x\"}";
+
+    /// <summary>The nested-model identifier flattened into the query on the nested-path request.</summary>
+    private const int NestedModelId = 5;
+
+    /// <summary>The sample byte-array multipart payload.</summary>
+    private static readonly byte[] _payloadBytes = [1, 2, 3];
+
+    /// <summary>The sample bytes backing the stream multipart part.</summary>
+    private static readonly byte[] _streamBytes = [9, 9, 9];
+
+    /// <summary>Every distinctly attributed parameter reaches its destination on the built request: header, header
+    /// collection, authorization header, request-property option and scalar query, alongside the static headers.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task DenseAttributesRouteEachParameterToItsDestination()
+    {
+        var headerCollection = new Dictionary<string, string> { ["X-Extra"] = "extra" };
+        var output = await new RequestBuilderImplementation<IReflectionParseShapeApi>()
+            .BuildRequestFactoryForMethod(nameof(IReflectionParseShapeApi.DenseAttributes))(
+                ["key123", headerCollection, "tok", "trace-1", "filtered"]);
+
+        await Assert.That(output.RequestUri!.PathAndQuery).IsEqualTo("/dense?filter=filtered");
+        await Assert.That(output.Headers.GetValues("X-Api-Key")).IsCollectionEqualTo(["key123"]);
+        await Assert.That(output.Headers.Authorization!.ToString()).IsEqualTo("Bearer tok");
+        await Assert.That(output.Headers.GetValues("X-Extra")).IsCollectionEqualTo(["extra"]);
+        await Assert.That(output.Headers.GetValues("X-Interface")).IsCollectionEqualTo(["iface"]);
+        await Assert.That(output.Headers.GetValues("X-Method")).IsCollectionEqualTo(["dense"]);
+
+        var found = output.Options.TryGetValue(new HttpRequestOptionsKey<object>("trace-id"), out var traceId);
+        await Assert.That(found).IsTrue();
+        await Assert.That(traceId).IsEqualTo("trace-1");
+    }
+
+    /// <summary>A nested-object path chain renders the bound value as a path segment while the remaining property flattens
+    /// into the query.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task NestedObjectPathRendersChainAndFlattensRemainder()
+    {
+        var model = new ReflectionParseShapeModel { Id = NestedModelId, Inner = new() { Code = "abc" } };
+
+        var output = await new RequestBuilderImplementation<IReflectionParseShapeApi>()
+            .BuildRequestFactoryForMethod(nameof(IReflectionParseShapeApi.NestedPath))([model]);
+
+        await Assert.That(output.RequestUri!.PathAndQuery).IsEqualTo("/orgs/abc/audit?Id=5");
+    }
+
+    /// <summary>An implicit body argument is serialized as the JSON request content on a POST.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task SerializedBodyPostsJsonContent()
+    {
+        var handler = await new RequestBuilderImplementation<IReflectionParseShapeApi>()
+            .RunRequest(nameof(IReflectionParseShapeApi.SerializedBody))([new BodyPayload { Name = "x" }]);
+
+        await Assert.That(handler.RequestMessage!.Method).IsEqualTo(HttpMethod.Post);
+        await Assert.That(handler.SendContent).IsEqualTo(SerializedBody);
+    }
+
+    /// <summary>A multipart upload emits one form-data part per argument, each under its parameter name.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task MultipartUploadBuildsOnePartPerArgument()
+    {
+        await using var stream = new MemoryStream(_streamBytes);
+        var handler = await new RequestBuilderImplementation<IReflectionParseShapeApi>()
+            .RunRequest(nameof(IReflectionParseShapeApi.Upload))(["hello", _payloadBytes, stream]);
+
+        // The captured request content is disposed by the HttpClient after sending, so assert against the multipart
+        // body the handler read before disposal: it carries one content-disposition part per argument.
+        await Assert.That(handler.RequestMessage!.Content).IsTypeOf<MultipartFormDataContent>();
+        var body = handler.SendContent!;
+        await Assert.That(body).Contains("name=title");
+        await Assert.That(body).Contains("name=payload");
+        await Assert.That(body).Contains("name=content");
+        await Assert.That(body).Contains("hello");
+    }
+
+    /// <summary>A <c>[Url]</c> parameter supplies the complete absolute request URI, bypassing the base address.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task AbsoluteUrlParameterSuppliesTheRequestUri()
+    {
+        var output = await new RequestBuilderImplementation<IReflectionParseShapeApi>()
+            .BuildRequestFactoryForMethod(nameof(IReflectionParseShapeApi.AbsoluteUrl))(
+                ["https://other.test/path?x=1"]);
+
+        await Assert.That(output.RequestUri!.AbsoluteUri).IsEqualTo("https://other.test/path?x=1");
+    }
+}

--- a/src/tests/Refit.Reflection.Tests/ReflectionPropertyQueryParameterTests.cs
+++ b/src/tests/Refit.Reflection.Tests/ReflectionPropertyQueryParameterTests.cs
@@ -1,0 +1,28 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Refit.Reflection.Tests;
+
+/// <summary>Pins how the reflection request builder classifies parameters that carry <see cref="PropertyAttribute"/> and/or
+/// <see cref="QueryAttribute"/>: a property-only parameter is kept out of the query string, while a parameter that is both a
+/// property and a query parameter still contributes to the query. Both classifications are also written as request options.</summary>
+public sealed class ReflectionPropertyQueryParameterTests
+{
+    /// <summary>Verifies a property-only parameter is excluded from the query while a property+query parameter is retained,
+    /// and both are stored as request options.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task PropertyOnlyParameterExcludedWhilePropertyQueryParameterRetained()
+    {
+        var request = await new RequestBuilderImplementation<IReflectionPropertyQueryApi>()
+            .BuildRequestFactoryForMethod(nameof(IReflectionPropertyQueryApi.Search))(["hello", "trace-42", "blue"]);
+
+        await Assert.That(request.RequestUri!.PathAndQuery).IsEqualTo("/search?q=hello&tag=blue");
+
+        await Assert.That(request.Options.TryGetValue(new HttpRequestOptionsKey<string>("trace-id"), out var trace)).IsTrue();
+        await Assert.That(trace).IsEqualTo("trace-42");
+        await Assert.That(request.Options.TryGetValue(new HttpRequestOptionsKey<string>("tag-prop"), out var tag)).IsTrue();
+        await Assert.That(tag).IsEqualTo("blue");
+    }
+}

--- a/src/tests/Refit.Reflection.Tests/ReflectionQueryMapCachingTests.cs
+++ b/src/tests/Refit.Reflection.Tests/ReflectionQueryMapCachingTests.cs
@@ -1,0 +1,63 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Refit.Reflection.Tests;
+
+/// <summary>Pins the exact query string the reflection request builder flattens for a combined query object, including on
+/// the second call that reuses the cached per-type query-property metadata, and confirms it matches the generator.</summary>
+public sealed class ReflectionQueryMapCachingTests
+{
+    /// <summary>The base address used when building request URIs.</summary>
+    private const string BaseAddress = "http://api/";
+
+    /// <summary>The exact relative URI both builders must produce for the combined query model.</summary>
+    private const string ExpectedPathAndQuery =
+        "/list?Id=101&handle=widgets%20%26%20gadgets&Page=3&Tags=1&Tags=2&Tags=3&Inner.Code=abc&Inner.Label=primary";
+
+    /// <summary>The scalar identifier rendered under its CLR name.</summary>
+    private const int ModelId = 101;
+
+    /// <summary>The page number rendered under its CLR name.</summary>
+    private const int ModelPage = 3;
+
+    /// <summary>The multi-expanded tag collection flattened to one repeated key per element.</summary>
+    private static readonly int[] _modelTags = [1, 2, 3];
+
+    /// <summary>Verifies the combined query object flattens to the same exact query string via the generator and via two
+    /// separate reflection builders (the second reusing the cached per-type query-property metadata).</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task CombinedQueryObjectFlattensIdenticallyAcrossBuildersAndCache()
+    {
+        var query = CreateModel();
+
+        var handler = new TestHttpMessageHandler();
+        using var client = new HttpClient(handler) { BaseAddress = new(BaseAddress) };
+        var generated = RestService.ForGenerated<IReflectionCachingQueryApi>(client, new RefitSettings());
+        _ = await generated.Flatten(query);
+        var generatedUri = handler.RequestMessage!.RequestUri!.PathAndQuery;
+
+        var first = await new RequestBuilderImplementation<IReflectionCachingQueryApi>()
+            .BuildRequestFactoryForMethod(nameof(IReflectionCachingQueryApi.Flatten))([query]);
+        var second = await new RequestBuilderImplementation<IReflectionCachingQueryApi>()
+            .BuildRequestFactoryForMethod(nameof(IReflectionCachingQueryApi.Flatten))([query]);
+
+        await Assert.That(generatedUri).IsEqualTo(ExpectedPathAndQuery);
+        await Assert.That(first.RequestUri!.PathAndQuery).IsEqualTo(ExpectedPathAndQuery);
+        await Assert.That(second.RequestUri!.PathAndQuery).IsEqualTo(ExpectedPathAndQuery);
+    }
+
+    /// <summary>Builds the canonical combined query model shared by the flattening assertions.</summary>
+    /// <returns>A populated query model.</returns>
+    private static ReflectionCachingQueryModel CreateModel() =>
+        new()
+        {
+            Id = ModelId,
+            Name = "widgets & gadgets",
+            Page = ModelPage,
+            Ignored = "secret",
+            Tags = _modelTags,
+            Inner = new() { Code = "abc", Label = "primary" },
+        };
+}

--- a/src/tests/Refit.Reflection.Tests/ReflectionRequestBuildingTests.cs
+++ b/src/tests/Refit.Reflection.Tests/ReflectionRequestBuildingTests.cs
@@ -2,7 +2,7 @@
 // ReactiveUI and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-namespace Refit.Tests;
+namespace Refit.Reflection.Tests;
 
 /// <summary>Verifies request-building paths of the reflection request builder that only the reflection path reaches:
 /// authorization parameters, synchronous and streaming body serialization, buffered bodies, round-tripping null path

--- a/src/tests/Refit.Reflection.Tests/ReflectionStaticHeaderTests.cs
+++ b/src/tests/Refit.Reflection.Tests/ReflectionStaticHeaderTests.cs
@@ -1,0 +1,62 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Refit.Reflection.Tests;
+
+/// <summary>Pins that class-level static headers are emitted unchanged, and that a dynamic header parameter overriding a
+/// static header does not corrupt the shared static header set for subsequent calls.</summary>
+public sealed class ReflectionStaticHeaderTests
+{
+    /// <summary>The static header emitted unchanged on every call.</summary>
+    private const string StaticHeaderName = "X-Static";
+
+    /// <summary>The value of the unchanged static header.</summary>
+    private const string StaticHeaderValue = "static-value";
+
+    /// <summary>The static header a dynamic parameter overrides.</summary>
+    private const string OverrideHeaderName = "X-Override";
+
+    /// <summary>The static default of the overridable header.</summary>
+    private const string OverrideDefault = "original";
+
+    /// <summary>Verifies a static-header-only method emits the same static headers on repeated calls.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task StaticHeadersEmittedIdenticallyAcrossCalls()
+    {
+        // One builder (so both calls share the cached method metadata and its static header set) with a fresh
+        // per-call request factory (each carries its own message handler).
+        var builder = new RequestBuilderImplementation<IReflectionStaticHeaderApi>();
+
+        var first = await builder.BuildRequestFactoryForMethod(nameof(IReflectionStaticHeaderApi.StaticOnly))([]);
+        var second = await builder.BuildRequestFactoryForMethod(nameof(IReflectionStaticHeaderApi.StaticOnly))([]);
+
+        await Assert.That(first.Headers.GetValues(StaticHeaderName).Single()).IsEqualTo(StaticHeaderValue);
+        await Assert.That(first.Headers.GetValues(OverrideHeaderName).Single()).IsEqualTo(OverrideDefault);
+        await Assert.That(second.Headers.GetValues(StaticHeaderName).Single()).IsEqualTo(StaticHeaderValue);
+        await Assert.That(second.Headers.GetValues(OverrideHeaderName).Single()).IsEqualTo(OverrideDefault);
+    }
+
+    /// <summary>Verifies a dynamic header parameter overrides its static counterpart for that call without leaking the
+    /// override into a later call that relies on the static default.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task DynamicHeaderOverrideDoesNotLeakIntoStaticHeaders()
+    {
+        var builder = new RequestBuilderImplementation<IReflectionStaticHeaderApi>();
+
+        var overridden = await builder
+            .BuildRequestFactoryForMethod(nameof(IReflectionStaticHeaderApi.WithDynamic))(["call-specific"]);
+
+        await Assert.That(overridden.Headers.GetValues(StaticHeaderName).Single()).IsEqualTo(StaticHeaderValue);
+        await Assert.That(overridden.Headers.GetValues(OverrideHeaderName).Single()).IsEqualTo("call-specific");
+
+        // A later static-only call must still see the original static default, proving the override never mutated the
+        // shared static header set.
+        var afterOverride = await builder
+            .BuildRequestFactoryForMethod(nameof(IReflectionStaticHeaderApi.StaticOnly))([]);
+
+        await Assert.That(afterOverride.Headers.GetValues(OverrideHeaderName).Single()).IsEqualTo(OverrideDefault);
+    }
+}

--- a/src/tests/Refit.Reflection.Tests/RequestBuilderTestExtensions.cs
+++ b/src/tests/Refit.Reflection.Tests/RequestBuilderTestExtensions.cs
@@ -1,0 +1,66 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+namespace Refit.Reflection.Tests;
+
+/// <summary>Test helpers for building and running requests through an <see cref="IRequestBuilder"/>.</summary>
+internal static class RequestBuilderTestExtensions
+{
+    /// <summary>Request-building helpers on <see cref="IRequestBuilder"/> for tests.</summary>
+    /// <param name="builder">The request builder under test.</param>
+    extension(IRequestBuilder builder)
+    {
+        /// <summary>Builds a factory that produces the request message for a method.</summary>
+        /// <param name="methodName">The name of the interface method to build a request for.</param>
+        /// <param name="baseAddress">The base address used by the test HTTP client.</param>
+        /// <returns>A factory that maps a parameter array to a task producing the request message.</returns>
+        public Func<object[], Task<HttpRequestMessage>> BuildRequestFactoryForMethod(
+            string methodName,
+            string baseAddress = "http://api/")
+        {
+            var factory = builder.BuildRestResultFuncForMethod(methodName);
+            var testHttpMessageHandler = new TestHttpMessageHandler();
+
+            return async paramList =>
+            {
+                var task = (Task)factory(
+                    new(testHttpMessageHandler) { BaseAddress = new(baseAddress) },
+                    paramList)!;
+                await task;
+                return testHttpMessageHandler.RequestMessage!;
+            };
+        }
+
+        /// <summary>Builds a factory that runs a request and returns the handler that observed it.</summary>
+        /// <param name="methodName">The name of the interface method to invoke.</param>
+        /// <param name="returnContent">Optional response content the handler returns.</param>
+        /// <param name="baseAddress">The base address used by the test HTTP client.</param>
+        /// <returns>A factory that maps a parameter array to a task producing the handler that observed the request.</returns>
+        public Func<object[], Task<TestHttpMessageHandler>> RunRequest(
+            string methodName,
+            string? returnContent = null,
+            string baseAddress = "http://api/")
+        {
+            var factory = builder.BuildRestResultFuncForMethod(methodName);
+            var testHttpMessageHandler = new TestHttpMessageHandler();
+            if (returnContent is not null)
+            {
+                testHttpMessageHandler.Content = new StringContent(returnContent);
+            }
+
+            return async paramList =>
+            {
+                var task = (Task)factory(
+                    new(testHttpMessageHandler) { BaseAddress = new(baseAddress) },
+                    paramList)!;
+                try
+                {
+                    await task;
+                }
+                catch (TaskCanceledException) { }
+
+                return testHttpMessageHandler;
+            };
+        }
+    }
+}

--- a/src/tests/Refit.Reflection.Tests/TestHttpMessageHandler.cs
+++ b/src/tests/Refit.Reflection.Tests/TestHttpMessageHandler.cs
@@ -1,0 +1,64 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Net;
+
+namespace Refit.Reflection.Tests;
+
+/// <summary>A test message handler capturing the request and returning canned content.</summary>
+public class TestHttpMessageHandler : HttpMessageHandler
+{
+    /// <summary>Initializes a new instance of the <see cref="TestHttpMessageHandler"/> class.</summary>
+    /// <param name="content">The canned response content body.</param>
+    [SuppressMessage(
+        "Design",
+        "SST2309:An externally visible member declares an optional parameter, so callers bake in the default",
+        Justification = "Test handler ctor convenience default; preserves existing call sites.")]
+    public TestHttpMessageHandler(string content = "test")
+    {
+        Content = new StringContent(content);
+        ContentFactory = () => Content;
+    }
+
+    /// <summary>Gets the last request message received.</summary>
+    public HttpRequestMessage? RequestMessage { get; private set; }
+
+    /// <summary>Gets or sets the number of messages sent.</summary>
+    public int MessagesSent { get; set; }
+
+    /// <summary>Gets or sets the response content.</summary>
+    public HttpContent Content { get; set; }
+
+    /// <summary>Gets or sets the factory used to produce response content.</summary>
+    public Func<HttpContent> ContentFactory { get; set; }
+
+    /// <summary>Gets or sets the cancellation token captured from the last request.</summary>
+    public CancellationToken CancellationToken { get; set; }
+
+    /// <summary>Gets or sets the content read from the last request.</summary>
+    public string? SendContent { get; set; }
+
+    /// <summary>Captures the request and returns the configured response.</summary>
+    /// <param name="request">The HTTP request message being sent.</param>
+    /// <param name="cancellationToken">The cancellation token for the request.</param>
+    /// <returns>The configured HTTP response message.</returns>
+    protected override async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        RequestMessage = request;
+        if (request.Content is not null)
+        {
+            SendContent = await request
+                .Content.ReadAsStringAsync(cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        CancellationToken = cancellationToken;
+        MessagesSent++;
+
+        return new(HttpStatusCode.OK) { Content = ContentFactory() };
+    }
+}

--- a/src/tests/Refit.Tests/NestedRoutePropertyBindingTests.cs
+++ b/src/tests/Refit.Tests/NestedRoutePropertyBindingTests.cs
@@ -21,4 +21,19 @@ public sealed class NestedRoutePropertyBindingTests
 
         await Assert.That(output.RequestUri!.ToString()).Contains("/items/abc");
     }
+
+    /// <summary>Verifies the chain walk stops at a null intermediate link so a missing nested object formats the
+    /// placeholder as an empty segment rather than throwing.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task NestedPropertyChainWithNullIntermediateFormatsEmptySegment()
+    {
+        var fixture = new RequestBuilderImplementation<INestedRouteApi>();
+        var factory = fixture.BuildRequestFactoryForMethod(nameof(INestedRouteApi.GetByNestedValue));
+        var request = new NestedRouteRequest { Inner = null };
+
+        var output = await factory([request]);
+
+        await Assert.That(output.RequestUri!.ToString()).IsEqualTo("http://api/items/");
+    }
 }

--- a/src/tests/Refit.Tests/RequestBuilderTests.Helpers.cs
+++ b/src/tests/Refit.Tests/RequestBuilderTests.Helpers.cs
@@ -186,6 +186,21 @@ public partial class RequestBuilderTests
         await Assert.That(uri.AbsolutePath).IsEqualTo("/foo/bar///");
     }
 
+    /// <summary>Renders a round-tripping path placeholder as an empty segment when the bound value itself is null,
+    /// rather than splitting a string form that does not exist.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task RoundTrippingPathWithNullValueFormatsAnEmptySegment()
+    {
+        var fixture = new RequestBuilderImplementation<IDummyHttpApi>();
+        var factory = fixture.BuildRequestFactoryForMethod(nameof(IDummyHttpApi.FetchSomeStuffWithRoundTrippingParam));
+
+        var output = await factory([null!, 1]);
+
+        var uri = new Uri(new(ApiBaseUrl), output.RequestUri!);
+        await Assert.That(uri.AbsolutePath).IsEqualTo("/foo/bar//1");
+    }
+
     /// <summary>Falls back to the derived file name when a multipart item supplies an empty one.</summary>
     /// <returns>A task that represents the asynchronous operation.</returns>
     [Test]


### PR DESCRIPTION
## What kind of change does this PR introduce?

Performance / refactor of the Refit.Reflection library (the reflection request builder). No behavioural change and no public API change.

## What is the new behavior?

Reduced memory allocations across the reflection request builder's per-request and per-method-parse paths, guided by a new GcVerbose micro-benchmark suite and verified behaviour-identical. Memory was the primary goal (time improvements are a bonus).

- Query subsystem: cache per-type query-property metadata and the attribute provider, cache the enumerable classification, drop an iterator, and parse an existing query string span-based without a `NameValueCollection` - object/collection query flatten down 69-82%.
- Object-path / multipart / headers: cache per-parameter attributes, build the route object-property lookup lazily, hold route bindings in a value tuple, emit static headers without a per-request copy.
- Cold parse: read each parameter's attributes in one `GetCustomAttributes` pass, cache the declared factory-method lookup (`FindDeclaredMethod` -> 0 B, `BuildRestResultFuncForMethod` -76%), lazy/presize the parameter maps.
- Adds a `Refit.Reflection.Benchmarks` GcVerbose micro-benchmark project (91 benchmarks) and a `Refit.Reflection.Tests` project pinning the request-builder contracts; the relevant private members are widened to internal (fields stay private) so the benchmarks can reach them.

## What is the current behavior?

The reflection request builder re-read attributes per call, materialised intermediate collections, and re-scanned method metadata, so each request build allocated more than necessary.

## What might this PR break?

None. Behaviour and serialised output are unchanged, verified by `Refit.Tests` (1152) plus a new `Refit.Reflection.Tests` (41) pinning the request-builder contracts. No public API changes; the widened members are `internal`.

## Additional information

Component-level allocation reductions (GcVerbose `Allocated`, deterministic) - the primary goal:

| Path | Before | After |
| --- | --- | --- |
| Query object flatten (`BuildQueryMapObject`) | 4561 B | 816 B (-82%) |
| Query object add (`AddQueryParametersObject`) | 5401 B | 1656 B (-69%) |
| `FindDeclaredMethod` | 1696 B | 0 B |
| `BuildRestResultFuncForMethod` | 2232 B | 536 B (-76%) |
| `ConstructBuilder` (parse all method infos) | 77.7 KB | 64.3 KB (-17%) |
| `BuildParameterMapMultiSegment` | 4952 B | 3768 B (-24%) |

End-to-end request build (public reflection path, net8.0) - the high-level A/B:

| Method | main | branch |
| --- | --- | --- |
| Query object + path + header | 6.54 us | 5.16 us (-21% time) |
| JSON body | 3.20 us | 3.13 us (same time, lower allocation) |

Every remaining allocation was trace-verified against its GcVerbose stack and is either the produced output (the request message, its Options/Uri/headers/body content, the built delegate, or stored value-equatable metadata), a framework allocation inside a call the reflection path must make (`System.Reflection`/`System.Text.Json`/`System.Uri`/`HttpClient`), or a value-type box the reflection API forces - nothing reducible remains in Refit.Reflection code.
