### PR TITLE
perf: call `PooledStringBuilder` directly, remove `ConcatParts` and `JoinParts`

### DIFF
--- a/src/InterfaceStubGenerator.Shared/Emitter.Buffers.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.Buffers.cs
@@ -26,67 +26,6 @@ internal static partial class Emitter
     private delegate void GeneratedStringAction<in TState>(Span<char> destination, TState state);
 #endif
 
-    /// <summary>Concatenates populated source fragments without allocating a trimmed array.</summary>
-    /// <param name="parts">The source fragments.</param>
-    /// <param name="count">The populated fragment count.</param>
-    /// <returns>The concatenated source.</returns>
-    internal static string ConcatParts(string[] parts, int count)
-    {
-        var length = 0;
-        for (var i = 0; i < count; i++)
-        {
-            length += parts[i].Length;
-        }
-
-        return CreateGeneratedString(
-            length,
-            (Parts: parts, Count: count),
-            static (destination, state) =>
-            {
-                var position = 0;
-                for (var i = 0; i < state.Count; i++)
-                {
-                    AppendText(destination, state.Parts[i], ref position);
-                }
-            });
-    }
-
-    /// <summary>Joins populated source fragments without allocating a trimmed array.</summary>
-    /// <param name="parts">The source fragments.</param>
-    /// <param name="count">The populated fragment count.</param>
-    /// <param name="separator">The separator text.</param>
-    /// <returns>The joined source.</returns>
-    internal static string JoinParts(string[] parts, int count, string separator)
-    {
-        if (count == 0)
-        {
-            return string.Empty;
-        }
-
-        var length = separator.Length * (count - 1);
-        for (var i = 0; i < count; i++)
-        {
-            length += parts[i].Length;
-        }
-
-        return CreateGeneratedString(
-            length,
-            (Parts: parts, Count: count, Separator: separator),
-            static (destination, state) =>
-            {
-                var position = 0;
-                for (var i = 0; i < state.Count; i++)
-                {
-                    if (i > 0)
-                    {
-                        AppendText(destination, state.Separator, ref position);
-                    }
-
-                    AppendText(destination, state.Parts[i], ref position);
-                }
-            });
-    }
-
     /// <summary>Builds a generated indentation string.</summary>
     /// <param name="level">The indentation level.</param>
     /// <returns>The generated indentation.</returns>

--- a/src/InterfaceStubGenerator.Shared/Emitter.Constraints.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.Constraints.cs
@@ -13,12 +13,13 @@ internal static partial class Emitter
     /// </summary>
     private const int KeywordConstraintCount = 5;
 
-    /// <summary>Builds the generic type constraint clauses for the given type parameters.</summary>
+    /// <summary>Appends the generic type constraint clauses for the given type parameters.</summary>
+    /// <param name="builder">The buffer accumulating the interface source.</param>
     /// <param name="typeParameters">The type parameter constraints to emit.</param>
     /// <param name="isOverrideOrExplicitImplementation">True if emitting for an override or explicit implementation.</param>
     /// <param name="indentationLevel">The generated indentation level.</param>
