### PR TITLE
fix: resolve solution-wide analyzer warnings

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -82,6 +82,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(IsTestProject)' == 'true'">
+    <Compile Include="$(MSBuildThisFileDirectory)tests\HttpClientTestFactory.cs" Link="Testing\HttpClientTestFactory.cs"/>
     <None Include="$(MSBuildThisFileDirectory)testconfig.json">
       <Link>$(AssemblyName).testconfig.json</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -109,8 +110,10 @@
   </ItemGroup>
 
   <!-- net8.0 has every other shim natively but lacks OverloadResolutionPriority (added in net9.0).
-       The net4* leg already pulls this in via the Polyfills\*.cs glob above. -->
-  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+       Only Refit.HttpClientFactory uses the attribute; compiling the shim into consumers that already
+       reference Refit would create a duplicate compiler-recognized type. The net4* leg already pulls
+       this in via the Polyfills\*.cs glob above. -->
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0' and '$(MSBuildProjectName)' == 'Refit.HttpClientFactory'">
     <Compile Include="$(MSBuildThisFileDirectory)Polyfills\OverloadResolutionPriorityAttribute.cs" Link="Polyfills\OverloadResolutionPriorityAttribute.cs"/>
   </ItemGroup>
 

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -5,25 +5,25 @@
   </PropertyGroup>
 
   <PropertyGroup Label="Shared Version Variables">
-    <PrimitivesVersion>6.0.0</PrimitivesVersion>
+    <PrimitivesVersion>7.0.0</PrimitivesVersion>
     <TUnitVersion>1.59.0</TUnitVersion>
 
     <!-- StyleSharp and PerformanceSharp ship from the same repo on a single version line. -->
-    <SharpAnalyzersVersion>3.26.0</SharpAnalyzersVersion>
+    <SharpAnalyzersVersion>3.33.0</SharpAnalyzersVersion>
   </PropertyGroup>
 
   <PropertyGroup Label="Framework-Aligned Versions">
     <AspNetVersion>8.0.28</AspNetVersion>
-    <AspNetVersion Condition="$(TargetFramework.StartsWith('net9'))">9.0.17</AspNetVersion>
-    <AspNetVersion Condition="$(TargetFramework.StartsWith('net10'))">10.0.9</AspNetVersion>
+    <AspNetVersion Condition="$(TargetFramework.StartsWith('net9'))">9.0.18</AspNetVersion>
+    <AspNetVersion Condition="$(TargetFramework.StartsWith('net10'))">10.0.10</AspNetVersion>
 
-    <MicrosoftExtensionsVersion>10.0.9</MicrosoftExtensionsVersion>
-    <SystemTextJsonVersion>10.0.9</SystemTextJsonVersion>
+    <MicrosoftExtensionsVersion>10.0.10</MicrosoftExtensionsVersion>
+    <SystemTextJsonVersion>10.0.10</SystemTextJsonVersion>
 
     <MicrosoftCodeAnalysisAnalyzersVersion>5.6.0</MicrosoftCodeAnalysisAnalyzersVersion>
     <MicrosoftCodeAnalysisWorkspacesVersion>4.14.0</MicrosoftCodeAnalysisWorkspacesVersion>
 
-    <SourceLinkVersion>10.0.300</SourceLinkVersion>
+    <SourceLinkVersion>10.0.301</SourceLinkVersion>
     <ThreadingAnalyzersVersion>18.7.23</ThreadingAnalyzersVersion>
     <NetFrameworkReferenceAssembliesVersion>1.0.3</NetFrameworkReferenceAssembliesVersion>
   </PropertyGroup>

