### PR TITLE
perf: Use String Interpolation In Code Generation

### DIFF
--- a/src/InterfaceStubGenerator.Shared/Emitter.Helpers.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.Helpers.cs
@@ -119,11 +119,12 @@ internal static partial class Emitter
     /// <summary>Appends one escaped C# string-literal character.</summary>
     /// <param name="builder">The target builder.</param>
     /// <param name="character">The character to append.</param>
+    /// <param name="isInterpolated">Indicates whether the character is part of an interpolated string.</param>
     [SuppressMessage(
         "Maintainability",
         "SST1442:A function has too many direct branch points",
         Justification = "A compact switch avoids a dictionary or repeated helper calls on the generator hot path.")]
-    internal static void AppendEscapedCharacter(PooledStringBuilder builder, char character) =>
+    internal static void AppendEscapedCharacter(PooledStringBuilder builder, char character, bool isInterpolated) =>
         _ = character switch
         {
             '\\' => builder.Append(@"\\"),
@@ -136,6 +137,8 @@ internal static partial class Emitter
             '\r' => builder.Append(@"\r"),
             '\t' => builder.Append(@"\t"),
             '\v' => builder.Append(@"\v"),
+            '{' when isInterpolated => builder.Append("{{"),
+            '}' when isInterpolated => builder.Append("}}"),
 
             // Line terminators that would break out of a regular C# string literal (CS1010).
             '\u0085' => builder.Append(@"\u0085"),

--- a/src/InterfaceStubGenerator.Shared/Emitter.Inline.Query.Object.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.Inline.Query.Object.cs
@@ -310,22 +310,26 @@ internal static partial class Emitter
         in InlineValueEmission emission,
         in QueryObjectContext context)
     {
-        var prefixExpr = $"{parentKeyExpr} + {ToCSharpStringLiteral(delimiter + (property.PrefixSegment ?? string.Empty))}";
+        var interpolatedString = new InterpolatedStringBuilder()
+            .AppendExpression(parentKeyExpr)
+            .AppendLiteral(delimiter)
+            .AppendLiteral(property.PrefixSegment ?? string.Empty);
 
         // An [AliasAs] name always wins and bypasses the key formatter.
         if (property.ExplicitName is { } alias)
         {
-            return $"{prefixExpr} + {ToCSharpStringLiteral(alias)}";
+            return interpolatedString.AppendLiteral(alias).Build();
         }
 
-        var propertyNameExpr = ToCSharpStringLiteral(property.ClrName);
+        var rawStringLiteral = interpolatedString.BuildRaw();
+        const string methodCalled = "global::Refit.GeneratedRequestRunner.BuildQueryKey";
         var formatterCall = context.PreEscapedKeys
-            ? $"{prefixExpr} + {propertyNameExpr}"
-            : $"global::Refit.GeneratedRequestRunner.BuildQueryKey({emission.SettingsLocal}, {propertyNameExpr}, null, {prefixExpr})";
+            ? new InterpolatedStringBuilder().FromRaw(rawStringLiteral).AppendLiteral(property.ClrName).Build()
+            : $"{methodCalled}({emission.SettingsLocal}, {ToCSharpStringLiteral(property.ClrName)}, null, {new InterpolatedStringBuilder().FromRaw(rawStringLiteral).Build()})";
 
         // A [JsonPropertyName] name is honored only when the runtime setting is enabled.
         return property.SerializerName is { } serializerName
-            ? $"{emission.SettingsLocal}.{HonorSerializerNamesFlag} ? ({prefixExpr} + {ToCSharpStringLiteral(serializerName)}) : ({formatterCall})"
+            ? $"{emission.SettingsLocal}.{HonorSerializerNamesFlag} ? ({new InterpolatedStringBuilder().FromRaw(rawStringLiteral).AppendLiteral(serializerName).Build()}) : ({formatterCall})"
             : formatterCall;
     }
 