-    /// <returns>The generated type constraint clauses.</returns>
-    internal static string BuildConstraints(
+    internal static void AppendConstraints(
+        PooledStringBuilder builder,
         ImmutableEquatableArray<TypeConstraint> typeParameters,
         bool isOverrideOrExplicitImplementation,
         int indentationLevel)
@@ -26,39 +27,39 @@ internal static partial class Emitter
         // The overwhelmingly common case is a non-generic method: skip the array allocation entirely.
         if (typeParameters.Count == 0)
         {
-            return string.Empty;
+            return;
         }
 
-        var parts = new string[typeParameters.Count];
-        var count = 0;
         for (var i = 0; i < typeParameters.Count; i++)
         {
-            var source = BuildConstraintsForTypeParameter(
+            AppendConstraintsForTypeParameter(
+                builder,
                 typeParameters[i],
                 isOverrideOrExplicitImplementation,
                 indentationLevel);
-            if (source.Length != 0)
-            {
-                parts[count] = source;
-                count++;
-            }
         }
-
-        return count == 0 ? string.Empty : ConcatParts(parts, count);
     }
 
-    /// <summary>Builds the constraint clause for a single type parameter.</summary>
+    /// <summary>Appends the constraint clause for a single type parameter.</summary>
+    /// <param name="builder">The buffer accumulating the interface source.</param>
     /// <param name="typeParameter">The type parameter constraint to emit.</param>
     /// <param name="isOverrideOrExplicitImplementation">True if emitting for an override or explicit implementation.</param>
     /// <param name="indentationLevel">The generated indentation level.</param>
-    /// <returns>The generated type constraint clause, or an empty string.</returns>
-    internal static string BuildConstraintsForTypeParameter(
+    internal static void AppendConstraintsForTypeParameter(
+        PooledStringBuilder builder,
         in TypeConstraint typeParameter,
         bool isOverrideOrExplicitImplementation,
-        int indentationLevel) =>
-        !HasConstraintKeywords(typeParameter, isOverrideOrExplicitImplementation)
-            ? string.Empty
-            : $"{Indent(indentationLevel)}where {typeParameter.TypeName} : {BuildConstraintList(typeParameter, isOverrideOrExplicitImplementation)}\n";
+        int indentationLevel)
+    {
+        if (!HasConstraintKeywords(typeParameter, isOverrideOrExplicitImplementation))
+        {
+            return;
+        }
+
+        _ = builder.Append(Indent(indentationLevel)).Append("where ").Append(typeParameter.TypeName).Append(" : ");
+        AppendConstraintList(builder, typeParameter, isOverrideOrExplicitImplementation);
+        _ = builder.AppendLine();
+    }
 
     /// <summary>Determines whether a type parameter has constraints that should be emitted.</summary>
     /// <param name="typeParameter">The type parameter constraint to inspect.</param>
@@ -77,63 +78,67 @@ internal static partial class Emitter
                                                            (knownConstraints & KnownTypeConstraint.New) != 0));
     }
 
-    /// <summary>Builds the comma-separated constraint list for a type parameter.</summary>
+    /// <summary>Appends the comma-separated constraint list for a type parameter.</summary>
+    /// <param name="builder">The buffer accumulating the interface source.</param>
     /// <param name="typeParameter">The type parameter constraint to inspect.</param>
     /// <param name="isOverrideOrExplicitImplementation">True if emitting for an override or explicit implementation.</param>
-    /// <returns>The generated constraint list.</returns>
-    internal static string BuildConstraintList(
+    internal static void AppendConstraintList(
+        PooledStringBuilder builder,
         in TypeConstraint typeParameter,
         bool isOverrideOrExplicitImplementation)
     {
-        var parts = new string[typeParameter.Constraints.Count + KeywordConstraintCount];
-        var count = 0;
         var knownConstraints = typeParameter.KnownTypeConstraint;
-        AddConstraint(parts, "class", (knownConstraints & KnownTypeConstraint.Class) != 0, ref count);
+        var addComma = false;
+        AddConstraint(builder, "class", (knownConstraints & KnownTypeConstraint.Class) != 0, ref addComma);
         AddConstraint(
-            parts,
+            builder,
             "unmanaged",
             (knownConstraints & KnownTypeConstraint.Unmanaged) != 0 && !isOverrideOrExplicitImplementation,
-            ref count);
-        AddConstraint(parts, "struct", (knownConstraints & KnownTypeConstraint.Struct) != 0, ref count);
+            ref addComma);
+        AddConstraint(builder, "struct", (knownConstraints & KnownTypeConstraint.Struct) != 0, ref addComma);
         AddConstraint(
-            parts,
+            builder,
             "notnull",
             (knownConstraints & KnownTypeConstraint.NotNull) != 0 && !isOverrideOrExplicitImplementation,
-            ref count);
+            ref addComma);
 
         if (!isOverrideOrExplicitImplementation)
         {
             foreach (var constraint in typeParameter.Constraints)
             {
-                AddConstraint(parts, constraint, true, ref count);
+                AddConstraint(builder, constraint, true, ref addComma);
             }
         }
 
         AddConstraint(
-            parts,
+            builder,
             "new()",
             (knownConstraints & KnownTypeConstraint.New) != 0 && !isOverrideOrExplicitImplementation,
-            ref count);
-        return JoinParts(parts, count, ", ");
+            ref addComma);
     }
 
     /// <summary>Adds one constraint keyword when the condition is true.</summary>