--- a/src/InterfaceStubGenerator.Shared/DiagnosticDescriptors.cs
+++ b/src/InterfaceStubGenerator.Shared/DiagnosticDescriptors.cs
@@ -10,7 +10,7 @@ internal static class DiagnosticDescriptors
 {
     /// <summary>Diagnostic reported when the Refit assembly is not referenced.</summary>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "RS2008", Justification = "Diagnostic IDs are stable and intentionally not tracked in an analyzer release-tracking file.")]
-    public static readonly DiagnosticDescriptor RefitNotReferenced =
+    internal static readonly DiagnosticDescriptor RefitNotReferenced =
         new(
             "RF002",
             "Refit must be referenced",
@@ -21,7 +21,7 @@ internal static class DiagnosticDescriptors
 
     /// <summary>Diagnostic reported when a source-generation-only attribute is used on a method that cannot generate inline.</summary>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "RS2008", Justification = "Diagnostic IDs are stable and intentionally not tracked in an analyzer release-tracking file.")]
-    public static readonly DiagnosticDescriptor SourceGenOnlyAttributeRequiresInlineRequest =
+    internal static readonly DiagnosticDescriptor SourceGenOnlyAttributeRequiresInlineRequest =
         new(
             "RF007",
             "Attribute requires generated request building",

--- a/src/InterfaceStubGenerator.Shared/Emitter.Constraints.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.Constraints.cs
@@ -58,12 +58,7 @@ internal static partial class Emitter
         int indentationLevel) =>
         !HasConstraintKeywords(typeParameter, isOverrideOrExplicitImplementation)
             ? string.Empty
-            : Indent(indentationLevel)
-                + "where "
-                + typeParameter.TypeName
-                + " : "
-                + BuildConstraintList(typeParameter, isOverrideOrExplicitImplementation)
-                + "\n";
+            : $"{Indent(indentationLevel)}where {typeParameter.TypeName} : {BuildConstraintList(typeParameter, isOverrideOrExplicitImplementation)}\n";
 
     /// <summary>Determines whether a type parameter has constraints that should be emitted.</summary>
     /// <param name="typeParameter">The type parameter constraint to inspect.</param>

--- a/src/InterfaceStubGenerator.Shared/Emitter.Helpers.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.Helpers.cs
@@ -99,10 +99,10 @@ internal static partial class Emitter
         {
             ReturnTypeInfo.AsyncVoid => (true, "await (", ").ConfigureAwait(false)"),
             ReturnTypeInfo.AsyncResult => (true, "return await (", ").ConfigureAwait(false)"),
-            ReturnTypeInfo.AsyncEnumerable => (false, ReturnStatementPrefix, string.Empty),
-            ReturnTypeInfo.Observable => (false, ReturnStatementPrefix, string.Empty),
-            ReturnTypeInfo.RequestMessage => (false, ReturnStatementPrefix, string.Empty),
-            ReturnTypeInfo.Return => (false, ReturnStatementPrefix, string.Empty),
+            ReturnTypeInfo.AsyncEnumerable
+            or ReturnTypeInfo.Observable
+            or ReturnTypeInfo.RequestMessage
+            or ReturnTypeInfo.Return => (false, ReturnStatementPrefix, string.Empty),
             ReturnTypeInfo.SyncVoid => (false, string.Empty, string.Empty),
             _ => throw new ArgumentOutOfRangeException(
                 nameof(returnTypeInfo),
@@ -324,8 +324,8 @@ internal static partial class Emitter
 
         var containingType = methodModel.ContainingType;
         return containingType.StartsWith(GlobalPrefix, StringComparison.Ordinal)
-            ? containingType + "."
-            : GlobalPrefix + containingType + ".";
+            ? $"{containingType}."
+            : $"{GlobalPrefix}{containingType}.";
     }
 
     /// <summary>Builds the generated method parameter list.</summary>

--- a/src/InterfaceStubGenerator.Shared/Emitter.Inline.Content.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.Inline.Content.cs
@@ -89,17 +89,17 @@ internal static partial class Emitter
     {
         var settingsLocal = emission.SettingsLocal;
         var bodyIndent = Indent(MethodBodyIndentation);
-        var inner = bodyIndent + "    ";
+        var inner = $"{bodyIndent}    ";
         var fields = bodyParameter.FormFields!.Value.AsArray();
-        var bodyExpr = "@" + bodyParameter.Name;
+        var bodyExpr = $"@{bodyParameter.Name}";
         var entriesLocal = locals.New("______formEntries");
 
         // Nullable reference annotations are a C# 8 feature; older consumers get the unannotated types, which also match
         // the .NET Framework/netstandard FormUrlEncodedContent constructor signature. The generated code stays
         // compilable down to the C# 7.3 floor (explicit KeyValuePair construction, != null guards - no C# 9 syntax).
         var nullable = supportsNullable ? "?" : string.Empty;
-        var kvpType = "global::System.Collections.Generic.KeyValuePair<string" + nullable + ", string" + nullable + ">";
-        var site = new FormUnrollSite(bodyExpr, entriesLocal, inner, "new " + kvpType, locals);
+        var kvpType = $"global::System.Collections.Generic.KeyValuePair<string{nullable}, string{nullable}>";
+        var site = new FormUnrollSite(bodyExpr, entriesLocal, inner, $"new {kvpType}", locals);
 
         var adds = new PooledStringBuilder();
         foreach (var field in fields)
@@ -137,11 +137,11 @@ internal static partial class Emitter
     {
         var indent = site.Indentation;
         var valueLocal = site.Locals.New("______formValue");
-        var keyExpr = "global::Refit.GeneratedRequestRunner.BuildQueryKey("
-            + emission.SettingsLocal + ", "
-            + ToCSharpStringLiteral(field.PropertyName) + ", "
-            + ToNullableCSharpStringLiteral(field.ExplicitName) + ", "
-            + ToNullableCSharpStringLiteral(field.PrefixSegment) + ")";
+        var propertyNameLiteral = ToCSharpStringLiteral(field.PropertyName);
+        var explicitNameLiteral = ToNullableCSharpStringLiteral(field.ExplicitName);
+        var prefixSegmentLiteral = ToNullableCSharpStringLiteral(field.PrefixSegment);
+        var keyExpr =
+            $"global::Refit.GeneratedRequestRunner.BuildQueryKey({emission.SettingsLocal}, {propertyNameLiteral}, {explicitNameLiteral}, {prefixSegmentLiteral})";
 
         _ = sb.Append(indent).Append("var ").Append(valueLocal).Append(" = ").Append(site.BodyExpr).Append(".@").Append(field.PropertyName).AppendLine(";");
 
@@ -155,7 +155,7 @@ internal static partial class Emitter
         }
 
         // "!= null" (not the C# 9 "is not null" pattern) keeps the emitted null guard compilable down to C# 7.3.
-        var childIndent = indent + "    ";
+        var childIndent = $"{indent}    ";
         _ = sb.Append(indent).Append("if (").Append(valueLocal).AppendLine(" != null)")
             .Append(indent).AppendLine("{");
         AppendFormEntryAdd(sb, in site, childIndent, keyExpr, valueExpr);

--- a/src/InterfaceStubGenerator.Shared/Emitter.Inline.FormFields.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.Inline.FormFields.cs
@@ -63,8 +63,7 @@ internal static partial class Emitter
 
         // The getter lambda degrades to the consumer's language version: 'static' is C# 9 and the 'object?' cast
         // annotation is C# 8, so both are omitted below those versions to keep generation compilable at the C# 7.3 floor.
-        var getterOpen = ">(" + (supportsStaticLambdas ? "static " : string.Empty)
-            + "body => (" + (supportsNullable ? "object?" : "object") + ")body.@";
+        var getterOpen = $">({(supportsStaticLambdas ? "static " : string.Empty)}body => ({(supportsNullable ? "object?" : "object")})body.@";
 
         var elements = BuildFormFieldElements(fields, bodyType, elementIndent, getterOpen);
 

--- a/src/InterfaceStubGenerator.Shared/Emitter.Inline.Multipart.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.Inline.Multipart.cs
@@ -78,7 +78,7 @@ internal static partial class Emitter
         UniqueNameBuilder locals)
     {
         var bodyIndent = Indent(MethodBodyIndentation);
-        var valueExpression = "@" + parameter.Name;
+        var valueExpression = $"@{parameter.Name}";
 
         // A reference-typed enumerable adds one part per element; a null collection contributes no parts, matching the
         // reflection builder's skip of a null parameter value.
@@ -89,7 +89,7 @@ internal static partial class Emitter
                 .Append(bodyIndent).AppendLine("{")
                 .Append(bodyIndent).Append("    foreach (var ").Append(elementLocal).Append(" in ").Append(valueExpression).AppendLine(")")
                 .Append(bodyIndent).AppendLine("    {");
-            AppendMultipartAdd(sb, part, settingsLocal, contentLocal, elementLocal, bodyIndent + "        ");
+            AppendMultipartAdd(sb, part, settingsLocal, contentLocal, elementLocal, $"{bodyIndent}        ");
             _ = sb.Append(bodyIndent).AppendLine("    }")
                 .Append(bodyIndent).AppendLine("}");
             return;
@@ -100,7 +100,7 @@ internal static partial class Emitter
         {
             _ = sb.Append(bodyIndent).Append("if (").Append(valueExpression).AppendLine(" != null)")
                 .Append(bodyIndent).AppendLine("{");
-            AppendMultipartAdd(sb, part, settingsLocal, contentLocal, valueExpression, bodyIndent + "    ");
+            AppendMultipartAdd(sb, part, settingsLocal, contentLocal, valueExpression, $"{bodyIndent}    ");
             _ = sb.Append(bodyIndent).AppendLine("}");
             return;
         }

--- a/src/InterfaceStubGenerator.Shared/Emitter.Inline.ParameterInfo.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.Inline.ParameterInfo.cs
@@ -226,7 +226,7 @@ internal static partial class Emitter
                 foreach (var binding in bindings)
                 {
                     var bindingValue = BuildPathValueExpressionCore(
-                        "@" + parameter.Name + "." + binding.PropertyClrName,
+                        $"@{parameter.Name}.{binding.PropertyClrName}",
                         binding.PropertyType,
                         binding.ValueFormat,
                         binding.PropertyCanBeNull,

--- a/src/InterfaceStubGenerator.Shared/Emitter.Inline.Path.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.Inline.Path.cs
@@ -16,7 +16,7 @@ internal static partial class Emitter
     /// <c>ReadOnlySpan</c> overload accepts via the array-to-span conversion. The array element type is inferred from the
     /// tuple values rather than stated, so no nullable reference annotation is emitted into a pre-C# 8 consumer.</remarks>
     internal static string WrapPathReplacements(string tuples, bool supportsCollectionExpressions) =>
-        supportsCollectionExpressions ? ", [" + tuples + "]" : ", new[] { " + tuples + " }";
+        supportsCollectionExpressions ? $", [{tuples}]" : $", new[] {{ {tuples} }}";
 
     /// <summary>Determines whether any path parameter passes its value through pre-encoded.</summary>
     /// <param name="request">The parsed request model.</param>
@@ -124,7 +124,7 @@ internal static partial class Emitter
         var template = ToCSharpStringLiteral(request.Path);
         var settingsLocal = emission.SettingsLocal;
         var allowUnmatched = $"{settingsLocal}.AllowUnmatchedRouteParameters";
-        var valueExpression = "@" + pathParameter.Value.Name;
+        var valueExpression = $"@{pathParameter.Value.Name}";
         _ = parameterInfoNames.TryGetValue(pathParameter.Value.Name, out var providerField);
         const string runner = "global::Refit.GeneratedRequestRunner.BuildRequestPath";
 

--- a/src/InterfaceStubGenerator.Shared/Emitter.Inline.Query.Dictionary.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.Inline.Query.Dictionary.cs
@@ -30,9 +30,9 @@ internal static partial class Emitter
         var dictionary = query.Dictionary!;
         var bodyIndent = Indent(MethodBodyIndentation);
         var guarded = parameter.CanBeNull;
-        var indent = guarded ? bodyIndent + "    " : bodyIndent;
-        var entryLocal = emission.QueryValueLocal + "_entry";
-        var keyLocal = emission.QueryValueLocal + "_key";
+        var indent = guarded ? $"{bodyIndent}    " : bodyIndent;
+        var entryLocal = $"{emission.QueryValueLocal}_entry";
+        var keyLocal = $"{emission.QueryValueLocal}_key";
         var valueLocal = emission.QueryValueLocal + ValueLocalSuffix;
 
         if (guarded)
@@ -44,7 +44,7 @@ internal static partial class Emitter
         _ = sb.Append(indent).Append(ForeachVarKeyword).Append(entryLocal).Append(" in @").Append(parameter.Name).AppendLine(")")
             .Append(indent).AppendLine("{");
 
-        var entryIndent = indent + "    ";
+        var entryIndent = $"{indent}    ";
         _ = sb.Append(entryIndent).Append("var ").Append(valueLocal).Append(" = ").Append(entryLocal).AppendLine(".Value;");
 
         var valueIndent = entryIndent;
@@ -53,7 +53,7 @@ internal static partial class Emitter
             // The reflection builder skips an entry whose value is null before it ever formats the key.
             _ = sb.Append(entryIndent).Append("if (").Append(valueLocal).AppendLine(NotNullCheckSuffix)
                 .Append(entryIndent).AppendLine("{");
-            valueIndent = entryIndent + "    ";
+            valueIndent = $"{entryIndent}    ";
         }
 
         var entry = new DictionaryEntrySite(entryLocal, keyLocal, valueLocal, valueIndent);
@@ -93,7 +93,7 @@ internal static partial class Emitter
         var (entryLocal, keyLocal, valueLocal, indent) = entry;
         var keyTypeOf = $"typeof({dictionary.KeyTypeName})";
         var customKey = EmitFormatUrlParameter($"{entryLocal}.Key", keyTypeOf, keyTypeOf, emission);
-        var fastKey = BuildFastFormatExpression(entryLocal + ".Key", dictionary.KeyFormat, emission);
+        var fastKey = BuildFastFormatExpression($"{entryLocal}.Key", dictionary.KeyFormat, emission);
         var keyExpression = fastKey is null
             ? customKey
             : $"{emission.UseDefaultFormattingLocal} ? ({fastKey}) : {customKey}";
@@ -102,7 +102,7 @@ internal static partial class Emitter
             .Append(indent).Append("if (!string.IsNullOrWhiteSpace(").Append(keyLocal).AppendLine("))")
             .Append(indent).AppendLine("{");
 
-        var innerIndent = indent + "    ";
+        var innerIndent = $"{indent}    ";
         if (dictionary.ValueProperties is { } valueProperties)
         {
             AppendDictionaryValueFlatten(sb, parameter, query, providerField, emission, entry, valueProperties);
@@ -146,12 +146,12 @@ internal static partial class Emitter
     {
         var dictionary = query.Dictionary!;
         var (_, keyLocal, valueLocal, entryIndent) = entry;
-        var indent = entryIndent + "    ";
+        var indent = $"{entryIndent}    ";
 
         var parentKeyExpression = keyLocal;
         if (dictionary.PrefixSegment is { } prefix)
         {
-            var parentKeyLocal = keyLocal + "_prefixed";
+            var parentKeyLocal = $"{keyLocal}_prefixed";
             _ = sb.Append(indent).Append("var ").Append(parentKeyLocal).Append(" = ")
                 .Append(ToCSharpStringLiteral(prefix)).Append(" + ").Append(keyLocal).AppendLine(";");
             parentKeyExpression = parentKeyLocal;

--- a/src/InterfaceStubGenerator.Shared/Emitter.Inline.Query.Formatters.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.Inline.Query.Formatters.cs
@@ -40,7 +40,7 @@ internal static partial class Emitter
     {
         var memberIndent = Indent(MethodMemberIndentation);
         var bodyIndent = Indent(MethodBodyIndentation);
-        var caseIndent = bodyIndent + "    ";
+        var caseIndent = $"{bodyIndent}    ";
         var format = valueFormat.Format;
 
         _ = memberSb.AppendLine()

--- a/src/InterfaceStubGenerator.Shared/Emitter.Inline.Query.Object.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.Inline.Query.Object.cs
@@ -29,7 +29,7 @@ internal static partial class Emitter
     {
         var bodyIndent = Indent(MethodBodyIndentation);
         var guarded = parameter.CanBeNull;
-        var indent = guarded ? bodyIndent + "    " : bodyIndent;
+        var indent = guarded ? $"{bodyIndent}    " : bodyIndent;
 
         if (guarded)
         {
@@ -46,8 +46,8 @@ internal static partial class Emitter
         // A Nullable<T> query object holds its underlying struct behind .Value; the != null guard above is the HasValue
         // check, so the deref is always safe here. A reference-type object flattens directly off the parameter.
         var accessExpr = query.ValueFormat.IsNullableValueType
-            ? "@" + parameter.Name + NullableValueAccess
-            : "@" + parameter.Name;
+            ? $"@{parameter.Name}{NullableValueAccess}"
+            : $"@{parameter.Name}";
         var scope = new ObjectFlattenScope(accessExpr, null, query.NestingDelimiter, string.Empty, indent);
         AppendObjectPropertyList(sb, context, query.ObjectProperties!.Value, scope, emission);
 
@@ -74,11 +74,11 @@ internal static partial class Emitter
     {
         foreach (var property in properties)
         {
-            var valueLocal = emission.QueryValueLocal + scope.LocalSuffix + "_" + property.ClrName;
+            var valueLocal = $"{emission.QueryValueLocal}{scope.LocalSuffix}_{property.ClrName}";
             var keyExpression = scope.ParentKeyExpr is { } parentKey
                 ? BuildNestedKeyExpression(property, parentKey, scope.Delimiter, emission)
                 : BuildQueryObjectKeyExpression(property, emission);
-            var site = new QueryPropertySite(valueLocal, keyExpression, context.PreEncoded, scope.Indentation + "    ");
+            var site = new QueryPropertySite(valueLocal, keyExpression, context.PreEncoded, $"{scope.Indentation}    ");
 
             if (property.Nested is { } children)
             {
@@ -148,22 +148,22 @@ internal static partial class Emitter
         in InlineValueEmission emission)
     {
         var indent = site.Indentation;
-        var entryLocal = site.ValueLocal + "_entry";
+        var entryLocal = $"{site.ValueLocal}_entry";
         var entryValueLocal = site.ValueLocal + ValueLocalSuffix;
-        var entryKeyLocal = site.ValueLocal + "_entrykey";
+        var entryKeyLocal = $"{site.ValueLocal}_entrykey";
 
         var loopIndent = indent;
         if (property.CanBeNull)
         {
             _ = sb.Append(indent).Append("if (").Append(site.ValueLocal).AppendLine(NotNullCheckSuffix)
                 .Append(indent).AppendLine("{");
-            loopIndent = indent + "    ";
+            loopIndent = $"{indent}    ";
         }
 
         _ = sb.Append(loopIndent).Append(ForeachVarKeyword).Append(entryLocal).Append(" in ").Append(site.ValueLocal).AppendLine(")")
             .Append(loopIndent).AppendLine("{");
 
-        var entryIndent = loopIndent + "    ";
+        var entryIndent = $"{loopIndent}    ";
         _ = sb.Append(entryIndent).Append("var ").Append(entryValueLocal).Append(" = ").Append(entryLocal).AppendLine(".Value;");
 
         var valueIndent = entryIndent;
@@ -171,7 +171,7 @@ internal static partial class Emitter
         {
             _ = sb.Append(entryIndent).Append("if (").Append(entryValueLocal).AppendLine(NotNullCheckSuffix)
                 .Append(entryIndent).AppendLine("{");
-            valueIndent = entryIndent + "    ";
+            valueIndent = $"{entryIndent}    ";
         }
 
         var (entryKeyExpression, valueExpression) = BuildDictionaryEntryExpressions(entryLocal, entryValueLocal, dictionary, property, context, emission);
@@ -220,7 +220,7 @@ internal static partial class Emitter
     {
         var keyTypeOf = $"typeof({dictionary.KeyTypeName})";
         var customKey = EmitFormatUrlParameter($"{entryLocal}.Key", keyTypeOf, keyTypeOf, emission);
-        var fastKey = BuildFastFormatExpression(entryLocal + ".Key", dictionary.KeyFormat, emission);
+        var fastKey = BuildFastFormatExpression($"{entryLocal}.Key", dictionary.KeyFormat, emission);
         var entryKeyExpression = fastKey is null
             ? customKey
             : $"{emission.UseDefaultFormattingLocal} ? ({fastKey}) : {customKey}";
@@ -251,9 +251,9 @@ internal static partial class Emitter
         in InlineValueEmission emission)
     {
         var indent = scope.Indentation;
-        var innerIndent = indent + "    ";
-        var keyLocal = site.ValueLocal + "_key";
-        var childSuffix = scope.LocalSuffix + "_" + property.ClrName;
+        var innerIndent = $"{indent}    ";
+        var keyLocal = $"{site.ValueLocal}_key";
+        var childSuffix = $"{scope.LocalSuffix}_{property.ClrName}";
 
         _ = sb.Append(indent).AppendLine("{")
             .Append(innerIndent).Append("var ").Append(site.ValueLocal).Append(" = ").Append(scope.AccessExpr)
@@ -262,7 +262,9 @@ internal static partial class Emitter
 
         // A nullable value-type nested object holds its underlying struct behind .Value; a reference type flattens off
         // the value directly. The null check above still runs against the value itself.
-        var childAccess = property.NestedThroughValue ? site.ValueLocal + NullableValueAccess : site.ValueLocal;
+        var childAccess = property.NestedThroughValue
+            ? string.Concat(site.ValueLocal, NullableValueAccess)
+            : site.ValueLocal;
 
         if (!property.CanBeNull)
         {
@@ -281,14 +283,14 @@ internal static partial class Emitter
                 .Append(innerIndent).AppendLine("}")
                 .Append(innerIndent).AppendLine("else")
                 .Append(innerIndent).AppendLine("{");
-            AppendObjectPropertyList(sb, context, children, new(childAccess, keyLocal, scope.Delimiter, childSuffix, innerIndent + "    "), emission);
+            AppendObjectPropertyList(sb, context, children, new(childAccess, keyLocal, scope.Delimiter, childSuffix, $"{innerIndent}    "), emission);
             _ = sb.Append(innerIndent).AppendLine("}").Append(indent).AppendLine("}");
             return;
         }
 
         _ = sb.Append(innerIndent).Append("if (").Append(site.ValueLocal).AppendLine(NotNullCheckSuffix)
             .Append(innerIndent).AppendLine("{");
-        AppendObjectPropertyList(sb, context, children, new(childAccess, keyLocal, scope.Delimiter, childSuffix, innerIndent + "    "), emission);
+        AppendObjectPropertyList(sb, context, children, new(childAccess, keyLocal, scope.Delimiter, childSuffix, $"{innerIndent}    "), emission);
         _ = sb.Append(innerIndent).AppendLine("}").Append(indent).AppendLine("}");
     }
 
@@ -343,7 +345,7 @@ internal static partial class Emitter
         in InlineValueEmission emission)
     {
         var indent = site.Indentation;
-        var keyLocal = site.ValueLocal + "_key";
+        var keyLocal = $"{site.ValueLocal}_key";
         _ = sb.Append(indent).Append("var ").Append(keyLocal).Append(" = ").Append(site.KeyExpression).AppendLine(";");
 
         var bodySite = site with { KeyExpression = keyLocal };
@@ -362,14 +364,14 @@ internal static partial class Emitter
                 .Append(indent).AppendLine("}")
                 .Append(indent).AppendLine("else")
                 .Append(indent).AppendLine("{");
-            AppendCollectionPropertyBody(sb, context, property, collection, bodySite with { Indentation = indent + "    " }, emission);
+            AppendCollectionPropertyBody(sb, context, property, collection, bodySite with { Indentation = $"{indent}    " }, emission);
             _ = sb.Append(indent).AppendLine("}");
             return;
         }
 
         _ = sb.Append(indent).Append("if (").Append(site.ValueLocal).AppendLine(NotNullCheckSuffix)
             .Append(indent).AppendLine("{");
-        AppendCollectionPropertyBody(sb, context, property, collection, bodySite with { Indentation = indent + "    " }, emission);
+        AppendCollectionPropertyBody(sb, context, property, collection, bodySite with { Indentation = $"{indent}    " }, emission);
         _ = sb.Append(indent).AppendLine("}");
     }
 
@@ -391,9 +393,9 @@ internal static partial class Emitter
     {
         var indent = site.Indentation;
         var formatExpression = BuildCollectionFormatExpression(collection.CollectionFormatValue, context.ParameterCollectionFormat, emission);
-        var elementLocal = site.ValueLocal + "_e";
+        var elementLocal = $"{site.ValueLocal}_e";
         var elementExpression = BuildFastCollectionElementExpression(elementLocal, property.ValueFormat, collection, emission);
-        var innerIndent = indent + "    ";
+        var innerIndent = $"{indent}    ";
 
         _ = sb.Append(indent).Append("if (").Append(emission.UseDefaultFormattingLocal).AppendLine(")")
             .Append(indent).AppendLine("{")
@@ -477,7 +479,7 @@ internal static partial class Emitter
         {
             _ = sb.Append(indent).Append("if (").Append(site.ValueLocal).AppendLine(NotNullCheckSuffix)
                 .Append(indent).AppendLine("{");
-            AppendObjectQueryPropertyValue(sb, parameter, property, site with { Indentation = indent + "    " }, providerField, emission);
+            AppendObjectQueryPropertyValue(sb, parameter, property, site with { Indentation = $"{indent}    " }, providerField, emission);
             _ = sb.Append(indent).AppendLine("}");
             return;
         }
@@ -491,7 +493,7 @@ internal static partial class Emitter
             .Append(indent).AppendLine("else")
             .Append(indent).AppendLine("{");
 
-        AppendObjectQueryPropertyValue(sb, parameter, property, site with { Indentation = indent + "    " }, providerField, emission);
+        AppendObjectQueryPropertyValue(sb, parameter, property, site with { Indentation = $"{indent}    " }, providerField, emission);
 
         _ = sb.Append(indent).AppendLine("}");
     }
@@ -566,7 +568,7 @@ internal static partial class Emitter
         // The form-url-encoded formatter applies the property format; a null result omits the pair entirely, and only
         // the surviving string reaches the URL parameter formatter.
         var indent = site.Indentation;
-        var formattedLocal = site.ValueLocal + "_formatted";
+        var formattedLocal = $"{site.ValueLocal}_formatted";
         var formatLiteral = ToNullableCSharpStringLiteral(property.PropertyFormat);
         var formExpression =
             $"{emission.SettingsLocal}.FormUrlEncodedParameterFormatter.Format({site.ValueLocal}, {formatLiteral})";

--- a/src/InterfaceStubGenerator.Shared/Emitter.Inline.Query.Values.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.Inline.Query.Values.cs
@@ -68,7 +68,7 @@ internal static partial class Emitter
         }
 
         return BuildPathValueExpressionCore(
-            "@" + parameter.Name,
+            $"@{parameter.Name}",
             parameter.Type,
             parameter.ValueFormat,
             parameter.CanBeNull,

--- a/src/InterfaceStubGenerator.Shared/Emitter.Inline.Query.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.Inline.Query.cs
@@ -307,7 +307,7 @@ internal static partial class Emitter
         {
             _ = sb.Append(bodyIndent).Append(IfParameterPrefix).Append(parameter.Name).AppendLine(NotNullCheckSuffix)
                 .Append(bodyIndent).AppendLine("{");
-            AppendScalarAddCall(sb, parameter, query, providerField, bodyIndent + "    ", emission);
+            AppendScalarAddCall(sb, parameter, query, providerField, $"{bodyIndent}    ", emission);
             _ = sb.Append(bodyIndent).AppendLine("}");
             return;
         }
@@ -335,7 +335,7 @@ internal static partial class Emitter
         if (query.Shape == QueryParameterShape.Flag)
         {
             // Scalar values are guarded by the outer null check, so the value is never null when formatted.
-            var flagValue = BuildFormattedValueExpression("@" + parameter.Name, false, parameter.Type, query, providerField, emission);
+            var flagValue = BuildFormattedValueExpression($"@{parameter.Name}", false, parameter.Type, query, providerField, emission);
             _ = sb.Append(indent).Append(emission.QueryBuilderLocal).Append(".AddFlag(").Append(flagValue).Append(", ")
                 .Append(preEncoded).AppendLine(");");
             return;
@@ -352,10 +352,10 @@ internal static partial class Emitter
             // A nullable value type writes the unwrapped .Value (span-formattable) on the fast path - the outer null
             // guard already ran - while the customized-formatter branch keeps the original value and declared type so
             // it matches the reflection builder's UrlParameterFormatter.Format call exactly.
-            var accessor = "@" + parameter.Name;
+            var accessor = $"@{parameter.Name}";
             var fastAccessor = query.ValueFormat.IsNullableValueType ? accessor + NullableValueAccess : accessor;
             var customExpression = BuildUrlFormatterCall(accessor, parameter.Type, providerField, emission);
-            var innerIndent = indent + "    ";
+            var innerIndent = $"{indent}    ";
             _ = sb.Append(indent).Append("if (").Append(emission.UseDefaultFormattingLocal).AppendLine(")")
                 .Append(indent).AppendLine("{")
                 .Append(innerIndent).Append(emission.QueryBuilderLocal).Append(".AddFormattedPreEscapedKey(").Append(key).Append(", ")
@@ -369,7 +369,7 @@ internal static partial class Emitter
             return;
         }
 
-        var valueExpression = BuildFormattedValueExpression("@" + parameter.Name, false, parameter.Type, query, providerField, emission);
+        var valueExpression = BuildFormattedValueExpression($"@{parameter.Name}", false, parameter.Type, query, providerField, emission);
         _ = sb.Append(indent).Append(emission.QueryBuilderLocal).Append(".AddPreEscapedKey(").Append(key).Append(", ").Append(valueExpression)
             .Append(", ").Append(preEncoded).AppendLine(");");
     }
@@ -405,7 +405,7 @@ internal static partial class Emitter
         // AddCollectionValueFormatted renders with the default format only.
         var fast = !isFlag && IsCollectionSpanFormattableFast(query);
         var guarded = parameter.CanBeNull;
-        var loopIndent = guarded ? bodyIndent + "    " : bodyIndent;
+        var loopIndent = guarded ? $"{bodyIndent}    " : bodyIndent;
 
         if (guarded)
         {
@@ -420,7 +420,7 @@ internal static partial class Emitter
 
         _ = sb.Append(loopIndent).Append(ForeachVarKeyword).Append(emission.QueryValueLocal).Append(" in @").Append(parameter.Name).AppendLine(")")
             .Append(loopIndent).AppendLine("{");
-        var itemIndent = loopIndent + "    ";
+        var itemIndent = $"{loopIndent}    ";
         if (fast)
         {
             AppendFastCollectionElement(sb, parameter, providerField, emission, itemIndent);
@@ -502,7 +502,7 @@ internal static partial class Emitter
         string itemIndent)
     {
         var customExpression = BuildUrlFormatterCall(emission.QueryValueLocal, parameter.Type, providerField, emission);
-        var innerIndent = itemIndent + "    ";
+        var innerIndent = $"{itemIndent}    ";
         _ = sb.Append(itemIndent).Append("if (").Append(emission.UseDefaultFormattingLocal).AppendLine(")")
             .Append(itemIndent).AppendLine("{")
             .Append(innerIndent).Append(emission.QueryBuilderLocal).Append(".AddCollectionValueFormatted(").Append(emission.QueryValueLocal).AppendLine(");")
@@ -527,7 +527,7 @@ internal static partial class Emitter
         var converter = query.Converter!;
         var bodyIndent = Indent(MethodBodyIndentation);
         var guarded = parameter.CanBeNull;
-        var indent = guarded ? bodyIndent + "    " : bodyIndent;
+        var indent = guarded ? $"{bodyIndent}    " : bodyIndent;
         var converterField = GetOrAddConverterField(converter.ConverterTypeName, emission);
 
         if (guarded)
@@ -620,12 +620,12 @@ internal static partial class Emitter
     internal sealed class EnumFormatterScope(UniqueNameBuilder uniqueNames)
     {
         /// <summary>Gets the emitted helper names keyed by enum type and compile-time format.</summary>
-        public Dictionary<(string TypeName, string? Format), string> Formatters { get; } = new();
+        internal Dictionary<(string TypeName, string? Format), string> Formatters { get; } = new();
 
         /// <summary>Gets the emitted cached converter field names keyed by converter type.</summary>
-        public Dictionary<string, string> Converters { get; } = new(StringComparer.Ordinal);
+        internal Dictionary<string, string> Converters { get; } = new(StringComparer.Ordinal);
 
         /// <summary>Gets the unique member name builder for the interface scope.</summary>
-        public UniqueNameBuilder UniqueNames { get; } = uniqueNames;
+        internal UniqueNameBuilder UniqueNames { get; } = uniqueNames;
     }
 }

--- a/src/InterfaceStubGenerator.Shared/Emitter.Inline.RequestProperties.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.Inline.RequestProperties.cs
@@ -94,7 +94,7 @@ internal static partial class Emitter
             if (parameter.Kind == RequestParameterKind.Property)
             {
                 var key = ToCSharpStringLiteral(parameter.PropertyKey);
-                AppendRequestProperty(sb, bodyIndent, requestLocal, parameter.Type, key, "@" + parameter.Name);
+                AppendRequestProperty(sb, bodyIndent, requestLocal, parameter.Type, key, $"@{parameter.Name}");
             }
         }
     }

--- a/src/InterfaceStubGenerator.Shared/Emitter.Inline.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.Inline.cs
@@ -291,7 +291,7 @@ internal static partial class Emitter
 
         _ = prologue.AppendLine(");");
         AppendInlineQueryStatements(prologue, request, parameterInfoNames, emission);
-        return emission.QueryBuilderLocal + ".Build()";
+        return $"{emission.QueryBuilderLocal}.Build()";
     }
 
     /// <summary>Assembles a cold-observable inline method: a per-subscription request factory and its send.</summary>
@@ -498,7 +498,7 @@ internal static partial class Emitter
                     {
                         // An [Authorize] parameter carries a "{scheme} " prefix; a plain [Header] has none.
                         var headerValueExpression = parameter.HeaderValuePrefix is { } valuePrefix
-                            ? ToCSharpStringLiteral(valuePrefix) + " + " + BuildHeaderValueExpression(parameter)
+                            ? $"{ToCSharpStringLiteral(valuePrefix)} + {BuildHeaderValueExpression(parameter)}"
                             : BuildHeaderValueExpression(parameter);
                         sb ??= new PooledStringBuilder();
                         var headerName = ToCSharpStringLiteral(parameter.HeaderName);

--- a/src/InterfaceStubGenerator.Shared/Emitter.ReflectionArguments.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.ReflectionArguments.cs
@@ -60,7 +60,7 @@ internal static partial class Emitter
         const string suffix = " }";
         if (parameters.Length == 0)
         {
-            return prefix + "}";
+            return $"{prefix}}}";
         }
 
         var length = prefix.Length + suffix.Length + ((parameters.Length - 1) * ListSeparatorLength);

--- a/src/InterfaceStubGenerator.Shared/Emitter.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.cs
@@ -67,7 +67,7 @@ internal static partial class Emitter
     /// <summary>Emits the shared preserve attribute and factory registration code.</summary>
     /// <param name="model">The context generation model describing the interfaces.</param>
     /// <param name="addSource">Callback used to add generated source files.</param>
-    public static void EmitSharedCode(
+    internal static void EmitSharedCode(
         ContextGenerationModel model,
         Action<string, SourceText> addSource)
     {
@@ -84,7 +84,7 @@ internal static partial class Emitter
     /// <summary>Emits the generated implementation source for a single interface.</summary>
     /// <param name="model">The interface model to emit.</param>
     /// <returns>The generated source text for the interface implementation.</returns>
-    public static SourceText EmitInterface(InterfaceModel model)
+    internal static SourceText EmitInterface(InterfaceModel model)
     {
         var uniqueNames = new UniqueNameBuilder();
         uniqueNames.Reserve(model.MemberNames);
@@ -196,11 +196,7 @@ internal static partial class Emitter
         // This generator assembly always carries a name and version, so no placeholder fallback is reachable.
         var assemblyName = typeof(Emitter).Assembly.GetName();
         return
-            "[global::System.CodeDom.Compiler.GeneratedCodeAttribute("
-            + ToCSharpStringLiteral(assemblyName.Name!)
-            + ", "
-            + ToCSharpStringLiteral(assemblyName.Version!.ToString())
-            + ")]";
+            $"[global::System.CodeDom.Compiler.GeneratedCodeAttribute({ToCSharpStringLiteral(assemblyName.Name!)}, {ToCSharpStringLiteral(assemblyName.Version!.ToString())})]";
     }
 
     /// <summary>Escapes text for generated XML documentation comments.</summary>
@@ -502,7 +498,7 @@ internal static partial class Emitter
         // quotes with a single concat instead of allocating a builder and appending each character.
         if (!NeedsCSharpEscaping(value))
         {
-            return "\"" + value + "\"";
+            return $"\"{value}\"";
         }
 
         var builder = new PooledStringBuilder(value.Length + StringLiteralQuoteLength);
@@ -567,7 +563,7 @@ internal static partial class Emitter
         var visibility = property.IsExplicitInterface ? string.Empty : "public ";
         var annotation = supportsNullable && property.Annotation ? "?" : string.Empty;
         var explicitInterface = property.IsExplicitInterface
-            ? EnsureGlobalPrefix(property.ContainingType) + "."
+            ? $"{EnsureGlobalPrefix(property.ContainingType)}."
             : string.Empty;
         var getter = property.HasGetter ? " get;" : string.Empty;
         var setter = property.HasSetter ? " set;" : string.Empty;

--- a/src/InterfaceStubGenerator.Shared/IImmutableEquatableArrayEnumerable.cs
+++ b/src/InterfaceStubGenerator.Shared/IImmutableEquatableArrayEnumerable.cs
@@ -1,0 +1,14 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Refit.Generator;
+
+/// <summary>Defines the allocation-free enumeration pattern used by immutable equatable arrays.</summary>
+/// <typeparam name="T">The element type.</typeparam>
+internal interface IImmutableEquatableArrayEnumerable<T>
+{
+    /// <summary>Returns a span enumerator for the underlying values.</summary>
+    /// <returns>An allocation-free span enumerator.</returns>
+    ReadOnlySpan<T>.Enumerator GetEnumerator();
+}

--- a/src/InterfaceStubGenerator.Shared/ITypeSymbolExtensions.cs
+++ b/src/InterfaceStubGenerator.Shared/ITypeSymbolExtensions.cs
@@ -16,7 +16,7 @@ internal static class ITypeSymbolExtensions
         /// <param name="baseType">The base type to look for.</param>
         /// <param name="includeInterfaces">True to also consider implemented interfaces.</param>
         /// <returns>True if the type inherits from or equals the base type.</returns>
-        public bool InheritsFromOrEquals(ITypeSymbol baseType, bool includeInterfaces)
+        internal bool InheritsFromOrEquals(ITypeSymbol baseType, bool includeInterfaces)
         {
             if (type.InheritsFromOrEquals(baseType))
             {
@@ -43,7 +43,7 @@ internal static class ITypeSymbolExtensions
         /// <summary>Determines whether the type inherits from or equals the base type, ignoring interfaces.</summary>
         /// <param name="baseType">The base type to look for.</param>
         /// <returns>True if the type inherits from or equals the base type.</returns>
-        public bool InheritsFromOrEquals(ITypeSymbol baseType)
+        internal bool InheritsFromOrEquals(ITypeSymbol baseType)
         {
             var current = type;
             while (current is not null)

--- a/src/InterfaceStubGenerator.Shared/ImmutableEquatableArray.Public.cs
+++ b/src/InterfaceStubGenerator.Shared/ImmutableEquatableArray.Public.cs
@@ -1,0 +1,74 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Collections;
+
+namespace Refit.Generator;
+
+/// <summary>Provides the public collection and equality contracts for an immutable equatable array.</summary>
+internal readonly partial struct ImmutableEquatableArray<T>
+    : IEquatable<ImmutableEquatableArray<T>>,
+        IReadOnlyList<T>,
+        IImmutableEquatableArrayEnumerable<T>
+    where T : IEquatable<T>
+{
+    /// <summary>Gets the number of elements in the array.</summary>
+    public int Count => _values?.Length ?? 0;
+
+    /// <summary>Gets the element at the specified index.</summary>
+    /// <param name="index">The zero-based index.</param>
+    /// <returns>The element at the given index.</returns>
+    public T this[int index] => _values![index];
+
+    /// <inheritdoc/>
+    public bool Equals(ImmutableEquatableArray<T> other)
+    {
+        var values = _values;
+        var otherValues = other._values;
+        var length = values?.Length ?? 0;
+        if (length != (otherValues?.Length ?? 0))
+        {
+            return false;
+        }
+
+        for (var i = 0; i < length; i++)
+        {
+            if (!values![i].Equals(otherValues![i]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <inheritdoc/>
+    public override bool Equals(object? obj) =>
+        obj is ImmutableEquatableArray<T> other && Equals(other);
+
+    /// <inheritdoc/>
+    public override int GetHashCode()
+    {
+        var values = _values;
+        var hash = 0;
+        if (values is not null)
+        {
+            for (var i = 0; i < values.Length; i++)
+            {
+                hash = Combine(hash, values[i].GetHashCode());
+            }
+        }
+
+        return hash;
+    }
+
+    /// <inheritdoc/>
+    public ReadOnlySpan<T>.Enumerator GetEnumerator() => new ReadOnlySpan<T>(_values ?? []).GetEnumerator();
+
+    /// <inheritdoc/>
+    IEnumerator<T> IEnumerable<T>.GetEnumerator() => ((IEnumerable<T>)(_values ?? [])).GetEnumerator();
+
+    /// <inheritdoc/>
+    IEnumerator IEnumerable.GetEnumerator() => (_values ?? []).GetEnumerator();
+}

--- a/src/InterfaceStubGenerator.Shared/ImmutableEquatableArray.cs
+++ b/src/InterfaceStubGenerator.Shared/ImmutableEquatableArray.cs
@@ -1,9 +1,6 @@
 // Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
 // ReactiveUI and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
-using System.Collections;
-using System.Diagnostics.CodeAnalysis;
-
 namespace Refit.Generator;
 
 /// <summary>Provides an immutable list implementation which implements sequence equality.</summary>
@@ -11,9 +8,7 @@ namespace Refit.Generator;
 /// <remarks>A <see langword="readonly struct"/> so the value sits inline in its owning model instead of adding a
 /// separate wrapper heap object per parsed collection. It still carries sequence value-equality (the incremental
 /// cache key) and an allocation-free struct enumerator; only the explicit <see cref="IEnumerable{T}"/> path boxes.</remarks>
-internal readonly struct ImmutableEquatableArray<T>
-    : IEquatable<ImmutableEquatableArray<T>>,
-        IReadOnlyList<T>
+internal readonly partial struct ImmutableEquatableArray<T>
     where T : IEquatable<T>
 {
     /// <summary>The backing array of values, or null for a defaulted value (treated as empty).</summary>
@@ -21,74 +16,14 @@ internal readonly struct ImmutableEquatableArray<T>
 
     /// <summary>Initializes a new instance of the <see cref="ImmutableEquatableArray{T}"/> struct.</summary>
     /// <param name="values">The array to wrap.</param>
-    public ImmutableEquatableArray(T[] values) => _values = values;
+    internal ImmutableEquatableArray(T[] values) => _values = values;
 
     /// <summary>Gets a shared empty array instance.</summary>
-    public static ImmutableEquatableArray<T> Empty => default;
-
-    /// <summary>Gets the number of elements in the array.</summary>
-    public int Count => _values?.Length ?? 0;
-
-    /// <summary>Gets the element at the specified index.</summary>
-    /// <param name="index">The zero-based index.</param>
-    /// <returns>The element at the given index.</returns>
-    public T this[int index] => _values![index];
+    internal static ImmutableEquatableArray<T> Empty => default;
 
     /// <summary>Returns the underlying array.</summary>
     /// <returns>The backing array of values.</returns>
-    public T[] AsArray() => _values ?? [];
-
-    /// <inheritdoc/>
-    public bool Equals(ImmutableEquatableArray<T> other)
-    {
-        var values = _values;
-        var otherValues = other._values;
-        var length = values?.Length ?? 0;
-        if (length != (otherValues?.Length ?? 0))
-        {
-            return false;
-        }
-
-        for (var i = 0; i < length; i++)
-        {
-            if (!values![i].Equals(otherValues![i]))
-            {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    /// <inheritdoc/>
-    public override bool Equals(object? obj) =>
-        obj is ImmutableEquatableArray<T> other && Equals(other);
-
-    /// <inheritdoc/>
-    public override int GetHashCode()
-    {
-        var values = _values;
-        var hash = 0;
-        if (values is not null)
-        {
-            for (var i = 0; i < values.Length; i++)
-            {
-                hash = Combine(hash, values[i].GetHashCode());
-            }
-        }
-
-        return hash;
-    }
-
-    /// <summary>Returns an allocation-free enumerator over the array.</summary>
-    /// <returns>An enumerator for the array.</returns>
-    public Enumerator GetEnumerator() => new(_values ?? []);
-
-    /// <inheritdoc/>
-    IEnumerator<T> IEnumerable<T>.GetEnumerator() => ((IEnumerable<T>)(_values ?? [])).GetEnumerator();
-
-    /// <inheritdoc/>
-    IEnumerator IEnumerable.GetEnumerator() => (_values ?? []).GetEnumerator();
+    internal T[] AsArray() => _values ?? [];
 
     /// <summary>Combines two hash codes into one.</summary>
     /// <param name="h1">The accumulated hash code.</param>
@@ -100,42 +35,5 @@ internal readonly struct ImmutableEquatableArray<T>
         // Related GitHub pull request: https://github.com/dotnet/coreclr/pull/1830
         var rol5 = ((uint)h1 << 5) | ((uint)h1 >> 27);
         return ((int)rol5 + h1) ^ h2;
-    }
-
-    /// <summary>A struct enumerator that iterates the backing array without allocation.</summary>
-    [SuppressMessage("Style", "SST1803:Type can be made readonly", Justification = "Mutable iterator state (_index); cannot be readonly.")]
-    public record struct Enumerator
-    {
-        /// <summary>The array being enumerated.</summary>
-        private readonly T[] _values;
-
-        /// <summary>The current zero-based position within the array.</summary>
-        private int _index;
-
-        /// <summary>Initializes a new instance of the <see cref="Enumerator"/> struct.</summary>
-        /// <param name="values">The array to enumerate.</param>
-        internal Enumerator(T[] values)
-        {
-            _values = values;
-            _index = -1;
-        }
-
-        /// <summary>Gets the element at the current position.</summary>
-        public readonly T Current => _values[_index];
-
-        /// <summary>Advances the enumerator to the next element.</summary>
-        /// <returns><see langword="true"/> if there is another element; otherwise <see langword="false"/>.</returns>
-        public bool MoveNext()
-        {
-            var newIndex = _index + 1;
-
-            if ((uint)newIndex >= (uint)_values.Length)
-            {
-                return false;
-            }
-
-            _index = newIndex;
-            return true;
-        }
     }
 }

--- a/src/InterfaceStubGenerator.Shared/ImmutableEquatableArrayExtensions.cs
+++ b/src/InterfaceStubGenerator.Shared/ImmutableEquatableArrayExtensions.cs
@@ -15,7 +15,7 @@ internal static class ImmutableEquatableArrayExtensions
     {
         /// <summary>Creates an immutable equatable array from a list.</summary>
         /// <returns>An immutable equatable array containing the list values.</returns>
-        public ImmutableEquatableArray<T> ToImmutableEquatableArray() =>
+        internal ImmutableEquatableArray<T> ToImmutableEquatableArray() =>
             values is null
                 ? ImmutableEquatableArrayFactory.Empty<T>()
                 : ImmutableEquatableArrayFactory.FromList(values);

--- a/src/InterfaceStubGenerator.Shared/ImmutableEquatableArrayFactory.cs
+++ b/src/InterfaceStubGenerator.Shared/ImmutableEquatableArrayFactory.cs
@@ -15,14 +15,14 @@ internal static class ImmutableEquatableArrayFactory
         "Design",
         "SST2307:Generic method type parameters should be inferable from the parameters",
         Justification = "Type parameter is intentionally specified explicitly by callers.")]
-    public static ImmutableEquatableArray<T> Empty<T>()
+    internal static ImmutableEquatableArray<T> Empty<T>()
         where T : IEquatable<T> => ImmutableEquatableArray<T>.Empty;
 
     /// <summary>Wraps an array without another copy.</summary>
     /// <param name="values">The values to wrap.</param>
     /// <typeparam name="T">The element type.</typeparam>
     /// <returns>An immutable equatable array over <paramref name="values"/>.</returns>
-    public static ImmutableEquatableArray<T> FromArray<T>(T[] values)
+    internal static ImmutableEquatableArray<T> FromArray<T>(T[] values)
         where T : IEquatable<T> =>
         values.Length == 0 ? Empty<T>() : new(values);
 
@@ -30,7 +30,7 @@ internal static class ImmutableEquatableArrayFactory
     /// <param name="values">The values to copy.</param>
     /// <typeparam name="T">The element type.</typeparam>
     /// <returns>An immutable equatable array containing <paramref name="values"/>.</returns>
-    public static ImmutableEquatableArray<T> FromList<T>(List<T> values)
+    internal static ImmutableEquatableArray<T> FromList<T>(List<T> values)
         where T : IEquatable<T>
     {
         if (values.Count == 0)

--- a/src/InterfaceStubGenerator.Shared/IncrementalValuesProviderExtensions.cs
+++ b/src/InterfaceStubGenerator.Shared/IncrementalValuesProviderExtensions.cs
@@ -15,7 +15,7 @@ internal static class IncrementalValuesProviderExtensions
     {
         /// <summary>Registers an output node into an <see cref="IncrementalGeneratorInitializationContext"/> to output diagnostics.</summary>
         /// <param name="diagnostics">The input <see cref="IncrementalValuesProvider{TValues}"/> sequence of diagnostics.</param>
-        public void ReportDiagnostics(
+        internal void ReportDiagnostics(
             in IncrementalValueProvider<ImmutableEquatableArray<Diagnostic>> diagnostics) =>
             context.RegisterSourceOutput(
                 diagnostics,
@@ -29,7 +29,7 @@ internal static class IncrementalValuesProviderExtensions
 
         /// <summary>Registers an implementation source output for the provided mappers.</summary>
         /// <param name="model">The interfaces stubs.</param>
-        public void EmitSource(
+        internal void EmitSource(
             in IncrementalValuesProvider<InterfaceModel> model) =>
             context.RegisterImplementationSourceOutput(
                 model,

--- a/src/InterfaceStubGenerator.Shared/InterfaceStubGeneratorV2.cs
+++ b/src/InterfaceStubGenerator.Shared/InterfaceStubGeneratorV2.cs
@@ -410,25 +410,25 @@ public class InterfaceStubGeneratorV2 : IIncrementalGenerator
     internal readonly record struct StandardHttpMethodCandidates
     {
         /// <summary>Gets the methods decorated with <c>DeleteAttribute</c>.</summary>
-        public ImmutableArray<MethodDeclarationSyntax> DeleteMethods { get; init; }
+        internal ImmutableArray<MethodDeclarationSyntax> DeleteMethods { get; init; }
 
         /// <summary>Gets the methods decorated with <c>GetAttribute</c>.</summary>
-        public ImmutableArray<MethodDeclarationSyntax> GetMethods { get; init; }
+        internal ImmutableArray<MethodDeclarationSyntax> GetMethods { get; init; }
 
         /// <summary>Gets the methods decorated with <c>HeadAttribute</c>.</summary>
-        public ImmutableArray<MethodDeclarationSyntax> HeadMethods { get; init; }
+        internal ImmutableArray<MethodDeclarationSyntax> HeadMethods { get; init; }
 
         /// <summary>Gets the methods decorated with <c>OptionsAttribute</c>.</summary>
-        public ImmutableArray<MethodDeclarationSyntax> OptionsMethods { get; init; }
+        internal ImmutableArray<MethodDeclarationSyntax> OptionsMethods { get; init; }
 
         /// <summary>Gets the methods decorated with <c>PatchAttribute</c>.</summary>
-        public ImmutableArray<MethodDeclarationSyntax> PatchMethods { get; init; }
+        internal ImmutableArray<MethodDeclarationSyntax> PatchMethods { get; init; }
 
         /// <summary>Gets the methods decorated with <c>PostAttribute</c>.</summary>
-        public ImmutableArray<MethodDeclarationSyntax> PostMethods { get; init; }
+        internal ImmutableArray<MethodDeclarationSyntax> PostMethods { get; init; }
 
         /// <summary>Gets the methods decorated with <c>PutAttribute</c>.</summary>
-        public ImmutableArray<MethodDeclarationSyntax> PutMethods { get; init; }
+        internal ImmutableArray<MethodDeclarationSyntax> PutMethods { get; init; }
     }
 
     /// <summary>The generator options visible through analyzer config.</summary>

--- a/src/InterfaceStubGenerator.Shared/Models/InlineValueFormatModel.cs
+++ b/src/InterfaceStubGenerator.Shared/Models/InlineValueFormatModel.cs
@@ -19,10 +19,10 @@ internal sealed record InlineValueFormatModel(
     /// <summary>Gets a value indicating whether the value is a non-nullable, unformatted integer whose
     /// <c>ISpanFormattable</c> output is inherently URL-safe (digits and <c>-</c>), so generated path code can format it
     /// straight into a stack buffer with no intermediate string and no escaping. Only set for net6+ consumers.</summary>
-    public bool IsUrlSafeSpanFormattable { get; init; }
+    internal bool IsUrlSafeSpanFormattable { get; init; }
 
     /// <summary>Gets a value indicating whether the value is a non-nullable <c>ISpanFormattable</c> that generated path
     /// code can format into a stack buffer and escape span-to-string without the intermediate formatted string. Only set
     /// for net10+ consumers, where <c>Uri.EscapeDataString(ReadOnlySpan&lt;char&gt;)</c> exists.</summary>
-    public bool IsSpanFormattableEscapable { get; init; }
+    internal bool IsSpanFormattableEscapable { get; init; }
 }

--- a/src/InterfaceStubGenerator.Shared/Models/RequestModel.cs
+++ b/src/InterfaceStubGenerator.Shared/Models/RequestModel.cs
@@ -29,7 +29,7 @@ internal readonly record struct RequestModel(
     ImmutableEquatableArray<RequestParameterModel> Parameters)
 {
     /// <summary>Gets an empty model used for non-Refit method placeholders.</summary>
-    public static RequestModel Empty { get; } = new(
+    internal static RequestModel Empty { get; } = new(
         string.Empty,
         string.Empty,
         string.Empty,
@@ -44,19 +44,19 @@ internal readonly record struct RequestModel(
     /// <summary>Gets a value indicating whether the method is a <c>[Multipart]</c> request whose form parts are
     /// constructed inline. When set, the generated method builds a <c>MultipartFormDataContent</c> as the request body
     /// instead of following the normal single-body path.</summary>
-    public bool IsMultipart { get; init; }
+    internal bool IsMultipart { get; init; }
 
     /// <summary>Gets the multipart boundary text, used only when <see cref="IsMultipart"/> is set. Mirrors the
     /// reflection builder's boundary selection: the <c>[Multipart(boundary)]</c> argument, or the attribute default.</summary>
-    public string MultipartBoundary { get; init; } = string.Empty;
+    internal string MultipartBoundary { get; init; } = string.Empty;
 
     /// <summary>Gets the <c>System.UriFormat</c> value from the method's <c>[QueryUriFormat]</c> attribute, or null when
     /// absent. When set, the built path and query are re-encoded with this mode, matching the reflection builder's final
     /// <c>Uri.GetComponents(PathAndQuery, QueryUriFormat)</c> pass.</summary>
-    public int? QueryUriFormat { get; init; }
+    internal int? QueryUriFormat { get; init; }
 
     /// <summary>Gets the per-call timeout in milliseconds from the method's <c>[Timeout]</c> attribute, or 0 when absent.
     /// The value is emitted into the generated send call and layered onto the request's effective cancellation token,
     /// mirroring the reflection builder's <c>RestMethodInfoInternal.TimeoutMilliseconds</c>.</summary>
-    public int TimeoutMilliseconds { get; init; }
+    internal int TimeoutMilliseconds { get; init; }
 }

--- a/src/InterfaceStubGenerator.Shared/Models/RequestParameterModel.cs
+++ b/src/InterfaceStubGenerator.Shared/Models/RequestParameterModel.cs
@@ -31,35 +31,35 @@ internal readonly record struct RequestParameterModel(
     /// Gets the reflection-free form field descriptors for a URL-encoded body, or <see langword="null"/> when the
     /// body type is not eligible and the reflection-based form path must be used.
     /// </summary>
-    public ImmutableEquatableArray<FormFieldModel>? FormFields { get; init; }
+    internal ImmutableEquatableArray<FormFieldModel>? FormFields { get; init; }
 
     /// <summary>
     /// Gets the query-binding metadata when this parameter feeds the query string — set for
     /// <see cref="RequestParameterKind.Query"/> parameters and for <see cref="RequestParameterKind.Property"/>
     /// parameters that also carry <c>[Query]</c>.
     /// </summary>
-    public QueryParameterModel? Query { get; init; }
+    internal QueryParameterModel? Query { get; init; }
 
     /// <summary>Gets the reflection-free rendering strategy for a path parameter value, or <see langword="null"/> for non-path parameters.</summary>
-    public InlineValueFormatModel? ValueFormat { get; init; }
+    internal InlineValueFormatModel? ValueFormat { get; init; }
 
     /// <summary>Gets a value indicating whether a path parameter value passes through verbatim because the parameter carries <c>[Encoded]</c>.</summary>
-    public bool PreEncoded { get; init; }
+    internal bool PreEncoded { get; init; }
 
     /// <summary>Gets the literal prefix prepended to a header value, or <see langword="null"/>. Set for an
     /// <c>[Authorize]</c> parameter, whose <c>Authorization</c> header value is <c>"{scheme} " + value</c>.</summary>
-    public string? HeaderValuePrefix { get; init; }
+    internal string? HeaderValuePrefix { get; init; }
 
     /// <summary>Gets a value indicating whether a path parameter binds a round-trip <c>{**param}</c> catch-all whose
     /// value is split on <c>/</c> with each segment formatted and escaped, preserving the separators.</summary>
-    public bool IsRoundTrip { get; init; }
+    internal bool IsRoundTrip { get; init; }
 
     /// <summary>Gets the dotted <c>{param.Prop}</c> path placeholder bindings for an object path parameter, or
     /// <see langword="null"/>. When set, the parameter contributes no direct path value; each binding fills its own
     /// placeholder with a formatted property value.</summary>
-    public ImmutableEquatableArray<PathObjectBindingModel>? PathObjectBindings { get; init; }
+    internal ImmutableEquatableArray<PathObjectBindingModel>? PathObjectBindings { get; init; }
 
     /// <summary>Gets the multipart part descriptor when this parameter contributes a <c>[Multipart]</c> form part —
     /// set for <see cref="RequestParameterKind.MultipartPart"/> parameters and <see langword="null"/> otherwise.</summary>
-    public MultipartPartModel? MultipartPart { get; init; }
+    internal MultipartPartModel? MultipartPart { get; init; }
 }

--- a/src/InterfaceStubGenerator.Shared/Models/WellKnownTypes.cs
+++ b/src/InterfaceStubGenerator.Shared/Models/WellKnownTypes.cs
@@ -30,7 +30,7 @@ public class WellKnownTypes(Compilation compilation)
                 return fullName;
             }
 
-            throw new InvalidOperationException("Could not get name of type " + candidate.Name);
+            throw new InvalidOperationException($"Could not get name of type {candidate.Name}");
         }
     }
 
@@ -54,5 +54,5 @@ public class WellKnownTypes(Compilation compilation)
     /// <param name="typeFullName">Full name of the type.</param>
     /// <returns>The resolved named type symbol.</returns>
     private INamedTypeSymbol Get(string typeFullName) =>
-        TryGet(typeFullName) ?? throw new InvalidOperationException("Could not get type " + typeFullName);
+        TryGet(typeFullName) ?? throw new InvalidOperationException($"Could not get type {typeFullName}");
 }

--- a/src/InterfaceStubGenerator.Shared/Parser.Aliases.cs
+++ b/src/InterfaceStubGenerator.Shared/Parser.Aliases.cs
@@ -131,9 +131,9 @@ internal static partial class Parser
     internal static string AliasedDisplay(ITypeSymbol type, in InterfaceGenerationContext context) =>
         type switch
         {
-            IArrayTypeSymbol array => AliasedDisplay(array.ElementType, context) + "[]",
+            IArrayTypeSymbol array => $"{AliasedDisplay(array.ElementType, context)}[]",
             INamedTypeSymbol { OriginalDefinition.SpecialType: SpecialType.System_Nullable_T } nullable =>
-                AliasedDisplay(nullable.TypeArguments[0], context) + "?",
+                $"{AliasedDisplay(nullable.TypeArguments[0], context)}?",
             INamedTypeSymbol named => AliasedNamedDisplay(named, context),
             _ => type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)
         };
@@ -150,7 +150,8 @@ internal static partial class Parser
             _ = context.ExternAliases.Add(alias);
         }
 
-        var name = (alias ?? "global") + "::" + named.ToDisplayString(AliasQualifiedNameFormat);
+        var effectiveAlias = alias ?? "global";
+        var name = $"{effectiveAlias}::{named.ToDisplayString(AliasQualifiedNameFormat)}";
         if (named.TypeArguments.IsEmpty)
         {
             return name;
@@ -162,6 +163,6 @@ internal static partial class Parser
             arguments[i] = AliasedDisplay(named.TypeArguments[i], context);
         }
 
-        return name + "<" + string.Join(", ", arguments) + ">";
+        return $"{name}<{string.Join(", ", arguments)}>";
     }
 }

--- a/src/InterfaceStubGenerator.Shared/Parser.GeneratedNaming.cs
+++ b/src/InterfaceStubGenerator.Shared/Parser.GeneratedNaming.cs
@@ -30,7 +30,7 @@ internal static partial class Parser
         var assemblyScope = SanitizeAssemblyScope(assemblyName);
         var rawNamespace = assemblyScope.Length == 0
             ? prefixedNamespace
-            : prefixedNamespace + "." + assemblyScope;
+            : $"{prefixedNamespace}.{assemblyScope}";
         var parts = rawNamespace.Split('.');
         var builder = new StringBuilder(rawNamespace.Length);
 
@@ -118,7 +118,7 @@ internal static partial class Parser
         var normalized = builder.ToString();
         return SyntaxFacts.GetKeywordKind(normalized) != SyntaxKind.None
             || SyntaxFacts.GetContextualKeywordKind(normalized) != SyntaxKind.None
-            ? "_" + normalized
+            ? $"_{normalized}"
             : normalized;
     }
 }

--- a/src/InterfaceStubGenerator.Shared/Parser.Helpers.cs
+++ b/src/InterfaceStubGenerator.Shared/Parser.Helpers.cs
@@ -65,7 +65,7 @@ internal static partial class Parser
     /// <param name="identifier">The simple identifier to escape.</param>
     /// <returns>The identifier, prefixed with <c>@</c> when it is a reserved keyword; otherwise the identifier itself.</returns>
     internal static string EscapeIdentifier(string identifier) =>
-        SyntaxFacts.GetKeywordKind(identifier) != SyntaxKind.None ? "@" + identifier : identifier;
+        SyntaxFacts.GetKeywordKind(identifier) != SyntaxKind.None ? $"@{identifier}" : identifier;
 
     /// <summary>Determines whether a method is decorated with a Refit HTTP method attribute.</summary>
     /// <param name="methodSymbol">The method symbol to inspect.</param>

--- a/src/InterfaceStubGenerator.Shared/Parser.Request.Helpers.cs
+++ b/src/InterfaceStubGenerator.Shared/Parser.Request.Helpers.cs
@@ -103,7 +103,7 @@ internal static partial class Parser
         var trimmedPath = path.TrimStart('/');
         return trimmedPath.Length == 0
             ? trimmedPrefix
-            : trimmedPrefix + "/" + trimmedPath;
+            : $"{trimmedPrefix}/{trimmedPath}";
     }
 
     /// <summary>Normalizes constant inline paths to match the reflection request builder URI cleanup.</summary>

--- a/src/InterfaceStubGenerator.Shared/Parser.Request.ParameterKinds.cs
+++ b/src/InterfaceStubGenerator.Shared/Parser.Request.ParameterKinds.cs
@@ -65,7 +65,7 @@ internal static partial class Parser
         // every integer width, decimal, float, double) through System_Double - so a range check covers them all
         // in one comparison. string and DateTime sit just outside that block.
         static bool IsScalarSpecialType(SpecialType specialType) =>
-            (specialType >= SpecialType.System_Boolean && specialType <= SpecialType.System_Double)
+            specialType is >= SpecialType.System_Boolean and <= SpecialType.System_Double
             || specialType == SpecialType.System_String
             || specialType == SpecialType.System_DateTime;
 
@@ -402,7 +402,7 @@ internal static partial class Parser
             string.Empty,
             BodyBufferMode.None)
         {
-            HeaderValuePrefix = scheme + " ",
+            HeaderValuePrefix = $"{scheme} ",
         };
 
     /// <summary>Builds an unsupported request parameter model.</summary>

--- a/src/InterfaceStubGenerator.Shared/Parser.Request.Path.cs
+++ b/src/InterfaceStubGenerator.Shared/Parser.Request.Path.cs
@@ -118,7 +118,7 @@ internal static partial class Parser
         string urlName,
         in LooseParameterContext context)
     {
-        var prefix = urlName + ".";
+        var prefix = $"{urlName}.";
         var bindings = new List<PathObjectBindingModel>();
         var occurrences = context.ParameterLocations.Occurrences;
         for (var index = 0; index < occurrences.Length; index++)

--- a/src/InterfaceStubGenerator.Shared/Parser.Request.PathParameterLocations.Public.cs
+++ b/src/InterfaceStubGenerator.Shared/Parser.Request.PathParameterLocations.Public.cs
@@ -1,0 +1,34 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Refit.Generator;
+
+/// <summary>Provides request parsing helpers for the Refit source generator.</summary>
+internal static partial class Parser
+{
+    /// <summary>Provides equality contracts for parsed path-parameter locations.</summary>
+    internal readonly partial struct PathParameterLocations
+    {
+        /// <summary>Determines whether two placeholder sets share the same backing occurrences.</summary>
+        /// <param name="left">The left value.</param>
+        /// <param name="right">The right value.</param>
+        /// <returns><see langword="true"/> when both wrap the same occurrence array.</returns>
+        public static bool operator ==(PathParameterLocations left, PathParameterLocations right) => left.Equals(right);
+
+        /// <summary>Determines whether two placeholder sets wrap different backing occurrences.</summary>
+        /// <param name="left">The left value.</param>
+        /// <param name="right">The right value.</param>
+        /// <returns><see langword="true"/> when the values differ.</returns>
+        public static bool operator !=(PathParameterLocations left, PathParameterLocations right) => !left.Equals(right);
+
+        /// <inheritdoc/>
+        public bool Equals(PathParameterLocations other) => ReferenceEquals(_occurrences, other._occurrences);
+
+        /// <inheritdoc/>
+        public override bool Equals(object? obj) => obj is PathParameterLocations other && Equals(other);
+
+        /// <inheritdoc/>
+        public override int GetHashCode() => _occurrences?.GetHashCode() ?? 0;
+    }
+}

--- a/src/InterfaceStubGenerator.Shared/Parser.Request.cs
+++ b/src/InterfaceStubGenerator.Shared/Parser.Request.cs
@@ -593,7 +593,7 @@ internal static partial class Parser
     /// <summary>The path parameter placeholders discovered in one method's URL template.</summary>
     /// <remarks>Backed by a single occurrence array (or none for the shared empty value); placeholder counts are tiny,
     /// so parameters are matched by a linear scan instead of a dictionary keyed by name.</remarks>
-    internal readonly struct PathParameterLocations : IEquatable<PathParameterLocations>
+    internal readonly partial struct PathParameterLocations : IEquatable<PathParameterLocations>
     {
         /// <summary>The length of the round-trip placeholder prefix (<c>**</c>).</summary>
         private const int RoundTripPrefixLength = 2;
@@ -605,7 +605,7 @@ internal static partial class Parser
         /// <param name="occurrences">The placeholder occurrences in template order.</param>
         /// <param name="hasRoundTrip">Whether any placeholder is a round-trip (<c>{**name}</c>) placeholder.</param>
         /// <param name="hasDotted">Whether any placeholder name binds a nested property (<c>{param.Prop}</c>).</param>
-        public PathParameterLocations(PathPlaceholderOccurrence[] occurrences, bool hasRoundTrip, bool hasDotted)
+        internal PathParameterLocations(PathPlaceholderOccurrence[] occurrences, bool hasRoundTrip, bool hasDotted)
         {
             _occurrences = occurrences;
             HasRoundTrip = hasRoundTrip;
@@ -613,34 +613,22 @@ internal static partial class Parser
         }
 
         /// <summary>Gets the shared empty value for paths that declare no placeholders.</summary>
-        public static PathParameterLocations Empty => default;
+        internal static PathParameterLocations Empty => default;
 
         /// <summary>Gets a value indicating whether any placeholder is a round-trip (<c>{**name}</c>) placeholder.</summary>
-        public bool HasRoundTrip { get; }
+        internal bool HasRoundTrip { get; }
 
         /// <summary>Gets a value indicating whether any placeholder binds a nested property (<c>{param.Prop}</c>).</summary>
-        public bool HasDotted { get; }
+        internal bool HasDotted { get; }
 
         /// <summary>Gets the placeholder occurrences in template order.</summary>
-        public ReadOnlySpan<PathPlaceholderOccurrence> Occurrences => _occurrences;
-
-        /// <summary>Determines whether two placeholder sets share the same backing occurrences.</summary>
-        /// <param name="left">The left value.</param>
-        /// <param name="right">The right value.</param>
-        /// <returns><see langword="true"/> when both wrap the same occurrence array.</returns>
-        public static bool operator ==(PathParameterLocations left, PathParameterLocations right) => left.Equals(right);
-
-        /// <summary>Determines whether two placeholder sets wrap different backing occurrences.</summary>
-        /// <param name="left">The left value.</param>
-        /// <param name="right">The right value.</param>
-        /// <returns><see langword="true"/> when the values differ.</returns>
-        public static bool operator !=(PathParameterLocations left, PathParameterLocations right) => !left.Equals(right);
+        internal ReadOnlySpan<PathPlaceholderOccurrence> Occurrences => _occurrences;
 
         /// <summary>Collects the ranges of the placeholder whose name matches a parameter's URL name.</summary>
         /// <param name="name">The parameter's URL name.</param>
         /// <param name="locations">Receives the matching placeholder ranges in template order.</param>
         /// <returns><see langword="true"/> when at least one placeholder matches.</returns>
-        public bool TryGetDirectLocations(string name, out ImmutableEquatableArray<Range> locations)
+        internal bool TryGetDirectLocations(string name, out ImmutableEquatableArray<Range> locations)
         {
             var occurrences = _occurrences;
             if (occurrences is not null)
@@ -669,7 +657,7 @@ internal static partial class Parser
         /// <param name="name">The parameter's URL name.</param>
         /// <param name="locations">Receives the matching placeholder ranges in template order.</param>
         /// <returns><see langword="true"/> when at least one round-trip placeholder matches.</returns>
-        public bool TryGetRoundTripLocations(string name, out ImmutableEquatableArray<Range> locations)
+        internal bool TryGetRoundTripLocations(string name, out ImmutableEquatableArray<Range> locations)
         {
             var occurrences = _occurrences;
             if (occurrences is not null)
@@ -693,15 +681,6 @@ internal static partial class Parser
             locations = ImmutableEquatableArray<Range>.Empty;
             return false;
         }
-
-        /// <inheritdoc/>
-        public bool Equals(PathParameterLocations other) => ReferenceEquals(_occurrences, other._occurrences);
-
-        /// <inheritdoc/>
-        public override bool Equals(object? obj) => obj is PathParameterLocations other && Equals(other);
-
-        /// <inheritdoc/>
-        public override int GetHashCode() => _occurrences?.GetHashCode() ?? 0;
 
         /// <summary>Determines whether a placeholder name is the round-trip form (<c>**name</c>) of a parameter name.</summary>
         /// <param name="placeholderName">The placeholder name.</param>
@@ -757,7 +736,7 @@ internal static partial class Parser
 
         /// <summary>Initializes a new instance of the <see cref="PathPlaceholderScanner"/> struct.</summary>
         /// <param name="path">The path template to scan.</param>
-        public PathPlaceholderScanner(ReadOnlySpan<char> path)
+        internal PathPlaceholderScanner(ReadOnlySpan<char> path)
         {
             _path = path;
             _i = path.IndexOf('{');
@@ -767,14 +746,14 @@ internal static partial class Parser
         }
 
         /// <summary>Gets the index of the current placeholder's opening brace.</summary>
-        public int Start { get; private set; }
+        internal int Start { get; private set; }
 
         /// <summary>Gets the index of the current placeholder's closing brace.</summary>
-        public int End { get; private set; }
+        internal int End { get; private set; }
 
         /// <summary>Advances to the next <c>}</c>-terminated placeholder.</summary>
         /// <returns><see langword="true"/> when a placeholder was found.</returns>
-        public bool MoveNext()
+        internal bool MoveNext()
         {
             // _i always points at a '{' that IndexOf located, so it is always in range; only _j can fall behind _i
             // (when no '}' or '/' follows the brace), which ends the scan.

--- a/src/InterfaceStubGenerator.Shared/Parser.cs
+++ b/src/InterfaceStubGenerator.Shared/Parser.cs
@@ -26,7 +26,7 @@ internal static partial class Parser
     /// <param name="candidateInterfaces">The candidate interfaces.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The collected diagnostics and the model used to generate the stubs.</returns>
-    public static (
+    internal static (
         List<Diagnostic> diagnostics,
         ContextGenerationModel contextGenerationSpec) GenerateInterfaceStubs(
         CSharpCompilation compilation,

--- a/src/InterfaceStubGenerator.Shared/PooledStringBuilder.Public.cs
+++ b/src/InterfaceStubGenerator.Shared/PooledStringBuilder.Public.cs
@@ -1,0 +1,21 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Refit.Generator;
+
+/// <summary>Provides the object contract for materializing pooled string-builder content.</summary>
+internal sealed partial class PooledStringBuilder
+{
+    /// <summary>Materializes the accumulated content into a string and returns the pooled buffer.</summary>
+    /// <returns>The accumulated string.</returns>
+    public override string ToString()
+    {
+        var result = _pos == 0 ? string.Empty : new string(_buffer, 0, _pos);
+        var toReturn = _buffer;
+        _buffer = [];
+        _pos = 0;
+        ReturnBuffer(toReturn);
+        return result;
+    }
+}

--- a/src/InterfaceStubGenerator.Shared/PooledStringBuilder.cs
+++ b/src/InterfaceStubGenerator.Shared/PooledStringBuilder.cs
@@ -9,7 +9,7 @@ namespace Refit.Generator;
 /// <remarks>The emitter builds many transient fragment strings. Backing accumulation with a pooled <c>char[]</c> lets the
 /// underlying buffer be reused across emissions instead of allocating fresh <see cref="System.Text.StringBuilder"/>
 /// chunks each time. The final <see cref="ToString"/> returns the buffer to the pool, so an instance is single-use.</remarks>
-internal sealed class PooledStringBuilder
+internal sealed partial class PooledStringBuilder
 {
     /// <summary>The default rented capacity, sized to hold a typical generated statement block without growing.</summary>
     private const int DefaultCapacity = 256;
@@ -42,19 +42,19 @@ internal sealed class PooledStringBuilder
     private int _pos;
 
     /// <summary>Initializes a new instance of the <see cref="PooledStringBuilder"/> class.</summary>
-    public PooledStringBuilder()
+    internal PooledStringBuilder()
         : this(DefaultCapacity)
     {
     }
 
     /// <summary>Initializes a new instance of the <see cref="PooledStringBuilder"/> class with an initial capacity.</summary>
     /// <param name="capacity">The initial buffer capacity to rent.</param>
-    public PooledStringBuilder(int capacity) => _buffer = RentBuffer(Math.Max(capacity, DefaultCapacity));
+    internal PooledStringBuilder(int capacity) => _buffer = RentBuffer(Math.Max(capacity, DefaultCapacity));
 
     /// <summary>Appends a string.</summary>
     /// <param name="value">The string to append, or null.</param>
     /// <returns>This builder, for chaining.</returns>
-    public PooledStringBuilder Append(string? value)
+    internal PooledStringBuilder Append(string? value)
     {
         if (string.IsNullOrEmpty(value))
         {
@@ -70,12 +70,12 @@ internal sealed class PooledStringBuilder
     /// <summary>Appends the invariant decimal rendering of a 32-bit integer.</summary>
     /// <param name="value">The value to append.</param>
     /// <returns>This builder, for chaining.</returns>
-    public PooledStringBuilder Append(int value) => Append(value.ToString(CultureInfo.InvariantCulture));
+    internal PooledStringBuilder Append(int value) => Append(value.ToString(CultureInfo.InvariantCulture));
 
     /// <summary>Appends a single character.</summary>
     /// <param name="value">The character to append.</param>
     /// <returns>This builder, for chaining.</returns>
-    public PooledStringBuilder Append(char value)
+    internal PooledStringBuilder Append(char value)
     {
         EnsureCapacity(_pos + 1);
         _buffer[_pos] = value;
@@ -88,7 +88,7 @@ internal sealed class PooledStringBuilder
     /// <returns>This builder, for chaining.</returns>
     /// <remarks>Copies buffer to buffer so a nested fragment builder's content joins this one without materializing an
     /// intermediate string. The source is drained (its buffer returned to the pool), matching <see cref="ToString"/>.</remarks>
-    public PooledStringBuilder Append(PooledStringBuilder other)
+    internal PooledStringBuilder Append(PooledStringBuilder other)
     {
         if (other._pos != 0)
         {
@@ -107,23 +107,11 @@ internal sealed class PooledStringBuilder
     /// <summary>Appends a string followed by a line terminator.</summary>
     /// <param name="value">The string to append, or null.</param>
     /// <returns>This builder, for chaining.</returns>
-    public PooledStringBuilder AppendLine(string? value) => Append(value).Append(NewLine);
+    internal PooledStringBuilder AppendLine(string? value) => Append(value).Append(NewLine);
 
     /// <summary>Appends a line terminator.</summary>
     /// <returns>This builder, for chaining.</returns>
-    public PooledStringBuilder AppendLine() => Append(NewLine);
-
-    /// <summary>Materializes the accumulated content into a string and returns the pooled buffer.</summary>
-    /// <returns>The accumulated string.</returns>
-    public override string ToString()
-    {
-        var result = _pos == 0 ? string.Empty : new string(_buffer, 0, _pos);
-        var toReturn = _buffer;
-        _buffer = [];
-        _pos = 0;
-        ReturnBuffer(toReturn);
-        return result;
-    }
+    internal PooledStringBuilder AppendLine() => Append(NewLine);
 
     /// <summary>Ensures the backing buffer can hold at least the requested number of characters.</summary>
     /// <param name="required">The required total capacity.</param>

--- a/src/InterfaceStubGenerator.Shared/RefitGeneratorStepName.cs
+++ b/src/InterfaceStubGenerator.Shared/RefitGeneratorStepName.cs
@@ -7,8 +7,8 @@ namespace Refit.Generator;
 internal static class RefitGeneratorStepName
 {
     /// <summary>The tracking name for the diagnostics reporting step.</summary>
-    public const string ReportDiagnostics = "ReportDiagnostics";
+    internal const string ReportDiagnostics = "ReportDiagnostics";
 
     /// <summary>The tracking name for the Refit stub building step.</summary>
-    public const string BuildRefit = "BuildRefit";
+    internal const string BuildRefit = "BuildRefit";
 }

--- a/src/Polyfills/ArgumentExceptionHelper.cs
+++ b/src/Polyfills/ArgumentExceptionHelper.cs
@@ -17,7 +17,7 @@ internal static class ArgumentExceptionHelper
     /// <summary>Throws an <see cref="ArgumentNullException"/> if <paramref name="argument"/> is <see langword="null"/>.</summary>
     /// <param name="argument">The reference type argument to validate as non-null.</param>
     /// <param name="paramName">The parameter name.</param>
-    public static void ThrowIfNull(
+    internal static void ThrowIfNull(
         [NotNull] object? argument,
         [CallerArgumentExpression(nameof(argument))] string? paramName = null)
     {

--- a/src/Polyfills/ArgumentOutOfRangeExceptionHelper.cs
+++ b/src/Polyfills/ArgumentOutOfRangeExceptionHelper.cs
@@ -14,7 +14,7 @@ internal static class ArgumentOutOfRangeExceptionHelper
     /// <summary>Throws when <paramref name="value"/> is negative.</summary>
     /// <param name="value">The value to validate.</param>
     /// <param name="paramName">The parameter name.</param>
-    public static void ThrowIfNegative(int value, [CallerArgumentExpression(nameof(value))] string? paramName = null)
+    internal static void ThrowIfNegative(int value, [CallerArgumentExpression(nameof(value))] string? paramName = null)
     {
         if (value >= 0)
         {
@@ -27,7 +27,7 @@ internal static class ArgumentOutOfRangeExceptionHelper
     /// <summary>Throws when <paramref name="value"/> is negative or zero.</summary>
     /// <param name="value">The value to validate.</param>
     /// <param name="paramName">The parameter name.</param>
-    public static void ThrowIfNegativeOrZero(int value, [CallerArgumentExpression(nameof(value))] string? paramName = null)
+    internal static void ThrowIfNegativeOrZero(int value, [CallerArgumentExpression(nameof(value))] string? paramName = null)
     {
         if (value > 0)
         {

--- a/src/Polyfills/CallerArgumentExpressionAttribute.cs
+++ b/src/Polyfills/CallerArgumentExpressionAttribute.cs
@@ -13,8 +13,16 @@ namespace System.Runtime.CompilerServices;
 [ExcludeFromCodeCoverage]
 [DebuggerNonUserCode]
 [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false, Inherited = false)]
-internal sealed class CallerArgumentExpressionAttribute(string parameterName) : Attribute
+internal sealed class CallerArgumentExpressionAttribute(string parameterName)
+    : Attribute, CallerArgumentExpressionAttribute.IMetadata
 {
+    /// <summary>Defines the compiler-required public metadata contract.</summary>
+    internal interface IMetadata
+    {
+        /// <summary>Gets the parameter whose source expression should be captured.</summary>
+        string ParameterName { get; }
+    }
+
     /// <summary>Gets the parameter whose source expression should be captured.</summary>
     public string ParameterName { get; } = parameterName;
 }

--- a/src/Polyfills/CollectionExtensions.cs
+++ b/src/Polyfills/CollectionExtensions.cs
@@ -33,7 +33,7 @@ internal static class CollectionExtensions
         /// As with the built-in overload, <paramref name="valueFactory"/> runs outside the lock and may
         /// run more than once under contention; the first value inserted wins.
         /// </remarks>
-        public TValue GetOrAdd<TArg>(TKey key, Func<TKey, TArg, TValue> valueFactory, TArg arg) =>
+        internal TValue GetOrAdd<TArg>(TKey key, Func<TKey, TArg, TValue> valueFactory, TArg arg) =>
             dictionary.TryGetValue(key, out var existing)
                 ? existing
                 : dictionary.GetOrAdd(key, valueFactory(key, arg));
@@ -50,7 +50,7 @@ internal static class CollectionExtensions
         /// <param name="key">The key to add.</param>
         /// <param name="value">The value to add.</param>
         /// <returns><see langword="true"/> if the pair was added; <see langword="false"/> if the key was already present.</returns>
-        public bool TryAdd(TKey key, TValue value)
+        internal bool TryAdd(TKey key, TValue value)
         {
             if (dictionary.ContainsKey(key))
             {

--- a/src/Polyfills/CompilerFeatureRequiredAttribute.cs
+++ b/src/Polyfills/CompilerFeatureRequiredAttribute.cs
@@ -9,10 +9,21 @@ namespace System.Runtime.CompilerServices;
 /// <param name="featureName">The name of the required compiler feature.</param>
 [Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 [AttributeUsage(AttributeTargets.All, AllowMultiple = true, Inherited = false)]
-internal sealed class CompilerFeatureRequiredAttribute(string featureName) : Attribute
+internal sealed class CompilerFeatureRequiredAttribute(string featureName)
+    : Attribute, CompilerFeatureRequiredAttribute.IMetadata
 {
     /// <summary>The <see cref="FeatureName"/> value used for the <c>required</c> members feature.</summary>
-    public const string RequiredMembers = nameof(RequiredMembers);
+    internal const string RequiredMembers = nameof(RequiredMembers);
+
+    /// <summary>Defines the compiler-required public metadata contract.</summary>
+    internal interface IMetadata
+    {
+        /// <summary>Gets the required compiler feature name.</summary>
+        string FeatureName { get; }
+
+        /// <summary>Gets whether an unaware compiler may safely ignore the feature.</summary>
+        bool IsOptional { get; init; }
+    }
 
     /// <summary>Gets the name of the required compiler feature.</summary>
     public string FeatureName { get; } = featureName;

--- a/src/Polyfills/DoesNotReturnIfAttribute.cs
+++ b/src/Polyfills/DoesNotReturnIfAttribute.cs
@@ -12,8 +12,16 @@ namespace System.Diagnostics.CodeAnalysis;
 [ExcludeFromCodeCoverage]
 [DebuggerNonUserCode]
 [AttributeUsage(AttributeTargets.Parameter)]
-internal sealed class DoesNotReturnIfAttribute(bool parameterValue) : Attribute
+internal sealed class DoesNotReturnIfAttribute(bool parameterValue)
+    : Attribute, DoesNotReturnIfAttribute.IMetadata
 {
+    /// <summary>Defines the analysis-required public metadata contract.</summary>
+    internal interface IMetadata
+    {
+        /// <summary>Gets the parameter value that prevents the method from returning.</summary>
+        bool ParameterValue { get; }
+    }
+
     /// <summary>Gets the parameter value that signals the method will not return.</summary>
     public bool ParameterValue { get; } = parameterValue;
 }

--- a/src/Polyfills/DynamicDependencyAttribute.cs
+++ b/src/Polyfills/DynamicDependencyAttribute.cs
@@ -8,7 +8,8 @@ namespace System.Diagnostics.CodeAnalysis;
 /// <summary>Polyfill of the DynamicDependency attribute for older target frameworks.</summary>
 [ExcludeFromCodeCoverage]
 [AttributeUsage(AttributeTargets.Constructor | AttributeTargets.Method, AllowMultiple = true)]
-internal sealed class DynamicDependencyAttribute : Attribute
+internal sealed class DynamicDependencyAttribute
+    : Attribute, DynamicDependencyAttribute.IMetadata
 {
     /// <summary>Initializes a new instance of the <see cref="DynamicDependencyAttribute"/> class.</summary>
     /// <param name="memberTypes">The member types to preserve.</param>
@@ -26,6 +27,19 @@ internal sealed class DynamicDependencyAttribute : Attribute
     {
         MemberSignature = memberSignature;
         Type = type;
+    }
+
+    /// <summary>Defines the trimming-required public metadata contract.</summary>
+    internal interface IMetadata
+    {
+        /// <summary>Gets the member categories that form the dependency.</summary>
+        DynamicallyAccessedMemberTypes MemberTypes { get; }
+
+        /// <summary>Gets the type that owns the dependency.</summary>
+        Type? Type { get; }
+
+        /// <summary>Gets the dependent member signature.</summary>
+        string? MemberSignature { get; }
     }
 
     /// <summary>Gets the member types that must be preserved.</summary>

--- a/src/Polyfills/DynamicallyAccessedMembersAttribute.cs
+++ b/src/Polyfills/DynamicallyAccessedMembersAttribute.cs
@@ -19,8 +19,16 @@ namespace System.Diagnostics.CodeAnalysis;
     AttributeTargets.Struct,
     Inherited = false)]
 [ExcludeFromCodeCoverage]
-internal sealed class DynamicallyAccessedMembersAttribute(DynamicallyAccessedMemberTypes memberTypes) : Attribute
+internal sealed class DynamicallyAccessedMembersAttribute(DynamicallyAccessedMemberTypes memberTypes)
+    : Attribute, DynamicallyAccessedMembersAttribute.IMetadata
 {
+    /// <summary>Defines the trimming-required public metadata contract.</summary>
+    internal interface IMetadata
+    {
+        /// <summary>Gets the dynamically accessed member categories.</summary>
+        DynamicallyAccessedMemberTypes MemberTypes { get; }
+    }
+
     /// <summary>Gets the member types that are dynamically accessed.</summary>
     public DynamicallyAccessedMemberTypes MemberTypes { get; } = memberTypes;
 }

--- a/src/Polyfills/HashCode.Public.cs
+++ b/src/Polyfills/HashCode.Public.cs
@@ -1,0 +1,14 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+#if NETFRAMEWORK
+namespace System;
+
+/// <summary>Provides the object hash-code contract for the .NET Framework polyfill.</summary>
+internal ref partial struct HashCode
+{
+    /// <inheritdoc/>
+    public override readonly int GetHashCode() => ToHashCode();
+}
+#endif

--- a/src/Polyfills/HashCode.cs
+++ b/src/Polyfills/HashCode.cs
@@ -15,7 +15,7 @@ namespace System;
 /// compared, so it needs no equality members.
 /// </remarks>
 [Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-internal ref struct HashCode
+internal ref partial struct HashCode
 {
     /// <summary>The second prime multiplier.</summary>
     private const int Prime2 = -2_048_144_777;
@@ -57,7 +57,7 @@ internal ref struct HashCode
     /// <typeparam name="T1">The first value type.</typeparam>
     /// <param name="value1">The first value.</param>
     /// <returns>The combined hash code.</returns>
-    public static int Combine<T1>(T1 value1)
+    internal static int Combine<T1>(T1 value1)
     {
         HashCode hashCode = default;
         hashCode.Add(value1);
@@ -70,7 +70,7 @@ internal ref struct HashCode
     /// <param name="value1">The first value.</param>
     /// <param name="value2">The second value.</param>
     /// <returns>The combined hash code.</returns>
-    public static int Combine<T1, T2>(T1 value1, T2 value2)
+    internal static int Combine<T1, T2>(T1 value1, T2 value2)
     {
         HashCode hashCode = default;
         hashCode.Add(value1);
@@ -86,7 +86,7 @@ internal ref struct HashCode
     /// <param name="value2">The second value.</param>
     /// <param name="value3">The third value.</param>
     /// <returns>The combined hash code.</returns>
-    public static int Combine<T1, T2, T3>(T1 value1, T2 value2, T3 value3)
+    internal static int Combine<T1, T2, T3>(T1 value1, T2 value2, T3 value3)
     {
         HashCode hashCode = default;
         hashCode.Add(value1);
@@ -105,7 +105,7 @@ internal ref struct HashCode
     /// <param name="value3">The third value.</param>
     /// <param name="value4">The fourth value.</param>
     /// <returns>The combined hash code.</returns>
-    public static int Combine<T1, T2, T3, T4>(T1 value1, T2 value2, T3 value3, T4 value4)
+    internal static int Combine<T1, T2, T3, T4>(T1 value1, T2 value2, T3 value3, T4 value4)
     {
         HashCode hashCode = default;
         hashCode.Add(value1);
@@ -118,13 +118,13 @@ internal ref struct HashCode
     /// <summary>Adds a value to the hash code.</summary>
     /// <typeparam name="T">The value type.</typeparam>
     /// <param name="value">The value.</param>
-    public void Add<T>(T value) => Add(value, EqualityComparer<T>.Default);
+    internal void Add<T>(T value) => Add(value, EqualityComparer<T>.Default);
 
     /// <summary>Adds a value to the hash code using the specified comparer.</summary>
     /// <typeparam name="T">The value type.</typeparam>
     /// <param name="value">The value.</param>
     /// <param name="comparer">The equality comparer.</param>
-    public void Add<T>(T value, IEqualityComparer<T>? comparer)
+    internal void Add<T>(T value, IEqualityComparer<T>? comparer)
     {
         var hashCode = value is null ? 0 : (comparer?.GetHashCode(value) ?? value.GetHashCode());
         Add(hashCode);
@@ -132,7 +132,7 @@ internal ref struct HashCode
 
     /// <summary>Returns the final hash code.</summary>
     /// <returns>The final hash code.</returns>
-    public readonly int ToHashCode()
+    internal readonly int ToHashCode()
     {
         var hash = _count == 0 ? Prime5 : _hash;
         hash += _count * BytesPerQueuedValue;
@@ -143,9 +143,6 @@ internal ref struct HashCode
         hash ^= (int)((uint)hash >> AvalancheShift3);
         return hash;
     }
-
-    /// <inheritdoc/>
-    public override readonly int GetHashCode() => ToHashCode();
 
     /// <summary>Mixes one queued value into the hash.</summary>
     /// <param name="hash">The current hash.</param>

--- a/src/Polyfills/Index.cs
+++ b/src/Polyfills/Index.cs
@@ -34,16 +34,16 @@ internal readonly struct Index : IEquatable<Index>
     }
 
     /// <summary>Gets an <see cref="Index"/> that points to the start of a sequence.</summary>
-    public static Index Start => new(0);
+    internal static Index Start => new(0);
 
     /// <summary>Gets an <see cref="Index"/> that points just past the end of a sequence.</summary>
-    public static Index End => new(0, true);
+    internal static Index End => new(0, true);
 
     /// <summary>Gets the index value.</summary>
-    public int Value { get; }
+    internal int Value { get; }
 
     /// <summary>Gets a value indicating whether the index is from the end of the sequence.</summary>
-    public bool IsFromEnd { get; }
+    internal bool IsFromEnd { get; }
 
     /// <summary>Implicitly converts an <see cref="int"/> to an <see cref="Index"/> from the start.</summary>
     /// <param name="value">The zero-based index from the start.</param>
@@ -55,21 +55,6 @@ internal readonly struct Index : IEquatable<Index>
     /// <inheritdoc/>
     public static bool operator !=(Index left, Index right) => !left.Equals(right);
 
-    /// <summary>Creates an <see cref="Index"/> from the start of a sequence.</summary>
-    /// <param name="value">The zero-based index from the start.</param>
-    /// <returns>The created <see cref="Index"/>.</returns>
-    public static Index FromStart(int value) => new(value);
-
-    /// <summary>Creates an <see cref="Index"/> from the end of a sequence.</summary>
-    /// <param name="value">The zero-based index from the end.</param>
-    /// <returns>The created <see cref="Index"/>.</returns>
-    public static Index FromEnd(int value) => new(value, true);
-
-    /// <summary>Calculates the zero-based offset for a sequence of the given length.</summary>
-    /// <param name="length">The sequence length.</param>
-    /// <returns>The zero-based offset from the start of the sequence.</returns>
-    public int GetOffset(int length) => IsFromEnd ? length - Value : Value;
-
     /// <inheritdoc/>
     public bool Equals(Index other) => Value == other.Value && IsFromEnd == other.IsFromEnd;
 
@@ -80,6 +65,21 @@ internal readonly struct Index : IEquatable<Index>
     public override int GetHashCode() => HashCode.Combine(Value, IsFromEnd);
 
     /// <inheritdoc/>
-    public override string ToString() => IsFromEnd ? "^" + Value.ToString() : Value.ToString();
+    public override string ToString() => IsFromEnd ? $"^{Value}" : Value.ToString();
+
+    /// <summary>Creates an <see cref="Index"/> from the start of a sequence.</summary>
+    /// <param name="value">The zero-based index from the start.</param>
+    /// <returns>The created <see cref="Index"/>.</returns>
+    internal static Index FromStart(int value) => new(value);
+
+    /// <summary>Creates an <see cref="Index"/> from the end of a sequence.</summary>
+    /// <param name="value">The zero-based index from the end.</param>
+    /// <returns>The created <see cref="Index"/>.</returns>
+    internal static Index FromEnd(int value) => new(value, true);
+
+    /// <summary>Calculates the zero-based offset for a sequence of the given length.</summary>
+    /// <param name="length">The sequence length.</param>
+    /// <returns>The zero-based offset from the start of the sequence.</returns>
+    internal int GetOffset(int length) => IsFromEnd ? length - Value : Value;
 }
 #endif

--- a/src/Polyfills/MaybeNullWhenAttribute.cs
+++ b/src/Polyfills/MaybeNullWhenAttribute.cs
@@ -12,8 +12,16 @@ namespace System.Diagnostics.CodeAnalysis;
 [ExcludeFromCodeCoverage]
 [DebuggerNonUserCode]
 [AttributeUsage(AttributeTargets.Parameter)]
-internal sealed class MaybeNullWhenAttribute(bool returnValue) : Attribute
+internal sealed class MaybeNullWhenAttribute(bool returnValue)
+    : Attribute, MaybeNullWhenAttribute.IMetadata
 {
+    /// <summary>Defines the nullable-analysis public metadata contract.</summary>
+    internal interface IMetadata
+    {
+        /// <summary>Gets the return value for which the parameter may be null.</summary>
+        bool ReturnValue { get; }
+    }
+
     /// <summary>Gets the return value condition under which the parameter may be null.</summary>
     public bool ReturnValue { get; } = returnValue;
 }

--- a/src/Polyfills/MemberNotNullWhenAttribute.cs
+++ b/src/Polyfills/MemberNotNullWhenAttribute.cs
@@ -13,8 +13,19 @@ namespace System.Diagnostics.CodeAnalysis;
 [ExcludeFromCodeCoverage]
 [DebuggerNonUserCode]
 [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, Inherited = false, AllowMultiple = true)]
-internal sealed class MemberNotNullWhenAttribute(bool returnValue, params string[] members) : Attribute
+internal sealed class MemberNotNullWhenAttribute(bool returnValue, params string[] members)
+    : Attribute, MemberNotNullWhenAttribute.IMetadata
 {
+    /// <summary>Defines the nullable-analysis public metadata contract.</summary>
+    internal interface IMetadata
+    {
+        /// <summary>Gets the return value for which the members are non-null.</summary>
+        bool ReturnValue { get; }
+
+        /// <summary>Gets the members that are non-null.</summary>
+        string[] Members { get; }
+    }
+
     /// <summary>Gets the return value condition under which the members are non-null.</summary>
     public bool ReturnValue { get; } = returnValue;
 

--- a/src/Polyfills/NotNullWhenAttribute.cs
+++ b/src/Polyfills/NotNullWhenAttribute.cs
@@ -12,8 +12,16 @@ namespace System.Diagnostics.CodeAnalysis;
 [ExcludeFromCodeCoverage]
 [DebuggerNonUserCode]
 [AttributeUsage(AttributeTargets.Parameter)]
-internal sealed class NotNullWhenAttribute(bool returnValue) : Attribute
+internal sealed class NotNullWhenAttribute(bool returnValue)
+    : Attribute, NotNullWhenAttribute.IMetadata
 {
+    /// <summary>Defines the nullable-analysis public metadata contract.</summary>
+    internal interface IMetadata
+    {
+        /// <summary>Gets the return value for which the parameter is not null.</summary>
+        bool ReturnValue { get; }
+    }
+
     /// <summary>Gets the return value for which the parameter is guaranteed not null.</summary>
     public bool ReturnValue { get; } = returnValue;
 }

--- a/src/Polyfills/OverloadResolutionPriorityAttribute.cs
+++ b/src/Polyfills/OverloadResolutionPriorityAttribute.cs
@@ -16,8 +16,16 @@ namespace System.Runtime.CompilerServices;
     AttributeTargets.Method | AttributeTargets.Constructor | AttributeTargets.Property,
     AllowMultiple = false,
     Inherited = false)]
-internal sealed class OverloadResolutionPriorityAttribute(int priority) : Attribute
+internal sealed class OverloadResolutionPriorityAttribute(int priority)
+    : Attribute, OverloadResolutionPriorityAttribute.IMetadata
 {
+    /// <summary>Defines the compiler-required public metadata contract.</summary>
+    internal interface IMetadata
+    {
+        /// <summary>Gets the relative overload-resolution priority.</summary>
+        int Priority { get; }
+    }
+
     /// <summary>Gets the priority of the annotated member.</summary>
     public int Priority { get; } = priority;
 }

--- a/src/Polyfills/Range.cs
+++ b/src/Polyfills/Range.cs
@@ -27,45 +27,19 @@ internal readonly struct Range : IEquatable<Range>
     }
 
     /// <summary>Gets a <see cref="Range"/> that represents the entire sequence.</summary>
-    public static Range All => new(Index.Start, Index.End);
+    internal static Range All => new(Index.Start, Index.End);
 
     /// <summary>Gets the inclusive start index.</summary>
-    public Index Start { get; }
+    internal Index Start { get; }
 
     /// <summary>Gets the exclusive end index.</summary>
-    public Index End { get; }
-
-    /// <summary>Creates a <see cref="Range"/> that starts at the specified index and ends at <see cref="Index.End"/>.</summary>
-    /// <param name="start">The inclusive start index.</param>
-    /// <returns>The created <see cref="Range"/>.</returns>
-    public static Range StartAt(Index start) => new(start, Index.End);
-
-    /// <summary>Creates a <see cref="Range"/> that starts at <see cref="Index.Start"/> and ends at the specified index.</summary>
-    /// <param name="end">The exclusive end index.</param>
-    /// <returns>The created <see cref="Range"/>.</returns>
-    public static Range EndAt(Index end) => new(Index.Start, end);
+    internal Index End { get; }
 
     /// <inheritdoc/>
     public static bool operator ==(Range left, Range right) => left.Equals(right);
 
     /// <inheritdoc/>
     public static bool operator !=(Range left, Range right) => !left.Equals(right);
-
-    /// <summary>Calculates the start offset and length for a sequence of the given length.</summary>
-    /// <param name="length">The sequence length.</param>
-    /// <returns>The offset and length represented by the range.</returns>
-    public (int Offset, int Length) GetOffsetAndLength(int length)
-    {
-        var start = Start.GetOffset(length);
-        var end = End.GetOffset(length);
-
-        if ((uint)end > (uint)length || (uint)start > (uint)end)
-        {
-            throw new ArgumentOutOfRangeException(nameof(length));
-        }
-
-        return (start, end - start);
-    }
 
     /// <inheritdoc/>
     public bool Equals(Range other) => Start.Equals(other.Start) && End.Equals(other.End);
@@ -77,6 +51,32 @@ internal readonly struct Range : IEquatable<Range>
     public override int GetHashCode() => HashCode.Combine(Start, End);
 
     /// <inheritdoc/>
-    public override string ToString() => Start.ToString() + ".." + End.ToString();
+    public override string ToString() => $"{Start}..{End}";
+
+    /// <summary>Creates a <see cref="Range"/> that starts at the specified index and ends at <see cref="Index.End"/>.</summary>
+    /// <param name="start">The inclusive start index.</param>
+    /// <returns>The created <see cref="Range"/>.</returns>
+    internal static Range StartAt(Index start) => new(start, Index.End);
+
+    /// <summary>Creates a <see cref="Range"/> that starts at <see cref="Index.Start"/> and ends at the specified index.</summary>
+    /// <param name="end">The exclusive end index.</param>
+    /// <returns>The created <see cref="Range"/>.</returns>
+    internal static Range EndAt(Index end) => new(Index.Start, end);
+
+    /// <summary>Calculates the start offset and length for a sequence of the given length.</summary>
+    /// <param name="length">The sequence length.</param>
+    /// <returns>The offset and length represented by the range.</returns>
+    internal (int Offset, int Length) GetOffsetAndLength(int length)
+    {
+        var start = Start.GetOffset(length);
+        var end = End.GetOffset(length);
+
+        if ((uint)end > (uint)length || (uint)start > (uint)end)
+        {
+            throw new ArgumentOutOfRangeException(nameof(length));
+        }
+
+        return (start, end - start);
+    }
 }
 #endif

--- a/src/Polyfills/RequiresDynamicCodeAttribute.cs
+++ b/src/Polyfills/RequiresDynamicCodeAttribute.cs
@@ -9,8 +9,22 @@ namespace System.Diagnostics.CodeAnalysis;
 /// <param name="message">A message describing the dynamic code requirement.</param>
 [ExcludeFromCodeCoverage]
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Constructor | AttributeTargets.Method, Inherited = false)]
-internal sealed class RequiresDynamicCodeAttribute(string message) : Attribute
+internal sealed class RequiresDynamicCodeAttribute(string message)
+    : Attribute, RequiresDynamicCodeAttribute.IMetadata
 {
+    /// <summary>Defines the runtime-required public metadata contract.</summary>
+    internal interface IMetadata
+    {
+        /// <summary>Gets the dynamic-code requirement message.</summary>
+        string Message { get; }
+
+        /// <summary>Gets or sets whether static members are excluded.</summary>
+        bool ExcludeStatics { get; set; }
+
+        /// <summary>Gets or sets an optional information URL.</summary>
+        string? Url { get; set; }
+    }
+
     /// <summary>Gets the message describing the dynamic code requirement.</summary>
     public string Message { get; } = message;
 

--- a/src/Polyfills/RequiresUnreferencedCodeAttribute.cs
+++ b/src/Polyfills/RequiresUnreferencedCodeAttribute.cs
@@ -9,8 +9,19 @@ namespace System.Diagnostics.CodeAnalysis;
 /// <param name="message">The message describing why the code is required.</param>
 [ExcludeFromCodeCoverage]
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Constructor | AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Event, Inherited = false)]
-internal sealed class RequiresUnreferencedCodeAttribute(string message) : Attribute
+internal sealed class RequiresUnreferencedCodeAttribute(string message)
+    : Attribute, RequiresUnreferencedCodeAttribute.IMetadata
 {
+    /// <summary>Defines the trimming-required public metadata contract.</summary>
+    internal interface IMetadata
+    {
+        /// <summary>Gets the trimming requirement message.</summary>
+        string Message { get; }
+
+        /// <summary>Gets or sets an optional information URL.</summary>
+        string? Url { get; set; }
+    }
+
     /// <summary>Gets the message describing why the code is required.</summary>
     public string Message { get; } = message;
 

--- a/src/Polyfills/UnconditionalSuppressMessageAttribute.cs
+++ b/src/Polyfills/UnconditionalSuppressMessageAttribute.cs
@@ -13,8 +13,28 @@ namespace System.Diagnostics.CodeAnalysis;
     AllowMultiple = true,
     Inherited = false)]
 [ExcludeFromCodeCoverage]
-internal sealed class UnconditionalSuppressMessageAttribute(string category, string checkId) : Attribute
+internal sealed class UnconditionalSuppressMessageAttribute(string category, string checkId)
+    : Attribute, UnconditionalSuppressMessageAttribute.IMetadata
 {
+    /// <summary>Defines the analysis-required public metadata contract.</summary>
+    internal interface IMetadata
+    {
+        /// <summary>Gets the diagnostic category.</summary>
+        string Category { get; }
+
+        /// <summary>Gets the diagnostic identifier.</summary>
+        string CheckId { get; }
+
+        /// <summary>Gets or sets the suppression justification.</summary>
+        string? Justification { get; set; }
+
+        /// <summary>Gets or sets the diagnostic scope.</summary>
+        string? Scope { get; set; }
+
+        /// <summary>Gets or sets the suppression target.</summary>
+        string? Target { get; set; }
+    }
+
     /// <summary>Gets the category for the suppressed diagnostic.</summary>
     public string Category { get; } = category;
 

--- a/src/Refit.Analyzers.Roslyn48/Refit.Analyzers.Roslyn48.csproj
+++ b/src/Refit.Analyzers.Roslyn48/Refit.Analyzers.Roslyn48.csproj
@@ -31,6 +31,7 @@
     <Compile Include="..\InterfaceStubGenerator.Shared\Parser.Adapters.cs" LinkBase="InterfaceStubGenerator.Shared"/>
     <Compile Include="..\InterfaceStubGenerator.Shared\Parser.Aliases.cs" LinkBase="InterfaceStubGenerator.Shared"/>
     <Compile Include="..\InterfaceStubGenerator.Shared\Parser.Request.cs" LinkBase="InterfaceStubGenerator.Shared"/>
+    <Compile Include="..\InterfaceStubGenerator.Shared\Parser.Request.PathParameterLocations.Public.cs" LinkBase="InterfaceStubGenerator.Shared"/>
     <Compile Include="..\InterfaceStubGenerator.Shared\Parser.Request.Parameters.cs" LinkBase="InterfaceStubGenerator.Shared"/>
     <Compile Include="..\InterfaceStubGenerator.Shared\Parser.Request.ParameterKinds.cs" LinkBase="InterfaceStubGenerator.Shared"/>
     <Compile Include="..\InterfaceStubGenerator.Shared\Parser.Request.HttpMethod.cs" LinkBase="InterfaceStubGenerator.Shared"/>
@@ -43,6 +44,8 @@
     <Compile Include="..\InterfaceStubGenerator.Shared\Parser.InlineEligibility.cs" LinkBase="InterfaceStubGenerator.Shared"/>
     <Compile Include="..\InterfaceStubGenerator.Shared\DiagnosticDescriptors.cs" LinkBase="InterfaceStubGenerator.Shared"/>
     <Compile Include="..\InterfaceStubGenerator.Shared\ImmutableEquatableArray.cs" LinkBase="InterfaceStubGenerator.Shared"/>
+    <Compile Include="..\InterfaceStubGenerator.Shared\ImmutableEquatableArray.Public.cs" LinkBase="InterfaceStubGenerator.Shared"/>
+    <Compile Include="..\InterfaceStubGenerator.Shared\IImmutableEquatableArrayEnumerable.cs" LinkBase="InterfaceStubGenerator.Shared"/>
     <Compile Include="..\InterfaceStubGenerator.Shared\ImmutableEquatableArrayExtensions.cs" LinkBase="InterfaceStubGenerator.Shared"/>
     <Compile Include="..\InterfaceStubGenerator.Shared\ImmutableEquatableArrayFactory.cs" LinkBase="InterfaceStubGenerator.Shared"/>
     <Compile Include="..\InterfaceStubGenerator.Shared\ITypeSymbolExtensions.cs" LinkBase="InterfaceStubGenerator.Shared"/>

--- a/src/Refit.Analyzers.Roslyn50/Refit.Analyzers.Roslyn50.csproj
+++ b/src/Refit.Analyzers.Roslyn50/Refit.Analyzers.Roslyn50.csproj
@@ -31,6 +31,7 @@
     <Compile Include="..\InterfaceStubGenerator.Shared\Parser.Adapters.cs" LinkBase="InterfaceStubGenerator.Shared"/>
     <Compile Include="..\InterfaceStubGenerator.Shared\Parser.Aliases.cs" LinkBase="InterfaceStubGenerator.Shared"/>
     <Compile Include="..\InterfaceStubGenerator.Shared\Parser.Request.cs" LinkBase="InterfaceStubGenerator.Shared"/>
+    <Compile Include="..\InterfaceStubGenerator.Shared\Parser.Request.PathParameterLocations.Public.cs" LinkBase="InterfaceStubGenerator.Shared"/>
     <Compile Include="..\InterfaceStubGenerator.Shared\Parser.Request.Parameters.cs" LinkBase="InterfaceStubGenerator.Shared"/>
     <Compile Include="..\InterfaceStubGenerator.Shared\Parser.Request.ParameterKinds.cs" LinkBase="InterfaceStubGenerator.Shared"/>
     <Compile Include="..\InterfaceStubGenerator.Shared\Parser.Request.HttpMethod.cs" LinkBase="InterfaceStubGenerator.Shared"/>
@@ -43,6 +44,8 @@
     <Compile Include="..\InterfaceStubGenerator.Shared\Parser.InlineEligibility.cs" LinkBase="InterfaceStubGenerator.Shared"/>
     <Compile Include="..\InterfaceStubGenerator.Shared\DiagnosticDescriptors.cs" LinkBase="InterfaceStubGenerator.Shared"/>
     <Compile Include="..\InterfaceStubGenerator.Shared\ImmutableEquatableArray.cs" LinkBase="InterfaceStubGenerator.Shared"/>
+    <Compile Include="..\InterfaceStubGenerator.Shared\ImmutableEquatableArray.Public.cs" LinkBase="InterfaceStubGenerator.Shared"/>
+    <Compile Include="..\InterfaceStubGenerator.Shared\IImmutableEquatableArrayEnumerable.cs" LinkBase="InterfaceStubGenerator.Shared"/>
     <Compile Include="..\InterfaceStubGenerator.Shared\ImmutableEquatableArrayExtensions.cs" LinkBase="InterfaceStubGenerator.Shared"/>
     <Compile Include="..\InterfaceStubGenerator.Shared\ImmutableEquatableArrayFactory.cs" LinkBase="InterfaceStubGenerator.Shared"/>
     <Compile Include="..\InterfaceStubGenerator.Shared\ITypeSymbolExtensions.cs" LinkBase="InterfaceStubGenerator.Shared"/>

--- a/src/Refit.Analyzers.Shared/DiagnosticDescriptors.cs
+++ b/src/Refit.Analyzers.Shared/DiagnosticDescriptors.cs
@@ -10,7 +10,7 @@ internal static class DiagnosticDescriptors
 {
     /// <summary>Diagnostic for a Refit member missing a valid HTTP method attribute.</summary>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "RS2008", Justification = "Diagnostic IDs are stable and intentionally not tracked in an analyzer release-tracking file.")]
-    public static readonly DiagnosticDescriptor InvalidRefitMember =
+    internal static readonly DiagnosticDescriptor InvalidRefitMember =
         new(
             DiagnosticIds.InvalidRefitMember,
             "Refit types must have Refit HTTP method attributes",
@@ -21,7 +21,7 @@ internal static class DiagnosticDescriptors
 
     /// <summary>Diagnostic reported when a Refit route contains a backslash.</summary>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "RS2008", Justification = "Diagnostic IDs are stable and intentionally not tracked in an analyzer release-tracking file.")]
-    public static readonly DiagnosticDescriptor InvalidRouteBackslash =
+    internal static readonly DiagnosticDescriptor InvalidRouteBackslash =
         new(
             DiagnosticIds.InvalidRouteBackslash,
             "Refit routes should use forward slashes",
@@ -32,7 +32,7 @@ internal static class DiagnosticDescriptors
 
     /// <summary>Diagnostic reported when a Refit method has more than one cancellation token.</summary>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "RS2008", Justification = "Diagnostic IDs are stable and intentionally not tracked in an analyzer release-tracking file.")]
-    public static readonly DiagnosticDescriptor MultipleCancellationTokens =
+    internal static readonly DiagnosticDescriptor MultipleCancellationTokens =
         new(
             DiagnosticIds.MultipleCancellationTokens,
             "Refit methods can only have one CancellationToken parameter",
@@ -43,7 +43,7 @@ internal static class DiagnosticDescriptors
 
     /// <summary>Diagnostic reported when a header collection parameter uses an unsupported type.</summary>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "RS2008", Justification = "Diagnostic IDs are stable and intentionally not tracked in an analyzer release-tracking file.")]
-    public static readonly DiagnosticDescriptor InvalidHeaderCollectionParameter =
+    internal static readonly DiagnosticDescriptor InvalidHeaderCollectionParameter =
         new(
             DiagnosticIds.InvalidHeaderCollectionParameter,
             "HeaderCollection parameters must be IDictionary<string, string>",
@@ -54,20 +54,21 @@ internal static class DiagnosticDescriptors
 
     /// <summary>Diagnostic reported when a Refit method cannot use generated request building and falls back to reflection.</summary>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "RS2008", Justification = "Diagnostic IDs are stable and intentionally not tracked in an analyzer release-tracking file.")]
-    public static readonly DiagnosticDescriptor GeneratedRequestBuildingFallback =
+    internal static readonly DiagnosticDescriptor GeneratedRequestBuildingFallback =
         new(
             DiagnosticIds.GeneratedRequestBuildingFallback,
             "Refit method is not compatible with generated-only client registration",
-            "Method {0}.{1} uses request features the Refit source generator cannot build without reflection, so it falls back to the reflection request builder. "
-            + "It will throw at runtime when resolved through AddRefitGeneratedClient (generated-only) or under NativeAOT. "
-            + "Use RestService.For where reflection is acceptable, or change the method to use only features supported by generated request building.",
+            string.Concat(
+                "Method {0}.{1} uses request features the Refit source generator cannot build without reflection, so it falls back to the reflection request builder. ",
+                "It will throw at runtime when resolved through AddRefitGeneratedClient (generated-only) or under NativeAOT. ",
+                "Use RestService.For where reflection is acceptable, or change the method to use only features supported by generated request building."),
             Category,
             DiagnosticSeverity.Warning,
             true);
 
     /// <summary>Diagnostic reported when a Refit method declares more than one HeaderCollection parameter.</summary>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "RS2008", Justification = "Diagnostic IDs are stable and intentionally not tracked in an analyzer release-tracking file.")]
-    public static readonly DiagnosticDescriptor MultipleHeaderCollections =
+    internal static readonly DiagnosticDescriptor MultipleHeaderCollections =
         new(
             DiagnosticIds.MultipleHeaderCollections,
             "Refit methods can only have one HeaderCollection parameter",
@@ -78,7 +79,7 @@ internal static class DiagnosticDescriptors
 
     /// <summary>Diagnostic reported when a Refit method declares more than one Authorize parameter.</summary>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "RS2008", Justification = "Diagnostic IDs are stable and intentionally not tracked in an analyzer release-tracking file.")]
-    public static readonly DiagnosticDescriptor MultipleAuthorizeParameters =
+    internal static readonly DiagnosticDescriptor MultipleAuthorizeParameters =
         new(
             DiagnosticIds.MultipleAuthorizeParameters,
             "Refit methods can only have one Authorize parameter",
@@ -89,7 +90,7 @@ internal static class DiagnosticDescriptors
 
     /// <summary>Diagnostic reported when a Refit method declares more than one Body parameter.</summary>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "RS2008", Justification = "Diagnostic IDs are stable and intentionally not tracked in an analyzer release-tracking file.")]
-    public static readonly DiagnosticDescriptor MultipleBodyParameters =
+    internal static readonly DiagnosticDescriptor MultipleBodyParameters =
         new(
             DiagnosticIds.MultipleBodyParameters,
             "Refit methods can only have one Body parameter",
@@ -100,7 +101,7 @@ internal static class DiagnosticDescriptors
 
     /// <summary>Diagnostic reported when a multipart Refit method also declares a Body parameter.</summary>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "RS2008", Justification = "Diagnostic IDs are stable and intentionally not tracked in an analyzer release-tracking file.")]
-    public static readonly DiagnosticDescriptor MultipartBodyParameter =
+    internal static readonly DiagnosticDescriptor MultipartBodyParameter =
         new(
             DiagnosticIds.MultipartBodyParameter,
             "Multipart Refit methods cannot declare a Body parameter",

--- a/src/Refit.Analyzers.Shared/DiagnosticIds.cs
+++ b/src/Refit.Analyzers.Shared/DiagnosticIds.cs
@@ -7,29 +7,29 @@ namespace Refit.Analyzers;
 internal static class DiagnosticIds
 {
     /// <summary>Diagnostic for a Refit member missing a valid HTTP method attribute.</summary>
-    public const string InvalidRefitMember = "RF001";
+    internal const string InvalidRefitMember = "RF001";
 
     /// <summary>Diagnostic reported when a Refit route contains a backslash.</summary>
-    public const string InvalidRouteBackslash = "RF003";
+    internal const string InvalidRouteBackslash = "RF003";
 
     /// <summary>Diagnostic reported when a Refit method has more than one cancellation token.</summary>
-    public const string MultipleCancellationTokens = "RF004";
+    internal const string MultipleCancellationTokens = "RF004";
 
     /// <summary>Diagnostic reported when a header collection parameter uses an unsupported type.</summary>
-    public const string InvalidHeaderCollectionParameter = "RF005";
+    internal const string InvalidHeaderCollectionParameter = "RF005";
 
     /// <summary>Diagnostic reported when a Refit method falls back to the reflection request builder and is not compatible with generated-only registration.</summary>
-    public const string GeneratedRequestBuildingFallback = "RF006";
+    internal const string GeneratedRequestBuildingFallback = "RF006";
 
     /// <summary>Diagnostic reported when a Refit method declares more than one <c>[HeaderCollection]</c> parameter.</summary>
-    public const string MultipleHeaderCollections = "RF008";
+    internal const string MultipleHeaderCollections = "RF008";
 
     /// <summary>Diagnostic reported when a Refit method declares more than one <c>[Authorize]</c> parameter.</summary>
-    public const string MultipleAuthorizeParameters = "RF009";
+    internal const string MultipleAuthorizeParameters = "RF009";
 
     /// <summary>Diagnostic reported when a Refit method declares more than one <c>[Body]</c> parameter.</summary>
-    public const string MultipleBodyParameters = "RF011";
+    internal const string MultipleBodyParameters = "RF011";
 
     /// <summary>Diagnostic reported when a multipart Refit method also declares a <c>[Body]</c> parameter.</summary>
-    public const string MultipartBodyParameter = "RF012";
+    internal const string MultipartBodyParameter = "RF012";
 }

--- a/src/Refit.Analyzers.Shared/RefitInterfaceAnalyzer.cs
+++ b/src/Refit.Analyzers.Shared/RefitInterfaceAnalyzer.cs
@@ -126,7 +126,7 @@ public sealed class RefitInterfaceAnalyzer : DiagnosticAnalyzer
     /// <returns>The parsed option value.</returns>
     private static bool GetBooleanOption(AnalyzerConfigOptions options, string name, bool defaultValue)
     {
-        if (options.TryGetValue("build_property." + name, out var buildPropertyValue)
+        if (options.TryGetValue($"build_property.{name}", out var buildPropertyValue)
             && bool.TryParse(buildPropertyValue, out var buildPropertyParsed))
         {
             return buildPropertyParsed;

--- a/src/Refit.CodeFixes.Shared/RefitInterfaceCodeFixProvider.cs
+++ b/src/Refit.CodeFixes.Shared/RefitInterfaceCodeFixProvider.cs
@@ -2,7 +2,6 @@
 // ReactiveUI and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 using System.Collections.Immutable;
-using System.Composition;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -14,7 +13,6 @@ namespace Refit.CodeFixes;
 
 /// <summary>Provides safe code fixes for Refit interface analyzer diagnostics.</summary>
 [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(RefitInterfaceCodeFixProvider))]
-[Shared]
 public sealed class RefitInterfaceCodeFixProvider : CodeFixProvider
 {
     /// <summary>The title for the route slash code fix.</summary>

--- a/src/Refit.HttpClientFactory/HttpClientFactoryCore.cs
+++ b/src/Refit.HttpClientFactory/HttpClientFactoryCore.cs
@@ -128,7 +128,7 @@ internal static class HttpClientFactoryCore
 
         // add typed client using framework AddTypedClient
         return builder.AddTypedClient(static (client, serviceProvider) =>
-            RestService.For<T>(
+            RestService.For(
                 client,
                 serviceProvider.GetRequiredService<IRequestBuilder<T>>()));
     }
@@ -259,7 +259,7 @@ internal static class HttpClientFactoryCore
             {
                 var httpClientFactory = s.GetRequiredService<IHttpClientFactory>();
                 var httpClient = httpClientFactory.CreateClient(builder.Name);
-                return RestService.For<T>(
+                return RestService.For(
                     httpClient,
                     s.GetRequiredKeyedService<IRequestBuilder<T>>(serviceKey));
             });

--- a/src/Refit.NativeAotSmoke/NativeAotSmokeHandler.cs
+++ b/src/Refit.NativeAotSmoke/NativeAotSmokeHandler.cs
@@ -10,13 +10,13 @@ namespace Refit.NativeAotSmoke;
 internal sealed class NativeAotSmokeHandler : HttpMessageHandler
 {
     /// <summary>Gets a value indicating whether a POST body containing the expected payload was observed.</summary>
-    public bool SawPostBody { get; private set; }
+    internal bool SawPostBody { get; private set; }
 
     /// <summary>Gets a value indicating whether a URL-encoded form body was observed.</summary>
-    public bool SawFormBody { get; private set; }
+    internal bool SawFormBody { get; private set; }
 
     /// <summary>Gets a value indicating whether the generated query string matched the expected shape.</summary>
-    public bool SawExpectedQuery { get; private set; }
+    internal bool SawExpectedQuery { get; private set; }
 
     /// <inheritdoc/>
     protected override async Task<HttpResponseMessage> SendAsync(

--- a/src/Refit.NativeAotSmoke/SmokeApiFactory.cs
+++ b/src/Refit.NativeAotSmoke/SmokeApiFactory.cs
@@ -14,7 +14,7 @@ internal static class SmokeApiFactory
     /// <param name="client">The <see cref="HttpClient"/> the implementation will use.</param>
     /// <param name="jsonOptions">The source-generated JSON serializer options.</param>
     /// <returns>An AOT-safe implementation of <see cref="INativeAotApi"/>.</returns>
-    public static INativeAotApi Create(HttpClient client, JsonSerializerOptions jsonOptions) =>
+    internal static INativeAotApi Create(HttpClient client, JsonSerializerOptions jsonOptions) =>
         RestService.ForGenerated<INativeAotApi>(
             client,
             new RefitSettings(new SystemTextJsonContentSerializer(jsonOptions)));

--- a/src/Refit.Reflection/CloseGenericMethodKey.cs
+++ b/src/Refit.Reflection/CloseGenericMethodKey.cs
@@ -18,10 +18,10 @@ internal readonly struct CloseGenericMethodKey : IEquatable<CloseGenericMethodKe
     }
 
     /// <summary>Gets the open generic method definition.</summary>
-    public MethodInfo OpenMethodInfo { get; }
+    internal MethodInfo OpenMethodInfo { get; }
 
     /// <summary>Gets the type arguments used to close the method.</summary>
-    public Type[] Types { get; }
+    internal Type[] Types { get; }
 
     /// <summary>Determines whether this key equals another key by open method definition and type arguments.</summary>
     /// <param name="other">The key to compare against.</param>

--- a/src/Refit.Reflection/ParameterFragment.cs
+++ b/src/Refit.Reflection/ParameterFragment.cs
@@ -13,30 +13,30 @@ namespace Refit;
 internal readonly record struct ParameterFragment(string? Value, int ArgumentIndex, int PropertyIndex, bool IsOptional = false)
 {
     /// <summary>Gets a value indicating whether the fragment is a constant string.</summary>
-    public bool IsConstant => Value is not null;
+    internal bool IsConstant => Value is not null;
 
     /// <summary>Gets a value indicating whether the fragment is a dynamic route value.</summary>
-    public bool IsDynamicRoute => ArgumentIndex >= 0 && PropertyIndex < 0;
+    internal bool IsDynamicRoute => ArgumentIndex >= 0 && PropertyIndex < 0;
 
     /// <summary>Gets a value indicating whether the fragment is a property of a parameter object.</summary>
-    public bool IsObjectProperty => ArgumentIndex >= 0 && PropertyIndex >= 0;
+    internal bool IsObjectProperty => ArgumentIndex >= 0 && PropertyIndex >= 0;
 
     /// <summary>Creates a constant URL fragment.</summary>
     /// <param name="value">The constant string value.</param>
     /// <returns>A constant fragment.</returns>
-    public static ParameterFragment Constant(string value) => new(value, -1, -1);
+    internal static ParameterFragment Constant(string value) => new(value, -1, -1);
 
     /// <summary>Creates a dynamic route fragment bound to a parameter.</summary>
     /// <param name="index">The parameter index supplying the value.</param>
     /// <param name="isOptional">Whether the placeholder was declared optional with the <c>{name?}</c> syntax.</param>
     /// <returns>A dynamic route fragment.</returns>
-    public static ParameterFragment Dynamic(int index, bool isOptional = false) => new(null, index, -1, isOptional);
+    internal static ParameterFragment Dynamic(int index, bool isOptional = false) => new(null, index, -1, isOptional);
 
     /// <summary>Creates a dynamic fragment bound to a property of a parameter object.</summary>
     /// <param name="index">The parameter index supplying the object.</param>
     /// <param name="propertyIndex">The property index within the parameter object.</param>
     /// <param name="isOptional">Whether the placeholder was declared optional with the <c>{name?}</c> syntax.</param>
     /// <returns>A dynamic object property fragment.</returns>
-    public static ParameterFragment DynamicObject(int index, int propertyIndex, bool isOptional = false) =>
+    internal static ParameterFragment DynamicObject(int index, int propertyIndex, bool isOptional = false) =>
         new(null, index, propertyIndex, isOptional);
 }

--- a/src/Refit.Reflection/RequestBuilderImplementation.Execution.cs
+++ b/src/Refit.Reflection/RequestBuilderImplementation.Execution.cs
@@ -198,10 +198,11 @@ internal partial class RequestBuilderImplementation
         object[] paramList,
         [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
+        var builder = this;
         var methodCt = GetMethodCancellationToken(restMethod, paramList);
         var linked = CancellationTokenSource.CreateLinkedTokenSource(methodCt, cancellationToken);
 
-        await foreach (var item in StreamAsyncEnumerableRequestAsync<T>(client, restMethod, paramList, linked)
+        await foreach (var item in builder.StreamAsyncEnumerableRequestAsync<T>(client, restMethod, paramList, linked)
             .ConfigureAwait(false))
         {
             yield return item;

--- a/src/Refit.Reflection/RequestBuilderImplementation.Payload.cs
+++ b/src/Refit.Reflection/RequestBuilderImplementation.Payload.cs
@@ -356,9 +356,10 @@ internal partial class RequestBuilderImplementation
             e = ex;
         }
 
+        const string allowedTypes = "String, Stream, FileInfo, Byte array and anything that's JSON serializable";
+        var parameterType = itemValue.GetType().Name;
         throw new ArgumentException(
-            $"Unexpected parameter type in a Multipart request. Parameter {fileName} is of type {itemValue.GetType().Name}, "
-                + "whereas allowed types are String, Stream, FileInfo, Byte array and anything that's JSON serializable",
+            $"Unexpected parameter type in a Multipart request. Parameter {fileName} is of type {parameterType}, whereas allowed types are {allowedTypes}",
             nameof(itemValue),
             e);
     }

--- a/src/Refit.Reflection/RequestBuilderImplementation.QueryAndHeaders.cs
+++ b/src/Refit.Reflection/RequestBuilderImplementation.QueryAndHeaders.cs
@@ -222,7 +222,7 @@ internal partial class RequestBuilderImplementation
         {
             if (string.Equals(parsed[i].Key, key, StringComparison.InvariantCultureIgnoreCase))
             {
-                parsed[i] = new(parsed[i].Key, parsed[i].Value + "," + value);
+                parsed[i] = new(parsed[i].Key, $"{parsed[i].Value},{value}");
                 return;
             }
         }

--- a/src/Refit.Reflection/RequestBuilderImplementation.cs
+++ b/src/Refit.Reflection/RequestBuilderImplementation.cs
@@ -94,11 +94,11 @@ internal partial class RequestBuilderImplementation : IRequestBuilder
         _interfaceHttpMethods = dict;
     }
 
-    /// <summary>Gets the Refit interface type this builder targets.</summary>
-    public Type TargetType { get; }
-
     /// <inheritdoc/>
     public RefitSettings Settings => _settings;
+
+    /// <summary>Gets the Refit interface type this builder targets.</summary>
+    internal Type TargetType { get; }
 
     /// <inheritdoc/>
     [RequiresUnreferencedCode("Building request delegates from reflected method metadata requires generic method metadata to be available at runtime.")]
@@ -475,7 +475,8 @@ internal partial class RequestBuilderImplementation : IRequestBuilder
     internal Func<HttpClient, object[], object?> BuildAdapterFuncForMethodGeneric<T, TBody>(
         RestMethodInfoInternal restMethod)
     {
-        var taskFunc = BuildCancellableTaskFuncForMethod<T, TBody>(restMethod);
+        var builder = this;
+        var taskFunc = builder.BuildCancellableTaskFuncForMethod<T, TBody>(restMethod);
 
         // This runs only when HasReturnTypeAdapter already matched an adapter for this exact return type and adapter
         // set, so ResolveClosedAdapterType resolves the same match and never returns null here.
@@ -576,7 +577,8 @@ internal partial class RequestBuilderImplementation : IRequestBuilder
     internal Func<HttpClient, object[], IObservable<T?>> BuildRxFuncForMethod<T, TBody>(
         RestMethodInfoInternal restMethod)
     {
-        var taskFunc = BuildCancellableTaskFuncForMethod<T, TBody>(restMethod);
+        var builder = this;
+        var taskFunc = builder.BuildCancellableTaskFuncForMethod<T, TBody>(restMethod);
 
         return (client, paramList) =>
             new FromAsyncSignal<T?>(ct =>
@@ -612,8 +614,11 @@ internal partial class RequestBuilderImplementation : IRequestBuilder
         Justification = "The second type parameter is required so this factory matches the two-type-argument shape invoked reflectively by BuildResultFuncForMethod.")]
     [RequiresDynamicCode("Serializing a body by runtime Type requires runtime generic method instantiation.")]
     internal Func<HttpClient, object[], IAsyncEnumerable<T?>> BuildAsyncEnumerableFuncForMethod<T, TBody>(
-        RestMethodInfoInternal restMethod) =>
-        (client, paramList) => ExecuteAsyncEnumerableRequestAsync<T>(client, restMethod, paramList);
+        RestMethodInfoInternal restMethod)
+    {
+        var builder = this;
+        return (client, paramList) => builder.ExecuteAsyncEnumerableRequestAsync<T>(client, restMethod, paramList);
+    }
 
     /// <summary>Builds a task invocation delegate for a method.</summary>
     /// <typeparam name="T">The result type returned to the caller.</typeparam>
@@ -628,7 +633,8 @@ internal partial class RequestBuilderImplementation : IRequestBuilder
     internal Func<HttpClient, object[], Task<T?>> BuildTaskFuncForMethod<T, TBody>(
         RestMethodInfoInternal restMethod)
     {
-        var ret = BuildCancellableTaskFuncForMethod<T, TBody>(restMethod);
+        var builder = this;
+        var ret = builder.BuildCancellableTaskFuncForMethod<T, TBody>(restMethod);
 
         return (client, paramList) =>
             restMethod.CancellationToken is not null
@@ -649,7 +655,8 @@ internal partial class RequestBuilderImplementation : IRequestBuilder
     internal Func<HttpClient, object[], ValueTask<T?>> BuildValueTaskFuncForMethod<T, TBody>(
         RestMethodInfoInternal restMethod)
     {
-        var ret = BuildTaskFuncForMethod<T, TBody>(restMethod);
+        var builder = this;
+        var ret = builder.BuildTaskFuncForMethod<T, TBody>(restMethod);
 
         return (client, paramList) => new(ret(client, paramList));
     }

--- a/src/Refit.Reflection/RestMethodInfoInternal.PathPrefix.cs
+++ b/src/Refit.Reflection/RestMethodInfoInternal.PathPrefix.cs
@@ -29,6 +29,6 @@ internal partial class RestMethodInfoInternal
         var trimmedPath = path.TrimStart('/');
         return trimmedPath.Length == 0
             ? trimmedPrefix
-            : trimmedPrefix + "/" + trimmedPath;
+            : $"{trimmedPrefix}/{trimmedPath}";
     }
 }

--- a/src/Refit.Reflection/RestMethodInfoInternal.cs
+++ b/src/Refit.Reflection/RestMethodInfoInternal.cs
@@ -120,95 +120,95 @@ internal partial class RestMethodInfoInternal
     }
 
     /// <summary>Gets the interface type that declares the method.</summary>
-    public Type Type { get; }
+    internal Type Type { get; }
 
     /// <summary>Gets the reflected method information.</summary>
-    public MethodInfo MethodInfo { get; }
+    internal MethodInfo MethodInfo { get; }
 
     /// <summary>Gets the HTTP method used by the request.</summary>
-    public HttpMethod HttpMethod { get; }
+    internal HttpMethod HttpMethod { get; }
 
     /// <summary>Gets the relative URL path template for the method, including any client interface path prefix.</summary>
-    public string RelativePath { get; }
+    internal string RelativePath { get; }
 
     /// <summary>Gets the shared route prefix declared by the client interface's <see cref="PathPrefixAttribute"/>, or an empty string when none applies.</summary>
-    public string ClientPathPrefix { get; }
+    internal string ClientPathPrefix { get; }
 
     /// <summary>Gets a value indicating whether the request is a multipart request.</summary>
-    public bool IsMultipart { get; }
+    internal bool IsMultipart { get; }
 
     /// <summary>Gets the multipart boundary string used for multipart requests.</summary>
-    public string MultipartBoundary { get; }
+    internal string MultipartBoundary { get; }
 
     /// <summary>Gets the public metadata describing this REST method.</summary>
-    public RestMethodInfo RestMethodInfo { get; }
+    internal RestMethodInfo RestMethodInfo { get; }
 
     /// <summary>Gets the cancellation token parameter, or null when none is present.</summary>
-    public ParameterInfo? CancellationToken { get; }
+    internal ParameterInfo? CancellationToken { get; }
 
     /// <summary>Gets the URI escaping format used for query parameters.</summary>
-    public UriFormat QueryUriFormat { get; }
+    internal UriFormat QueryUriFormat { get; }
 
     /// <summary>Gets the per-call timeout in milliseconds from the method's <see cref="TimeoutAttribute"/>, or 0 when absent.</summary>
-    public int TimeoutMilliseconds { get; }
+    internal int TimeoutMilliseconds { get; }
 
     /// <summary>Gets the static headers associated with the method.</summary>
-    public Dictionary<string, string?> Headers { get; }
+    internal Dictionary<string, string?> Headers { get; }
 
     /// <summary>Gets the map of parameter indexes to header names.</summary>
-    public Dictionary<int, string> HeaderParameterMap { get; }
+    internal Dictionary<int, string> HeaderParameterMap { get; }
 
     /// <summary>Gets the map of parameter indexes to request property keys.</summary>
-    public Dictionary<int, string> PropertyParameterMap { get; }
+    internal Dictionary<int, string> PropertyParameterMap { get; }
 
     /// <summary>Gets the body parameter information, or null when there is no body parameter.</summary>
-    public Tuple<BodySerializationMethod, bool, int>? BodyParameterInfo { get; }
+    internal Tuple<BodySerializationMethod, bool, int>? BodyParameterInfo { get; }
 
     /// <summary>Gets the authorization parameter information, or null when there is no authorize parameter.</summary>
-    public Tuple<string, int>? AuthorizeParameterInfo { get; }
+    internal Tuple<string, int>? AuthorizeParameterInfo { get; }
 
     /// <summary>Gets the index of the <c>[Url]</c> parameter that supplies the absolute request URI, or a negative
     /// value when the method dispatches relative to the client base address.</summary>
-    public int UrlParameterInfo { get; }
+    internal int UrlParameterInfo { get; }
 
     /// <summary>Gets the map of parameter indexes to query string names.</summary>
-    public Dictionary<int, string> QueryParameterMap { get; }
+    internal Dictionary<int, string> QueryParameterMap { get; }
 
     /// <summary>Gets the map of parameter indexes to multipart attachment names.</summary>
-    public Dictionary<int, Tuple<string, string>> AttachmentNameMap { get; }
+    internal Dictionary<int, Tuple<string, string>> AttachmentNameMap { get; }
 
     /// <summary>Gets the array of parameters excluding cancellation tokens.</summary>
-    public ParameterInfo[] ParameterInfoArray { get; }
+    internal ParameterInfo[] ParameterInfoArray { get; }
 
     /// <summary>Gets the map of parameter indexes to route parameter information.</summary>
-    public Dictionary<int, RestMethodParameterInfo> ParameterMap { get; }
+    internal Dictionary<int, RestMethodParameterInfo> ParameterMap { get; }
 
     /// <summary>Gets or sets the ordered fragments that make up the URL path.</summary>
-    public List<ParameterFragment> FragmentPath { get; set; }
+    internal List<ParameterFragment> FragmentPath { get; set; }
 
     /// <summary>Gets or sets the declared return type of the method.</summary>
-    public Type ReturnType { get; set; }
+    internal Type ReturnType { get; set; }
 
     /// <summary>Gets or sets the result type wrapped by the return type.</summary>
-    public Type ReturnResultType { get; set; }
+    internal Type ReturnResultType { get; set; }
 
     /// <summary>Gets or sets the type that the response content is deserialized into.</summary>
-    public Type DeserializedResultType { get; set; }
+    internal Type DeserializedResultType { get; set; }
 
     /// <summary>Gets a value indicating whether a registered <see cref="IReturnTypeAdapter{TReturn, TResult}"/> surfaces this method's return type.</summary>
-    public bool HasReturnTypeAdapter { get; }
+    internal bool HasReturnTypeAdapter { get; }
 
     /// <summary>Gets the Refit settings used when building the request.</summary>
-    public RefitSettings RefitSettings { get; }
+    internal RefitSettings RefitSettings { get; }
 
     /// <summary>Gets a value indicating whether the method returns an API response wrapper.</summary>
-    public bool IsApiResponse { get; }
+    internal bool IsApiResponse { get; }
 
     /// <summary>Gets a value indicating whether the response must be disposed by the caller.</summary>
-    public bool ShouldDisposeResponse { get; }
+    internal bool ShouldDisposeResponse { get; }
 
     /// <summary>Gets a value indicating whether the method has a header collection parameter.</summary>
-    public bool HasHeaderCollection => _headerCollectionParameterIndex >= 0;
+    internal bool HasHeaderCollection => _headerCollectionParameterIndex >= 0;
 
     /// <summary>Gets the name of the method.</summary>
     internal string Name => MethodInfo.Name;
@@ -226,12 +226,6 @@ internal partial class RestMethodInfoInternal
     /// <summary>Gets a flag per parameter indicating whether it carries <see cref="FormObjectAttribute"/> on a multipart
     /// method, indexed to match <see cref="ParameterInfoArray"/>; a shared empty array for non-multipart methods.</summary>
     internal bool[] ParameterFormObjectFlags { get; }
-
-    /// <summary>Determines whether the parameter at the given index is the header collection parameter.</summary>
-    /// <param name="index">The parameter index to test.</param>
-    /// <returns><see langword="true"/> when the parameter is the header collection parameter; otherwise <see langword="false"/>.</returns>
-    public bool HeaderCollectionAt(int index) =>
-        _headerCollectionParameterIndex >= 0 && _headerCollectionParameterIndex == index;
 
     /// <summary>Removes cancellation-token parameters from a reflected parameter array.</summary>
     /// <param name="parameters">The reflected method parameters.</param>
@@ -513,6 +507,12 @@ internal partial class RestMethodInfoInternal
     /// <returns>The parameter matching regular expression.</returns>
     internal static Regex ParameterRegex() => _parameterRegexValue;
 #endif
+
+    /// <summary>Determines whether the parameter at the given index is the header collection parameter.</summary>
+    /// <param name="index">The parameter index to test.</param>
+    /// <returns><see langword="true"/> when the parameter is the header collection parameter; otherwise <see langword="false"/>.</returns>
+    internal bool HeaderCollectionAt(int index) =>
+        _headerCollectionParameterIndex >= 0 && _headerCollectionParameterIndex == index;
 
     /// <summary>Builds the map of parameter indexes to multipart attachment names.</summary>
     /// <returns>A map of parameter indexes to attachment name pairs.</returns>

--- a/src/Refit/Buffers/PooledBufferWriter.Stream.NETStandard21.cs
+++ b/src/Refit/Buffers/PooledBufferWriter.Stream.NETStandard21.cs
@@ -18,26 +18,6 @@ internal sealed partial class PooledBufferWriter
     /// <summary>An in-memory <see cref="Stream"/> that uses memory buffers rented from a shared pool.</summary>
     internal sealed partial class PooledMemoryStream : Stream
     {
-        /// <summary>Asynchronously copies the remaining buffered bytes to the destination stream.</summary>
-        /// <param name="destination">The stream to copy the buffered bytes to.</param>
-        /// <param name="cancellationToken">A token to cancel the operation.</param>
-        /// <returns>A task representing the copy operation.</returns>
-        public Task CopyToInternalAsync(Stream destination, CancellationToken cancellationToken)
-        {
-            if (_pooledBuffer is null)
-            {
-                throw CreateObjectDisposedException();
-            }
-
-            var bytesAvailable = _length - _position;
-
-            var source = _pooledBuffer.AsMemory(_position, bytesAvailable);
-
-            _position += source.Length;
-
-            return destination.WriteAsync(source, cancellationToken).AsTask();
-        }
-
         /// <inheritdoc/>
         [System.Diagnostics.CodeAnalysis.SuppressMessage(
             "Roslynator",
@@ -90,6 +70,24 @@ internal sealed partial class PooledBufferWriter
             _position += bytesCopied;
 
             return bytesCopied;
+        }
+
+        /// <summary>Asynchronously copies the remaining buffered bytes to the destination stream.</summary>
+        /// <param name="destination">The stream to copy the buffered bytes to.</param>
+        /// <param name="cancellationToken">A token to cancel the operation.</param>
+        /// <returns>A task representing the copy operation.</returns>
+        internal Task CopyToInternalAsync(Stream destination, CancellationToken cancellationToken)
+        {
+            if (_pooledBuffer is null)
+            {
+                throw CreateObjectDisposedException();
+            }
+
+            var bytesAvailable = _length - _position;
+            var source = _pooledBuffer.AsMemory(_position, bytesAvailable);
+            _position += source.Length;
+
+            return destination.WriteAsync(source, cancellationToken).AsTask();
         }
     }
 }

--- a/src/Refit/Buffers/PooledBufferWriter.Stream.cs
+++ b/src/Refit/Buffers/PooledBufferWriter.Stream.cs
@@ -26,7 +26,7 @@ internal sealed partial class PooledBufferWriter
 
         /// <summary>Initializes a new instance of the <see cref="PooledMemoryStream"/> class.</summary>
         /// <param name="writer">The <see cref="PooledBufferWriter"/> whose buffer is detached into the stream.</param>
-        public PooledMemoryStream(PooledBufferWriter writer)
+        internal PooledMemoryStream(PooledBufferWriter writer)
         {
             _length = writer._position;
             _pooledBuffer = writer._buffer;

--- a/src/Refit/Buffers/PooledBufferWriter.cs
+++ b/src/Refit/Buffers/PooledBufferWriter.cs
@@ -10,7 +10,7 @@ namespace Refit.Buffers;
 internal sealed partial class PooledBufferWriter : IBufferWriter<byte>, IDisposable
 {
     /// <summary>The default size to use to create new <see cref="PooledBufferWriter"/> instances.</summary>
-    public const int DefaultSize = 1024;
+    internal const int DefaultSize = 1024;
 
     /// <summary>The <see cref="byte"/> array current in use.</summary>
     private byte[] _buffer;
@@ -19,7 +19,7 @@ internal sealed partial class PooledBufferWriter : IBufferWriter<byte>, IDisposa
     private int _position;
 
     /// <summary>Initializes a new instance of the <see cref="PooledBufferWriter"/> class.</summary>
-    public PooledBufferWriter()
+    internal PooledBufferWriter()
     {
         _buffer = ArrayPool<byte>.Shared.Rent(DefaultSize);
         _position = 0;
@@ -70,7 +70,7 @@ internal sealed partial class PooledBufferWriter : IBufferWriter<byte>, IDisposa
 
     /// <summary>Gets a readable <see cref="Stream"/> for the current instance, by detaching the used buffer.</summary>
     /// <returns>A readable <see cref="Stream"/> with the contents of the current instance.</returns>
-    public Stream DetachStream()
+    internal Stream DetachStream()
     {
         var stream = new PooledMemoryStream(this);
 

--- a/src/Refit/FormValueMultimap.cs
+++ b/src/Refit/FormValueMultimap.cs
@@ -44,7 +44,7 @@ internal sealed class FormValueMultimap : IEnumerable<KeyValuePair<string?, stri
     /// <summary>Initializes a new instance of the <see cref="FormValueMultimap"/> class from a source object.</summary>
     /// <param name="source">The source object or dictionary to convert into form entries.</param>
     /// <param name="settings">The Refit settings controlling formatting.</param>
-    public FormValueMultimap(object source, RefitSettings settings)
+    internal FormValueMultimap(object source, RefitSettings settings)
         : this(source, settings, null)
     {
     }
@@ -78,7 +78,7 @@ internal sealed class FormValueMultimap : IEnumerable<KeyValuePair<string?, stri
     }
 
     /// <summary>Gets a key for each entry. If multiple entries share the same key, the key is returned multiple times.</summary>
-    public IEnumerable<string?> Keys => GetKeys();
+    internal IEnumerable<string?> Keys => GetKeys();
 
     /// <summary>Returns an enumerator over the form key/value entries.</summary>
     /// <returns>An enumerator over the entries.</returns>

--- a/src/Refit/GeneratedOnlyRequestBuilder.cs
+++ b/src/Refit/GeneratedOnlyRequestBuilder.cs
@@ -21,9 +21,13 @@ internal sealed class GeneratedOnlyRequestBuilder : IRequestBuilder
     public Func<HttpClient, object[], object?> BuildRestResultFuncForMethod(
         string methodName,
         Type[]? parameterTypes = null,
-        Type[]? genericArgumentTypes = null) =>
+        Type[]? genericArgumentTypes = null)
+    {
+        var methodContext =
+            $"This Refit client was created with the generated-only API, but the generated client needs the reflection request builder for '{methodName}'.";
         throw new NotSupportedException(
-            "This Refit client was created with the generated-only API, but the generated client "
-            + $"needs the reflection request builder for '{methodName}'. Enable generated request "
-            + "building for this method or use RestService.For when reflection is acceptable.");
+            string.Concat(
+                methodContext,
+                " Enable generated request building for this method or use RestService.For when reflection is acceptable."));
+    }
 }

--- a/src/Refit/GeneratedQueryStringBuilder.cs
+++ b/src/Refit/GeneratedQueryStringBuilder.cs
@@ -281,6 +281,44 @@ public ref struct GeneratedQueryStringBuilder
 
         return written;
     }
+
+    /// <summary>Formats a span-formattable value into a stack buffer (growing a rented buffer when it overflows) and
+    /// appends it to the target, escaping the formatted span in place when requested.</summary>
+    /// <typeparam name="T">The span-formattable value type.</typeparam>
+    /// <param name="target">The buffer receiving the rendered value.</param>
+    /// <param name="value">The value to render.</param>
+    /// <param name="format">The compile-time format, or null for the default rendering.</param>
+    /// <param name="escape">Whether the formatted span is URI-data-escaped before it is appended.</param>
+    internal static void AppendFormattedValue<T>(ref ValueStringBuilder target, T value, string? format, bool escape)
+        where T : ISpanFormattable
+    {
+        Span<char> buffer = stackalloc char[FormatBufferLength];
+        char[]? rented = null;
+        try
+        {
+            var written = FormatWithGrowth(value, ref buffer, ref rented, format);
+
+            var formatted = (ReadOnlySpan<char>)buffer[..written];
+            if (escape)
+            {
+                // Percent-encode straight into the builder with no intermediate escaped string, on every target
+                // framework (the span overload of Uri.EscapeDataString only exists on net9+).
+                StringHelpers.AppendUriDataEscaped(ref target, formatted);
+                return;
+            }
+
+            // Copy into a reserved slice so the stack buffer is never captured by the builder (ref-safety), matching a
+            // verbatim span append with no intermediate string.
+            formatted.CopyTo(target.AppendSpan(written));
+        }
+        finally
+        {
+            if (rented is not null)
+            {
+                System.Buffers.ArrayPool<char>.Shared.Return(rented);
+            }
+        }
+    }
 #endif
 
     /// <summary>Appends the <c>?</c> or <c>&amp;</c> separator, materializing the text buffer on first use.</summary>
@@ -325,44 +363,6 @@ public ref struct GeneratedQueryStringBuilder
         _text.Append(keyEscaped || preEncoded ? name : StringHelpers.EscapeDataString(name));
         _text.Append('=');
         AppendFormattedValue(ref _text, value, format, escape: !preEncoded);
-    }
-
-    /// <summary>Formats a span-formattable value into a stack buffer (growing a rented buffer when it overflows) and
-    /// appends it to the target, escaping the formatted span in place when requested.</summary>
-    /// <typeparam name="T">The span-formattable value type.</typeparam>
-    /// <param name="target">The buffer receiving the rendered value.</param>
-    /// <param name="value">The value to render.</param>
-    /// <param name="format">The compile-time format, or null for the default rendering.</param>
-    /// <param name="escape">Whether the formatted span is URI-data-escaped before it is appended.</param>
-    internal readonly void AppendFormattedValue<T>(ref ValueStringBuilder target, T value, string? format, bool escape)
-        where T : ISpanFormattable
-    {
-        Span<char> buffer = stackalloc char[FormatBufferLength];
-        char[]? rented = null;
-        try
-        {
-            var written = FormatWithGrowth(value, ref buffer, ref rented, format);
-
-            var formatted = (ReadOnlySpan<char>)buffer[..written];
-            if (escape)
-            {
-                // Percent-encode straight into the builder with no intermediate escaped string, on every target
-                // framework (the span overload of Uri.EscapeDataString only exists on net9+).
-                StringHelpers.AppendUriDataEscaped(ref target, formatted);
-                return;
-            }
-
-            // Copy into a reserved slice so the stack buffer is never captured by the builder (ref-safety), matching a
-            // verbatim span append with no intermediate string.
-            formatted.CopyTo(target.AppendSpan(written));
-        }
-        finally
-        {
-            if (rented is not null)
-            {
-                System.Buffers.ArrayPool<char>.Shared.Return(rented);
-            }
-        }
     }
 
 #endif

--- a/src/Refit/GeneratedRequestRunner.cs
+++ b/src/Refit/GeneratedRequestRunner.cs
@@ -529,7 +529,7 @@ public static partial class GeneratedRequestRunner
             }
         }
 
-        AddRequestProperty<Type>(request, HttpRequestMessageOptions.InterfaceType, interfaceType);
+        AddRequestProperty(request, HttpRequestMessageOptions.InterfaceType, interfaceType);
 
 #if NET6_0_OR_GREATER
         request.Version = settings.Version;
@@ -571,9 +571,10 @@ public static partial class GeneratedRequestRunner
         }
         catch (Exception ex)
         {
+            var parameterType = value?.GetType().Name;
+            const string allowedTypes = "String, Stream, FileInfo, Byte array and anything that's JSON serializable";
             throw new ArgumentException(
-                $"Unexpected parameter type in a Multipart request. Parameter {fieldName} is of type {value?.GetType().Name}, "
-                    + "whereas allowed types are String, Stream, FileInfo, Byte array and anything that's JSON serializable",
+                $"Unexpected parameter type in a Multipart request. Parameter {fieldName} is of type {parameterType}, whereas allowed types are {allowedTypes}",
                 nameof(value),
                 ex);
         }

--- a/src/Refit/NameValueCollection.cs
+++ b/src/Refit/NameValueCollection.cs
@@ -8,5 +8,5 @@ namespace System.Collections.Specialized;
 internal class NameValueCollection : Dictionary<string, string>
 {
     /// <summary>Gets all of the keys currently stored in the collection.</summary>
-    public string[] AllKeys => [.. Keys];
+    internal string[] AllKeys => [.. Keys];
 }

--- a/src/Refit/RequestExecutionHelpers.cs
+++ b/src/Refit/RequestExecutionHelpers.cs
@@ -15,7 +15,7 @@ internal static partial class RequestExecutionHelpers
     /// <summary>Throws when a client cannot build relative generated requests.</summary>
     /// <param name="client">The HTTP client to inspect.</param>
     /// <exception cref="InvalidOperationException">Thrown when no base address is configured.</exception>
-    public static void ThrowIfBaseAddressMissing(HttpClient client)
+    internal static void ThrowIfBaseAddressMissing(HttpClient client)
     {
         if (client.BaseAddress is not null)
         {
@@ -30,7 +30,7 @@ internal static partial class RequestExecutionHelpers
     /// <param name="cancellationToken">The already-resolved effective cancellation token for the request.</param>
     /// <returns>The token the request should run against, and the timeout source to dispose once the request completes
     /// (null when no timeout was applied).</returns>
-    public static (CancellationToken Token, CancellationTokenSource? TimeoutSource) CreateTimeoutToken(
+    internal static (CancellationToken Token, CancellationTokenSource? TimeoutSource) CreateTimeoutToken(
         int timeoutMilliseconds,
         CancellationToken cancellationToken)
     {
@@ -53,7 +53,7 @@ internal static partial class RequestExecutionHelpers
     /// <param name="timeoutMilliseconds">The per-call timeout in milliseconds; values that are not positive disable it.</param>
     /// <param name="cancellationToken">A token to cancel the request.</param>
     /// <returns>A task that completes when the request finishes.</returns>
-    public static async Task SendVoidAsync(
+    internal static async Task SendVoidAsync(
         HttpClient client,
         HttpRequestMessage request,
         RefitSettings settings,
@@ -114,7 +114,7 @@ internal static partial class RequestExecutionHelpers
         "Design",
         "SST2307:Generic method type parameters should be inferable from the parameters",
         Justification = "TBody is intentionally passed explicitly by generated and reflection callers for ApiResponse<T> body deserialization.")]
-    public static async Task<T?> SendAndProcessResponseAsync<T, TBody>(
+    internal static async Task<T?> SendAndProcessResponseAsync<T, TBody>(
         HttpClient client,
         HttpRequestMessage request,
         RefitSettings settings,
@@ -184,7 +184,7 @@ internal static partial class RequestExecutionHelpers
         "Design",
         "SST2307:Generic method type parameters should be inferable from the parameters",
         Justification = "Type parameter intentionally specified explicitly by generated and reflection callers.")]
-    public static IAsyncEnumerable<T?> StreamResponseAsync<T>(
+    internal static IAsyncEnumerable<T?> StreamResponseAsync<T>(
         HttpClient client,
         HttpRequestMessage request,
         RefitSettings settings,
@@ -216,7 +216,7 @@ internal static partial class RequestExecutionHelpers
     /// <param name="settings">The Refit settings to use.</param>
     /// <param name="cancellationToken">A token to cancel the token getter.</param>
     /// <returns>A task that completes when the header has been updated.</returns>
-    public static async Task AddAuthorizationHeaderFromGetterAsync(
+    internal static async Task AddAuthorizationHeaderFromGetterAsync(
         HttpRequestMessage request,
         RefitSettings settings,
         CancellationToken cancellationToken)
@@ -669,24 +669,24 @@ internal static partial class RequestExecutionHelpers
         }
 
         /// <summary>Gets a value indicating whether the send produced a response.</summary>
-        public bool HasResponse { get; }
+        internal bool HasResponse { get; }
 
         /// <summary>Gets the response, or null when the send failed.</summary>
-        public HttpResponseMessage? Response { get; }
+        internal HttpResponseMessage? Response { get; }
 
         /// <summary>Gets the captured failure result, valid only when <see cref="HasResponse"/> is false.</summary>
-        public T? FailureResult { get; }
+        internal T? FailureResult { get; }
 
         /// <summary>Creates a successful result wrapping the given response.</summary>
         /// <param name="response">The response produced by the send.</param>
         /// <returns>A result indicating a response is present.</returns>
-        public static SendResult<T> FromResponse(HttpResponseMessage response) =>
+        internal static SendResult<T> FromResponse(HttpResponseMessage response) =>
             new(true, response, default);
 
         /// <summary>Creates a failed result wrapping the captured failure value.</summary>
         /// <param name="failureResult">The captured failure result.</param>
         /// <returns>A result indicating the send failed.</returns>
-        public static SendResult<T> FromFailure(T? failureResult) =>
+        internal static SendResult<T> FromFailure(T? failureResult) =>
             new(false, null, failureResult);
     }
 }

--- a/src/Refit/RequestExecutionOptions.cs
+++ b/src/Refit/RequestExecutionOptions.cs
@@ -12,7 +12,7 @@ internal readonly struct RequestExecutionOptions : IEquatable<RequestExecutionOp
     /// <param name="shouldDisposeResponse">Whether the response should be disposed by the response processor.</param>
     /// <param name="bufferBody">Whether request content should be buffered before sending.</param>
     /// <param name="applyAuthorizationHeader">Whether to run the authorization-header value getter before sending.</param>
-    public RequestExecutionOptions(
+    internal RequestExecutionOptions(
         bool isApiResponse,
         bool shouldDisposeResponse,
         bool bufferBody,
@@ -25,16 +25,16 @@ internal readonly struct RequestExecutionOptions : IEquatable<RequestExecutionOp
     }
 
     /// <summary>Gets a value indicating whether the caller expects an API response wrapper.</summary>
-    public bool IsApiResponse { get; }
+    internal bool IsApiResponse { get; }
 
     /// <summary>Gets a value indicating whether the response should be disposed by the response processor.</summary>
-    public bool ShouldDisposeResponse { get; }
+    internal bool ShouldDisposeResponse { get; }
 
     /// <summary>Gets a value indicating whether request content should be buffered before sending.</summary>
-    public bool BufferBody { get; }
+    internal bool BufferBody { get; }
 
     /// <summary>Gets a value indicating whether the authorization-header getter should run before sending.</summary>
-    public bool ApplyAuthorizationHeader { get; }
+    internal bool ApplyAuthorizationHeader { get; }
 
     /// <inheritdoc/>
     public static bool operator ==(RequestExecutionOptions left, RequestExecutionOptions right) =>

--- a/src/Refit/RestService.cs
+++ b/src/Refit/RestService.cs
@@ -447,12 +447,11 @@ public static class RestService
     /// <returns>The generated-client exception.</returns>
     internal static InvalidOperationException CreateMissingGeneratedFactoryException(Type refitInterfaceType)
     {
-        var message =
-            refitInterfaceType.Name
-            + " doesn't look like a Refit interface. Make sure it has at least one "
-            + "method with a Refit HTTP method attribute, the Refit source generator is installed in the project, "
-            + "and your build produced the generated client. For Native AOT or trimmed apps, prefer generated clients "
-            + "plus source-generated System.Text.Json metadata.";
+        var message = string.Concat(
+            refitInterfaceType.Name,
+            " doesn't look like a Refit interface. Make sure it has at least one method with a Refit HTTP method attribute, ",
+            "the Refit source generator is installed in the project, and your build produced the generated client. ",
+            "For Native AOT or trimmed apps, prefer generated clients plus source-generated System.Text.Json metadata.");
 
         return new(message);
     }

--- a/src/Refit/SeparatedCaseFormatter.cs
+++ b/src/Refit/SeparatedCaseFormatter.cs
@@ -16,7 +16,7 @@ internal static class SeparatedCaseFormatter
     /// <param name="key">The identifier to format.</param>
     /// <param name="separator">The character inserted between words.</param>
     /// <returns>The lower-case, separator-delimited form of <paramref name="key"/>.</returns>
-    public static string Format(string key, char separator)
+    internal static string Format(string key, char separator)
     {
         if (string.IsNullOrEmpty(key))
         {

--- a/src/Refit/SeparatedCaseJsonNamingPolicy.cs
+++ b/src/Refit/SeparatedCaseJsonNamingPolicy.cs
@@ -11,10 +11,10 @@ namespace Refit;
 internal sealed class SeparatedCaseJsonNamingPolicy(char separator) : JsonNamingPolicy
 {
     /// <summary>Gets a policy that renders names in snake_case.</summary>
-    public static JsonNamingPolicy Snake { get; } = new SeparatedCaseJsonNamingPolicy('_');
+    internal static JsonNamingPolicy Snake { get; } = new SeparatedCaseJsonNamingPolicy('_');
 
     /// <summary>Gets a policy that renders names in kebab-case.</summary>
-    public static JsonNamingPolicy Kebab { get; } = new SeparatedCaseJsonNamingPolicy('-');
+    internal static JsonNamingPolicy Kebab { get; } = new SeparatedCaseJsonNamingPolicy('-');
 
     /// <inheritdoc/>
     public override string ConvertName(string name) => SeparatedCaseFormatter.Format(name, separator);

--- a/src/Refit/SystemTextJsonContentSerializer.cs
+++ b/src/Refit/SystemTextJsonContentSerializer.cs
@@ -253,7 +253,7 @@ public sealed class SystemTextJsonContentSerializer(JsonSerializerOptions jsonSe
 
         foreach (var b in line)
         {
-            if (b != (byte)' ' && b != (byte)'\t')
+            if (b is not ((byte)' ' or (byte)'\t'))
             {
                 return false;
             }
@@ -284,7 +284,6 @@ public sealed class SystemTextJsonContentSerializer(JsonSerializerOptions jsonSe
     internal static JsonTypeInfo GetJsonTypeInfo(Type type, JsonSerializerOptions jsonSerializerOptions) =>
         jsonSerializerOptions.GetTypeInfo(type); // Returns non-null metadata for the requested type or throws; there is no null case to guard.
 
-#if NET11_0_OR_GREATER
     /// <summary>Gets the JSON type metadata for the given type from the supplied options.</summary>
     /// <typeparam name="T">The type to resolve metadata for.</typeparam>
     /// <param name="jsonSerializerOptions">The serializer options to consult.</param>
@@ -294,7 +293,10 @@ public sealed class SystemTextJsonContentSerializer(JsonSerializerOptions jsonSe
         "SST2307:Generic method type parameters should be inferable from the parameters",
         Justification = "Type parameter intentionally specified explicitly by callers.")]
     internal static JsonTypeInfo<T> GetJsonTypeInfo<T>(JsonSerializerOptions jsonSerializerOptions) =>
+#if NET11_0_OR_GREATER
         jsonSerializerOptions.GetTypeInfo<T>();
+#else
+        (JsonTypeInfo<T>)GetJsonTypeInfo(typeof(T), jsonSerializerOptions);
 #endif
 #endif
 
@@ -306,12 +308,7 @@ public sealed class SystemTextJsonContentSerializer(JsonSerializerOptions jsonSe
         "Design",
         "SST2307:Generic method type parameters should be inferable from the parameters",
         Justification = "Type parameter intentionally specified explicitly by callers.")]
-    internal JsonTypeInfo<T> GetJsonTypeInfo<T>() =>
-#if NET11_0_OR_GREATER
-        GetJsonTypeInfo<T>(jsonSerializerOptions); // Returns the strongly typed metadata for the exact type T, never null.
-#else
-        (JsonTypeInfo<T>)GetJsonTypeInfo(typeof(T), jsonSerializerOptions); // GetTypeInfo(typeof(T)) is the exact JsonTypeInfo<T>, so the cast always succeeds.
-#endif
+    internal JsonTypeInfo<T> GetJsonTypeInfo<T>() => GetJsonTypeInfo<T>(jsonSerializerOptions);
 #endif
 
     /// <summary>Serializes the item to HTTP content using the supplied runtime type.</summary>
@@ -441,28 +438,15 @@ public sealed class SystemTextJsonContentSerializer(JsonSerializerOptions jsonSe
         Justification = "Type parameter intentionally specified explicitly by callers.")]
     internal IAsyncEnumerable<T?> DeserializeJsonArrayAsync<T>(Stream stream, CancellationToken cancellationToken)
     {
+        var options = jsonSerializerOptions;
 #if NET8_0_OR_GREATER
-        return jsonSerializerOptions.TypeInfoResolver is not null
-            ? JsonSerializer.DeserializeAsyncEnumerable<T>(stream, GetJsonTypeInfo<T>(), cancellationToken)
-            : DeserializeJsonArrayReflectionAsync<T>(stream, cancellationToken);
+        return options.TypeInfoResolver is not null
+            ? JsonSerializer.DeserializeAsyncEnumerable(stream, GetJsonTypeInfo<T>(options), cancellationToken)
+            : SystemTextJsonStreamingDeserializer.DeserializeJsonArrayReflectionAsync<T>(stream, options, cancellationToken);
 #else
-        return DeserializeJsonArrayReflectionAsync<T>(stream, cancellationToken);
+        return SystemTextJsonStreamingDeserializer.DeserializeJsonArrayReflectionAsync<T>(stream, options, cancellationToken);
 #endif
     }
-
-    /// <summary>Streams JSON array elements using reflection-based metadata.</summary>
-    /// <typeparam name="T">The element type to deserialize.</typeparam>
-    /// <param name="stream">The response body stream.</param>
-    /// <param name="cancellationToken">A token to cancel enumeration.</param>
-    /// <returns>An asynchronous sequence of deserialized elements.</returns>
-    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = ReflectionFallbackJustification)]
-    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = ReflectionFallbackJustification)]
-    [SuppressMessage(
-        "Design",
-        "SST2307:Generic method type parameters should be inferable from the parameters",
-        Justification = "Type parameter intentionally specified explicitly by callers.")]
-    internal IAsyncEnumerable<T?> DeserializeJsonArrayReflectionAsync<T>(Stream stream, CancellationToken cancellationToken) =>
-        JsonSerializer.DeserializeAsyncEnumerable<T>(stream, jsonSerializerOptions, cancellationToken);
 
     /// <summary>Streams newline-delimited JSON values from the response body.</summary>
     /// <typeparam name="T">The element type to deserialize.</typeparam>
@@ -475,151 +459,17 @@ public sealed class SystemTextJsonContentSerializer(JsonSerializerOptions jsonSe
         Justification = "Type parameter intentionally specified explicitly by callers.")]
     internal IAsyncEnumerable<T?> DeserializeJsonLinesAsync<T>(Stream stream, CancellationToken cancellationToken)
     {
+        var options = jsonSerializerOptions;
 #if NET9_0_OR_GREATER
         // .NET 9 added the topLevelValues overload, which reads a stream of whitespace-separated
         // top-level JSON values - exactly the JSON Lines framing - without per-line buffering.
-        return jsonSerializerOptions.TypeInfoResolver is not null
-            ? JsonSerializer.DeserializeAsyncEnumerable<T>(stream, GetJsonTypeInfo<T>(), topLevelValues: true, cancellationToken)
-            : DeserializeJsonLinesTopLevelReflectionAsync<T>(stream, cancellationToken);
+        return options.TypeInfoResolver is not null
+            ? JsonSerializer.DeserializeAsyncEnumerable(stream, GetJsonTypeInfo<T>(options), topLevelValues: true, cancellationToken)
+            : SystemTextJsonStreamingDeserializer.DeserializeJsonLinesTopLevelReflectionAsync<T>(stream, options, cancellationToken);
 #else
-        return DeserializeJsonLinesManualAsync<T>(stream, cancellationToken);
+        return SystemTextJsonStreamingDeserializer.DeserializeJsonLinesManualAsync<T>(stream, options, cancellationToken);
 #endif
     }
-
-#if NET9_0_OR_GREATER
-    /// <summary>Streams top-level JSON values using reflection-based metadata.</summary>
-    /// <typeparam name="T">The element type to deserialize.</typeparam>
-    /// <param name="stream">The response body stream.</param>
-    /// <param name="cancellationToken">A token to cancel enumeration.</param>
-    /// <returns>An asynchronous sequence of deserialized values.</returns>
-    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = ReflectionFallbackJustification)]
-    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = ReflectionFallbackJustification)]
-    [SuppressMessage(
-        "Design",
-        "SST2307:Generic method type parameters should be inferable from the parameters",
-        Justification = "Type parameter intentionally specified explicitly by callers.")]
-    internal IAsyncEnumerable<T?> DeserializeJsonLinesTopLevelReflectionAsync<T>(Stream stream, CancellationToken cancellationToken) =>
-        JsonSerializer.DeserializeAsyncEnumerable<T>(stream, topLevelValues: true, jsonSerializerOptions, cancellationToken);
-#else
-    /// <summary>Reads newline-delimited JSON from a stream using a pooled UTF-8 buffer, deserializing each line.</summary>
-    /// <typeparam name="T">The element type to deserialize.</typeparam>
-    /// <param name="stream">The response body stream.</param>
-    /// <param name="cancellationToken">A token to cancel enumeration.</param>
-    /// <returns>An asynchronous sequence of deserialized values.</returns>
-    [SuppressMessage(
-        "Design",
-        "SST2307:Generic method type parameters should be inferable from the parameters",
-        Justification = "Type parameter intentionally specified explicitly by callers.")]
-    [ExcludeFromCodeCoverage] // async-iterator dispose-mode epilogue: the compiler-generated <>w__disposeMode false-edge cannot be exercised or removed.
-    internal async IAsyncEnumerable<T?> DeserializeJsonLinesManualAsync<T>(
-        Stream stream,
-        [EnumeratorCancellation] CancellationToken cancellationToken)
-    {
-        // The initial pooled buffer, and the factor it grows by when a single line does not fit in it.
-        const int lineScanBufferSize = 4096;
-        const int lineScanBufferGrowthFactor = 2;
-
-        var buffer = ArrayPool<byte>.Shared.Rent(lineScanBufferSize);
-        var start = 0;
-        var end = 0;
-        try
-        {
-            while (true)
-            {
-                var newline = Array.IndexOf(buffer, (byte)'\n', start, end - start);
-                if (newline >= 0)
-                {
-                    var length = newline - start;
-                    if (!IsBlankLine(buffer, start, length))
-                    {
-                        yield return DeserializeLine<T>(buffer, start, length);
-                    }
-
-                    start = newline + 1;
-                    continue;
-                }
-
-                if (start > 0)
-                {
-                    Buffer.BlockCopy(buffer, start, buffer, 0, end - start);
-                    end -= start;
-                    start = 0;
-                }
-
-                if (end == buffer.Length)
-                {
-                    buffer = GrowLineScanBuffer(buffer, end, lineScanBufferGrowthFactor);
-                }
-
-#if NET8_0_OR_GREATER
-                var read = await stream
-                    .ReadAsync(buffer.AsMemory(end), cancellationToken)
-                    .ConfigureAwait(false);
-#else
-                var read = await stream
-                    .ReadAsync(buffer, end, buffer.Length - end, cancellationToken)
-                    .ConfigureAwait(false);
-#endif
-                if (read == 0)
-                {
-                    if (!IsBlankLine(buffer, start, end - start))
-                    {
-                        yield return DeserializeLine<T>(buffer, start, end - start);
-                    }
-
-                    yield break;
-                }
-
-                end += read;
-            }
-        }
-        finally
-        {
-            ArrayPool<byte>.Shared.Return(buffer);
-        }
-    }
-
-    /// <summary>Deserializes a single buffered JSON line, trimming a trailing carriage return.</summary>
-    /// <typeparam name="T">The element type to deserialize.</typeparam>
-    /// <param name="buffer">The buffer holding the line bytes.</param>
-    /// <param name="start">The offset of the line.</param>
-    /// <param name="length">The length of the line.</param>
-    /// <returns>The deserialized value.</returns>
-    [SuppressMessage(
-        "Design",
-        "SST2307:Generic method type parameters should be inferable from the parameters",
-        Justification = "Type parameter intentionally specified explicitly by callers.")]
-    internal T? DeserializeLine<T>(byte[] buffer, int start, int length)
-    {
-        // DeserializeLine is only called for non-blank lines, so the span is never empty here.
-        var span = new ReadOnlySpan<byte>(buffer, start, length);
-        if (span[span.Length - 1] == (byte)'\r')
-        {
-            span = span.Slice(0, span.Length - 1);
-        }
-
-#if NET8_0_OR_GREATER
-        return jsonSerializerOptions.TypeInfoResolver is not null
-            ? JsonSerializer.Deserialize(span, GetJsonTypeInfo<T>())
-            : DeserializeLineReflection<T>(span);
-#else
-        return DeserializeLineReflection<T>(span);
-#endif
-    }
-
-    /// <summary>Deserializes a JSON line using reflection-based metadata.</summary>
-    /// <typeparam name="T">The element type to deserialize.</typeparam>
-    /// <param name="utf8Json">The UTF-8 encoded JSON value.</param>
-    /// <returns>The deserialized value.</returns>
-    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = ReflectionFallbackJustification)]
-    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = ReflectionFallbackJustification)]
-    [SuppressMessage(
-        "Design",
-        "SST2307:Generic method type parameters should be inferable from the parameters",
-        Justification = "Type parameter intentionally specified explicitly by callers.")]
-    internal T? DeserializeLineReflection<T>(ReadOnlySpan<byte> utf8Json) =>
-        JsonSerializer.Deserialize<T>(utf8Json, jsonSerializerOptions);
-#endif
 
     /// <summary>Streams the JSON <c>data</c> payload of each server-sent event, yielding one deserialized value per event as it arrives.</summary>
     /// <typeparam name="T">The element type each event's <c>data</c> payload is deserialized to.</typeparam>
@@ -635,46 +485,15 @@ public sealed class SystemTextJsonContentSerializer(JsonSerializerOptions jsonSe
         Stream stream,
         [EnumeratorCancellation] CancellationToken cancellationToken)
     {
-        var parser = SseParser.Create(stream, DeserializeSseData<T>);
+        var options = jsonSerializerOptions;
+        var parser = SseParser.Create(
+            stream,
+            (eventType, data) => SystemTextJsonStreamingDeserializer.DeserializeSseData<T>(eventType, data, options));
         await foreach (var item in parser.EnumerateAsync(cancellationToken).ConfigureAwait(false))
         {
             yield return item.Data;
         }
     }
-
-    /// <summary>Deserializes a single server-sent event's UTF-8 JSON <c>data</c> payload, using source-gen metadata when a resolver is configured.</summary>
-    /// <typeparam name="T">The element type to deserialize.</typeparam>
-    /// <param name="eventType">The event's <c>event</c> field; ignored because only the <c>data</c> payload is surfaced.</param>
-    /// <param name="data">The UTF-8 encoded JSON payload bytes.</param>
-    /// <returns>The deserialized value.</returns>
-    [SuppressMessage(
-        "Design",
-        "SST2307:Generic method type parameters should be inferable from the parameters",
-        Justification = "Type parameter intentionally specified explicitly by callers.")]
-    internal T? DeserializeSseData<T>(string eventType, ReadOnlySpan<byte> data)
-    {
-        _ = eventType;
-#if NET8_0_OR_GREATER
-        return jsonSerializerOptions.TypeInfoResolver is not null
-            ? JsonSerializer.Deserialize(data, GetJsonTypeInfo<T>())
-            : DeserializeSseDataReflection<T>(data);
-#else
-        return DeserializeSseDataReflection<T>(data);
-#endif
-    }
-
-    /// <summary>Deserializes a server-sent event payload using reflection-based metadata.</summary>
-    /// <typeparam name="T">The element type to deserialize.</typeparam>
-    /// <param name="utf8Json">The UTF-8 encoded JSON payload bytes.</param>
-    /// <returns>The deserialized value.</returns>
-    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = ReflectionFallbackJustification)]
-    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = ReflectionFallbackJustification)]
-    [SuppressMessage(
-        "Design",
-        "SST2307:Generic method type parameters should be inferable from the parameters",
-        Justification = "Type parameter intentionally specified explicitly by callers.")]
-    internal T? DeserializeSseDataReflection<T>(ReadOnlySpan<byte> utf8Json) =>
-        JsonSerializer.Deserialize<T>(utf8Json, jsonSerializerOptions);
 
     /// <summary>Deserializes a buffered string using reflection-based metadata.</summary>
     /// <typeparam name="T">The type to deserialize.</typeparam>

--- a/src/Refit/SystemTextJsonQueryFlattener.cs
+++ b/src/Refit/SystemTextJsonQueryFlattener.cs
@@ -95,7 +95,7 @@ internal static class SystemTextJsonQueryFlattener
             return;
         }
 
-        FlattenObject(propertyValue, key + ".", ref builder, settings, options, depth + 1);
+        FlattenObject(propertyValue, $"{key}.", ref builder, settings, options, depth + 1);
     }
 
     /// <summary>Formats one value through the configured URL parameter formatter.</summary>

--- a/src/Refit/SystemTextJsonStreamingDeserializer.cs
+++ b/src/Refit/SystemTextJsonStreamingDeserializer.cs
@@ -1,0 +1,218 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+#if !NET9_0_OR_GREATER
+using System.Buffers;
+using System.Runtime.CompilerServices;
+#endif
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+
+namespace Refit;
+
+/// <summary>Provides stateless streaming JSON deserialization helpers.</summary>
+internal static class SystemTextJsonStreamingDeserializer
+{
+    /// <summary>Justification shared by reflection-fallback trim and AOT suppressions.</summary>
+    private const string ReflectionFallbackJustification =
+        "Deserializing without supplied JSON type metadata requires runtime serializer metadata.";
+
+    /// <summary>Streams JSON array elements using reflection-based metadata.</summary>
+    /// <typeparam name="T">The element type to deserialize.</typeparam>
+    /// <param name="stream">The response body stream.</param>
+    /// <param name="options">The serializer options to use.</param>
+    /// <param name="cancellationToken">A token to cancel enumeration.</param>
+    /// <returns>An asynchronous sequence of deserialized elements.</returns>
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = ReflectionFallbackJustification)]
+    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = ReflectionFallbackJustification)]
+    [SuppressMessage(
+        "Design",
+        "SST2307:Generic method type parameters should be inferable from the parameters",
+        Justification = "Type parameter intentionally specified explicitly by callers.")]
+    internal static IAsyncEnumerable<T?> DeserializeJsonArrayReflectionAsync<T>(
+        Stream stream,
+        JsonSerializerOptions options,
+        CancellationToken cancellationToken) =>
+        JsonSerializer.DeserializeAsyncEnumerable<T>(stream, options, cancellationToken);
+
+#if NET9_0_OR_GREATER
+    /// <summary>Streams top-level JSON values using reflection-based metadata.</summary>
+    /// <typeparam name="T">The element type to deserialize.</typeparam>
+    /// <param name="stream">The response body stream.</param>
+    /// <param name="options">The serializer options to use.</param>
+    /// <param name="cancellationToken">A token to cancel enumeration.</param>
+    /// <returns>An asynchronous sequence of deserialized values.</returns>
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = ReflectionFallbackJustification)]
+    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = ReflectionFallbackJustification)]
+    [SuppressMessage(
+        "Design",
+        "SST2307:Generic method type parameters should be inferable from the parameters",
+        Justification = "Type parameter intentionally specified explicitly by callers.")]
+    internal static IAsyncEnumerable<T?> DeserializeJsonLinesTopLevelReflectionAsync<T>(
+        Stream stream,
+        JsonSerializerOptions options,
+        CancellationToken cancellationToken) =>
+        JsonSerializer.DeserializeAsyncEnumerable<T>(stream, topLevelValues: true, options, cancellationToken);
+#else
+    /// <summary>Reads newline-delimited JSON from a stream using a pooled UTF-8 buffer.</summary>
+    /// <typeparam name="T">The element type to deserialize.</typeparam>
+    /// <param name="stream">The response body stream.</param>
+    /// <param name="options">The serializer options to use.</param>
+    /// <param name="cancellationToken">A token to cancel enumeration.</param>
+    /// <returns>An asynchronous sequence of deserialized values.</returns>
+    [SuppressMessage(
+        "Design",
+        "SST2307:Generic method type parameters should be inferable from the parameters",
+        Justification = "Type parameter intentionally specified explicitly by callers.")]
+    [ExcludeFromCodeCoverage]
+    internal static async IAsyncEnumerable<T?> DeserializeJsonLinesManualAsync<T>(
+        Stream stream,
+        JsonSerializerOptions options,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        const int lineScanBufferSize = 4096;
+        const int lineScanBufferGrowthFactor = 2;
+
+        var buffer = ArrayPool<byte>.Shared.Rent(lineScanBufferSize);
+        var start = 0;
+        var end = 0;
+        try
+        {
+            while (true)
+            {
+                var newline = Array.IndexOf(buffer, (byte)'\n', start, end - start);
+                if (newline >= 0)
+                {
+                    var length = newline - start;
+                    if (!SystemTextJsonContentSerializer.IsBlankLine(buffer, start, length))
+                    {
+                        yield return DeserializeLine<T>(buffer, start, length, options);
+                    }
+
+                    start = newline + 1;
+                    continue;
+                }
+
+                if (start > 0)
+                {
+                    Buffer.BlockCopy(buffer, start, buffer, 0, end - start);
+                    end -= start;
+                    start = 0;
+                }
+
+                if (end == buffer.Length)
+                {
+                    buffer = SystemTextJsonContentSerializer.GrowLineScanBuffer(buffer, end, lineScanBufferGrowthFactor);
+                }
+
+#if NET8_0_OR_GREATER
+                var read = await stream
+                    .ReadAsync(buffer.AsMemory(end), cancellationToken)
+                    .ConfigureAwait(false);
+#else
+                var read = await stream
+                    .ReadAsync(buffer, end, buffer.Length - end, cancellationToken)
+                    .ConfigureAwait(false);
+#endif
+                if (read == 0)
+                {
+                    if (!SystemTextJsonContentSerializer.IsBlankLine(buffer, start, end - start))
+                    {
+                        yield return DeserializeLine<T>(buffer, start, end - start, options);
+                    }
+
+                    yield break;
+                }
+
+                end += read;
+            }
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+    }
+
+    /// <summary>Deserializes a single buffered JSON line, trimming a trailing carriage return.</summary>
+    /// <typeparam name="T">The element type to deserialize.</typeparam>
+    /// <param name="buffer">The buffer holding the line bytes.</param>
+    /// <param name="start">The offset of the line.</param>
+    /// <param name="length">The length of the line.</param>
+    /// <param name="options">The serializer options to use.</param>
+    /// <returns>The deserialized value.</returns>
+    [SuppressMessage(
+        "Design",
+        "SST2307:Generic method type parameters should be inferable from the parameters",
+        Justification = "Type parameter intentionally specified explicitly by callers.")]
+    internal static T? DeserializeLine<T>(byte[] buffer, int start, int length, JsonSerializerOptions options)
+    {
+        var span = new ReadOnlySpan<byte>(buffer, start, length);
+        if (span[span.Length - 1] == (byte)'\r')
+        {
+            span = span.Slice(0, span.Length - 1);
+        }
+
+#if NET8_0_OR_GREATER
+        return options.TypeInfoResolver is not null
+            ? JsonSerializer.Deserialize(span, SystemTextJsonContentSerializer.GetJsonTypeInfo<T>(options))
+            : DeserializeLineReflection<T>(span, options);
+#else
+        return DeserializeLineReflection<T>(span, options);
+#endif
+    }
+
+    /// <summary>Deserializes a JSON line using reflection-based metadata.</summary>
+    /// <typeparam name="T">The element type to deserialize.</typeparam>
+    /// <param name="utf8Json">The UTF-8 encoded JSON value.</param>
+    /// <param name="options">The serializer options to use.</param>
+    /// <returns>The deserialized value.</returns>
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = ReflectionFallbackJustification)]
+    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = ReflectionFallbackJustification)]
+    [SuppressMessage(
+        "Design",
+        "SST2307:Generic method type parameters should be inferable from the parameters",
+        Justification = "Type parameter intentionally specified explicitly by callers.")]
+    internal static T? DeserializeLineReflection<T>(ReadOnlySpan<byte> utf8Json, JsonSerializerOptions options) =>
+        JsonSerializer.Deserialize<T>(utf8Json, options);
+#endif
+
+    /// <summary>Deserializes a server-sent event's UTF-8 JSON data payload.</summary>
+    /// <typeparam name="T">The element type to deserialize.</typeparam>
+    /// <param name="eventType">The event type, which is not surfaced by this serializer.</param>
+    /// <param name="data">The UTF-8 encoded JSON payload bytes.</param>
+    /// <param name="options">The serializer options to use.</param>
+    /// <returns>The deserialized value.</returns>
+    [SuppressMessage(
+        "Design",
+        "SST2307:Generic method type parameters should be inferable from the parameters",
+        Justification = "Type parameter intentionally specified explicitly by callers.")]
+    internal static T? DeserializeSseData<T>(
+        string eventType,
+        ReadOnlySpan<byte> data,
+        JsonSerializerOptions options)
+    {
+        _ = eventType;
+#if NET8_0_OR_GREATER
+        return options.TypeInfoResolver is not null
+            ? JsonSerializer.Deserialize(data, SystemTextJsonContentSerializer.GetJsonTypeInfo<T>(options))
+            : DeserializeSseDataReflection<T>(data, options);
+#else
+        return DeserializeSseDataReflection<T>(data, options);
+#endif
+    }
+
+    /// <summary>Deserializes a server-sent event payload using reflection-based metadata.</summary>
+    /// <typeparam name="T">The element type to deserialize.</typeparam>
+    /// <param name="utf8Json">The UTF-8 encoded JSON payload bytes.</param>
+    /// <param name="options">The serializer options to use.</param>
+    /// <returns>The deserialized value.</returns>
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = ReflectionFallbackJustification)]
+    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = ReflectionFallbackJustification)]
+    [SuppressMessage(
+        "Design",
+        "SST2307:Generic method type parameters should be inferable from the parameters",
+        Justification = "Type parameter intentionally specified explicitly by callers.")]
+    internal static T? DeserializeSseDataReflection<T>(ReadOnlySpan<byte> utf8Json, JsonSerializerOptions options) =>
+        JsonSerializer.Deserialize<T>(utf8Json, options);
+}

--- a/src/Refit/ValueStringBuilder.cs
+++ b/src/Refit/ValueStringBuilder.cs
@@ -24,7 +24,7 @@ internal ref struct ValueStringBuilder
 
     /// <summary>Initializes a new instance of the <c>ValueStringBuilder</c> struct using an initial stack buffer.</summary>
     /// <param name="initialBuffer">The initial buffer to write into.</param>
-    public ValueStringBuilder(Span<char> initialBuffer)
+    internal ValueStringBuilder(Span<char> initialBuffer)
     {
         _arrayToReturnToPool = null;
         _chars = initialBuffer;
@@ -33,7 +33,7 @@ internal ref struct ValueStringBuilder
 
     /// <summary>Initializes a new instance of the <c>ValueStringBuilder</c> struct using a pooled buffer of the given capacity.</summary>
     /// <param name="initialCapacity">The initial capacity to rent.</param>
-    public ValueStringBuilder(int initialCapacity)
+    internal ValueStringBuilder(int initialCapacity)
     {
         _arrayToReturnToPool = ArrayPool<char>.Shared.Rent(initialCapacity);
         _chars = _arrayToReturnToPool;
@@ -41,7 +41,7 @@ internal ref struct ValueStringBuilder
     }
 
     /// <summary>Gets or sets the number of characters currently in the builder.</summary>
-    public int Length
+    internal int Length
     {
         readonly get => _pos;
         set
@@ -53,10 +53,10 @@ internal ref struct ValueStringBuilder
     }
 
     /// <summary>Gets the total capacity of the current buffer.</summary>
-    public readonly int Capacity => _chars.Length;
+    internal readonly int Capacity => _chars.Length;
 
     /// <summary>Gets the underlying storage of the builder.</summary>
-    public readonly Span<char> RawChars => _chars;
+    internal readonly Span<char> RawChars => _chars;
 
     /// <summary>Gets the DebuggerDisplay attribute.</summary>
     /// <remarks>ToString() clears the builder, so we need a side-effect free debugger display.</remarks>
@@ -67,7 +67,7 @@ internal ref struct ValueStringBuilder
     /// <summary>Gets a reference to the character at the specified index.</summary>
     /// <param name="index">The zero-based index of the character.</param>
     /// <returns>A reference to the character at the index.</returns>
-    public ref char this[int index]
+    internal ref char this[int index]
     {
         get
         {
@@ -76,9 +76,17 @@ internal ref struct ValueStringBuilder
         }
     }
 
+    /// <inheritdoc/>
+    public override string ToString()
+    {
+        var s = _chars[.._pos].ToString();
+        Dispose();
+        return s;
+    }
+
     /// <summary>Ensures the builder can hold at least the requested number of characters.</summary>
     /// <param name="capacity">The required capacity.</param>
-    public void EnsureCapacity(int capacity)
+    internal void EnsureCapacity(int capacity)
     {
         // This is not expected to be called this with negative capacity
         Debug.Assert(capacity >= 0, "Capacity must not be negative.");
@@ -99,12 +107,12 @@ internal ref struct ValueStringBuilder
     /// the explicit method call, and write eg "fixed (char* c = builder)".
     /// </summary>
     /// <returns>A reference to the first character of the builder.</returns>
-    public readonly ref char GetPinnableReference() => ref MemoryMarshal.GetReference(_chars);
+    internal readonly ref char GetPinnableReference() => ref MemoryMarshal.GetReference(_chars);
 
     /// <summary>Get a pinnable reference to the builder.</summary>
     /// <param name="terminate">Ensures that the builder has a null char after <see cref="Length"/>.</param>
     /// <returns>A reference to the first character of the builder.</returns>
-    public ref char GetPinnableReference(bool terminate)
+    internal ref char GetPinnableReference(bool terminate)
     {
         if (terminate)
         {
@@ -115,18 +123,10 @@ internal ref struct ValueStringBuilder
         return ref MemoryMarshal.GetReference(_chars);
     }
 
-    /// <inheritdoc/>
-    public override string ToString()
-    {
-        var s = _chars[.._pos].ToString();
-        Dispose();
-        return s;
-    }
-
     /// <summary>Returns a span around the contents of the builder.</summary>
     /// <param name="terminate">Ensures that the builder has a null char after <see cref="Length"/>.</param>
     /// <returns>A span over the contents of the builder.</returns>
-    public ReadOnlySpan<char> AsSpan(bool terminate)
+    internal ReadOnlySpan<char> AsSpan(bool terminate)
     {
         if (terminate)
         {
@@ -139,24 +139,24 @@ internal ref struct ValueStringBuilder
 
     /// <summary>Returns a span over the current contents of the builder.</summary>
     /// <returns>A span over the contents of the builder.</returns>
-    public readonly ReadOnlySpan<char> AsSpan() => _chars[.._pos];
+    internal readonly ReadOnlySpan<char> AsSpan() => _chars[.._pos];
 
     /// <summary>Returns a span over the contents from the given start index to the end.</summary>
     /// <param name="start">The start index.</param>
     /// <returns>A span over the requested portion of the builder.</returns>
-    public readonly ReadOnlySpan<char> AsSpan(int start) => _chars.Slice(start, _pos - start);
+    internal readonly ReadOnlySpan<char> AsSpan(int start) => _chars.Slice(start, _pos - start);
 
     /// <summary>Returns a span over the contents at the given start index with the given length.</summary>
     /// <param name="start">The start index.</param>
     /// <param name="length">The length of the span.</param>
     /// <returns>A span over the requested portion of the builder.</returns>
-    public readonly ReadOnlySpan<char> AsSpan(int start, int length) => _chars.Slice(start, length);
+    internal readonly ReadOnlySpan<char> AsSpan(int start, int length) => _chars.Slice(start, length);
 
     /// <summary>Attempts to copy the contents of the builder into the destination span.</summary>
     /// <param name="destination">The destination span.</param>
     /// <param name="charsWritten">When this method returns, contains the number of characters copied.</param>
     /// <returns><see langword="true"/> if the contents were copied; otherwise, <see langword="false"/>.</returns>
-    public bool TryCopyTo(Span<char> destination, out int charsWritten)
+    internal bool TryCopyTo(Span<char> destination, out int charsWritten)
     {
         if (_chars[.._pos].TryCopyTo(destination))
         {
@@ -174,7 +174,7 @@ internal ref struct ValueStringBuilder
     /// <param name="index">The index at which to insert.</param>
     /// <param name="value">The character to insert.</param>
     /// <param name="count">The number of times to insert the character.</param>
-    public void Insert(int index, char value, int count)
+    internal void Insert(int index, char value, int count)
     {
         if (_pos > _chars.Length - count)
         {
@@ -190,7 +190,7 @@ internal ref struct ValueStringBuilder
     /// <summary>Inserts a string at the given index.</summary>
     /// <param name="index">The index at which to insert.</param>
     /// <param name="s">The string to insert.</param>
-    public void Insert(int index, string? s)
+    internal void Insert(int index, string? s)
     {
         if (s is null)
         {
@@ -217,7 +217,7 @@ internal ref struct ValueStringBuilder
     /// <summary>Appends a single character to the builder.</summary>
     /// <param name="c">The character to append.</param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void Append(char c)
+    internal void Append(char c)
     {
         var pos = _pos;
         var chars = _chars;
@@ -235,7 +235,7 @@ internal ref struct ValueStringBuilder
     /// <summary>Appends a string to the builder.</summary>
     /// <param name="s">The string to append.</param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void Append(string? s)
+    internal void Append(string? s)
     {
         if (s is null)
         {
@@ -259,7 +259,7 @@ internal ref struct ValueStringBuilder
     /// <summary>Appends a character repeated a number of times.</summary>
     /// <param name="c">The character to append.</param>
     /// <param name="count">The number of times to append the character.</param>
-    public void Append(char c, int count)
+    internal void Append(char c, int count)
     {
         if (_pos > _chars.Length - count)
         {
@@ -277,7 +277,7 @@ internal ref struct ValueStringBuilder
 
     /// <summary>Appends the characters of a span to the builder.</summary>
     /// <param name="value">The characters to append.</param>
-    public void Append(ReadOnlySpan<char> value)
+    internal void Append(ReadOnlySpan<char> value)
     {
         var pos = _pos;
         if (pos > _chars.Length - value.Length)
@@ -293,7 +293,7 @@ internal ref struct ValueStringBuilder
     /// <param name="length">The number of characters to reserve.</param>
     /// <returns>A writable span for the reserved characters.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public Span<char> AppendSpan(int length)
+    internal Span<char> AppendSpan(int length)
     {
         var origPos = _pos;
         if (origPos > _chars.Length - length)
@@ -307,7 +307,7 @@ internal ref struct ValueStringBuilder
 
     /// <summary>Returns any rented buffer to the pool and resets the builder.</summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void Dispose()
+    internal void Dispose()
     {
         var toReturn = _arrayToReturnToPool;
         this = default; // for safety, to avoid using pooled array if this instance is erroneously appended to again

--- a/src/Shared/HttpContentExtensions.cs
+++ b/src/Shared/HttpContentExtensions.cs
@@ -14,20 +14,20 @@ internal static class HttpContentExtensions
         /// <summary>Loads the content into a buffer, ignoring the cancellation token.</summary>
         /// <param name="cancellationToken">A token to cancel the operation.</param>
         /// <returns>A task representing the buffering operation.</returns>
-        public Task LoadIntoBufferAsync(CancellationToken cancellationToken) =>
+        internal Task LoadIntoBufferAsync(CancellationToken cancellationToken) =>
             httpContent.LoadIntoBufferAsync();
 
 #if !NET6_0_OR_GREATER
         /// <summary>Reads the content as a stream, ignoring the cancellation token.</summary>
         /// <param name="cancellationToken">A token to cancel the operation.</param>
         /// <returns>A task producing the content stream.</returns>
-        public Task<Stream> ReadAsStreamAsync(CancellationToken cancellationToken) =>
+        internal Task<Stream> ReadAsStreamAsync(CancellationToken cancellationToken) =>
             httpContent.ReadAsStreamAsync();
 
         /// <summary>Reads the content as a string, ignoring the cancellation token.</summary>
         /// <param name="cancellationToken">A token to cancel the operation.</param>
         /// <returns>A task producing the content string.</returns>
-        public Task<string> ReadAsStringAsync(CancellationToken cancellationToken) =>
+        internal Task<string> ReadAsStringAsync(CancellationToken cancellationToken) =>
             httpContent.ReadAsStringAsync();
 #endif
     }

--- a/src/benchmarks/Refit.Benchmarks/GeneratorBenchmarkHarness.cs
+++ b/src/benchmarks/Refit.Benchmarks/GeneratorBenchmarkHarness.cs
@@ -34,7 +34,7 @@ internal static class GeneratorBenchmarkHarness
     /// <summary>Creates a compilation for the source text and a generator driver for it.</summary>
     /// <param name="sourceText">The source text to compile and feed to the generator.</param>
     /// <returns>The compilation and generator driver.</returns>
-    public static (Compilation Compilation, CSharpGeneratorDriver Driver) Create(string sourceText)
+    internal static (Compilation Compilation, CSharpGeneratorDriver Driver) Create(string sourceText)
     {
         var references = new List<MetadataReference>();
         foreach (var assembly in GetAssemblyReferencesForCodegen())
@@ -61,7 +61,7 @@ internal static class GeneratorBenchmarkHarness
     /// <summary>Runs the generator once and primes the driver for an incremental (cached) re-run.</summary>
     /// <param name="sourceText">The source text to compile and feed to the generator.</param>
     /// <returns>The compilation and primed generator driver.</returns>
-    public static (Compilation Compilation, CSharpGeneratorDriver Driver) CreatePrimedForCachedRun(
+    internal static (Compilation Compilation, CSharpGeneratorDriver Driver) CreatePrimedForCachedRun(
         string sourceText)
     {
         var (compilation, driver) = Create(sourceText);

--- a/src/benchmarks/Refit.Generator.Benchmarks/GeneratorCorpus.cs
+++ b/src/benchmarks/Refit.Generator.Benchmarks/GeneratorCorpus.cs
@@ -44,7 +44,7 @@ internal static class GeneratorCorpus
     ];
 
     /// <summary>Gets a single small CRUD interface: the common "one client, a handful of methods" case.</summary>
-    public static string Small { get; } =
+    internal static string Small { get; } =
         Preamble +
         """
         public sealed class Widget
@@ -73,13 +73,13 @@ internal static class GeneratorCorpus
         """;
 
     /// <summary>Gets a mid-sized corpus exercising query, path, header, and body binding across several interfaces.</summary>
-    public static string Medium { get; } = BuildMedium();
+    internal static string Medium { get; } = BuildMedium();
 
     /// <summary>Gets a large multi-interface, multi-method corpus for cold-run and throughput measurement.</summary>
-    public static string Large { get; } = BuildLarge();
+    internal static string Large { get; } = BuildLarge();
 
     /// <summary>Gets a query-heavy corpus exercising scalar, collection, object, and converter query bindings.</summary>
-    public static string QueryHeavy { get; } =
+    internal static string QueryHeavy { get; } =
         Preamble +
         """
         using System.Runtime.Serialization;
@@ -121,7 +121,7 @@ internal static class GeneratorCorpus
         """;
 
     /// <summary>Gets a multipart-heavy corpus exercising stream, byte-array, string, and typed multipart parts.</summary>
-    public static string MultipartHeavy { get; } =
+    internal static string MultipartHeavy { get; } =
         Preamble +
         """
         using System.IO;
@@ -149,7 +149,7 @@ internal static class GeneratorCorpus
     /// <summary>Gets the corpus source text for a given size.</summary>
     /// <param name="size">The corpus size.</param>
     /// <returns>The corpus source text.</returns>
-    public static string SourceFor(CorpusSize size) => size switch
+    internal static string SourceFor(CorpusSize size) => size switch
     {
         CorpusSize.Small => Small,
         CorpusSize.Medium => Medium,
@@ -232,7 +232,7 @@ internal static class GeneratorCorpus
 
         for (var i = 0; i < LargeInterfaceCount; i++)
         {
-            var route = "/res" + i.ToString(System.Globalization.CultureInfo.InvariantCulture);
+            var route = string.Create(System.Globalization.CultureInfo.InvariantCulture, $"/res{i}");
             _ = builder.Append("public interface IResource").Append(i).Append("Api\n{\n");
             for (var m = 0; m < LargeMethodsPerInterface; m++)
             {

--- a/src/benchmarks/Refit.Generator.Benchmarks/GeneratorHarness.cs
+++ b/src/benchmarks/Refit.Generator.Benchmarks/GeneratorHarness.cs
@@ -39,7 +39,7 @@ internal static class GeneratorHarness
     /// <summary>Builds a compilation for the source text.</summary>
     /// <param name="sourceText">The source text to compile.</param>
     /// <returns>The compilation.</returns>
-    public static CSharpCompilation BuildCompilation(string sourceText)
+    internal static CSharpCompilation BuildCompilation(string sourceText)
     {
         var references = new List<MetadataReference>();
         foreach (var assembly in GetAssemblyReferencesForCodegen())
@@ -62,7 +62,7 @@ internal static class GeneratorHarness
     /// <summary>Creates a compilation and a fresh (cold) generator driver for the source text.</summary>
     /// <param name="sourceText">The source text to compile and feed to the generator.</param>
     /// <returns>The compilation and generator driver.</returns>
-    public static (Compilation Compilation, CSharpGeneratorDriver Driver) CreateColdState(string sourceText)
+    internal static (Compilation Compilation, CSharpGeneratorDriver Driver) CreateColdState(string sourceText)
     {
         var compilation = BuildCompilation(sourceText);
         var driver = CSharpGeneratorDriver.Create(new InterfaceStubGeneratorV2().AsSourceGenerator());
@@ -72,7 +72,7 @@ internal static class GeneratorHarness
     /// <summary>Runs the generator once and primes the driver for an incremental (cached) re-run.</summary>
     /// <param name="sourceText">The source text to compile and feed to the generator.</param>
     /// <returns>The compilation and primed generator driver, with an unrelated type added to the compilation.</returns>
-    public static (Compilation Compilation, CSharpGeneratorDriver Driver) CreatePrimedState(string sourceText)
+    internal static (Compilation Compilation, CSharpGeneratorDriver Driver) CreatePrimedState(string sourceText)
     {
         var (compilation, driver) = CreateColdState(sourceText);
         driver = (CSharpGeneratorDriver)driver.RunGeneratorsAndUpdateCompilation(compilation, out _, out _);
@@ -86,7 +86,7 @@ internal static class GeneratorHarness
     /// <summary>Collects the syntactic candidates the generator's providers would select from a compilation.</summary>
     /// <param name="compilation">The compilation to scan.</param>
     /// <returns>The candidate interface methods and candidate interfaces.</returns>
-    public static (ImmutableArray<MethodDeclarationSyntax> Methods, ImmutableArray<InterfaceDeclarationSyntax> Interfaces)
+    internal static (ImmutableArray<MethodDeclarationSyntax> Methods, ImmutableArray<InterfaceDeclarationSyntax> Interfaces)
         CollectCandidates(CSharpCompilation compilation)
     {
         var methods = ImmutableArray.CreateBuilder<MethodDeclarationSyntax>();
@@ -119,7 +119,7 @@ internal static class GeneratorHarness
     /// <param name="compilation">The compilation to parse.</param>
     /// <param name="candidates">The pre-collected syntactic candidates.</param>
     /// <returns>The context generation model produced by the parser.</returns>
-    public static ContextGenerationModel Parse(
+    internal static ContextGenerationModel Parse(
         CSharpCompilation compilation,
         (ImmutableArray<MethodDeclarationSyntax> Methods, ImmutableArray<InterfaceDeclarationSyntax> Interfaces) candidates) =>
         Parser.GenerateInterfaceStubs(
@@ -134,19 +134,19 @@ internal static class GeneratorHarness
     /// <summary>Resolves the Refit base HTTP method attribute symbol for a compilation.</summary>
     /// <param name="compilation">The compilation to resolve against.</param>
     /// <returns>The resolved attribute symbol.</returns>
-    public static INamedTypeSymbol GetHttpMethodBaseAttributeSymbol(CSharpCompilation compilation) =>
+    internal static INamedTypeSymbol GetHttpMethodBaseAttributeSymbol(CSharpCompilation compilation) =>
         compilation.GetTypeByMetadataName(HttpMethodAttributeMetadataName)!;
 
     /// <summary>Resolves <c>System.IFormattable</c> for a compilation.</summary>
     /// <param name="compilation">The compilation to resolve against.</param>
     /// <returns>The resolved symbol, or null when unavailable.</returns>
-    public static INamedTypeSymbol? GetFormattableSymbol(CSharpCompilation compilation) =>
+    internal static INamedTypeSymbol? GetFormattableSymbol(CSharpCompilation compilation) =>
         compilation.GetTypeByMetadataName("System.IFormattable");
 
     /// <summary>Collects the Refit method symbols declared across a compilation.</summary>
     /// <param name="compilation">The compilation to scan.</param>
     /// <returns>The Refit method symbols in declaration order.</returns>
-    public static List<IMethodSymbol> GetRefitMethodSymbols(CSharpCompilation compilation)
+    internal static List<IMethodSymbol> GetRefitMethodSymbols(CSharpCompilation compilation)
     {
         var httpAttribute = GetHttpMethodBaseAttributeSymbol(compilation);
         var (methods, _) = CollectCandidates(compilation);

--- a/src/examples/Meow.Common/Services/Issue2056And2058Demo.cs
+++ b/src/examples/Meow.Common/Services/Issue2056And2058Demo.cs
@@ -11,20 +11,22 @@ public static class Issue2056And2058Demo
     /// <summary>The number of items requested in the large payload validation.</summary>
     private const int LargePayloadItemCount = 2000;
 
+    /// <summary>The shared HTTP client used by the in-memory issue demonstration.</summary>
+    private static readonly HttpClient _httpClient = new(
+        new CustomerIdHeaderHandler(new DemoBackendHandler()))
+    { BaseAddress = new("https://demo.local") };
+
+    /// <summary>The shared Refit API backed by <see cref="_httpClient"/>.</summary>
+    private static readonly IIssueDemoApi _api = RestService.For<IIssueDemoApi>(
+        _httpClient,
+        new RefitSettings { ContentSerializer = new NewtonsoftJsonContentSerializer() });
+
     /// <summary>Runs both issue validations against an in-memory backend.</summary>
     /// <returns>A task that completes when both validations have run.</returns>
     public static async Task RunAsync()
     {
-        using var httpClient = new HttpClient(
-            new CustomerIdHeaderHandler(new DemoBackendHandler()))
-        { BaseAddress = new("https://demo.local") };
-
-        var api = RestService.For<IIssueDemoApi>(
-            httpClient,
-            new RefitSettings { ContentSerializer = new NewtonsoftJsonContentSerializer() });
-
-        await ValidateIssue2056Async(api).ConfigureAwait(false);
-        await ValidateIssue2058Async(api).ConfigureAwait(false);
+        await ValidateIssue2056Async(_api).ConfigureAwait(false);
+        await ValidateIssue2058Async(_api).ConfigureAwait(false);
     }
 
     /// <summary>Validates that per-request customer id headers are not shared across concurrent requests.</summary>

--- a/src/examples/SampleUsingLocalApi/ConsoleApplication/Program.cs
+++ b/src/examples/SampleUsingLocalApi/ConsoleApplication/Program.cs
@@ -36,7 +36,7 @@ internal static class Program
     /// <summary>Runs the interactive console loop that invokes the sample REST service.</summary>
     /// <param name="args">The command-line arguments.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    public static async Task Main(string[] args)
+    internal static async Task Main(string[] args)
     {
         Console.WriteLine("Hello World!");
         using var client = new HttpClient { BaseAddress = new("http://localhost:61868") };

--- a/src/examples/SampleUsingLocalApi/RestApiforTest/Program.cs
+++ b/src/examples/SampleUsingLocalApi/RestApiforTest/Program.cs
@@ -10,7 +10,7 @@ internal static class Program
     /// <remarks>This method configures and starts the web host. It is typically called automatically
     /// by the runtime and should not be invoked directly.</remarks>
     /// <param name="args">An array of command-line arguments supplied to the application.</param>
-    public static void Main(string[] args) => CreateWebHostBuilder(args).Build().Run();
+    internal static void Main(string[] args) => CreateWebHostBuilder(args).Build().Run();
 
     /// <summary>Initializes a new instance of the web host builder with pre-configured defaults and the specified startup class.</summary>
     /// <remarks>This method sets up the web host with default configuration, logging, and Kestrel
@@ -18,7 +18,7 @@ internal static class Program
     /// application's entry point to configure and launch the ASP.NET Core application.</remarks>
     /// <param name="args">An array of command-line arguments to configure the web host. May be empty but cannot be null.</param>
     /// <returns>A configured web host builder instance that can be used to build and run the web application.</returns>
-    public static IHostBuilder CreateWebHostBuilder(string[] args) =>
+    internal static IHostBuilder CreateWebHostBuilder(string[] args) =>
         Host.CreateDefaultBuilder(args)
             .ConfigureWebHostDefaults(static webBuilder => webBuilder.UseStartup<Startup>());
 }

--- a/src/examples/SampleUsingLocalApi/RestApiforTest/Startup.cs
+++ b/src/examples/SampleUsingLocalApi/RestApiforTest/Startup.cs
@@ -8,7 +8,7 @@ namespace RestApiforTest;
 /// request pipeline for the application. It defines methods for registering services with the dependency injection
 /// container and for specifying how HTTP requests are handled. This class is typically specified as the entry point
 /// for application startup in the program's host configuration.</remarks>
-internal sealed class Startup
+public sealed class Startup
 {
     /// <summary>Initializes a new instance of the Startup class with the specified application configuration settings.</summary>
     /// <param name="configuration">The application configuration settings to be used for configuring services and the app's request pipeline.

--- a/src/tests/HttpClientTestFactory.cs
+++ b/src/tests/HttpClientTestFactory.cs
@@ -1,0 +1,30 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Refit;
+
+/// <summary>Creates deterministically disposable HTTP clients for isolated test handlers.</summary>
+internal static class HttpClientTestFactory
+{
+    /// <summary>Creates a client using the platform's default handler.</summary>
+    /// <returns>A client owned by the caller.</returns>
+    internal static HttpClient Create() => new();
+
+    /// <summary>Creates a client over an isolated test handler.</summary>
+    /// <param name="handler">The handler owned by the client.</param>
+    /// <returns>A client owned by the caller.</returns>
+    internal static HttpClient Create(HttpMessageHandler handler) => new(handler);
+
+    /// <summary>Creates a client using the platform's default handler and the supplied base address.</summary>
+    /// <param name="baseAddress">The base address assigned to the client.</param>
+    /// <returns>A client owned by the caller.</returns>
+    internal static HttpClient Create(Uri baseAddress) => new() { BaseAddress = baseAddress };
+
+    /// <summary>Creates a client over an isolated test handler and assigns its base address.</summary>
+    /// <param name="handler">The handler owned by the client.</param>
+    /// <param name="baseAddress">The base address assigned to the client.</param>
+    /// <returns>A client owned by the caller.</returns>
+    internal static HttpClient Create(HttpMessageHandler handler, Uri baseAddress) =>
+        new(handler) { BaseAddress = baseAddress };
+}

--- a/src/tests/Refit.Analyzers.Tests/AnalyzerFixture.cs
+++ b/src/tests/Refit.Analyzers.Tests/AnalyzerFixture.cs
@@ -27,14 +27,14 @@ internal static class AnalyzerFixture
     /// <param name="body">The interface body source.</param>
     /// <param name="generatedRequestBuilding">The value forced for the <c>RefitGeneratedRequestBuilding</c> option, or <see langword="null"/> to use the default.</param>
     /// <returns>The diagnostics produced by the analyzer.</returns>
-    public static Task<ImmutableArray<Diagnostic>> RunForBody(string body, bool? generatedRequestBuilding = null) =>
+    internal static Task<ImmutableArray<Diagnostic>> RunForBody(string body, bool? generatedRequestBuilding = null) =>
         Run(BuildBodySource(body), generatedRequestBuilding);
 
     /// <summary>Runs the Refit interface analyzer over a complete source string.</summary>
     /// <param name="source">The source to analyze.</param>
     /// <param name="generatedRequestBuilding">The value forced for the <c>RefitGeneratedRequestBuilding</c> option, or <see langword="null"/> to use the default.</param>
     /// <returns>The diagnostics produced by the analyzer.</returns>
-    public static Task<ImmutableArray<Diagnostic>> Run(string source, bool? generatedRequestBuilding = null)
+    internal static Task<ImmutableArray<Diagnostic>> Run(string source, bool? generatedRequestBuilding = null)
     {
         var analyzerOptions = generatedRequestBuilding is null
             ? null
@@ -55,7 +55,7 @@ internal static class AnalyzerFixture
     /// <param name="optionKey">The bare analyzer-config option key.</param>
     /// <param name="optionValue">The analyzer-config option value.</param>
     /// <returns>The diagnostics produced by the analyzer.</returns>
-    public static Task<ImmutableArray<Diagnostic>> RunForBodyWithAnalyzerConfigOption(string body, string optionKey, string optionValue) =>
+    internal static Task<ImmutableArray<Diagnostic>> RunForBodyWithAnalyzerConfigOption(string body, string optionKey, string optionValue) =>
         Analyze(
             BuildBodySource(body),
             new AnalyzerOptions([], new TestAnalyzerConfigOptionsProvider(optionKey, optionValue)));
@@ -63,7 +63,7 @@ internal static class AnalyzerFixture
     /// <summary>Runs the Refit interface analyzer over source without referencing Refit.</summary>
     /// <param name="source">The source to analyze.</param>
     /// <returns>The diagnostics produced by the analyzer.</returns>
-    public static Task<ImmutableArray<Diagnostic>> RunWithoutRefitReference(string source)
+    internal static Task<ImmutableArray<Diagnostic>> RunWithoutRefitReference(string source)
     {
         var compilation = CreateLibrary(source, includeRefitReference: false);
         var analyzer = new RefitInterfaceAnalyzer();

--- a/src/tests/Refit.CodeFixes.Tests/CodeFixFixture.cs
+++ b/src/tests/Refit.CodeFixes.Tests/CodeFixFixture.cs
@@ -2,6 +2,7 @@
 // ReactiveUI and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 using System.Collections.Immutable;
+using System.Composition.Hosting;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Microsoft.CodeAnalysis;
@@ -27,11 +28,16 @@ internal static class CodeFixFixture
     /// <summary>The in-memory document name used for code-fix test compilations.</summary>
     private const string DefaultTestFileName = "Test.cs";
 
+    /// <summary>The MEF host that creates the shared Refit code-fix provider.</summary>
+    private static readonly CompositionHost CodeFixProviderHost = new ContainerConfiguration()
+        .WithPart<RefitInterfaceCodeFixProvider>()
+        .CreateContainer();
+
     /// <summary>Applies the first available code fix for a diagnostic ID.</summary>
     /// <param name="source">The source to fix.</param>
     /// <param name="diagnosticId">The diagnostic ID to fix.</param>
     /// <returns>The updated source.</returns>
-    public static async Task<string> ApplyFirstFix(string source, string diagnosticId)
+    internal static async Task<string> ApplyFirstFix(string source, string diagnosticId)
     {
         using var workspace = new AdhocWorkspace();
         var project = workspace
@@ -47,15 +53,14 @@ internal static class CodeFixFixture
         var diagnostics = await compilation
             .WithAnalyzers([new RefitInterfaceAnalyzer()])
             .GetAnalyzerDiagnosticsAsync();
+        var compilerDiagnostics = string.Join(", ", compilation.GetDiagnostics().Select(static x => x.ToString()));
+        var analyzerDiagnostics = string.Join(", ", diagnostics.Select(static x => x.ToString()));
         var diagnostic = diagnostics.SingleOrDefault(x => x.Id == diagnosticId)
                          ?? throw new InvalidOperationException(
-                             "Expected diagnostic was not produced. Compiler diagnostics: "
-                             + string.Join(", ", compilation.GetDiagnostics().Select(static x => x.ToString()))
-                             + ". Analyzer diagnostics: "
-                             + string.Join(", ", diagnostics.Select(static x => x.ToString())));
+                             $"Expected diagnostic was not produced. Compiler diagnostics: {compilerDiagnostics}. Analyzer diagnostics: {analyzerDiagnostics}");
 
         var actions = new List<CodeAction>();
-        var provider = new RefitInterfaceCodeFixProvider();
+        var provider = GetCodeFixProvider();
         var context = new CodeFixContext(
             document,
             diagnostic,
@@ -81,14 +86,14 @@ internal static class CodeFixFixture
 
     /// <summary>Gets the fix-all provider from the Refit code-fix provider.</summary>
     /// <returns>The fix-all provider.</returns>
-    public static FixAllProvider? GetFixAllProvider() =>
-        new RefitInterfaceCodeFixProvider().GetFixAllProvider();
+    internal static FixAllProvider? GetFixAllProvider() =>
+        GetCodeFixProvider().GetFixAllProvider();
 
     /// <summary>Applies the forward-slash helper directly at the first occurrence of the marker.</summary>
     /// <param name="source">The source to update.</param>
     /// <param name="marker">The source marker used to create the diagnostic span.</param>
     /// <returns>The updated source.</returns>
-    public static async Task<string> UseForwardSlashesDirectly(string source, string marker)
+    internal static async Task<string> UseForwardSlashesDirectly(string source, string marker)
     {
         var document = CreateDocument(source);
         var diagnostic = CreateDiagnostic("RF003", source, marker);
@@ -101,7 +106,7 @@ internal static class CodeFixFixture
     /// <param name="source">The source to update.</param>
     /// <param name="marker">The source marker used to create the diagnostic span.</param>
     /// <returns>The updated source.</returns>
-    public static async Task<string> UseHeaderCollectionTypeDirectly(string source, string marker)
+    internal static async Task<string> UseHeaderCollectionTypeDirectly(string source, string marker)
     {
         var document = CreateDocument(source);
         var diagnostic = CreateDiagnostic("RF005", source, marker);
@@ -147,6 +152,11 @@ internal static class CodeFixFixture
             .AddMetadataReferences(GetMetadataReferences())
             .AddDocument(DefaultTestFileName, SourceText.From(source));
     }
+
+    /// <summary>Gets the code-fix provider through its configured MEF shared export.</summary>
+    /// <returns>The Refit code-fix provider.</returns>
+    private static CodeFixProvider GetCodeFixProvider() =>
+        CodeFixProviderHost.GetExport<CodeFixProvider>();
 
     /// <summary>Creates a diagnostic over the first occurrence of a marker string.</summary>
     /// <param name="diagnosticId">The diagnostic ID.</param>

--- a/src/tests/Refit.GeneratorTests/AotSafeAssertionExtensions.cs
+++ b/src/tests/Refit.GeneratorTests/AotSafeAssertionExtensions.cs
@@ -19,7 +19,7 @@ internal static class AotSafeAssertionExtensions
         /// <summary>Asserts collection equivalence with the element type's default comparer.</summary>
         /// <param name="expected">The expected element sequence.</param>
         /// <returns>The chained collection-equivalency assertion.</returns>
-        public IsEquivalentToAssertion<TCollection, TItem> IsCollectionEqualTo(
+        internal IsEquivalentToAssertion<TCollection, TItem> IsCollectionEqualTo(
             IEnumerable<TItem> expected) =>
             source.IsEquivalentTo(expected, EqualityComparer<TItem>.Default);
     }

--- a/src/tests/Refit.GeneratorTests/EscapedIdentifierBindingTests.cs
+++ b/src/tests/Refit.GeneratorTests/EscapedIdentifierBindingTests.cs
@@ -100,7 +100,7 @@ public sealed class EscapedIdentifierBindingTests
             if (!result.CompilesWithoutErrors)
             {
                 throw new InvalidOperationException(
-                    "Generated compilation failed: " + string.Join(Environment.NewLine, result.CompilationErrors));
+                    $"Generated compilation failed: {string.Join(Environment.NewLine, result.CompilationErrors)}");
             }
 
             var (assembly, loadContext) = Fixture.EmitAndLoad(result);

--- a/src/tests/Refit.GeneratorTests/ExternAliasTests.cs
+++ b/src/tests/Refit.GeneratorTests/ExternAliasTests.cs
@@ -142,7 +142,7 @@ public sealed class ExternAliasTests
             """;
 
         var generated = await RunAndAssertNoErrors(consumer);
-        await Assert.That(generated).Contains(AliasedWidgetQualifiedName + "[]");
+        await Assert.That(generated).Contains($"{AliasedWidgetQualifiedName}[]");
     }
 
     /// <summary>Verifies a nullable extern-aliased enum query parameter qualifies its underlying type as <c>alias::</c>.</summary>

--- a/src/tests/Refit.GeneratorTests/Incremental/IncrementalGeneratorRunReasons.cs
+++ b/src/tests/Refit.GeneratorTests/Incremental/IncrementalGeneratorRunReasons.cs
@@ -13,23 +13,23 @@ internal sealed record IncrementalGeneratorRunReasons(
     IncrementalStepRunReason ReportDiagnosticsStep)
 {
     /// <summary>The expected reasons for a brand-new generator run.</summary>
-    public static readonly IncrementalGeneratorRunReasons New =
+    internal static readonly IncrementalGeneratorRunReasons New =
         new(IncrementalStepRunReason.New, IncrementalStepRunReason.New);
 
     /// <summary>The expected reasons for a cached generator run.</summary>
     /// <remarks>The compilation step is always modified because a new compilation is passed each time.</remarks>
-    public static readonly IncrementalGeneratorRunReasons Cached =
+    internal static readonly IncrementalGeneratorRunReasons Cached =
         new(IncrementalStepRunReason.Cached, IncrementalStepRunReason.Unchanged);
 
     /// <summary>The expected reasons when both steps are modified.</summary>
-    public static readonly IncrementalGeneratorRunReasons Modified = Cached with
+    internal static readonly IncrementalGeneratorRunReasons Modified = Cached with
     {
         ReportDiagnosticsStep = IncrementalStepRunReason.Modified,
         BuildRefitStep = IncrementalStepRunReason.Modified
     };
 
     /// <summary>The expected reasons when only the source changed.</summary>
-    public static readonly IncrementalGeneratorRunReasons ModifiedSource = Cached with
+    internal static readonly IncrementalGeneratorRunReasons ModifiedSource = Cached with
     {
         ReportDiagnosticsStep = IncrementalStepRunReason.Unchanged,
         BuildRefitStep = IncrementalStepRunReason.Modified

--- a/src/tests/Refit.GeneratorTests/Incremental/RefitGeneratorStepName.cs
+++ b/src/tests/Refit.GeneratorTests/Incremental/RefitGeneratorStepName.cs
@@ -7,8 +7,8 @@ namespace Refit.GeneratorTests.Incremental;
 internal static class RefitGeneratorStepName
 {
     /// <summary>The name of the diagnostics reporting step.</summary>
-    public const string ReportDiagnostics = "ReportDiagnostics";
+    internal const string ReportDiagnostics = "ReportDiagnostics";
 
     /// <summary>The name of the Refit build step.</summary>
-    public const string BuildRefit = "BuildRefit";
+    internal const string BuildRefit = "BuildRefit";
 }

--- a/src/tests/Refit.GeneratorTests/Incremental/TestHelper.cs
+++ b/src/tests/Refit.GeneratorTests/Incremental/TestHelper.cs
@@ -137,7 +137,7 @@ internal static class TestHelper
         string interfaceName,
         IncrementalStepRunReason expectedReason)
     {
-        var qualifiedSuffix = "." + interfaceName;
+        var qualifiedSuffix = $".{interfaceName}";
         var interfaceOutput = driver
             .GetRunResult()
             .Results[0]

--- a/src/tests/Refit.GeneratorTests/LiveCompilationTests.cs
+++ b/src/tests/Refit.GeneratorTests/LiveCompilationTests.cs
@@ -71,10 +71,7 @@ public sealed class LiveCompilationTests
             .Single(type => type.IsClass && interfaceType.IsAssignableFrom(type));
 
         using var handler = new CapturingHandler();
-        using var client = new HttpClient(handler)
-        {
-            BaseAddress = new("https://example.test/base/")
-        };
+        using var client = HttpClientTestFactory.Create(handler, new("https://example.test/base/"));
         var settings = new RefitSettings();
         var requestBuilder = RequestBuilder.ForType(interfaceType, settings);
         var api = Activator.CreateInstance(generatedType, [client, requestBuilder])!;

--- a/src/tests/Refit.GeneratorTests/MultipartRequestBuildingLiveTests.cs
+++ b/src/tests/Refit.GeneratorTests/MultipartRequestBuildingLiveTests.cs
@@ -290,7 +290,7 @@ public sealed class MultipartRequestBuildingLiveTests
             if (!result.CompilesWithoutErrors)
             {
                 throw new InvalidOperationException(
-                    "Generated compilation failed: " + string.Join(Environment.NewLine, result.CompilationErrors));
+                    $"Generated compilation failed: {string.Join(Environment.NewLine, result.CompilationErrors)}");
             }
 
             var (assembly, loadContext) = Fixture.EmitAndLoad(result);

--- a/src/tests/Refit.GeneratorTests/ObservableReturnRequestBuildingLiveTests.cs
+++ b/src/tests/Refit.GeneratorTests/ObservableReturnRequestBuildingLiveTests.cs
@@ -90,7 +90,7 @@ public sealed class ObservableReturnRequestBuildingLiveTests
             if (!result.CompilesWithoutErrors)
             {
                 throw new InvalidOperationException(
-                    "Generated compilation failed: " + string.Join(Environment.NewLine, result.CompilationErrors));
+                    $"Generated compilation failed: {string.Join(Environment.NewLine, result.CompilationErrors)}");
             }
 
             var (assembly, loadContext) = Fixture.EmitAndLoad(result);

--- a/src/tests/Refit.GeneratorTests/QueryRequestBuildingLiveTests.cs
+++ b/src/tests/Refit.GeneratorTests/QueryRequestBuildingLiveTests.cs
@@ -561,7 +561,7 @@ public sealed partial class QueryRequestBuildingLiveTests
             if (!result.CompilesWithoutErrors)
             {
                 throw new InvalidOperationException(
-                    "Generated compilation failed: " + string.Join(Environment.NewLine, result.CompilationErrors));
+                    $"Generated compilation failed: {string.Join(Environment.NewLine, result.CompilationErrors)}");
             }
 
             var (assembly, loadContext) = Fixture.EmitAndLoad(result);

--- a/src/tests/Refit.GeneratorTests/RelativePathResolutionLiveTests.cs
+++ b/src/tests/Refit.GeneratorTests/RelativePathResolutionLiveTests.cs
@@ -67,7 +67,7 @@ public sealed class RelativePathResolutionLiveTests
     {
         using var context = Compile(out var interfaceType, out var generatedType);
         using var handler = new CapturingHandler();
-        using var client = new HttpClient(handler) { BaseAddress = new(BaseAddress) };
+        using var client = HttpClientTestFactory.Create(handler, new(BaseAddress));
         var requestBuilder = RequestBuilder.ForType(interfaceType, new RefitSettings { UrlResolution = UrlResolutionMode.Rfc3986 });
         var generatedApi = Activator.CreateInstance(generatedType, [client, requestBuilder])!;
 
@@ -91,7 +91,7 @@ public sealed class RelativePathResolutionLiveTests
     {
         using var context = Compile(out var interfaceType, out var generatedType);
         using var handler = new CapturingHandler();
-        using var client = new HttpClient(handler) { BaseAddress = new(BaseAddress) };
+        using var client = HttpClientTestFactory.Create(handler, new(BaseAddress));
 
         // The generated client, built from settings alone, rejects the relative path under legacy resolution.
         var generatedApi = Activator.CreateInstance(generatedType, [client, new RefitSettings()])!;
@@ -123,7 +123,7 @@ public sealed class RelativePathResolutionLiveTests
         if (!result.CompilesWithoutErrors)
         {
             throw new InvalidOperationException(
-                "Generated compilation failed: " + string.Join(Environment.NewLine, result.CompilationErrors));
+                $"Generated compilation failed: {string.Join(Environment.NewLine, result.CompilationErrors)}");
         }
 
         var (assembly, loadContext) = Fixture.EmitAndLoad(result);

--- a/src/tests/Refit.Reflection.Tests/AotSafeAssertionExtensions.cs
+++ b/src/tests/Refit.Reflection.Tests/AotSafeAssertionExtensions.cs
@@ -25,7 +25,7 @@ internal static class AotSafeAssertionExtensions
         /// </summary>
         /// <param name="expected">The expected element sequence.</param>
         /// <returns>The chained collection-equivalency assertion.</returns>
-        public IsEquivalentToAssertion<TCollection, TItem> IsCollectionEqualTo(IEnumerable<TItem> expected) =>
+        internal IsEquivalentToAssertion<TCollection, TItem> IsCollectionEqualTo(IEnumerable<TItem> expected) =>
             source.IsEquivalentTo(expected, EqualityComparer<TItem>.Default);
     }
 }

--- a/src/tests/Refit.Reflection.Tests/ReflectionQueryMapCachingTests.cs
+++ b/src/tests/Refit.Reflection.Tests/ReflectionQueryMapCachingTests.cs
@@ -33,7 +33,7 @@ public sealed class ReflectionQueryMapCachingTests
         var query = CreateModel();
 
         var handler = new TestHttpMessageHandler();
-        using var client = new HttpClient(handler) { BaseAddress = new(BaseAddress) };
+        using var client = HttpClientTestFactory.Create(handler, new(BaseAddress));
         var generated = RestService.ForGenerated<IReflectionCachingQueryApi>(client, new RefitSettings());
         _ = await generated.Flatten(query);
         var generatedUri = handler.RequestMessage!.RequestUri!.PathAndQuery;

--- a/src/tests/Refit.Reflection.Tests/RequestBuilderTestExtensions.cs
+++ b/src/tests/Refit.Reflection.Tests/RequestBuilderTestExtensions.cs
@@ -14,7 +14,7 @@ internal static class RequestBuilderTestExtensions
         /// <param name="methodName">The name of the interface method to build a request for.</param>
         /// <param name="baseAddress">The base address used by the test HTTP client.</param>
         /// <returns>A factory that maps a parameter array to a task producing the request message.</returns>
-        public Func<object[], Task<HttpRequestMessage>> BuildRequestFactoryForMethod(
+        internal Func<object[], Task<HttpRequestMessage>> BuildRequestFactoryForMethod(
             string methodName,
             string baseAddress = "http://api/")
         {
@@ -36,7 +36,7 @@ internal static class RequestBuilderTestExtensions
         /// <param name="returnContent">Optional response content the handler returns.</param>
         /// <param name="baseAddress">The base address used by the test HTTP client.</param>
         /// <returns>A factory that maps a parameter array to a task producing the handler that observed the request.</returns>
-        public Func<object[], Task<TestHttpMessageHandler>> RunRequest(
+        internal Func<object[], Task<TestHttpMessageHandler>> RunRequest(
             string methodName,
             string? returnContent = null,
             string baseAddress = "http://api/")

--- a/src/tests/Refit.Testing.Tests/NetworkBehaviorTests.cs
+++ b/src/tests/Refit.Testing.Tests/NetworkBehaviorTests.cs
@@ -111,7 +111,7 @@ public sealed class NetworkBehaviorTests
     /// <returns>The response produced by the handler.</returns>
     private static async Task<HttpResponseMessage> SendAsync(StubHttp handler, string url)
     {
-        using var client = new HttpClient(handler);
+        using var client = HttpClientTestFactory.Create(handler);
         return await client.GetAsync(new Uri(url));
     }
 }

--- a/src/tests/Refit.Testing.Tests/RetryAndTimeoutTests.cs
+++ b/src/tests/Refit.Testing.Tests/RetryAndTimeoutTests.cs
@@ -116,11 +116,8 @@ public sealed class RetryAndTimeoutTests
         const int clientTimeoutMilliseconds = 50;
         var handler = CreateDelayedHandler(TimeSpan.FromSeconds(injectedDelaySeconds));
 
-        using var client = new HttpClient(handler)
-        {
-            BaseAddress = new(BaseUrl),
-            Timeout = TimeSpan.FromMilliseconds(clientTimeoutMilliseconds),
-        };
+        using var client = HttpClientTestFactory.Create(handler, new(BaseUrl));
+        client.Timeout = TimeSpan.FromMilliseconds(clientTimeoutMilliseconds);
         var api = RestService.For<IUserApi>(client);
 
         var error = await Assert.That(async () => _ = await api.GetUser(SampleUserId)).ThrowsExactly<ApiRequestException>();
@@ -136,11 +133,8 @@ public sealed class RetryAndTimeoutTests
         const int clientTimeoutSeconds = 30;
         var handler = CreateDelayedHandler(TimeSpan.FromMilliseconds(1));
 
-        using var client = new HttpClient(handler)
-        {
-            BaseAddress = new(BaseUrl),
-            Timeout = TimeSpan.FromSeconds(clientTimeoutSeconds),
-        };
+        using var client = HttpClientTestFactory.Create(handler, new(BaseUrl));
+        client.Timeout = TimeSpan.FromSeconds(clientTimeoutSeconds);
         var api = RestService.For<IUserApi>(client);
 
         var user = await api.GetUser(SampleUserId);

--- a/src/tests/Refit.Testing.Tests/StubHttpCoverageTests.cs
+++ b/src/tests/Refit.Testing.Tests/StubHttpCoverageTests.cs
@@ -40,11 +40,11 @@ public sealed class StubHttpCoverageTests
             { Route.For(HttpMethod.Options, "/options"), Reply.Status(HttpStatusCode.OK) },
         };
 
-        await Assert.That((await SendAsync(handler, HttpMethod.Put, BaseUrl + "/put")).StatusCode).IsEqualTo(HttpStatusCode.OK);
-        await Assert.That((await SendAsync(handler, HttpMethod.Delete, BaseUrl + "/delete")).StatusCode).IsEqualTo(HttpStatusCode.OK);
-        await Assert.That((await SendAsync(handler, HttpMethod.Patch, BaseUrl + "/patch")).StatusCode).IsEqualTo(HttpStatusCode.OK);
-        await Assert.That((await SendAsync(handler, HttpMethod.Head, BaseUrl + "/head")).StatusCode).IsEqualTo(HttpStatusCode.OK);
-        await Assert.That((await SendAsync(handler, HttpMethod.Options, BaseUrl + "/options")).StatusCode).IsEqualTo(HttpStatusCode.OK);
+        await Assert.That((await SendAsync(handler, HttpMethod.Put, $"{BaseUrl}/put")).StatusCode).IsEqualTo(HttpStatusCode.OK);
+        await Assert.That((await SendAsync(handler, HttpMethod.Delete, $"{BaseUrl}/delete")).StatusCode).IsEqualTo(HttpStatusCode.OK);
+        await Assert.That((await SendAsync(handler, HttpMethod.Patch, $"{BaseUrl}/patch")).StatusCode).IsEqualTo(HttpStatusCode.OK);
+        await Assert.That((await SendAsync(handler, HttpMethod.Head, $"{BaseUrl}/head")).StatusCode).IsEqualTo(HttpStatusCode.OK);
+        await Assert.That((await SendAsync(handler, HttpMethod.Options, $"{BaseUrl}/options")).StatusCode).IsEqualTo(HttpStatusCode.OK);
         await handler.VerifyAllCalledAsync();
     }
 
@@ -55,7 +55,7 @@ public sealed class StubHttpCoverageTests
     {
         var handler = new StubHttp { { Route.Get("/j"), Reply.Json("{\"ok\":true}", HttpStatusCode.Created) } };
 
-        var response = await SendAsync(handler, HttpMethod.Get, BaseUrl + "/j");
+        var response = await SendAsync(handler, HttpMethod.Get, $"{BaseUrl}/j");
 
         await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.Created);
         await Assert.That(response.Content.Headers.ContentType?.MediaType).IsEqualTo("application/json");
@@ -68,7 +68,7 @@ public sealed class StubHttpCoverageTests
     {
         var handler = new StubHttp { { Route.Get("/t"), Reply.Text("<b>hi</b>", "text/html") } };
 
-        var response = await SendAsync(handler, HttpMethod.Get, BaseUrl + "/t");
+        var response = await SendAsync(handler, HttpMethod.Get, $"{BaseUrl}/t");
 
         await Assert.That(response.Content.Headers.ContentType?.MediaType).IsEqualTo("text/html");
         await Assert.That(await response.Content.ReadAsStringAsync()).IsEqualTo("<b>hi</b>");
@@ -81,7 +81,7 @@ public sealed class StubHttpCoverageTests
     {
         var handler = new StubHttp { { Route.Get("/c"), Reply.Content(new StringContent("raw-bytes")) } };
 
-        var response = await SendAsync(handler, HttpMethod.Get, BaseUrl + "/c");
+        var response = await SendAsync(handler, HttpMethod.Get, $"{BaseUrl}/c");
 
         await Assert.That(await response.Content.ReadAsStringAsync()).IsEqualTo("raw-bytes");
     }
@@ -131,7 +131,7 @@ public sealed class StubHttpCoverageTests
     {
         var handler = new StubHttp { { Route.Get("/none"), Reply.Status(HttpStatusCode.OK) } };
 
-        _ = await SendAsync(handler, HttpMethod.Get, BaseUrl + "/none");
+        _ = await SendAsync(handler, HttpMethod.Get, $"{BaseUrl}/none");
 
         await Assert.That(await handler.LastRequestBodyAsync<NewUser>()).IsNull();
     }
@@ -166,7 +166,7 @@ public sealed class StubHttpCoverageTests
     {
         var handler = new StubHttp { { Route.Get(PlaceholderRoute), Reply.Status(HttpStatusCode.OK) } };
 
-        await Assert.That(async () => _ = await SendAsync(handler, HttpMethod.Get, BaseUrl + "/a/"))
+        await Assert.That(async () => _ = await SendAsync(handler, HttpMethod.Get, $"{BaseUrl}/a/"))
             .ThrowsExactly<InvalidOperationException>();
     }
 
@@ -177,7 +177,7 @@ public sealed class StubHttpCoverageTests
     {
         var handler = new StubHttp { { Route.Get(PlaceholderRoute), Reply.Status(HttpStatusCode.OK) } };
 
-        await Assert.That(async () => _ = await SendAsync(handler, HttpMethod.Get, BaseUrl + "/a/1/extra"))
+        await Assert.That(async () => _ = await SendAsync(handler, HttpMethod.Get, $"{BaseUrl}/a/1/extra"))
             .ThrowsExactly<InvalidOperationException>();
     }
 
@@ -188,7 +188,7 @@ public sealed class StubHttpCoverageTests
     {
         var handler = new StubHttp { { Route.Get(PlaceholderRoute), Reply.Status(HttpStatusCode.OK) } };
 
-        await Assert.That(async () => _ = await SendAsync(handler, HttpMethod.Get, BaseUrl + "/b/1"))
+        await Assert.That(async () => _ = await SendAsync(handler, HttpMethod.Get, $"{BaseUrl}/b/1"))
             .ThrowsExactly<InvalidOperationException>();
     }
 
@@ -199,7 +199,7 @@ public sealed class StubHttpCoverageTests
     {
         var handler = new StubHttp { { new RouteMatcher { Method = HttpMethod.Get, Template = "/q", Query = [("a", "1")] }, Reply.Status(HttpStatusCode.OK) } };
 
-        var response = await SendAsync(handler, HttpMethod.Get, BaseUrl + "/q?a=1&&b=2");
+        var response = await SendAsync(handler, HttpMethod.Get, $"{BaseUrl}/q?a=1&&b=2");
 
         await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
     }
@@ -211,7 +211,7 @@ public sealed class StubHttpCoverageTests
     {
         var handler = new StubHttp { { new RouteMatcher { Method = HttpMethod.Get, Template = "/q", ExactQueryParams = [("a", "1")] }, Reply.Status(HttpStatusCode.OK) } };
 
-        await Assert.That(async () => _ = await SendAsync(handler, HttpMethod.Get, BaseUrl + "/q?a=2"))
+        await Assert.That(async () => _ = await SendAsync(handler, HttpMethod.Get, $"{BaseUrl}/q?a=2"))
             .ThrowsExactly<InvalidOperationException>();
     }
 
@@ -253,7 +253,7 @@ public sealed class StubHttpCoverageTests
     {
         var handler = new StubHttp { { new RouteMatcher { Method = HttpMethod.Post, Template = "/empty", Body = string.Empty }, Reply.Status(HttpStatusCode.OK) } };
 
-        var response = await SendAsync(handler, HttpMethod.Post, BaseUrl + "/empty");
+        var response = await SendAsync(handler, HttpMethod.Post, $"{BaseUrl}/empty");
 
         await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
     }
@@ -267,7 +267,7 @@ public sealed class StubHttpCoverageTests
         content.Headers.Add("Content-Language", "en");
         var handler = new StubHttp { { new RouteMatcher { Method = HttpMethod.Post, Template = "/h", Headers = [("Content-Language", "en")] }, Reply.Status(HttpStatusCode.OK) } };
 
-        var response = await SendAsync(handler, HttpMethod.Post, BaseUrl + "/h", content);
+        var response = await SendAsync(handler, HttpMethod.Post, $"{BaseUrl}/h", content);
 
         await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
     }
@@ -279,7 +279,7 @@ public sealed class StubHttpCoverageTests
     {
         var handler = new StubHttp { { new RouteMatcher { Method = HttpMethod.Get, Template = "/q", Query = [("flag", string.Empty)] }, Reply.Status(HttpStatusCode.OK) } };
 
-        var response = await SendAsync(handler, HttpMethod.Get, BaseUrl + "/q?flag&a=1");
+        var response = await SendAsync(handler, HttpMethod.Get, $"{BaseUrl}/q?flag&a=1");
 
         await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
     }
@@ -291,7 +291,7 @@ public sealed class StubHttpCoverageTests
     {
         var handler = new StubHttp { { new RouteMatcher { Method = HttpMethod.Post, Template = "/raw" }, Reply.Status(HttpStatusCode.OK) } };
 
-        _ = await SendAsync(handler, HttpMethod.Post, BaseUrl + "/raw", new ByteArrayContent("{\"Login\":\"z\"}"u8.ToArray()));
+        _ = await SendAsync(handler, HttpMethod.Post, $"{BaseUrl}/raw", new ByteArrayContent("{\"Login\":\"z\"}"u8.ToArray()));
 
         var sent = await handler.RequestBodyAsync<NewUser>(0);
         await Assert.That(sent!.Login).IsEqualTo("z");
@@ -328,7 +328,7 @@ public sealed class StubHttpCoverageTests
     {
         var handler = new StubHttp { { new RouteMatcher { Method = HttpMethod.Post, Template = "/u" }, Reply.Status(HttpStatusCode.OK) } };
 
-        var response = await SendAsync(handler, HttpMethod.Post, BaseUrl + "/u", new ThrowingContent());
+        var response = await SendAsync(handler, HttpMethod.Post, $"{BaseUrl}/u", new ThrowingContent());
 
         await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
         await Assert.That(await handler.LastRequestBodyAsync<NewUser>()).IsNull();
@@ -346,7 +346,7 @@ public sealed class StubHttpCoverageTests
         string url,
         HttpContent? content = null)
     {
-        using var client = new HttpClient(handler);
+        using var client = HttpClientTestFactory.Create(handler);
         using var request = new HttpRequestMessage(method, url) { Content = content };
         return await client.SendAsync(request);
     }

--- a/src/tests/Refit.Testing.Tests/StubHttpTests.cs
+++ b/src/tests/Refit.Testing.Tests/StubHttpTests.cs
@@ -169,7 +169,7 @@ public sealed class StubHttpTests
             },
         };
 
-        await Assert.That(async () => _ = await SendAsync(handler, HttpMethod.Get, QueryUrl + "?a=2"))
+        await Assert.That(async () => _ = await SendAsync(handler, HttpMethod.Get, $"{QueryUrl}?a=2"))
             .ThrowsExactly<InvalidOperationException>();
     }
 
@@ -186,7 +186,7 @@ public sealed class StubHttpTests
             },
         };
 
-        var response = await SendAsync(handler, HttpMethod.Get, QueryUrl + "?key%2C=value%2C");
+        var response = await SendAsync(handler, HttpMethod.Get, $"{QueryUrl}?key%2C=value%2C");
 
         await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
     }
@@ -221,7 +221,7 @@ public sealed class StubHttpTests
             },
         };
 
-        var response = await SendAsync(handler, HttpMethod.Get, QueryUrl + "?enums=k0%2Ck1");
+        var response = await SendAsync(handler, HttpMethod.Get, $"{QueryUrl}?enums=k0%2Ck1");
 
         await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
     }
@@ -257,7 +257,7 @@ public sealed class StubHttpTests
             },
         };
 
-        using var client = new HttpClient(handler);
+        using var client = HttpClientTestFactory.Create(handler);
         using var withHeader = new HttpRequestMessage(HttpMethod.Get, "https://api/h");
         withHeader.Headers.Add("X-Refit", "99");
         var ok = await client.SendAsync(withHeader);
@@ -337,7 +337,7 @@ public sealed class StubHttpTests
             },
         };
 
-        using var client = new HttpClient(handler);
+        using var client = HttpClientTestFactory.Create(handler);
         using var flagged = new HttpRequestMessage(HttpMethod.Get, "https://api/w");
         flagged.Headers.Add("X-Flag", "1");
 
@@ -388,7 +388,7 @@ public sealed class StubHttpTests
 
         for (var i = 0; i < callCount; i++)
         {
-            _ = await SendAsync(handler, HttpMethod.Get, "https://api/" + i);
+            _ = await SendAsync(handler, HttpMethod.Get, $"https://api/{i}");
         }
 
         await handler.VerifyAllCalledAsync();
@@ -517,7 +517,7 @@ public sealed class StubHttpTests
                 Reply.Status(HttpStatusCode.OK)
             },
         };
-        using var client = new HttpClient(handler);
+        using var client = HttpClientTestFactory.Create(handler);
 
         // Fire-and-forget: the request only lands after a delay, so a synchronous verify would fail.
         _ = Task.Run(async () =>
@@ -561,7 +561,7 @@ public sealed class StubHttpTests
         string url,
         HttpContent? content = null)
     {
-        using var client = new HttpClient(handler);
+        using var client = HttpClientTestFactory.Create(handler);
         using var request = new HttpRequestMessage(method, url) { Content = content };
         return await client.SendAsync(request);
     }

--- a/src/tests/Refit.Tests/AbsoluteUrlDispatchTests.cs
+++ b/src/tests/Refit.Tests/AbsoluteUrlDispatchTests.cs
@@ -39,7 +39,7 @@ public class AbsoluteUrlDispatchTests
     [Test]
     public async Task QueryParametersAppendToAbsoluteUrl()
     {
-        const string expected = AbsoluteUrl + "?token=abc";
+        const string expected = $"{AbsoluteUrl}?token=abc";
 
         var generated = await SendGeneratedAsync(static api => api.GetAbsoluteWithQuery(AbsoluteUrl, "abc"));
         var reflected = await ReflectAsync(nameof(IUrlDispatchApi.GetAbsoluteWithQuery), AbsoluteUrl, "abc");
@@ -53,8 +53,8 @@ public class AbsoluteUrlDispatchTests
     [Test]
     public async Task QueryParametersAppendToAbsoluteUrlThatAlreadyHasAQuery()
     {
-        const string urlWithQuery = AbsoluteUrl + "?existing=1";
-        const string expected = urlWithQuery + "&token=abc";
+        const string urlWithQuery = $"{AbsoluteUrl}?existing=1";
+        const string expected = $"{urlWithQuery}&token=abc";
 
         var generated = await SendGeneratedAsync(static api => api.GetAbsoluteWithQuery(urlWithQuery, "abc"));
         var reflected = await ReflectAsync(nameof(IUrlDispatchApi.GetAbsoluteWithQuery), urlWithQuery, "abc");
@@ -153,7 +153,7 @@ public class AbsoluteUrlDispatchTests
     private static async Task<TestHttpMessageHandler> SendGeneratedAsync(Func<IUrlDispatchApi, Task<string>> call)
     {
         var handler = new TestHttpMessageHandler();
-        using var client = new HttpClient(handler) { BaseAddress = new(BaseAddress) };
+        using var client = HttpClientTestFactory.Create(handler, new(BaseAddress));
         var api = RestService.ForGenerated<IUrlDispatchApi>(client, new RefitSettings());
 
         _ = await call(api);

--- a/src/tests/Refit.Tests/AotSafeAssertionExtensions.cs
+++ b/src/tests/Refit.Tests/AotSafeAssertionExtensions.cs
@@ -25,7 +25,7 @@ internal static class AotSafeAssertionExtensions
         /// </summary>
         /// <param name="expected">The expected element sequence.</param>
         /// <returns>The chained collection-equivalency assertion.</returns>
-        public IsEquivalentToAssertion<TCollection, TItem> IsCollectionEqualTo(IEnumerable<TItem> expected) =>
+        internal IsEquivalentToAssertion<TCollection, TItem> IsCollectionEqualTo(IEnumerable<TItem> expected) =>
             source.IsEquivalentTo(expected, EqualityComparer<TItem>.Default);
     }
 }

--- a/src/tests/Refit.Tests/AuthenticatedClientHandlerTests.cs
+++ b/src/tests/Refit.Tests/AuthenticatedClientHandlerTests.cs
@@ -25,13 +25,13 @@ public class AuthenticatedClientHandlerTests
     private const string BaseUrl = "http://api";
 
     /// <summary>Fully qualified URL of the authenticated endpoint.</summary>
-    private const string AuthUrl = BaseUrl + "/auth";
+    private const string AuthUrl = $"{BaseUrl}/auth";
 
     /// <summary>Name of the HTTP authorization header.</summary>
     private const string AuthorizationHeader = "Authorization";
 
     /// <summary>Authorization header value carrying the bearer token.</summary>
-    private const string BearerTokenValue = "Bearer " + TokenValue;
+    private const string BearerTokenValue = $"Bearer {TokenValue}";
 
     /// <summary>Authorization header value carrying the refreshed bearer token.</summary>
     private const string BearerTokenValue2 = "Bearer tokenValue2";

--- a/src/tests/Refit.Tests/DefaultUrlParameterFormatterTests.ValueFormatting.cs
+++ b/src/tests/Refit.Tests/DefaultUrlParameterFormatterTests.ValueFormatting.cs
@@ -36,20 +36,20 @@ public partial class DefaultUrlParameterFormatterTests
             .IsEqualTo(string.Empty);
     }
 
-    /// <summary>A non-formattable value whose <see cref="ToString"/> supplies the rendered text.</summary>
-    private sealed class NonFormattableValue
-    {
-        /// <inheritdoc/>
-        public override string ToString() => "custom-text";
-    }
-
     /// <summary>A non-formattable value whose <see cref="ToString"/> returns null, exercising the empty fallback.</summary>
-    private sealed class NullToStringValue
+    public sealed class NullToStringValue
     {
         /// <summary>Gets the backing text, left null so <see cref="ToString"/> yields the empty-string fallback.</summary>
         public string? Text { get; init; }
 
         /// <inheritdoc/>
         public override string? ToString() => Text;
+    }
+
+    /// <summary>A non-formattable value whose <see cref="ToString"/> supplies the rendered text.</summary>
+    private sealed class NonFormattableValue
+    {
+        /// <inheritdoc/>
+        public override string ToString() => "custom-text";
     }
 }

--- a/src/tests/Refit.Tests/ExplicitInterfaceRefitTests.cs
+++ b/src/tests/Refit.Tests/ExplicitInterfaceRefitTests.cs
@@ -21,7 +21,7 @@ public class ExplicitInterfaceRefitTests
     private const string BaseUrl = "http://foo";
 
     /// <summary>Fully qualified URL of the resource endpoint.</summary>
-    private const string ResourceUrl = BaseUrl + "/resource";
+    private const string ResourceUrl = $"{BaseUrl}/resource";
 
     /// <summary>Plain text content returned by the stubbed responses.</summary>
     private const string HelloContent = "hello";

--- a/src/tests/Refit.Tests/FormValueMultimapTests.cs
+++ b/src/tests/Refit.Tests/FormValueMultimapTests.cs
@@ -582,7 +582,7 @@ public partial class FormValueMultimapTests
     /// <summary>Formats the value carried by the <see cref="DeepNode"/> at the given depth.</summary>
     /// <param name="depth">The zero-based depth of the node.</param>
     /// <returns>The depth-tagged value.</returns>
-    private static string DeepNodeValue(int depth) => "v" + depth.ToString(CultureInfo.InvariantCulture);
+    private static string DeepNodeValue(int depth) => $"v{depth.ToString(CultureInfo.InvariantCulture)}";
 
     /// <summary>Test fixture with simple string properties used to verify object property loading.</summary>
     public class ObjectTestClass

--- a/src/tests/Refit.Tests/GeneratedFactoryApiClient.cs
+++ b/src/tests/Refit.Tests/GeneratedFactoryApiClient.cs
@@ -14,10 +14,10 @@ internal sealed class GeneratedFactoryApiClient(HttpClient client, IRequestBuild
     : IGeneratedFactoryApi
 {
     /// <summary>Gets the HTTP client supplied to the factory.</summary>
-    public HttpClient Client { get; } = client;
+    internal HttpClient Client { get; } = client;
 
     /// <summary>Gets the request builder supplied to the factory.</summary>
-    public IRequestBuilder Builder { get; } = builder;
+    internal IRequestBuilder Builder { get; } = builder;
 
     /// <inheritdoc/>
     public Task Get() => Task.CompletedTask;

--- a/src/tests/Refit.Tests/GeneratedRequestRunnerTests.RequestDispatch.cs
+++ b/src/tests/Refit.Tests/GeneratedRequestRunnerTests.RequestDispatch.cs
@@ -120,7 +120,7 @@ public partial class GeneratedRequestRunnerTests
     {
         using var request = new HttpRequestMessage(HttpMethod.Get, RelativeResourcePath);
 
-        GeneratedRequestRunner.AddRequestProperty<int>(request, "number", RequestPropertyValue);
+        GeneratedRequestRunner.AddRequestProperty(request, "number", RequestPropertyValue);
 
 #if NET6_0_OR_GREATER
         await Assert.That(request.Options.TryGetValue(new HttpRequestOptionsKey<int>("number"), out var value))
@@ -449,7 +449,7 @@ public partial class GeneratedRequestRunnerTests
     [Test]
     public async Task BuildRelativeUriThrowsWhenBaseAddressMissing()
     {
-        using var client = new HttpClient();
+        using var client = HttpClientTestFactory.Create();
 
         await Assert
             .That(() => GeneratedRequestRunner.BuildRelativeUri(client, "/x", UrlResolutionMode.RefitLegacy))
@@ -461,7 +461,7 @@ public partial class GeneratedRequestRunnerTests
     [Test]
     public async Task BuildRelativeUriPrependsBasePathInLegacyMode()
     {
-        using var client = new HttpClient { BaseAddress = new("http://foo/api/") };
+        using var client = HttpClientTestFactory.Create(new Uri("http://foo/api/"));
 
         var uri = GeneratedRequestRunner.BuildRelativeUri(client, "/x", UrlResolutionMode.RefitLegacy);
 
@@ -473,7 +473,7 @@ public partial class GeneratedRequestRunnerTests
     [Test]
     public async Task BuildRelativeUriEmitsRelativePathInRfcMode()
     {
-        using var client = new HttpClient();
+        using var client = HttpClientTestFactory.Create();
 
         var uri = GeneratedRequestRunner.BuildRelativeUri(client, "x", UrlResolutionMode.Rfc3986);
 
@@ -486,7 +486,7 @@ public partial class GeneratedRequestRunnerTests
     [Test]
     public async Task BuildRelativeUriWithQueryFormatEmitsRelativePathInRfcMode()
     {
-        using var client = new HttpClient();
+        using var client = HttpClientTestFactory.Create();
 
         var uri = GeneratedRequestRunner.BuildRelativeUri(client, "x", UrlResolutionMode.Rfc3986, UriFormat.UriEscaped);
 
@@ -498,7 +498,7 @@ public partial class GeneratedRequestRunnerTests
     [Test]
     public async Task BuildRelativeUriWithQueryFormatPrependsBasePathInLegacyMode()
     {
-        using var client = new HttpClient { BaseAddress = new("http://foo/api/") };
+        using var client = HttpClientTestFactory.Create(new Uri("http://foo/api/"));
 
         var uri = GeneratedRequestRunner.BuildRelativeUri(client, "/x", UrlResolutionMode.RefitLegacy, UriFormat.UriEscaped);
 
@@ -510,7 +510,7 @@ public partial class GeneratedRequestRunnerTests
     [Test]
     public async Task BuildRelativeUriWithQueryFormatUsesEmptyBasePathForRootBaseAddress()
     {
-        using var client = new HttpClient { BaseAddress = new("http://foo/") };
+        using var client = HttpClientTestFactory.Create(new Uri("http://foo/"));
 
         var uri = GeneratedRequestRunner.BuildRelativeUri(client, "/x", UrlResolutionMode.RefitLegacy, UriFormat.UriEscaped);
 
@@ -522,7 +522,7 @@ public partial class GeneratedRequestRunnerTests
     [Test]
     public async Task BuildRelativeUriWithQueryFormatThrowsWhenBaseAddressMissing()
     {
-        using var client = new HttpClient();
+        using var client = HttpClientTestFactory.Create();
 
         await Assert
             .That(() => GeneratedRequestRunner.BuildRelativeUri(client, "/x", UrlResolutionMode.RefitLegacy, UriFormat.UriEscaped))

--- a/src/tests/Refit.Tests/GeneratedRequestRunnerTests.ResponseErrorHandling.cs
+++ b/src/tests/Refit.Tests/GeneratedRequestRunnerTests.ResponseErrorHandling.cs
@@ -49,7 +49,7 @@ public partial class GeneratedRequestRunnerTests
     [Test]
     public async Task SendVoidAsyncRequiresBaseAddress()
     {
-        using var client = new HttpClient(new CapturingHandler());
+        using var client = HttpClientTestFactory.Create(new CapturingHandler());
         using var request = new HttpRequestMessage(HttpMethod.Get, RelativeResourcePath);
 
         var exception = await Assert
@@ -350,7 +350,7 @@ public partial class GeneratedRequestRunnerTests
     [Test]
     public async Task SendAsyncRequiresBaseAddress()
     {
-        using var client = new HttpClient(new CapturingHandler());
+        using var client = HttpClientTestFactory.Create(new CapturingHandler());
         using var request = new HttpRequestMessage(HttpMethod.Get, RelativeResourcePath);
 
         var exception = await Assert

--- a/src/tests/Refit.Tests/GeneratedRequestRunnerTests.cs
+++ b/src/tests/Refit.Tests/GeneratedRequestRunnerTests.cs
@@ -237,7 +237,7 @@ public partial class GeneratedRequestRunnerTests
             Hidden = "ignored"
         };
 
-        var result = GeneratedRequestRunner.CreateUrlEncodedBodyContent<DeclaredFormBody>(
+        var result = GeneratedRequestRunner.CreateUrlEncodedBodyContent(
             settings,
             body);
 
@@ -388,7 +388,7 @@ public partial class GeneratedRequestRunnerTests
         // The generated path for a complex body emits the reflection content overload; the reflection request builder
         // wraps the same FormValueMultimap directly. Both must produce identical wire content.
         var generated = await GeneratedRequestRunner
-            .CreateUrlEncodedBodyContent<NestedParityForm>(settings, body)
+            .CreateUrlEncodedBodyContent(settings, body)
             .ReadAsStringAsync();
         var reflection = await new FormUrlEncodedContent(new FormValueMultimap(body, settings))
             .ReadAsStringAsync();

--- a/src/tests/Refit.Tests/GeneratedSettingsFactoryApiClient.cs
+++ b/src/tests/Refit.Tests/GeneratedSettingsFactoryApiClient.cs
@@ -15,10 +15,10 @@ internal sealed class GeneratedSettingsFactoryApiClient(
     RefitSettings settings) : IGeneratedSettingsFactoryApi
 {
     /// <summary>Gets the HTTP client supplied to the factory.</summary>
-    public HttpClient Client { get; } = client;
+    internal HttpClient Client { get; } = client;
 
     /// <summary>Gets the settings supplied to the factory.</summary>
-    public RefitSettings Settings { get; } = settings;
+    internal RefitSettings Settings { get; } = settings;
 
     /// <inheritdoc/>
     public Task Get() => Task.CompletedTask;

--- a/src/tests/Refit.Tests/HttpClientFactoryExtensionsTests.cs
+++ b/src/tests/Refit.Tests/HttpClientFactoryExtensionsTests.cs
@@ -579,30 +579,4 @@ public partial class HttpClientFactoryExtensionsTests
         /// <summary>Gets or sets the content serializer injected into the Refit settings.</summary>
         public SystemTextJsonContentSerializer? Serializer { get; set; }
     }
-
-    /// <summary>HTTP handler that records the final authorization header it receives.</summary>
-    private sealed class RecordingHandler : HttpMessageHandler
-    {
-        /// <summary>Gets the authorization parameter observed by the handler.</summary>
-        public string? AuthorizationParameter { get; private set; }
-
-        /// <summary>Gets the request URI observed by the handler.</summary>
-        public Uri? RequestUri { get; private set; }
-
-        /// <summary>Gets the powered-by header observed by the handler.</summary>
-        public string? PoweredByHeader { get; private set; }
-
-        /// <inheritdoc />
-        protected override Task<HttpResponseMessage> SendAsync(
-            HttpRequestMessage request,
-            CancellationToken cancellationToken)
-        {
-            AuthorizationParameter = request.Headers.Authorization?.Parameter;
-            RequestUri = request.RequestUri;
-            PoweredByHeader = request.Headers.TryGetValues(PoweredByHeaderName, out var values)
-                ? values.FirstOrDefault()
-                : null;
-            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
-        }
-    }
 }

--- a/src/tests/Refit.Tests/MethodArgumentCaptureAssertions.cs
+++ b/src/tests/Refit.Tests/MethodArgumentCaptureAssertions.cs
@@ -14,7 +14,7 @@ internal static class MethodArgumentCaptureAssertions
     /// <param name="request">The built request message to inspect.</param>
     /// <param name="expectedArguments">The expected argument values, in declared parameter order.</param>
     /// <returns>A task that represents the asynchronous assertion.</returns>
-    public static async Task AssertCapturedAsync(HttpRequestMessage request, params object?[] expectedArguments)
+    internal static async Task AssertCapturedAsync(HttpRequestMessage request, params object?[] expectedArguments)
     {
         var captured = GetCapturedArguments(request);
         await Assert.That(captured).IsNotNull();
@@ -24,7 +24,7 @@ internal static class MethodArgumentCaptureAssertions
     /// <summary>Asserts the request did not capture the method-arguments option.</summary>
     /// <param name="request">The built request message to inspect.</param>
     /// <returns>A task that represents the asynchronous assertion.</returns>
-    public static async Task AssertAbsentAsync(HttpRequestMessage request) =>
+    internal static async Task AssertAbsentAsync(HttpRequestMessage request) =>
         await Assert.That(GetCapturedArguments(request)).IsNull();
 
     /// <summary>Reads the captured argument array from the request options, or null when it was not captured.</summary>

--- a/src/tests/Refit.Tests/MultipartFormattableValueFormattingTests.cs
+++ b/src/tests/Refit.Tests/MultipartFormattableValueFormattingTests.cs
@@ -40,7 +40,7 @@ public sealed class MultipartFormattableValueFormattingTests
         var fixture = new RequestBuilderImplementation<IRunscopeApi>(settings);
         var func = fixture.BuildRestResultFuncForMethod(nameof(IRunscopeApi.UploadFormattableValues));
         var handler = new MultipartCapturingHttpMessageHandler();
-        using var client = new HttpClient(handler) { BaseAddress = new("https://api/") };
+        using var client = HttpClientTestFactory.Create(handler, new("https://api/"));
         await (Task)func(client, [Guid.NewGuid(), DateTimeOffset.UnixEpoch])!;
 
         return handler.Parts.First(static part => part.Name == "id").Body;

--- a/src/tests/Refit.Tests/MultipartPartRoutingTests.cs
+++ b/src/tests/Refit.Tests/MultipartPartRoutingTests.cs
@@ -57,7 +57,7 @@ public sealed class MultipartPartRoutingTests
         var fixture = new RequestBuilderImplementation<IMultipartPartRoutingApi>();
         var func = fixture.BuildRestResultFuncForMethod(method);
         var handler = new MultipartCapturingHttpMessageHandler();
-        using var client = new HttpClient(handler) { BaseAddress = new("http://api/") };
+        using var client = HttpClientTestFactory.Create(handler, new("http://api/"));
         await (Task)func(client, args)!;
         return handler;
     }

--- a/src/tests/Refit.Tests/MultipartTests.PartUploads.cs
+++ b/src/tests/Refit.Tests/MultipartTests.PartUploads.cs
@@ -423,7 +423,7 @@ public partial class MultipartTests
 
         var fixture = new RequestBuilderImplementation<IRunscopeApi>();
         var factory = fixture.BuildRestResultFuncForMethod(nameof(IRunscopeApi.UploadHttpContents));
-        using var client = new HttpClient(handler) { BaseAddress = new(BaseAddress) };
+        using var client = HttpClientTestFactory.Create(handler, new(BaseAddress));
 
         var task = (Task)factory(client, [new List<HttpContent> { first, second }])!;
         await task;

--- a/src/tests/Refit.Tests/MultipartTests.cs
+++ b/src/tests/Refit.Tests/MultipartTests.cs
@@ -398,11 +398,10 @@ public partial class MultipartTests
 
         // compute resource name suffix
         var relativeName =
-            "."
-            + relativeFilePath
+            $".{relativeFilePath
                 .Replace('\\', namespaceSeparator)
                 .Replace('/', namespaceSeparator)
-                .Replace(' ', '_');
+                .Replace(' ', '_')}";
 
         // get resource stream
         var fullName = Array.Find(

--- a/src/tests/Refit.Tests/ObservableTestHelpers.cs
+++ b/src/tests/Refit.Tests/ObservableTestHelpers.cs
@@ -18,21 +18,21 @@ internal static class ObservableTestHelpers
     /// <typeparam name="T">The observable value type.</typeparam>
     /// <param name="source">The source observable.</param>
     /// <returns>A timeout-wrapped observable.</returns>
-    public static IObservable<T> WithTimeout<T>(IObservable<T> source) =>
+    internal static IObservable<T> WithTimeout<T>(IObservable<T> source) =>
         new ExpireSignal<T>(source, DefaultTimeout, ThreadPoolSequencer.Instance);
 
     /// <summary>Awaits the timeout-wrapped source.</summary>
     /// <typeparam name="T">The observable value type.</typeparam>
     /// <param name="source">The source observable.</param>
     /// <returns>The final observable value.</returns>
-    public static Task<T> AwaitWithTimeout<T>(IObservable<T> source) =>
+    internal static Task<T> AwaitWithTimeout<T>(IObservable<T> source) =>
         Await(WithTimeout(source));
 
     /// <summary>Awaits the source through a concrete Primitives await signal.</summary>
     /// <typeparam name="T">The observable value type.</typeparam>
     /// <param name="source">The source observable.</param>
     /// <returns>The final observable value.</returns>
-    public static async Task<T> Await<T>(IObservable<T> source)
+    internal static async Task<T> Await<T>(IObservable<T> source)
     {
         AsyncSignal<T> signal = new();
         using var subscription = source.Subscribe(signal);

--- a/src/tests/Refit.Tests/PathPrefixTests.cs
+++ b/src/tests/Refit.Tests/PathPrefixTests.cs
@@ -167,7 +167,7 @@ public class PathPrefixTests
     private static async Task<string> GeneratedPathAndQueryAsync<T>(Func<T, Task> call)
     {
         var handler = new TestHttpMessageHandler();
-        using var client = new HttpClient(handler) { BaseAddress = new(BaseAddress) };
+        using var client = HttpClientTestFactory.Create(handler, new(BaseAddress));
         var api = RestService.ForGenerated<T>(client, new RefitSettings());
 
         await call(api);

--- a/src/tests/Refit.Tests/QueryConverterTests.cs
+++ b/src/tests/Refit.Tests/QueryConverterTests.cs
@@ -101,7 +101,7 @@ public class QueryConverterTests
     private static async Task<string> SendAsync(RefitSettings settings, Func<IConverterApi, Task<string>> call)
     {
         var handler = new TestHttpMessageHandler();
-        using var client = new HttpClient(handler) { BaseAddress = new(BaseAddress) };
+        using var client = HttpClientTestFactory.Create(handler, new(BaseAddress));
         var api = RestService.ForGenerated<IConverterApi>(client, settings);
 
         _ = await call(api);

--- a/src/tests/Refit.Tests/QueryObjectFlatteningTests.cs
+++ b/src/tests/Refit.Tests/QueryObjectFlatteningTests.cs
@@ -419,7 +419,7 @@ public class QueryObjectFlatteningTests
     private static async Task<string> SendGeneratedAsync(RefitSettings settings, Func<IQueryObjectApi, Task<string>> call)
     {
         var handler = new TestHttpMessageHandler();
-        using var client = new HttpClient(handler) { BaseAddress = new(BaseAddress) };
+        using var client = HttpClientTestFactory.Create(handler, new(BaseAddress));
         var api = RestService.ForGenerated<IQueryObjectApi>(client, settings);
 
         _ = await call(api);

--- a/src/tests/Refit.Tests/RecordingHandler.cs
+++ b/src/tests/Refit.Tests/RecordingHandler.cs
@@ -1,0 +1,21 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Refit.Tests;
+
+/// <summary>HTTP handler that records the final authorization header it receives.</summary>
+internal sealed class RecordingHandler : HttpMessageHandler
+{
+    /// <summary>Gets the authorization parameter observed by the handler.</summary>
+    internal string? AuthorizationParameter { get; private set; }
+
+    /// <inheritdoc />
+    protected override Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        AuthorizationParameter = request.Headers.Authorization?.Parameter;
+        return Task.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.OK));
+    }
+}

--- a/src/tests/Refit.Tests/ReflectionPropertyHelpersTests.cs
+++ b/src/tests/Refit.Tests/ReflectionPropertyHelpersTests.cs
@@ -41,7 +41,7 @@ public sealed class ReflectionPropertyHelpersTests
     }
 
     /// <summary>A type whose properties span the readable and non-public-getter shapes.</summary>
-    private sealed class PropertyShapes
+    public sealed class PropertyShapes
     {
         /// <summary>Gets or sets a readable public property that is returned.</summary>
         public string? Readable { get; set; }

--- a/src/tests/Refit.Tests/ReflectionTests.cs
+++ b/src/tests/Refit.Tests/ReflectionTests.cs
@@ -544,7 +544,7 @@ public sealed class ReflectionTests
         };
         var service = RestService.For<IGenericMethodAndInterface<string>>(BaseUrl, settings);
 
-        await service.GetGenericParameter<string>("10", "Empty");
+        await service.GetGenericParameter("10", "Empty");
         await formatter.AssertNoOutstandingAssertions();
     }
 }

--- a/src/tests/Refit.Tests/RequestBuilderTestExtensions.cs
+++ b/src/tests/Refit.Tests/RequestBuilderTestExtensions.cs
@@ -14,7 +14,7 @@ internal static class RequestBuilderTestExtensions
         /// <param name="methodName">The name of the interface method to build a request for.</param>
         /// <param name="baseAddress">The base address used by the test HTTP client.</param>
         /// <returns>A factory that maps a parameter array to a task producing the request message.</returns>
-        public Func<object[], Task<HttpRequestMessage>> BuildRequestFactoryForMethod(
+        internal Func<object[], Task<HttpRequestMessage>> BuildRequestFactoryForMethod(
             string methodName,
             string baseAddress = "http://api/")
         {
@@ -36,7 +36,7 @@ internal static class RequestBuilderTestExtensions
         /// <param name="returnContent">Optional response content the handler returns.</param>
         /// <param name="baseAddress">The base address used by the test HTTP client.</param>
         /// <returns>A factory that maps a parameter array to a task producing the handler that observed the request.</returns>
-        public Func<object[], Task<TestHttpMessageHandler>> RunRequest(
+        internal Func<object[], Task<TestHttpMessageHandler>> RunRequest(
             string methodName,
             string? returnContent = null,
             string baseAddress = "http://api/")

--- a/src/tests/Refit.Tests/RequestBuilderTests.Dictionaries.cs
+++ b/src/tests/Refit.Tests/RequestBuilderTests.Dictionaries.cs
@@ -357,7 +357,7 @@ public partial class RequestBuilderTests
         var factory = fixture.RunRequest("PostAValueType", "true");
         const int valueTypeId = 7;
         var guid = Guid.NewGuid();
-        var expected = "\"" + guid + "\"";
+        var expected = $"\"{guid}\"";
         var output = await factory([valueTypeId, guid]);
 
         await Assert.That(output.SendContent).IsEqualTo(expected);

--- a/src/tests/Refit.Tests/RequestBuilderTests.Lookup.cs
+++ b/src/tests/Refit.Tests/RequestBuilderTests.Lookup.cs
@@ -63,7 +63,7 @@ public partial class RequestBuilderTests
 
         var fixture = new RequestBuilderImplementation<ICancellableMethods>();
         var func = fixture.BuildRestResultFuncForMethod(nameof(ICancellableMethods.GetWithCancellationAndReturn));
-        using var client = new HttpClient(handler) { BaseAddress = new(ApiBaseUrlWithSlash) };
+        using var client = HttpClientTestFactory.Create(handler, new(ApiBaseUrlWithSlash));
 
         var result = await (Task<string>)func(client, [CancellationToken.None])!;
 

--- a/src/tests/Refit.Tests/RequestBuilderTests.cs
+++ b/src/tests/Refit.Tests/RequestBuilderTests.cs
@@ -13,7 +13,7 @@ public partial class RequestBuilderTests
     private const string ApiBaseUrl = "http://api";
 
     /// <summary>The base API address with a trailing slash used as an <see cref="HttpClient.BaseAddress"/>.</summary>
-    private const string ApiBaseUrlWithSlash = ApiBaseUrl + "/";
+    private const string ApiBaseUrlWithSlash = $"{ApiBaseUrl}/";
 
     /// <summary>The name of the cancellable GET method exercised by the cancellation tests.</summary>
     private const string GetWithCancellationMethod = "GetWithCancellation";

--- a/src/tests/Refit.Tests/ResponseTests.cs
+++ b/src/tests/Refit.Tests/ResponseTests.cs
@@ -22,10 +22,10 @@ public sealed partial class ResponseTests
     private const string BaseAddress = "http://api";
 
     /// <summary>Endpoint URL for the alias test operation.</summary>
-    private const string AliasTestUrl = BaseAddress + "/aliasTest";
+    private const string AliasTestUrl = $"{BaseAddress}/aliasTest";
 
     /// <summary>Endpoint URL for the API response test operation.</summary>
-    private const string GetApiResponseTestObjectUrl = BaseAddress + "/GetApiResponseTestObject";
+    private const string GetApiResponseTestObjectUrl = $"{BaseAddress}/GetApiResponseTestObject";
 
     /// <summary>Media type used for RFC 7807 problem-details responses.</summary>
     private const string ProblemJsonMediaType = "application/problem+json";

--- a/src/tests/Refit.Tests/RestServiceExceptions.cs
+++ b/src/tests/Refit.Tests/RestServiceExceptions.cs
@@ -79,7 +79,7 @@ public class RestServiceExceptions
     {
         var repoPath = new RepoPath("some/repo dir");
         using var handler = new TestHttpMessageHandler();
-        using var client = new HttpClient(handler) { BaseAddress = new(BaseAddress) };
+        using var client = HttpClientTestFactory.Create(handler, new(BaseAddress));
         _ = await RestService.ForGenerated<IRoundTripNotString>(client).GetValue(repoPath);
         var generatedUri = handler.RequestMessage!.RequestUri!.PathAndQuery;
 

--- a/src/tests/Refit.Tests/RestServiceGeneratedFactoryFallbackTests.cs
+++ b/src/tests/Refit.Tests/RestServiceGeneratedFactoryFallbackTests.cs
@@ -19,7 +19,7 @@ public sealed class RestServiceGeneratedFactoryFallbackTests
         // Clear only the strongly typed holder so For<T> falls through to the type-keyed dictionary registered above.
         RestService.GeneratedSettingsFactory<IRestServiceFallbackApi>.Factory = null;
 
-        using var client = new HttpClient { BaseAddress = new("http://api/") };
+        using var client = HttpClientTestFactory.Create(new Uri("http://api/"));
         var api = RestService.For<IRestServiceFallbackApi>(client, new RefitSettings());
 
         await Assert.That(api).IsSameReferenceAs(stub);

--- a/src/tests/Refit.Tests/RestServiceIntegrationTests.Inheritance.cs
+++ b/src/tests/Refit.Tests/RestServiceIntegrationTests.Inheritance.cs
@@ -540,15 +540,15 @@ public partial class RestServiceIntegrationTests
         var handler = new StubHttp
         {
             {
-                Route.Get(url + "/"),
+                Route.Get($"{url}/"),
                 Reply.Json("{ }")
             },
             {
-                Route.Get(url + "/"),
+                Route.Get($"{url}/"),
                 Reply.Json("{ }")
             },
             {
-                Route.Get(url + "/"),
+                Route.Get($"{url}/"),
                 Reply.Json("{ }")
             },
         };

--- a/src/tests/Refit.Tests/RestServiceIntegrationTests.RequestOptionMetadata.cs
+++ b/src/tests/Refit.Tests/RestServiceIntegrationTests.RequestOptionMetadata.cs
@@ -23,7 +23,7 @@ public partial class RestServiceIntegrationTests
         // Generated path: RestService.For<T> dispatches through the source-generated client, which emits the two
         // request options as compile-time literals with no runtime reflection.
         var handler = new TestHttpMessageHandler("{}");
-        using var client = new HttpClient(handler) { BaseAddress = new(BaseUrl) };
+        using var client = HttpClientTestFactory.Create(handler, new(BaseUrl));
         var generatedFixture = RestService.For<IGitHubApi>(client);
 
         _ = await generatedFixture.GetUser(SampleUserName);

--- a/src/tests/Refit.Tests/RestServiceIntegrationTests.cs
+++ b/src/tests/Refit.Tests/RestServiceIntegrationTests.cs
@@ -113,7 +113,7 @@ public partial class RestServiceIntegrationTests
             typeof(IGeneratedFactoryApi),
             static (client, builder) => new GeneratedFactoryApiClient(client, builder));
 
-        using var client = new HttpClient { BaseAddress = new(BaseUrl) };
+        using var client = HttpClientTestFactory.Create(new Uri(BaseUrl));
 
         var instance = RestService.For<IGeneratedFactoryApi>(client);
         var generated = await Assert.That(instance).IsTypeOf<GeneratedFactoryApiClient>();
@@ -131,7 +131,7 @@ public partial class RestServiceIntegrationTests
             typeof(IGeneratedFactoryApi),
             static (client, builder) => new GeneratedFactoryApiClient(client, builder));
 
-        using var client = new HttpClient { BaseAddress = new(BaseUrl) };
+        using var client = HttpClientTestFactory.Create(new Uri(BaseUrl));
         var settings = new RefitSettings(new SystemTextJsonContentSerializer());
 
         var instance = RestService.ForGenerated<IGeneratedFactoryApi>(client, settings);
@@ -152,7 +152,7 @@ public partial class RestServiceIntegrationTests
         RestService.RegisterGeneratedSettingsFactory<IGeneratedSettingsFactoryApi>(
             static (client, settings) => new GeneratedSettingsFactoryApiClient(client, settings));
 
-        using var client = new HttpClient { BaseAddress = new(BaseUrl) };
+        using var client = HttpClientTestFactory.Create(new Uri(BaseUrl));
         var settings = new RefitSettings(new SystemTextJsonContentSerializer());
 
         var instance = RestService.ForGenerated<IGeneratedSettingsFactoryApi>(client, settings);
@@ -205,7 +205,7 @@ public partial class RestServiceIntegrationTests
             typeof(IGeneratedTypeFactoryApi),
             static (client, builder) => new GeneratedTypeFactoryApiClient(client, builder));
 
-        using var client = new HttpClient { BaseAddress = new(BaseUrl) };
+        using var client = HttpClientTestFactory.Create(new Uri(BaseUrl));
         var settings = new RefitSettings(new SystemTextJsonContentSerializer());
 
         var instance = RestService.ForGenerated(typeof(IGeneratedTypeFactoryApi), client, settings);
@@ -236,8 +236,8 @@ public partial class RestServiceIntegrationTests
             typeof(IGeneratedFactoryApi),
             static (client, builder) => new GeneratedFactoryApiClient(client, builder));
 
-        using var generatedClient = new HttpClient { BaseAddress = new("http://settings") };
-        using var reflectionClient = new HttpClient { BaseAddress = new("http://factory") };
+        using var generatedClient = HttpClientTestFactory.Create(new Uri("http://settings"));
+        using var reflectionClient = HttpClientTestFactory.Create(new Uri("http://factory"));
 
         var generatedOnly = RestService.ForGenerated<IGeneratedSettingsFactoryApi>(generatedClient);
         var reflectionPath = RestService.For(typeof(IGeneratedFactoryApi), reflectionClient);
@@ -260,7 +260,7 @@ public partial class RestServiceIntegrationTests
 
         try
         {
-            using var client = new HttpClient { BaseAddress = new("http://typed") };
+            using var client = HttpClientTestFactory.Create(new Uri("http://typed"));
             var settings = new RefitSettings(new SystemTextJsonContentSerializer());
 
             var instance = RestService.ForGenerated<IGeneratedTypedFactoryApi>(client, settings);
@@ -287,7 +287,7 @@ public partial class RestServiceIntegrationTests
 
         try
         {
-            using var client = new HttpClient { BaseAddress = new("http://typed-settings") };
+            using var client = HttpClientTestFactory.Create(new Uri("http://typed-settings"));
             var settings = new RefitSettings(new SystemTextJsonContentSerializer());
 
             var instance = RestService.ForGenerated<IGeneratedTypedSettingsFallbackApi>(client, settings);
@@ -307,7 +307,7 @@ public partial class RestServiceIntegrationTests
     [Test]
     public async Task ForGeneratedRequiresRegisteredFactory()
     {
-        using var client = new HttpClient { BaseAddress = new(BaseUrl) };
+        using var client = HttpClientTestFactory.Create(new Uri(BaseUrl));
         var settings = new RefitSettings(new SystemTextJsonContentSerializer());
 
         var exception = await Assert
@@ -638,11 +638,10 @@ public partial class RestServiceIntegrationTests
 
         // compute resource name suffix
         var relativeName =
-            "."
-            + relativeFilePath
+            $".{relativeFilePath
                 .Replace('\\', namespaceSeparator)
                 .Replace('/', namespaceSeparator)
-                .Replace(' ', '_');
+                .Replace(' ', '_')}";
 
         // get resource stream
         var fullName = Array.Find(

--- a/src/tests/Refit.Tests/ReturnTypeAdapterResolverTests.cs
+++ b/src/tests/Refit.Tests/ReturnTypeAdapterResolverTests.cs
@@ -274,7 +274,7 @@ public sealed class ReturnTypeAdapterResolverTests
 
     /// <summary>A non-generic return shape surfaced by a closed adapter; no interface method returns it, so the
     /// generator never references the adapter.</summary>
-    private sealed class AdapterShape
+    public sealed class AdapterShape
     {
         /// <summary>Gets the shape id.</summary>
         public int Id { get; init; }
@@ -283,10 +283,22 @@ public sealed class ReturnTypeAdapterResolverTests
     /// <summary>A single-parameter generic return shape used by the generic adapters; no interface method returns it,
     /// so the generator never references the adapters.</summary>
     /// <typeparam name="T">The wrapped value type.</typeparam>
-    private sealed class Wrapped<T>
+    public sealed class Wrapped<T>
     {
         /// <summary>Gets the wrapped value.</summary>
         public T? Value { get; init; }
+    }
+
+    /// <summary>A two-parameter generic return shape used by the reordered adapter.</summary>
+    /// <typeparam name="TFirst">The first wrapped value type.</typeparam>
+    /// <typeparam name="TSecond">The second wrapped value type.</typeparam>
+    public sealed class Paired<TFirst, TSecond>
+    {
+        /// <summary>Gets the first wrapped value.</summary>
+        public TFirst? First { get; init; }
+
+        /// <summary>Gets the second wrapped value.</summary>
+        public TSecond? Second { get; init; }
     }
 
     /// <summary>A closed adapter surfacing <see cref="AdapterShape"/> as a string.</summary>
@@ -362,18 +374,6 @@ public sealed class ReturnTypeAdapterResolverTests
     {
         /// <inheritdoc/>
         public Wrapped<int> Adapt(Func<CancellationToken, Task<T>> invoke) => new();
-    }
-
-    /// <summary>A two-parameter generic return shape used by the reordered adapter.</summary>
-    /// <typeparam name="TFirst">The first wrapped value type.</typeparam>
-    /// <typeparam name="TSecond">The second wrapped value type.</typeparam>
-    private sealed class Paired<TFirst, TSecond>
-    {
-        /// <summary>Gets the first wrapped value.</summary>
-        public TFirst? First { get; init; }
-
-        /// <summary>Gets the second wrapped value.</summary>
-        public TSecond? Second { get; init; }
     }
 
     /// <summary>An open generic adapter whose wrapper reorders the adapter's type parameters.</summary>

--- a/src/tests/Refit.Tests/StreamingResponseTests.cs
+++ b/src/tests/Refit.Tests/StreamingResponseTests.cs
@@ -301,7 +301,7 @@ public class StreamingResponseTests
         var bigGap = new string(' ', bufferExceedingGapLength);
 
         // Includes a whitespace-only line (skipped), a line larger than the read buffer, CRLF endings, and no final newline.
-        var payload = "{\"id\":1}\r\n   \r\n{" + bigGap + "\"id\":2}\r\n{\"id\":3}";
+        var payload = $"{{\"id\":1}}\r\n   \r\n{{{bigGap}\"id\":2}}\r\n{{\"id\":3}}";
         var fixture = CreateFixture(
             "application/x-jsonlines",
             payload,
@@ -444,7 +444,7 @@ public class StreamingResponseTests
     {
         var (builder, _) = CreateReflectionBuilder("[]");
         var func = builder.BuildRestResultFuncForMethod(nameof(IStreamingApi.GetArray));
-        using var clientWithoutBaseAddress = new HttpClient(new StubHttp());
+        using var clientWithoutBaseAddress = HttpClientTestFactory.Create(new StubHttp());
 
         await Assert.That(() => EnumerateAsync((IAsyncEnumerable<StreamItem?>)func(clientWithoutBaseAddress, [])!))
             .Throws<InvalidOperationException>();

--- a/src/tests/Refit.Tests/TimeoutAttributeTests.cs
+++ b/src/tests/Refit.Tests/TimeoutAttributeTests.cs
@@ -18,7 +18,7 @@ public sealed class TimeoutAttributeTests
     public async Task SourceGenVoidTimeoutCancelsSlowResponse()
     {
         using var handler = new DelayingHttpMessageHandler(Timeout.InfiniteTimeSpan);
-        using var client = new HttpClient(handler) { BaseAddress = new(BaseAddress) };
+        using var client = HttpClientTestFactory.Create(handler, new(BaseAddress));
         var api = RestService.For<ITimeoutApi>(client);
 
         await Assert.That(() => api.GetVoidShortTimeout()).Throws<OperationCanceledException>();
@@ -30,7 +30,7 @@ public sealed class TimeoutAttributeTests
     public async Task SourceGenValueTimeoutCancelsSlowResponse()
     {
         using var handler = new DelayingHttpMessageHandler(Timeout.InfiniteTimeSpan);
-        using var client = new HttpClient(handler) { BaseAddress = new(BaseAddress) };
+        using var client = HttpClientTestFactory.Create(handler, new(BaseAddress));
         var api = RestService.For<ITimeoutApi>(client);
 
         await Assert.That(() => (Task)api.GetStringShortTimeout()).Throws<OperationCanceledException>();
@@ -42,7 +42,7 @@ public sealed class TimeoutAttributeTests
     public async Task SourceGenVoidTimeoutAllowsFastResponse()
     {
         using var handler = new DelayingHttpMessageHandler(TimeSpan.Zero);
-        using var client = new HttpClient(handler) { BaseAddress = new(BaseAddress) };
+        using var client = HttpClientTestFactory.Create(handler, new(BaseAddress));
         var api = RestService.For<ITimeoutApi>(client);
 
         await api.GetVoidLongTimeout();
@@ -56,7 +56,7 @@ public sealed class TimeoutAttributeTests
     public async Task SourceGenValueTimeoutAllowsFastResponse()
     {
         using var handler = new DelayingHttpMessageHandler(TimeSpan.Zero);
-        using var client = new HttpClient(handler) { BaseAddress = new(BaseAddress) };
+        using var client = HttpClientTestFactory.Create(handler, new(BaseAddress));
         var api = RestService.For<ITimeoutApi>(client);
 
         var result = await api.GetStringLongTimeout();
@@ -70,7 +70,7 @@ public sealed class TimeoutAttributeTests
     public async Task SourceGenCallerCancellationCancelsAlongsideTimeout()
     {
         using var handler = new DelayingHttpMessageHandler(Timeout.InfiniteTimeSpan);
-        using var client = new HttpClient(handler) { BaseAddress = new(BaseAddress) };
+        using var client = HttpClientTestFactory.Create(handler, new(BaseAddress));
         var api = RestService.For<ITimeoutApi>(client);
         using var cts = new CancellationTokenSource();
         await cts.CancelAsync();
@@ -88,7 +88,7 @@ public sealed class TimeoutAttributeTests
         var fixture = new RequestBuilderImplementation<ITimeoutApi>();
         var factory = fixture.BuildRestResultFuncForMethod(nameof(ITimeoutApi.GetVoidShortTimeout));
         using var handler = new DelayingHttpMessageHandler(Timeout.InfiniteTimeSpan);
-        using var client = new HttpClient(handler) { BaseAddress = new(BaseAddress) };
+        using var client = HttpClientTestFactory.Create(handler, new(BaseAddress));
 
         await Assert.That(() => (Task)factory(client, [])!).Throws<OperationCanceledException>();
     }
@@ -101,7 +101,7 @@ public sealed class TimeoutAttributeTests
         var fixture = new RequestBuilderImplementation<ITimeoutApi>();
         var factory = fixture.BuildRestResultFuncForMethod(nameof(ITimeoutApi.GetStringShortTimeout));
         using var handler = new DelayingHttpMessageHandler(Timeout.InfiniteTimeSpan);
-        using var client = new HttpClient(handler) { BaseAddress = new(BaseAddress) };
+        using var client = HttpClientTestFactory.Create(handler, new(BaseAddress));
 
         await Assert.That(() => (Task)factory(client, [])!).Throws<OperationCanceledException>();
     }
@@ -114,7 +114,7 @@ public sealed class TimeoutAttributeTests
         var fixture = new RequestBuilderImplementation<ITimeoutApi>();
         var factory = fixture.BuildRestResultFuncForMethod(nameof(ITimeoutApi.GetStringLongTimeout));
         using var handler = new DelayingHttpMessageHandler(TimeSpan.Zero);
-        using var client = new HttpClient(handler) { BaseAddress = new(BaseAddress) };
+        using var client = HttpClientTestFactory.Create(handler, new(BaseAddress));
 
         var result = await (Task<string?>)factory(client, [])!;
 
@@ -129,7 +129,7 @@ public sealed class TimeoutAttributeTests
         var fixture = new RequestBuilderImplementation<ITimeoutApi>();
         var factory = fixture.BuildRestResultFuncForMethod(nameof(ITimeoutApi.GetStringLongTimeoutCancellable));
         using var handler = new DelayingHttpMessageHandler(Timeout.InfiniteTimeSpan);
-        using var client = new HttpClient(handler) { BaseAddress = new(BaseAddress) };
+        using var client = HttpClientTestFactory.Create(handler, new(BaseAddress));
         using var cts = new CancellationTokenSource();
         await cts.CancelAsync();
 

--- a/src/tests/Refit.Tests/UrlParameterFormatterMapTests.cs
+++ b/src/tests/Refit.Tests/UrlParameterFormatterMapTests.cs
@@ -110,7 +110,7 @@ public class UrlParameterFormatterMapTests
     private static async Task<string> SendGeneratedAsync(RefitSettings settings, Func<IFormatterMapApi, Task<string>> call)
     {
         var handler = new TestHttpMessageHandler();
-        using var client = new HttpClient(handler) { BaseAddress = new(BaseAddress) };
+        using var client = HttpClientTestFactory.Create(handler, new(BaseAddress));
         var api = RestService.ForGenerated<IFormatterMapApi>(client, settings);
 
         _ = await call(api);


### PR DESCRIPTION
## What kind of change does this PR introduce?

Build-quality maintenance that resolves the solution-wide active analyzer diagnostics through code changes and dependency alignment, without adding diagnostic suppressions.

## What is the new behavior?

- Updates SharpAnalyzers and the centralized package versions included in this branch.
- Refactors generator, runtime, reflection, polyfill, benchmark, sample, and test code to comply with the active analyzer rules.
- Extracts stateless streaming JSON deserialization, scopes the .NET 8 overload-priority polyfill, and adds deterministic shared HTTP test-client creation.
- Aligns the Reflection changes added recently on `main`, including helper accessibility, member ordering, string construction, and HTTP client ownership.
- Builds the full solution cleanly in Debug and Release and passes the complete TUnit target matrix.

## What is the current behavior?

The prior solution emits analyzer errors and warnings across production, generator, sample, benchmark, and test projects. Some test helpers also expose broader accessibility or shorter HTTP client lifetimes than their actual usage requires.

## Checklist
- [x] Tests have been added or updated (for bug fixes / features) 
- [ ] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the main branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) 

## Additional information

Validation run from `src`:

- `dotnet restore Refit.slnx --nologo`
- `dotnet build Refit.slnx -c Debug --no-restore --nologo`: 0 warnings, 0 errors
- `dotnet build Refit.slnx -c Release --no-restore --nologo`: 0 warnings, 0 errors
- `dotnet test Refit.slnx --no-restore --no-build`: 7,341 passed, 0 failed, 0 skipped
- Solution line coverage: 79.93% (3,824/4,784 lines)

Central package updates in this branch include ReactiveUI.Primitives 7.0.0, SharpAnalyzers 3.33.0, ASP.NET Core 9.0.18/10.0.10, Microsoft.Extensions 10.0.10, System.Text.Json 10.0.10, and Microsoft.SourceLink.GitHub 10.0.301.

There are no public API baseline changes. Existing trim/AOT annotations moved with extracted implementation code; no new analyzer bypass was added.