--- a/src/InterfaceStubGenerator.Shared/Emitter.Inline.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.Inline.cs
@@ -498,7 +498,7 @@ internal static partial class Emitter
                     {
                         // An [Authorize] parameter carries a "{scheme} " prefix; a plain [Header] has none.
                         var headerValueExpression = parameter.HeaderValuePrefix is { } valuePrefix
-                            ? $"{ToCSharpStringLiteral(valuePrefix)} + {BuildHeaderValueExpression(parameter)}"
+                            ? new InterpolatedStringBuilder().AppendLiteral(valuePrefix).AppendExpression(BuildHeaderValueExpression(parameter)).Build()
                             : BuildHeaderValueExpression(parameter);
                         sb ??= new PooledStringBuilder();
                         var headerName = ToCSharpStringLiteral(parameter.HeaderName);

--- a/src/InterfaceStubGenerator.Shared/Emitter.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.cs
@@ -599,4 +599,74 @@ internal static partial class Emitter
 
             """);
     }
+
+    /// <summary>Represents a handler for interpolated strings.</summary>
+    internal sealed class InterpolatedStringBuilder
+    {
+        /// <summary>The internal string builder used to accumulate the interpolated string content.</summary>
+        private readonly PooledStringBuilder _builder;
+
+        /// <summary>Indicates if the handler has any content.</summary>
+        private bool _hasContent;
+
+        /// <summary>Initializes a new instance of the <see cref="InterpolatedStringBuilder"/> class.</summary>
+        internal InterpolatedStringBuilder()
+        {
+            _builder = new();
+        }
+
+        /// <summary>Appends a c# expression to the interpolated string.</summary>
+        /// <param name="expression">The C# expression.</param>
+        /// <returns>The interpolated string handler.</returns>
+        internal InterpolatedStringBuilder AppendExpression(string expression)
+        {
+            Initialize();
+            _ = _builder.Append('{').Append(expression).Append('}');
+            return this;
+        }
+
+        /// <summary>Appends a literal.</summary>
+        /// <param name="literal">The literal string.</param>
+        /// <returns>The interpolated string handler.</returns>
+        internal InterpolatedStringBuilder AppendLiteral(string literal)
+        {
+            Initialize();
+            foreach (var c in literal)
+            {
+                AppendEscapedCharacter(_builder, c);
+            }
+
+            return this;
+        }
+
+        /// <summary>Builds the final interpolated string representation.</summary>
+        /// <returns>The interpolated string.</returns>
+        internal string Build() => _builder.Append('"').ToString();
+
+        /// <summary>Builds the final raw string representation.</summary>
+        /// <returns>The raw string.</returns>
+        internal string BuildRaw() => _builder.ToString();
+
+        /// <summary>Appends the specified raw string to the handler.</summary>
+        /// <param name="raw">The raw string.</param>
+        /// <returns>The interpolated string handler.</returns>
+        internal InterpolatedStringBuilder FromRaw(string raw)
+        {
+            _ = _builder.Append(raw);
+            _hasContent = true;
+            return this;
+        }
+
+        /// <summary>Initializes the handler if it has not been initialized.</summary>
+        private void Initialize()
+        {
+            if (_hasContent)
+            {
+                return;
+            }
+
+            _hasContent = true;
+            _ = _builder.Append('$').Append('"');
+        }
+    }
 }

--- a/src/InterfaceStubGenerator.Shared/Emitter.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.cs
@@ -506,7 +506,7 @@ internal static partial class Emitter
         _ = builder.Append('"');
         foreach (var c in value)
         {
-            AppendEscapedCharacter(builder, c);
+            AppendEscapedCharacter(builder, c, false);
         }
 
         _ = builder.Append('"');
@@ -633,7 +633,7 @@ internal static partial class Emitter
             Initialize();
             foreach (var c in literal)
             {
-                AppendEscapedCharacter(_builder, c);
+                AppendEscapedCharacter(_builder, c, true);
             }
 
             return this;

--- a/src/InterfaceStubGenerator.Shared/Emitter.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.cs
@@ -600,13 +600,13 @@ internal static partial class Emitter
             """);
     }
 