-    /// <param name="parts">The target constraint buffer.</param>
+    /// <param name="builder">The buffer accumulating the interface source.</param>
     /// <param name="keyword">The constraint keyword.</param>
     /// <param name="condition">Whether the keyword should be emitted.</param>
-    /// <param name="count">The populated part count.</param>
+    /// <param name="addComma">Whether a comma should be prepended.</param>
     internal static void AddConstraint(
-        string[] parts,
+        PooledStringBuilder builder,
         string keyword,
         bool condition,
-        ref int count)
+        ref bool addComma)
     {
         if (!condition)
         {
             return;
         }
 
-        parts[count] = keyword;
-        count++;
+        if (addComma)
+        {
+            _ = builder.Append(", ");
+        }
+
+        addComma = true;
+        _ = builder.Append(keyword);
     }
 }

--- a/src/InterfaceStubGenerator.Shared/Emitter.Helpers.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.Helpers.cs
@@ -235,16 +235,15 @@ internal static partial class Emitter
         var asyncKeyword = isAsync ? "async " : string.Empty;
         var explicitInterface = BuildExplicitInterfacePrefix(methodModel, isExplicitInterface);
         var methodIndent = Indent(MethodMemberIndentation);
-        var constraints = BuildConstraints(methodModel.Constraints, isDerivedExplicitImpl || isExplicitInterface, MethodBodyIndentation);
 
         _ = builder
             .AppendLine()
             .Append(methodIndent).AppendLine("/// <inheritdoc />")
             .Append(methodAttributes).Append(methodIndent).Append(visibility).Append(asyncKeyword)
             .Append(methodModel.ReturnType).Append(' ').Append(explicitInterface).Append(methodModel.DeclaredMethod)
-            .Append('(').Append(BuildParameterList(methodModel.Parameters, supportsNullable)).Append(')').AppendLine()
-            .Append(constraints)
-            .Append(methodIndent).Append('{').AppendLine();
+            .Append('(').Append(BuildParameterList(methodModel.Parameters, supportsNullable)).Append(')').AppendLine();
+        AppendConstraints(builder, methodModel.Constraints, isDerivedExplicitImpl || isExplicitInterface, MethodBodyIndentation);
+        _ = builder.Append(methodIndent).Append('{').AppendLine();
     }
 
     /// <summary>Builds the method signature, constraints, and opening brace.</summary>

--- a/src/InterfaceStubGenerator.Shared/Emitter.Testing.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.Testing.cs
@@ -31,14 +31,6 @@ internal static partial class Emitter
     internal static string BuildParameterTypeListForTesting(ImmutableEquatableArray<ParameterModel> parameters) =>
         BuildParameterTypeList(parameters);
 
-    /// <summary>Joins populated source fragments without allocating a trimmed array.</summary>
-    /// <param name="parts">The source fragments.</param>
-    /// <param name="count">The populated fragment count.</param>
-    /// <param name="separator">The separator text.</param>
-    /// <returns>The joined source.</returns>
-    internal static string JoinPartsForTesting(string[] parts, int count, string separator) =>
-        JoinParts(parts, count, separator);
-
     /// <summary>Determines whether a type parameter has constraints that should be emitted.</summary>
     /// <param name="typeParameter">The type parameter constraint to inspect.</param>
     /// <param name="isOverrideOrExplicitImplementation">True if emitting for an override or explicit implementation.</param>

