### PR TITLE
fix:Analyzer false positive on Indexed CollectionFormat

### DIFF
--- a/src/InterfaceStubGenerator.Shared/Emitter.Inline.Query.Object.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.Inline.Query.Object.cs
@@ -739,7 +739,7 @@ internal static partial class Emitter
         // collection properties fall back to settings default instead of inheriting Indexed.
         // PreEscapedKeys tells every leaf property to use AddPreEscapedKey so the brackets in the key are not re-encoded.
         var context = new QueryObjectContext(parameter, providerField, null, ToLowerInvariantString(query.PreEncoded), true);
-        var scope = new ObjectFlattenScope(emission.QueryValueLocal, keyLocal, query.NestingDelimiter, "_" + parameter.Name, itemIndent);
+        var scope = new ObjectFlattenScope(emission.QueryValueLocal, keyLocal, query.NestingDelimiter, $"_{parameter.Name}", itemIndent);
         AppendObjectPropertyList(sb, context, query.ObjectProperties!.Value, scope, emission);
 
         if (!query.ElementCanBeNull)

--- a/src/InterfaceStubGenerator.Shared/Emitter.Inline.Query.Object.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.Inline.Query.Object.cs
@@ -671,7 +671,7 @@ internal static partial class Emitter
     {
         var bodyIndent = Indent(MethodBodyIndentation);
         var guarded = parameter.CanBeNull;
-        var outerIndent = guarded ? bodyIndent + "    " : bodyIndent;
+        var outerIndent = guarded ? $"{bodyIndent}    " : bodyIndent;
 
         if (guarded)
         {
@@ -680,9 +680,9 @@ internal static partial class Emitter
         }
 
         // Wrap in a block so the index local is scoped to this parameter and cannot clash with other parameters.
-        var idxLocal = emission.QueryValueLocal + "_idx";
-        var blockIndent = outerIndent + "    ";
-        var foreachIndent = blockIndent + "    ";
+        var idxLocal = $"{emission.QueryValueLocal}_idx";
+        var blockIndent = $"{outerIndent}    ";
+        var foreachIndent = $"{blockIndent}    ";
 
         _ = sb.Append(outerIndent).AppendLine("{")
             .Append(blockIndent).Append("var ").Append(idxLocal).AppendLine(" = 0;")
@@ -732,7 +732,7 @@ internal static partial class Emitter
         {
             _ = sb.Append(foreachIndent).Append("if (").Append(emission.QueryValueLocal).AppendLine(NotNullCheckSuffix)
                 .Append(foreachIndent).AppendLine("{");
-            itemIndent = foreachIndent + "    ";
+            itemIndent = $"{foreachIndent}    ";
         }
 
         // Flatten the element's properties under the indexed key; pass null as collection format so nested

--- a/src/InterfaceStubGenerator.Shared/Parser.InlineEligibility.cs
+++ b/src/InterfaceStubGenerator.Shared/Parser.InlineEligibility.cs
@@ -35,13 +35,16 @@ internal static partial class Parser
     /// <param name="returnTypeAdapterInterface">The resolved <c>Refit.IReturnTypeAdapter`2</c> symbol, or null.</param>
     /// <param name="returnTypeAdapters">The discovered <c>IReturnTypeAdapter</c> implementations, so the analyzer agrees
     /// with the generator that an adapter-backed return type is inline-eligible.</param>
+    /// <param name="indexedCollectionFormatValue">The underlying integer value of <c>CollectionFormat.Indexed</c> resolved once from the
+    /// compilation, or <see langword="null"/> when the <c>Refit.CollectionFormat</c> type cannot be found.</param>
     /// <returns><see langword="true"/> when the method's request is inline-eligible.</returns>
     internal static bool CanBuildRequestInline(
         IMethodSymbol methodSymbol,
         INamedTypeSymbol httpMethodBaseAttributeSymbol,
         INamedTypeSymbol? formattableSymbol,
         INamedTypeSymbol? returnTypeAdapterInterface,
-        INamedTypeSymbol[] returnTypeAdapters)
+        INamedTypeSymbol[] returnTypeAdapters,
+        int? indexedCollectionFormatValue = null)
     {
         if (FindHttpMethodAttribute(methodSymbol, httpMethodBaseAttributeSymbol) is null)
         {
@@ -69,7 +72,8 @@ internal static partial class Parser
             ExternAliases: [],
             AssemblyAliasCache: new Dictionary<ISymbol, string?>(SymbolEqualityComparer.Default),
             QualifiedTypeCache: new Dictionary<ISymbol, string>(SymbolEqualityComparer.Default),
-            FormattableClassificationCache: new Dictionary<ISymbol, (bool Formattable, bool SpanFormattable)>(SymbolEqualityComparer.Default));
+            FormattableClassificationCache: new Dictionary<ISymbol, (bool Formattable, bool SpanFormattable)>(SymbolEqualityComparer.Default),
+            IndexedCollectionFormatValue: indexedCollectionFormatValue);
         return ParseRequest(methodSymbol, ClassifyInlineReturnShape(methodSymbol.ReturnType), context)
             .CanGenerateInline;
     }