-    /// <summary>Represents a handler for interpolated strings.</summary>
+    /// <summary>Represents a builder for interpolated strings.</summary>
     internal sealed class InterpolatedStringBuilder
     {
         /// <summary>The internal string builder used to accumulate the interpolated string content.</summary>
         private readonly PooledStringBuilder _builder;
 
-        /// <summary>Indicates if the handler has any content.</summary>
+        /// <summary>Indicates if the builder has any content.</summary>
         private bool _hasContent;
 
         /// <summary>Initializes a new instance of the <see cref="InterpolatedStringBuilder"/> class.</summary>
@@ -617,7 +617,7 @@ internal static partial class Emitter
 
         /// <summary>Appends a c# expression to the interpolated string.</summary>
         /// <param name="expression">The C# expression.</param>
-        /// <returns>The interpolated string handler.</returns>
+        /// <returns>The interpolated string builder.</returns>
         internal InterpolatedStringBuilder AppendExpression(string expression)
         {
             Initialize();
@@ -627,7 +627,7 @@ internal static partial class Emitter
 
         /// <summary>Appends a literal.</summary>
         /// <param name="literal">The literal string.</param>
-        /// <returns>The interpolated string handler.</returns>
+        /// <returns>The interpolated string builder.</returns>
         internal InterpolatedStringBuilder AppendLiteral(string literal)
         {
             Initialize();
@@ -643,13 +643,13 @@ internal static partial class Emitter
         /// <returns>The interpolated string.</returns>
         internal string Build() => _builder.Append('"').ToString();
 
-        /// <summary>Builds the final raw string representation.</summary>
+        /// <summary>Builds the final raw string representation without the final quote.</summary>
         /// <returns>The raw string.</returns>
         internal string BuildRaw() => _builder.ToString();
 
-        /// <summary>Appends the specified raw string to the handler.</summary>
+        /// <summary>Appends the specified raw string to the builder.</summary>
         /// <param name="raw">The raw string.</param>
-        /// <returns>The interpolated string handler.</returns>
+        /// <returns>The interpolated string builder.</returns>
         internal InterpolatedStringBuilder FromRaw(string raw)
         {
             _ = _builder.Append(raw);
@@ -657,7 +657,7 @@ internal static partial class Emitter
             return this;
         }
 
-        /// <summary>Initializes the handler if it has not been initialized.</summary>
+        /// <summary>Initializes the builder if it has not been initialized.</summary>
         private void Initialize()
         {
             if (_hasContent)

--- a/src/tests/Refit.GeneratorTests/GeneratorComponentTests.EmitterHelpers.cs
+++ b/src/tests/Refit.GeneratorTests/GeneratorComponentTests.EmitterHelpers.cs
@@ -46,12 +46,12 @@ public static partial class GeneratorComponentTests
         {
             var builder = new PooledStringBuilder();
 
-            foreach (var value in new[] { '\\', '"', '\0', '\a', '\b', '\f', '\n', '\r', '\t', '\v', '\u0085', '\u2028', '\u2029', 'x' })
+            foreach (var value in new[] { '\\', '"', '\0', '\a', '\b', '\f', '\n', '\r', '\t', '\v', '\u0085', '\u2028', '\u2029', '{', '}', 'x' })
             {
                 Emitter.AppendEscapedCharacter(builder, value, false);
             }
 
-            await Assert.That(builder.ToString()).IsEqualTo("""\\\"\0\a\b\f\n\r\t\v\u0085\u2028\u2029x""");
+            await Assert.That(builder.ToString()).IsEqualTo("""\\\"\0\a\b\f\n\r\t\v\u0085\u2028\u2029{}x""");
         }
 
         /// <summary>Verifies unguarded indexed query emission and the shared empty parameter provider.</summary>

--- a/src/tests/Refit.GeneratorTests/GeneratorComponentTests.EmitterHelpers.cs
+++ b/src/tests/Refit.GeneratorTests/GeneratorComponentTests.EmitterHelpers.cs
@@ -2,11 +2,6 @@
 // ReactiveUI and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
-
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
@@ -53,7 +48,7 @@ public static partial class GeneratorComponentTests
 
             foreach (var value in new[] { '\\', '"', '\0', '\a', '\b', '\f', '\n', '\r', '\t', '\v', '\u0085', '\u2028', '\u2029', 'x' })
             {
-                Emitter.AppendEscapedCharacter(builder, value);
+                Emitter.AppendEscapedCharacter(builder, value, false);
             }
 
             await Assert.That(builder.ToString()).IsEqualTo("""\\\"\0\a\b\f\n\r\t\v\u0085\u2028\u2029x""");

--- a/src/tests/Refit.GeneratorTests/IndexedCollectionGenerationTests.cs
+++ b/src/tests/Refit.GeneratorTests/IndexedCollectionGenerationTests.cs
@@ -159,6 +159,7 @@ public sealed class IndexedCollectionGenerationTests
 
         await Assert.That(result.CompilesWithoutErrors).IsTrue();
         await Assert.That(result.GeneratedSources[Hint]).Contains("items[{");
+        await Assert.That(result.GeneratedSources[Hint]).Contains("}.Id");
     }
 
     /// <summary>Verifies a Indexed collection whose element type has a scalar collection property flattens inline

--- a/src/tests/Refit.GeneratorTests/InterpolatedStringBuilderTest.cs
+++ b/src/tests/Refit.GeneratorTests/InterpolatedStringBuilderTest.cs
@@ -1,0 +1,140 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using Refit.Generator;
+
+namespace Refit.GeneratorTests;
+
+/// <summary>Tests interpolated strings emitted by the generator.</summary>
+public sealed class InterpolatedStringBuilderTest
+{
+    /// <summary>Verifies literal interpolation braces are doubled.</summary>
+    /// <returns>A task representing the test.</returns>
+    [Test]
+    public async Task BuilderEscapesLiteralBraces()
+    {
+        var actual = new Emitter.InterpolatedStringBuilder()
+            .AppendLiteral("{zip}")
+            .AppendExpression("value")
+            .Build();
+
+        await Assert.That(actual).IsEqualTo("$\"{{zip}}{value}\"");
+    }
+
+    /// <summary>Verifies braces in a nested alias produce valid generated code.</summary>
+    /// <returns>A task representing the test.</returns>
+    [Test]
+    public Task NestedAliasContainingBracesCompiles() =>
+        AssertGeneratedCodeCompiles(
+            """
+            using System.Threading.Tasks;
+            using Refit;
+
+            namespace RefitGeneratorTest;
+
+            public sealed class Inner
+            {
+                [AliasAs("{zip}")]
+                public string Zip { get; set; } = "";
+            }
+
+            public sealed class QueryModel
+            {
+                public Inner Nested { get; set; } = new();
+            }
+
+            public interface IGeneratedClient
+            {
+                [Get("/query")]
+                Task<string> Find([Query] QueryModel query);
+            }
+            """);
+
+    /// <summary>Verifies braces in a serializer name produce valid generated code.</summary>
+    /// <returns>A task representing the test.</returns>
+    [Test]
+    public Task NestedSerializerNameContainingBracesCompiles() =>
+        AssertGeneratedCodeCompiles(
+            """
+            using System.Text.Json.Serialization;
+            using System.Threading.Tasks;
+            using Refit;
+
+            namespace RefitGeneratorTest;
+
+            public sealed class Inner
+            {
+                [JsonPropertyName("{zip}")]
+                public string Zip { get; set; } = "";
+            }
+
+            public sealed class QueryModel
+            {
+                public Inner Nested { get; set; } = new();
+            }
+
+            public interface IGeneratedClient
+            {
+                [Get("/query")]
+                Task<string> Find([Query] QueryModel query);
+            }
+            """);
+
+    /// <summary>Verifies braces in query prefixes and delimiters produce valid generated code.</summary>
+    /// <returns>A task representing the test.</returns>
+    [Test]
+    public Task QueryPrefixAndDelimiterContainingBracesCompile() =>
+        AssertGeneratedCodeCompiles(
+            """
+            using System.Threading.Tasks;
+            using Refit;
+
+            namespace RefitGeneratorTest;
+
+            public sealed class Inner
+            {
+                public string Value { get; set; } = "";
+            }
+
+            public sealed class QueryModel
+            {
+                [Query("{delimiter}", "{prefix}")]
+                public Inner Nested { get; set; } = new();
+            }
+
+            public interface IGeneratedClient
+            {
+                [Get("/query")]
+                Task<string> Find([Query] QueryModel query);
+            }
+            """);
+
+    /// <summary>Verifies braces in authorization schemes produce valid generated code.</summary>
+    /// <returns>A task representing the test.</returns>
+    [Test]
+    public Task AuthorizationSchemeContainingBracesCompiles() =>
+        AssertGeneratedCodeCompiles(
+            """
+            using System.Threading.Tasks;
+            using Refit;
+
+            namespace RefitGeneratorTest;
+
+            public interface IGeneratedClient
+            {
+                [Get("/query")]
+                Task<string> Find([Authorize("{Bearer}")] string token);
+            }
+            """);
+
+    /// <summary>Runs the generator and verifies its output compiles.</summary>
+    /// <param name="source">The source being compiled.</param>
+    /// <returns>A task representing the assertion.</returns>
+    private static async Task AssertGeneratedCodeCompiles(string source)
+    {
+        var result = Fixture.RunGenerator(source, generatedRequestBuilding: true);
+
+        await Assert.That(result.CompilationErrors).IsEmpty();
+    }
+}

--- a/src/tests/Refit.GeneratorTests/RequestGenerationCoverageTests.RequestTargets.cs
+++ b/src/tests/Refit.GeneratorTests/RequestGenerationCoverageTests.RequestTargets.cs
@@ -198,6 +198,6 @@ public sealed partial class RequestGenerationCoverageTests
 
         await Assert.That(result.CompilesWithoutErrors).IsTrue();
         await Assert.That(generated).DoesNotContain(ReflectiveRequestBuilderCall);
-        await Assert.That(generated).Contains("\"Bearer \"");
+        await Assert.That(generated).Contains("\"Bearer {");
     }
 }

--- a/src/tests/Refit.GeneratorTests/RequestGenerationCoverageTests.cs
+++ b/src/tests/Refit.GeneratorTests/RequestGenerationCoverageTests.cs
@@ -243,8 +243,8 @@ public sealed partial class RequestGenerationCoverageTests
         await Assert.That(result.CompilesWithoutErrors).IsTrue();
         await Assert.That(generated).DoesNotContain(ReflectiveRequestBuilderCall);
         await Assert.That(generated).Contains("\"Authorization\"");
-        await Assert.That(generated).Contains("\"Bearer \"");
-        await Assert.That(generated).Contains("\"Token \"");
+        await Assert.That(generated).Contains("\"Bearer {");
+        await Assert.That(generated).Contains("\"Token {");
     }
 
     /// <summary>Verifies a dotted path placeholder whose intermediate segment property does not exist falls back.</summary>