--- a/src/InterfaceStubGenerator.Shared/Emitter.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.cs
@@ -114,7 +114,6 @@ internal static partial class Emitter
         string requestBuilderFieldName,
         string settingsFieldName)
     {
-        var typeParameterDocs = BuildTypeParameterDocumentation(model.Constraints, ClassMemberIndentation);
         var requestBuilderFieldType = model.SupportsNullable
             ? "global::Refit.IRequestBuilder?"
             : "global::Refit.IRequestBuilder";
@@ -128,16 +127,20 @@ internal static partial class Emitter
             .AppendLine("    /// <summary>Contains generated Refit implementation types.</summary>")
             .Append("    internal partial class ").Append(model.GeneratedClassName).AppendLine()
             .AppendLine("    {")
-            .Append("        /// <summary>Generated Refit implementation for ").Append(ToXmlDocumentationText(model.InterfaceDisplayName)).AppendLine(".</summary>")
-            .Append(typeParameterDocs).Append("        ").Append(GeneratedCodeAttribute).AppendLine()
+            .Append("        /// <summary>Generated Refit implementation for ").Append(ToXmlDocumentationText(model.InterfaceDisplayName)).AppendLine(".</summary>");
+        AppendTypeParameterDocumentation(builder, model.Constraints, ClassMemberIndentation);
+        _ = builder
+            .Append("        ").Append(GeneratedCodeAttribute).AppendLine()
             .AppendLine("        [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]")
             .AppendLine("        [global::System.Diagnostics.DebuggerNonUserCode]")
             .Append("        [").Append(model.PreserveAttributeDisplayName).AppendLine("]")
             .AppendLine("        [global::System.Reflection.Obfuscation(Exclude=true)]")
             .AppendLine("        [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]")
             .Append("        private sealed class ").Append(model.Ns).Append(model.ClassDeclaration).AppendLine()
-            .Append("            : ").Append(model.InterfaceDisplayName).AppendLine()
-            .Append(BuildConstraints(model.Constraints, false, ClassMemberIndentation)).AppendLine("        {")
+            .Append("            : ").Append(model.InterfaceDisplayName).AppendLine();
+        AppendConstraints(builder, model.Constraints, false, ClassMemberIndentation);
+        _ = builder
+            .AppendLine("        {")
             .AppendLine("            /// <summary>The request builder used to create Refit method delegates.</summary>")
             .Append("            private readonly ").Append(requestBuilderFieldType).Append(" ").Append(requestBuilderFieldName).AppendLine(";")
             .AppendLine()
@@ -400,27 +403,25 @@ internal static partial class Emitter
         return true;
     }
 
-    /// <summary>Builds documentation for generated type parameters.</summary>
+    /// <summary>Appends documentation for generated type parameters.</summary>
+    /// <param name="builder">The buffer accumulating the interface's generated member source.</param>
     /// <param name="typeParameters">The parsed type parameter constraints.</param>
     /// <param name="indentationLevel">The generated indentation level.</param>