--- a/src/InterfaceStubGenerator.Shared/Parser.Request.Query.cs
+++ b/src/InterfaceStubGenerator.Shared/Parser.Request.Query.cs
@@ -293,6 +293,7 @@ internal static partial class Parser
     /// per generation pass, so per-parameter checks are a direct integer comparison rather than a symbol lookup.</summary>
     /// <param name="compilation">The compilation to resolve against.</param>
     /// <returns>The integer value, or <see langword="null"/> when the type cannot be found.</returns>
+    [ExcludeFromCodeCoverage]
     internal static int? ResolveIndexedCollectionFormatValue(Compilation compilation)
     {
         var collectionFormatType = compilation.GetTypeByMetadataName(CollectionFormatTypeName);

--- a/src/Refit.Analyzers.Shared/RefitInterfaceAnalyzer.cs
+++ b/src/Refit.Analyzers.Shared/RefitInterfaceAnalyzer.cs
@@ -403,9 +403,9 @@ public sealed class RefitInterfaceAnalyzer : DiagnosticAnalyzer
     private static bool IsCancellationToken(ITypeSymbol type) =>
         type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)
         == "global::System.Threading.CancellationToken" || (type is INamedTypeSymbol
-        {
-            OriginalDefinition.SpecialType: SpecialType.System_Nullable_T
-        } namedType
+                                                            {
+                                                                OriginalDefinition.SpecialType: SpecialType.System_Nullable_T
+                                                            } namedType
                                                             && namedType.TypeArguments[0].ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)
                                                             == "global::System.Threading.CancellationToken");
 

--- a/src/Refit.Analyzers.Shared/RefitInterfaceAnalyzer.cs
+++ b/src/Refit.Analyzers.Shared/RefitInterfaceAnalyzer.cs
@@ -2,7 +2,6 @@
 // ReactiveUI and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 using System.Collections.Immutable;
-using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 
@@ -113,7 +112,8 @@ public sealed class RefitInterfaceAnalyzer : DiagnosticAnalyzer
                     formattableInterface,
                     returnTypeAdapterInterface,
                     returnTypeAdapters,
-                    reportGeneratedRequestBuildingFallback),
+                    reportGeneratedRequestBuildingFallback,
+                    Refit.Generator.Parser.ResolveIndexedCollectionFormatValue(context.Compilation)),
                 symbolContext.ReportDiagnostic,
                 symbolContext.CancellationToken),
             SymbolKind.NamedType);
@@ -230,7 +230,8 @@ public sealed class RefitInterfaceAnalyzer : DiagnosticAnalyzer
                 httpMethodAttribute,
                 analysis.FormattableInterface,
                 analysis.ReturnTypeAdapterInterface,
-                analysis.ReturnTypeAdapters))
+                analysis.ReturnTypeAdapters,
+                analysis.IndexedCollectionFormatValue))
         {
             return;
         }
@@ -402,9 +403,9 @@ public sealed class RefitInterfaceAnalyzer : DiagnosticAnalyzer
     private static bool IsCancellationToken(ITypeSymbol type) =>
         type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)
         == "global::System.Threading.CancellationToken" || (type is INamedTypeSymbol
-                                                            {
-                                                                OriginalDefinition.SpecialType: SpecialType.System_Nullable_T
-                                                            } namedType
+        {
+            OriginalDefinition.SpecialType: SpecialType.System_Nullable_T
+        } namedType
                                                             && namedType.TypeArguments[0].ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)
                                                             == "global::System.Threading.CancellationToken");
 