### PR DESCRIPTION
## What kind of change does this PR introduce?
Performace, it uses InterpolatedStrings instead of concatenating strings with a + on the code Generation. Initial change on #2277

## What is the new behavior?
```c#
refitQueryBuilder.AddPreEscapedKey($"{refitQueryValue_key}.Id", refitUseDefaultFormatting ? (global::Refit.GeneratedRequestRunner.FormatInvariant(refitQueryValue_items_Id, null)) : global::Refit.GeneratedRequestRunner.FormatUrlParameter(refitSettings, refitQueryValue_items_Id, ______itemsAttributeProvider, typeof(global::System.Collections.Generic.IReadOnlyList<global::RefitGeneratorTest.Item>)), false);
``` 

## What is the current behavior?
```c#
refitQueryBuilder.AddPreEscapedKey(refitQueryValue_key + "." + "Id", refitUseDefaultFormatting ? (global::Refit.GeneratedRequestRunner.FormatInvariant(refitQueryValue_items_Id, null)) : global::Refit.GeneratedRequestRunner.FormatUrlParameter(refitSettings, refitQueryValue_items_Id, ______itemsAttributeProvider, typeof(global::System.Collections.Generic.IReadOnlyList<global::RefitGeneratorTest.Item>)), false);
``` 

## What might this PR break?
Different scape sequences for interpolatedStrings? If it's so the code generated could not compile 

## Checklist
- [X] I have read the [Contribute guide](https://www.reactiveui.net/contribute/index.html)
- [X] Tests have been added or updated (for bug fixes / features)
- [X] Docs have been added or updated (for bug fixes / features)
- [X] Changes target the `main` branch
- [X] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional information
I change the name of StringInterpolationHandler to StringInterpolationBuilder to be more accurate on the naming