-    /// <returns>The generated type parameter documentation.</returns>
-    internal static string BuildTypeParameterDocumentation(
+    internal static void AppendTypeParameterDocumentation(
+        PooledStringBuilder builder,
         ImmutableEquatableArray<TypeConstraint> typeParameters,
         int indentationLevel)
     {
         if (typeParameters.Count == 0)
         {
-            return string.Empty;
+            return;
         }
 
-        var parts = new string[typeParameters.Count];
         var indentation = Indent(indentationLevel);
         for (var i = 0; i < typeParameters.Count; i++)
         {
-            parts[i] = $"{indentation}/// <typeparam name=\"{typeParameters[i].DeclaredName}\">The generated interface type parameter.</typeparam>\n";
+            _ = builder.Append(indentation).Append("/// <typeparam name=\"").Append(typeParameters[i].DeclaredName).AppendLine("\">The generated interface type parameter.</typeparam>");
         }
-
-        return ConcatParts(parts, parts.Length);
     }
 
     /// <summary>Appends the generated interface property implementations into the member buffer.</summary>

--- a/src/benchmarks/Refit.Generator.Benchmarks/LayoutEmissionBenchmarks.cs
+++ b/src/benchmarks/Refit.Generator.Benchmarks/LayoutEmissionBenchmarks.cs
@@ -6,9 +6,9 @@ using BenchmarkDotNet.Diagnosers;
 
 namespace Refit.Generator.Benchmarks;
 
-/// <summary>Micro-benchmarks for the emitter's indentation and fragment-concatenation layout primitives.</summary>
+/// <summary>Micro-benchmarks for the emitter's indentation primitives.</summary>
 /// <remarks><c>Indent</c> is called for every generated line; the cached-level path must not allocate, while deeper
-/// levels allocate a fresh string. <c>ConcatParts</c> joins the per-member source fragments of an interface.</remarks>
+/// levels allocate a fresh string.</remarks>
 [ShortRunJob]
 [MemoryDiagnoser]
 [EventPipeProfiler(EventPipeProfile.GcVerbose)]
@@ -20,16 +20,6 @@ public class LayoutEmissionBenchmarks
     /// <summary>An indentation level beyond the cache that allocates a fresh string.</summary>
     private readonly int _uncachedLevel = 20;
 
-    /// <summary>Representative per-member source fragments joined into one interface body.</summary>
-    private readonly string[] _parts =
-    [
-        "        public Task<Entity> Get0(int id) { }\n",
-        "        public Task<List<Entity>> List1() { }\n",
-        "        public Task<Entity> Create2(Entity e) { }\n",
-        "        public Task Update3(int id, Entity e) { }\n",
-        "        public Task Delete4(int id) { }\n",
-    ];
-
     /// <summary>Returns a cached indentation string (no-allocation fast path).</summary>
     /// <returns>The indentation string.</returns>
     [Benchmark]
@@ -39,9 +29,4 @@ public class LayoutEmissionBenchmarks
     /// <returns>The indentation string.</returns>
     [Benchmark]
     public string IndentUncached() => Emitter.Indent(_uncachedLevel);
-
-    /// <summary>Concatenates the interface's per-member source fragments.</summary>
-    /// <returns>The joined source.</returns>
-    [Benchmark]
-    public string ConcatParts() => Emitter.ConcatParts(_parts, _parts.Length);
 }

--- a/src/tests/Refit.GeneratorTests/GeneratorComponentTests.EmitterHelpers.cs
+++ b/src/tests/Refit.GeneratorTests/GeneratorComponentTests.EmitterHelpers.cs
@@ -276,15 +276,6 @@ public static partial class GeneratorComponentTests
                 .IsEqualTo("typeof(string), typeof(global::System.Int32)");
         }
 
-        /// <summary>Verifies source fragment joining avoids extra separators for empty input.</summary>
-        /// <returns>A task representing the asynchronous test.</returns>
-        [Test]
-        public async Task JoinParts_HandlesEmptyAndPopulatedParts()
-        {
-            await Assert.That(Emitter.JoinPartsForTesting([], 0, ", ")).IsEqualTo(string.Empty);
-            await Assert.That(Emitter.JoinPartsForTesting(["a", "b", "ignored"], PopulatedPartCount, ", ")).IsEqualTo("a, b");
-        }
-
         /// <summary>Verifies candidate method combining preserves standard and custom methods.</summary>
         /// <returns>A task representing the asynchronous test.</returns>
         [Test]


### PR DESCRIPTION
Append directly to `PooledStringBuilder` instead of creating an intermediary `string`
- This has minor performance benefits, but the main advantage is that we can remove `JoinParts` and `ConcatParts`

On a related note I do wonder if `CreateGeneratedString` is necessary. Using it seems pretty cumbersome, compared to `PooledStringBuilder` directly