@@ -618,11 +619,14 @@ public sealed class RefitInterfaceAnalyzer : DiagnosticAnalyzer
     /// <param name="ReturnTypeAdapterInterface">The <c>Refit.IReturnTypeAdapter`2</c> symbol, if available.</param>
     /// <param name="ReturnTypeAdapters">The discovered <c>IReturnTypeAdapter</c> implementations, kept in lockstep with the generator.</param>
     /// <param name="ReportGeneratedRequestBuildingFallback">Whether the RF006 fallback diagnostic is enabled.</param>
+    /// /// <param name="IndexedCollectionFormatValue">The underlying integer value of <c>CollectionFormat.Indexed</c> resolved once from the
+    /// compilation, or <see langword="null"/> when the <c>Refit.CollectionFormat</c> type cannot be found.</param>
     private readonly record struct CompilationAnalysisState(
         INamedTypeSymbol HttpMethodAttribute,
         INamedTypeSymbol DisposableInterface,
         INamedTypeSymbol? FormattableInterface,
         INamedTypeSymbol? ReturnTypeAdapterInterface,
         INamedTypeSymbol[] ReturnTypeAdapters,
-        bool ReportGeneratedRequestBuildingFallback);
+        bool ReportGeneratedRequestBuildingFallback,
+        int? IndexedCollectionFormatValue = null);
 }

--- a/src/tests/Refit.Analyzers.Tests/RefitInterfaceAnalyzerTests.cs
+++ b/src/tests/Refit.Analyzers.Tests/RefitInterfaceAnalyzerTests.cs
@@ -255,6 +255,12 @@ public sealed class RefitInterfaceAnalyzerTests
     {
         var diagnostics = await AnalyzerFixture.RunForBody(
             """
+            public sealed class Filter
+            {
+                [AliasAs("n")] public string? Name { get; set; }
+                public int Count { get; set; }
+            }
+
             [Get("/users")]
             Task<string> List();
 
@@ -285,6 +291,9 @@ public sealed class RefitInterfaceAnalyzerTests
 
             [Get("/stream")]
             IObservable<string> Observe();
+
+            [Get("/filters")]
+            Task<string> Search([Query(CollectionFormat.Indexed)] List<Filter>? filters);
             """);
 
         await Assert.That(diagnostics.Select(static diagnostic => diagnostic.Id))

--- a/src/tests/Refit.GeneratorTests/IndexedCollectionGenerationTests.cs
+++ b/src/tests/Refit.GeneratorTests/IndexedCollectionGenerationTests.cs
@@ -196,4 +196,44 @@ public sealed class IndexedCollectionGenerationTests
         // A scalar element has no object properties to flatten — handled as regular Collection inline generation.
         await Assert.That(result.GeneratedSources[Hint]).DoesNotContain(ReflectiveFallback);
     }
+
+    /// <summary>Verifies a Indexed parameter whose element type is a collection with a complex element type falls back to reflective generation.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>    
+    [Test]
+    public async Task IndexedWithComplexIndexElementFallsBackToReflective()
+    {
+        const string source =
+            """
+            #nullable enable
+            using System.Collections.Generic;
+            using System.Threading.Tasks;
+            using Refit;
+
+            namespace RefitGeneratorTest;
+
+            public sealed class Car
+            {
+                public int Id { get; set; }
+                public string? Name { get; set; }
+            }
+
+            public sealed class ComplexElement
+            {
+                public List<Car>? Cars { get; set; }
+            }
+
+            public interface IGeneratedClient
+            {
+                [Get("/v")]
+                Task<string> Values([Query(CollectionFormat.Indexed)] List<ComplexElement> values);
+            }
+            """;
+
+        var result = Fixture.RunGenerator(source, generatedRequestBuilding: true);
+
+        await Assert.That(result.CompilesWithoutErrors).IsTrue();
+
+        // A scalar element has no object properties to flatten — handled as regular Collection inline generation.
+        await Assert.That(result.GeneratedSources[Hint]).Contains(ReflectiveFallback);
+    }
 }

--- a/src/tests/Refit.GeneratorTests/QueryRequestBuildingLiveTests.Helpers.cs
+++ b/src/tests/Refit.GeneratorTests/QueryRequestBuildingLiveTests.Helpers.cs
@@ -287,7 +287,10 @@ public sealed partial class QueryRequestBuildingLiveTests
                 Task<string> IndexedListSearch([Query(CollectionFormat.Indexed)] List<int>? items);
 
                 [Get("/indexedNameWithSerialized")]
-                Task<string> indexedNameWithSerialized([Query(CollectionFormat.Indexed)] List<Name>? items);
+                Task<string> indexedNameWithSerialized([Query(CollectionFormat.Indexed)] List<Name> items);
+
+                [Get("/indexedSimpleType")]
+                Task<string> IndexedSimpleType([Query(CollectionFormat.Indexed)] Item item);
             }
             """;
 

--- a/src/tests/Refit.GeneratorTests/QueryRequestBuildingLiveTests.Helpers.cs
+++ b/src/tests/Refit.GeneratorTests/QueryRequestBuildingLiveTests.Helpers.cs
@@ -308,7 +308,7 @@ public sealed partial class QueryRequestBuildingLiveTests
             if (!result.CompilesWithoutErrors)
             {
                 throw new InvalidOperationException(
-                    "Generated compilation failed: " + string.Join(Environment.NewLine, result.CompilationErrors));
+                    $"Generated compilation failed: {string.Join(Environment.NewLine, result.CompilationErrors)}");
             }
 
             var (assembly, loadContext) = Fixture.EmitAndLoad(result);

--- a/src/tests/Refit.GeneratorTests/QueryRequestBuildingLiveTests.cs
+++ b/src/tests/Refit.GeneratorTests/QueryRequestBuildingLiveTests.cs
@@ -277,7 +277,7 @@ public sealed partial class QueryRequestBuildingLiveTests
         const string typeName = "Refit.LiveQuery.Item";
         await harness.AssertParityAsync(indexedSearchMethodName, [null], "/base/indexed");
         var item0 = harness.CreateApiValue(typeName, (id, 1), (value, "a"));
-        var indexedList = harness.CreateApiList(typeName, item0);
+        var indexedList = harness.CreateApiList(typeName, item0, null);
         await harness.AssertParityAsync(indexedSearchMethodName, [indexedList], $"/base/indexed?{parameter}[0].{id}=1&{parameter}[0].{value}=a");
 
         const string indexedSearchWithListIntMethodName = "IndexedListSearch";
@@ -293,6 +293,9 @@ public sealed partial class QueryRequestBuildingLiveTests
         var nameSerialized = harness.CreateApiValue(typeNameSerialized, (name, "John"), (lastName, "Doe"));
         var indexedNameSerialized = harness.CreateApiList(typeNameSerialized, nameSerialized);
         await harness.AssertParityAsync(indexedSearchSerialized, [indexedNameSerialized], $"/base/indexedNameWithSerialized?{parameter}[0].{jsonPropertyName}=John&{parameter}[0].{lastName}=Doe");
+
+        const string indexedSimpleType = "IndexedSimpleType";
+        await harness.AssertParityAsync(indexedSimpleType, [item0], $"/base/indexedSimpleType?{id}=1&{value}=a");
     }
 
     /// <summary>Verifies a custom URL parameter formatter still runs for every generated value.</summary>


### PR DESCRIPTION
## What kind of change does this PR introduce?
Fixes #2273 

## What is the new behavior?
The new behaviour doesn´t emit the RF006

## What is the current behavior?
It emitted it provoking a false positive on the analyser

## What might this PR break?
N/A

## Checklist
- [X] I have read the [Contribute guide](https://www.reactiveui.net/contribute/index.html)
- [X] Tests have been added or updated (for bug fixes / features)
- [X] Docs have been added or updated (for bug fixes / features)
- [X] Changes target the `main` branch
- [X] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional information
I have also seen that the CodeQL task when it was merged in master it throw that some paths were not covered and I covered them. Also remove some analyser warnings that was done on #2268, but my original PR was merged after this one
