### PR TITLE
fix(generator): support path and header bindings

### DIFF
--- a/src/InterfaceStubGenerator.Roslyn48/InterfaceStubGenerator.Roslyn48.csproj
+++ b/src/InterfaceStubGenerator.Roslyn48/InterfaceStubGenerator.Roslyn48.csproj
@@ -31,6 +31,7 @@
 
   <ItemGroup>
     <Compile Include="..\InterfaceStubGenerator.Shared\**\*.cs" LinkBase="InterfaceStubGenerator.Shared"/>
+    <Compile Include="..\Polyfills\NotNullWhenAttribute.cs" Link="Polyfills\NotNullWhenAttribute.cs"/>
   </ItemGroup>
 
   <Target Name="SetBuildVer" AfterTargets="GetBuildVersion" BeforeTargets="SetCloudBuildVersionVars;SetCloudBuildNumberWithVersion">

--- a/src/InterfaceStubGenerator.Roslyn50/InterfaceStubGenerator.Roslyn50.csproj
+++ b/src/InterfaceStubGenerator.Roslyn50/InterfaceStubGenerator.Roslyn50.csproj
@@ -30,6 +30,7 @@
 
   <ItemGroup>
     <Compile Include="..\InterfaceStubGenerator.Shared\**\*.cs" LinkBase="InterfaceStubGenerator.Shared"/>
+    <Compile Include="..\Polyfills\NotNullWhenAttribute.cs" Link="Polyfills\NotNullWhenAttribute.cs"/>
   </ItemGroup>
 
   <Target Name="SetBuildVer" AfterTargets="GetBuildVersion" BeforeTargets="SetCloudBuildVersionVars;SetCloudBuildNumberWithVersion">

--- a/src/InterfaceStubGenerator.Shared/Emitter.Inline.ParameterInfo.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.Inline.ParameterInfo.cs
@@ -68,29 +68,13 @@ internal static partial class Emitter
     /// <param name="sb">The target builder.</param>
     internal static void BuildParameterInfoField(in RequestParameterModel parameter, string method, string paramInfoFieldName, PooledStringBuilder sb)
     {
-        // Build the initializer.
         var memberIndent = Indent(MethodMemberIndentation);
-        Dictionary<string, List<ParameterAttributeModel>> grouped = new();
-
-        foreach (var attribute in parameter.Attributes)
-        {
-            var key = $"typeof({attribute.TypeExpression})";
-            if (grouped.TryGetValue(key, out var groupedAttributes))
-            {
-                groupedAttributes.Add(attribute);
-            }
-            else
-            {
-                grouped.Add(key, [attribute]);
-            }
-        }
-
         _ = sb.AppendLine().Append(memberIndent).Append("/// <summary>Cached attribute provider for the generated ")
             .Append(ToXmlDocumentationText(method)).Append(" method's ").Append(ToXmlDocumentationText(parameter.Name)).AppendLine(" parameter.</summary>")
             .Append(memberIndent).Append("private static readonly global::Refit.GeneratedParameterAttributeProvider ").Append(paramInfoFieldName).Append(" = ");
 
         // A parameter with no attributes shares the singleton empty provider instead of allocating an empty dictionary.
-        if (grouped.Count == 0)
+        if (parameter.Attributes.Count == 0)
         {
             _ = sb.AppendLine("global::Refit.GeneratedParameterAttributeProvider.Empty;");
             return;
@@ -98,24 +82,69 @@ internal static partial class Emitter
 
         const string dictType = "global::System.Collections.Generic.Dictionary<global::System.Type, object[]>";
         _ = sb.Append("new global::Refit.GeneratedParameterAttributeProvider(new ").Append(dictType).Append("() {");
-        var i = 0;
-        foreach (var kv in grouped)
+        var groupIndex = 0;
+        for (var attributeIndex = 0; attributeIndex < parameter.Attributes.Count; attributeIndex++)
         {
-            _ = AppendJoining("{ ", i, sb).Append(kv.Key).Append(", new object[] { ");
-            i++;
-            var argIndex = 0;
-            foreach (var arg in kv.Value)
+            var attribute = parameter.Attributes[attributeIndex];
+            if (HasEarlierAttributeOfType(parameter.Attributes, attributeIndex, attribute.TypeExpression))
             {
-                // Multiple attributes of the same type must be comma-separated inside the array.
-                _ = AppendSeparator(argIndex, sb);
-                argIndex++;
-                AppendAttributeValue(arg, sb);
+                continue;
             }
 
+            _ = AppendJoining("{ typeof(", groupIndex, sb).Append(attribute.TypeExpression).Append("), new object[] { ");
+            groupIndex++;
+            AppendAttributesOfType(parameter.Attributes, attributeIndex, attribute.TypeExpression, sb);
             _ = sb.Append("} }");
         }
 
         _ = sb.Append('}').AppendLine(");");
+    }
+
+    /// <summary>Determines whether an attribute type has already been emitted.</summary>
+    /// <param name="attributes">The parameter attributes.</param>
+    /// <param name="attributeIndex">The current attribute index.</param>
+    /// <param name="typeExpression">The current attribute type expression.</param>
+    /// <returns><see langword="true"/> when an earlier attribute has the same type.</returns>
+    internal static bool HasEarlierAttributeOfType(
+        ImmutableEquatableArray<ParameterAttributeModel> attributes,
+        int attributeIndex,
+        string typeExpression)
+    {
+        for (var i = 0; i < attributeIndex; i++)
+        {
+            if (string.Equals(attributes[i].TypeExpression, typeExpression, StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>Appends every attribute of one type without allocating a temporary grouping collection.</summary>
+    /// <param name="attributes">The parameter attributes.</param>
+    /// <param name="startIndex">The first attribute index to inspect.</param>
+    /// <param name="typeExpression">The attribute type expression to append.</param>
+    /// <param name="sb">The target builder.</param>
+    internal static void AppendAttributesOfType(
+        ImmutableEquatableArray<ParameterAttributeModel> attributes,
+        int startIndex,
+        string typeExpression,
+        PooledStringBuilder sb)
+    {
+        var emittedCount = 0;
+        for (var i = startIndex; i < attributes.Count; i++)
+        {
+            var attribute = attributes[i];
+            if (!string.Equals(attribute.TypeExpression, typeExpression, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            _ = AppendSeparator(emittedCount, sb);
+            emittedCount++;
+            AppendAttributeValue(attribute, sb);
+        }
     }
 
     /// <summary>Assigns the unique cached field name for each attribute-provider parameter and emits its field.</summary>

--- a/src/InterfaceStubGenerator.Shared/Emitter.Inline.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.Inline.cs
@@ -490,41 +490,47 @@ internal static partial class Emitter
             AppendSetHeader(sb, bodyIndent, requestLocal, name, value, settingsLocal);
         }
 
-        foreach (var parameter in request.Parameters)
-        {
-            switch (parameter.Kind)
-            {
-                case RequestParameterKind.Header:
-                    {
-                        // An [Authorize] parameter carries a "{scheme} " prefix; a plain [Header] has none.
-                        var headerValueExpression = parameter.HeaderValuePrefix is { } valuePrefix
-                            ? new InterpolatedStringBuilder().AppendLiteral(valuePrefix).AppendExpression(BuildHeaderValueExpression(parameter)).Build()
-                            : BuildHeaderValueExpression(parameter);
-                        sb ??= new PooledStringBuilder();
-                        var headerName = ToCSharpStringLiteral(parameter.HeaderName);
-                        AppendSetHeader(sb, bodyIndent, requestLocal, headerName, headerValueExpression, settingsLocal);
-                        break;
-                    }
-
-                case RequestParameterKind.HeaderCollection:
-                    {
-                        sb ??= new PooledStringBuilder();
-                        _ = sb.Append(bodyIndent).Append("global::Refit.GeneratedRequestRunner.AddHeaderCollection(")
-                            .Append(requestLocal).Append(ArgumentSeparator).Append("@").Append(parameter.Name)
-                            .Append(ArgumentSeparator).Append(settingsLocal).Append(ValidateHeadersMember).AppendLine(");");
-                        break;
-                    }
-
-                default:
-                    {
-                        // All other parameter kinds (Path, Query, Body, Property, CancellationToken, ...)
-                        // are not headers and contribute nothing to header application here.
-                        break;
-                    }
-            }
-        }
-
+        AppendInlineParameterHeaders(ref sb, request.Parameters, bodyIndent, requestLocal, settingsLocal);
         return sb?.ToString() ?? string.Empty;
+    }
+
+    /// <summary>Appends dynamic parameter headers to the generated request body.</summary>
+    /// <param name="sb">The lazily allocated output buffer.</param>
+    /// <param name="parameters">The request parameters.</param>
+    /// <param name="bodyIndent">The method-body indentation.</param>
+    /// <param name="requestLocal">The generated request-message local.</param>
+    /// <param name="settingsLocal">The generated settings local.</param>
+    internal static void AppendInlineParameterHeaders(
+        ref PooledStringBuilder? sb,
+        ImmutableEquatableArray<RequestParameterModel> parameters,
+        string bodyIndent,
+        string requestLocal,
+        string settingsLocal)
+    {
+        foreach (var parameter in parameters)
+        {
+            if (parameter.HeaderName.Length > 0)
+            {
+                // HeaderName is independent of the primary binding kind so one parameter can also bind the path.
+                var headerValueExpression = parameter.HeaderValuePrefix is { } valuePrefix
+                    ? new InterpolatedStringBuilder().AppendLiteral(valuePrefix).AppendExpression(BuildHeaderValueExpression(parameter)).Build()
+                    : BuildHeaderValueExpression(parameter);
+                sb ??= new PooledStringBuilder();
+                var headerName = ToCSharpStringLiteral(parameter.HeaderName);
+                AppendSetHeader(sb, bodyIndent, requestLocal, headerName, headerValueExpression, settingsLocal);
+                continue;
+            }
+
+            if (parameter.Kind != RequestParameterKind.HeaderCollection)
+            {
+                continue;
+            }
+
+            sb ??= new PooledStringBuilder();
+            _ = sb.Append(bodyIndent).Append("global::Refit.GeneratedRequestRunner.AddHeaderCollection(")
+                .Append(requestLocal).Append(ArgumentSeparator).Append("@").Append(parameter.Name)
+                .Append(ArgumentSeparator).Append(settingsLocal).Append(ValidateHeadersMember).AppendLine(");");
+        }
     }
 
     /// <summary>Appends one <c>SetHeader</c> statement directly into the header buffer.</summary>

--- a/src/InterfaceStubGenerator.Shared/Models/RequestParameterModel.cs
+++ b/src/InterfaceStubGenerator.Shared/Models/RequestParameterModel.cs
@@ -9,9 +9,10 @@ namespace Refit.Generator;
 /// <param name="Type">The fully-qualified parameter type.</param>
 /// <param name="Locations">The parameter's location in the URL template string, when this is a path parameter.</param>
 /// <param name="Attributes">The parameter's attributes.</param>
-/// <param name="Kind">The generated request binding kind.</param>
+/// <param name="Kind">The primary generated request binding kind.</param>
 /// <param name="CanBeNull">Whether generated code must null-check the parameter before dereferencing.</param>
-/// <param name="HeaderName">The request header name, when this is a header parameter.</param>
+/// <param name="HeaderName">The request header name when the parameter contributes a dynamic header, independently
+/// of its primary binding kind.</param>
 /// <param name="PropertyKey">The request property key, when this is a property parameter.</param>
 /// <param name="BodySerializationMethod">The Refit body serialization method name, when this is a body parameter.</param>
 /// <param name="BodyBufferMode">The body buffering mode, when this is a body parameter.</param>

--- a/src/InterfaceStubGenerator.Shared/Parser.Request.ParameterKinds.cs
+++ b/src/InterfaceStubGenerator.Shared/Parser.Request.ParameterKinds.cs
@@ -208,17 +208,11 @@ internal static partial class Parser
         return false;
     }
 
-    /// <summary>Tries to parse a dynamic header parameter.</summary>
+    /// <summary>Tries to resolve a dynamic header name.</summary>
     /// <param name="parameter">The parameter to inspect.</param>
-    /// <param name="parameterType">The parameter type display string.</param>
-    /// <param name="context">The interface generation context, used to qualify extern-aliased types.</param>
-    /// <param name="headerParameter">Receives the header parameter model.</param>
+    /// <param name="headerName">Receives the trimmed header name.</param>
     /// <returns><see langword="true"/> when the parameter has a supported header attribute.</returns>
-    internal static bool TryParseHeaderParameter(
-        IParameterSymbol parameter,
-        string parameterType,
-        in InterfaceGenerationContext context,
-        out RequestParameterModel headerParameter)
+    internal static bool TryGetHeaderName(IParameterSymbol parameter, [NotNullWhen(true)] out string? headerName)
     {
         foreach (var attribute in parameter.GetAttributes())
         {
@@ -228,29 +222,42 @@ internal static partial class Parser
             }
 
             var arguments = attribute.ConstructorArguments;
-            if (arguments.IsEmpty || arguments[0].Value is not string headerName ||
-                string.IsNullOrWhiteSpace(headerName))
+            if (arguments.IsEmpty || arguments[0].Value is not string candidateHeaderName ||
+                string.IsNullOrWhiteSpace(candidateHeaderName))
             {
                 continue;
             }
 
-            headerParameter = new(
-                parameter.MetadataName,
-                parameterType,
-                null,
-                BuildParameterAttributes(parameter, context),
-                RequestParameterKind.Header,
-                CanBeNull(parameter.Type, parameter.NullableAnnotation),
-                headerName.Trim(),
-                string.Empty,
-                string.Empty,
-                BodyBufferMode.None);
+            headerName = candidateHeaderName.Trim();
             return true;
         }
 
-        headerParameter = default;
+        headerName = null;
         return false;
     }
+
+    /// <summary>Builds a dynamic header parameter.</summary>
+    /// <param name="parameter">The parameter symbol.</param>
+    /// <param name="parameterType">The parameter type display string.</param>
+    /// <param name="headerName">The resolved header name.</param>
+    /// <param name="context">The interface generation context, used to qualify extern-aliased types.</param>
+    /// <returns>The header request model.</returns>
+    internal static RequestParameterModel BuildHeaderParameter(
+        IParameterSymbol parameter,
+        string parameterType,
+        string headerName,
+        in InterfaceGenerationContext context) =>
+        new(
+            parameter.MetadataName,
+            parameterType,
+            null,
+            BuildParameterAttributes(parameter, context),
+            RequestParameterKind.Header,
+            CanBeNull(parameter.Type, parameter.NullableAnnotation),
+            headerName,
+            string.Empty,
+            string.Empty,
+            BodyBufferMode.None);
 
     /// <summary>Tries to parse a dynamic header collection parameter.</summary>
     /// <param name="parameter">The parameter to inspect.</param>

--- a/src/InterfaceStubGenerator.Shared/Parser.Request.Parameters.cs
+++ b/src/InterfaceStubGenerator.Shared/Parser.Request.Parameters.cs
@@ -178,9 +178,19 @@ internal static partial class Parser
             return new(bodyParameter, bodyEligible, 1, 0, 0);
         }
 
-        if (TryParseHeaderParameter(parameter, parameterType, context.Generation, out var headerParameter))
+        if (TryGetHeaderName(parameter, out var headerName))
         {
-            return new(headerParameter, true, 0, 0, 0);
+            return ParseBoundPathParameter(parameter, parameterType, context) is { } pathParameter
+                ? pathParameter with
+                {
+                    Parameter = pathParameter.Parameter with { HeaderName = headerName },
+                }
+                : new(
+                    BuildHeaderParameter(parameter, parameterType, headerName, context.Generation),
+                    true,
+                    0,
+                    0,
+                    0);
         }
 
         if (TryParseHeaderCollectionParameter(parameter, parameterType, context.Generation, out var headerCollectionParameter))

--- a/src/Refit.Analyzers.Roslyn48/Refit.Analyzers.Roslyn48.csproj
+++ b/src/Refit.Analyzers.Roslyn48/Refit.Analyzers.Roslyn48.csproj
@@ -20,11 +20,12 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="Refit.GeneratorTests"/>
-    <InternalsVisibleTo Include="Refit.Analyzers.Tests"/>
+    <InternalsVisibleTo Include="Refit.Analyzers.Internals.Tests"/>
   </ItemGroup>
 
   <ItemGroup>
     <Compile Include="..\Refit.Analyzers.Shared\**\*.cs" LinkBase="Refit.Analyzers.Shared"/>
+    <Compile Include="..\Polyfills\NotNullWhenAttribute.cs" Link="Polyfills\NotNullWhenAttribute.cs"/>
   </ItemGroup>
 
   <ItemGroup Label="Shared generator request classification (keeps RF006 in lockstep with CanGenerateInline)">

--- a/src/Refit.Analyzers.Roslyn50/Refit.Analyzers.Roslyn50.csproj
+++ b/src/Refit.Analyzers.Roslyn50/Refit.Analyzers.Roslyn50.csproj
@@ -20,11 +20,12 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="Refit.GeneratorTests"/>
-    <InternalsVisibleTo Include="Refit.Analyzers.Tests"/>
+    <InternalsVisibleTo Include="Refit.Analyzers.Internals.Tests"/>
   </ItemGroup>
 
   <ItemGroup>
     <Compile Include="..\Refit.Analyzers.Shared\**\*.cs" LinkBase="Refit.Analyzers.Shared"/>
+    <Compile Include="..\Polyfills\NotNullWhenAttribute.cs" Link="Polyfills\NotNullWhenAttribute.cs"/>
   </ItemGroup>
 
   <ItemGroup Label="Shared generator request classification (keeps RF006 in lockstep with CanGenerateInline)">

--- a/src/Refit.slnx
+++ b/src/Refit.slnx
@@ -37,6 +37,7 @@
     </Folder>
     <Folder Name="/Tests/">
         <Project Path="tests/Refit.Analyzers.Tests/Refit.Analyzers.Tests.csproj" />
+        <Project Path="tests/Refit.Analyzers.Internals.Tests/Refit.Analyzers.Internals.Tests.csproj" />
         <Project Path="tests/Refit.CodeFixes.Tests/Refit.CodeFixes.Tests.csproj" />
         <Project Path="tests/Refit.GeneratedCode.TestModels/Refit.GeneratedCode.TestModels.csproj" />
         <Project Path="tests/Refit.GeneratorTests/Refit.GeneratorTests.csproj" />

--- a/src/benchmarks/Refit.Benchmarks/IPathHeaderRequestService.cs
+++ b/src/benchmarks/Refit.Benchmarks/IPathHeaderRequestService.cs
@@ -1,0 +1,23 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+namespace Refit.Benchmarks;
+
+/// <summary>Request shapes used to compare generated and reflection-built path/header binding.</summary>
+public interface IPathHeaderRequestService
+{
+    /// <summary>Sends a request with one path parameter.</summary>
+    /// <param name="id">The path identifier.</param>
+    /// <returns>The HTTP response message.</returns>
+    [Get("/users/{userId}")]
+    Task<HttpResponseMessage> PathOnlyAsync([AliasAs("userId")] int id);
+
+    /// <summary>Sends a request with one argument bound to both the path and a header.</summary>
+    /// <param name="id">The identifier used by both bindings.</param>
+    /// <returns>The HTTP response message.</returns>
+    [Get("/users/{userId}")]
+    Task<HttpResponseMessage> PathAndHeaderAsync(
+        [AliasAs("userId")]
+        [Header("X-User-Id")]
+        int id);
+}

--- a/src/benchmarks/Refit.Benchmarks/PathHeaderRequestBuildingBenchmarks.cs
+++ b/src/benchmarks/Refit.Benchmarks/PathHeaderRequestBuildingBenchmarks.cs
@@ -1,0 +1,85 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+using System.Net;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Diagnosers;
+
+namespace Refit.Benchmarks;
+
+/// <summary>Compares generated and reflection request building for path-only and dual path/header parameters.</summary>
+[ShortRunJob]
+[MemoryDiagnoser]
+[EventPipeProfiler(EventPipeProfile.GcVerbose)]
+[GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]
+[CategoriesColumn]
+public class PathHeaderRequestBuildingBenchmarks
+{
+    /// <summary>The base host address used for requests.</summary>
+    private const string Host = "https://api.example.test";
+
+    /// <summary>The identifier passed to every benchmarked request.</summary>
+    private const int Identifier = 42;
+
+    /// <summary>The generated client.</summary>
+    private IPathHeaderRequestService _generated = null!;
+
+    /// <summary>The HTTP client used by both request builders.</summary>
+    private HttpClient _client = null!;
+
+    /// <summary>The cached reflection path-only request delegate.</summary>
+    private Func<HttpClient, object[], object?> _reflectionPathOnly = null!;
+
+    /// <summary>The cached reflection path-and-header request delegate.</summary>
+    private Func<HttpClient, object[], object?> _reflectionPathAndHeader = null!;
+
+    /// <summary>Creates the generated client and cached reflection delegates.</summary>
+    [GlobalSetup]
+    public void Setup()
+    {
+        var settings = new RefitSettings();
+        _client = new(new StaticValueHttpResponseHandler("Ok", HttpStatusCode.OK))
+        {
+            BaseAddress = new(Host),
+        };
+        _generated = RestService.ForGenerated<IPathHeaderRequestService>(_client, settings);
+
+        var reflectionBuilder = RequestBuilder.ForType<IPathHeaderRequestService>(settings);
+        _reflectionPathOnly = reflectionBuilder.BuildRestResultFuncForMethod(
+            nameof(IPathHeaderRequestService.PathOnlyAsync));
+        _reflectionPathAndHeader = reflectionBuilder.BuildRestResultFuncForMethod(
+            nameof(IPathHeaderRequestService.PathAndHeaderAsync));
+    }
+
+    /// <summary>Disposes the shared HTTP client.</summary>
+    [GlobalCleanup]
+    public void Cleanup() => _client.Dispose();
+
+    /// <summary>Builds and sends a generated path-only request.</summary>
+    /// <returns>The HTTP response message.</returns>
+    [Benchmark(Baseline = true)]
+    [BenchmarkCategory("PathOnly")]
+    public Task<HttpResponseMessage> GeneratedPathOnlyAsync() => _generated.PathOnlyAsync(Identifier);
+
+    /// <summary>Builds and sends a reflection path-only request.</summary>
+    /// <returns>The HTTP response message.</returns>
+    [Benchmark]
+    [BenchmarkCategory("PathOnly")]
+    public Task<HttpResponseMessage> ReflectionPathOnlyAsync() =>
+        (Task<HttpResponseMessage>)_reflectionPathOnly(_client, [Identifier])!;
+
+    /// <summary>Builds and sends a generated request whose identifier also contributes a header.</summary>
+    /// <returns>The HTTP response message.</returns>
+    [Benchmark(Baseline = true)]
+    [BenchmarkCategory("PathAndHeader")]
+    public Task<HttpResponseMessage> GeneratedPathAndHeaderAsync() =>
+        _generated.PathAndHeaderAsync(Identifier);
+
+    /// <summary>Builds and sends a reflection request whose identifier also contributes a header.</summary>
+    /// <returns>The HTTP response message.</returns>
+    [Benchmark]
+    [BenchmarkCategory("PathAndHeader")]
+    public Task<HttpResponseMessage> ReflectionPathAndHeaderAsync() =>
+        (Task<HttpResponseMessage>)_reflectionPathAndHeader(_client, [Identifier])!;
+}

--- a/src/benchmarks/Refit.Generator.Benchmarks/PathHeaderBindingGenerationBenchmarks.cs
+++ b/src/benchmarks/Refit.Generator.Benchmarks/PathHeaderBindingGenerationBenchmarks.cs
@@ -1,0 +1,103 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+using System.Collections.Immutable;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Diagnosers;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Refit.Generator.Benchmarks;
+
+/// <summary>Measures parser and emitter costs for a path parameter with and without an additional header binding.</summary>
+[ShortRunJob]
+[MemoryDiagnoser]
+[EventPipeProfiler(EventPipeProfile.GcVerbose)]
+[GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]
+[CategoriesColumn]
+public class PathHeaderBindingGenerationBenchmarks
+{
+    /// <summary>The source containing a path-only parameter.</summary>
+    private const string PathOnlySource =
+        """
+        using System.Threading.Tasks;
+        using Refit;
+
+        public interface IPathOnlyApi
+        {
+            [Get("/users/{userId}")]
+            Task<string> Get([AliasAs("userId")] int id);
+        }
+        """;
+
+    /// <summary>The source containing one parameter bound to both the path and a header.</summary>
+    private const string PathAndHeaderSource =
+        """
+        using System.Threading.Tasks;
+        using Refit;
+
+        public interface IPathAndHeaderApi
+        {
+            [Get("/users/{userId}")]
+            Task<string> Get([AliasAs("userId"), Header("X-User-Id")] int id);
+        }
+        """;
+
+    /// <summary>The path-only compilation.</summary>
+    private CSharpCompilation _pathOnlyCompilation = null!;
+
+    /// <summary>The path-only syntax candidates.</summary>
+    private (ImmutableArray<MethodDeclarationSyntax> Methods, ImmutableArray<InterfaceDeclarationSyntax> Interfaces) _pathOnlyCandidates;
+
+    /// <summary>The path-and-header compilation.</summary>
+    private CSharpCompilation _pathAndHeaderCompilation = null!;
+
+    /// <summary>The path-and-header syntax candidates.</summary>
+    private (ImmutableArray<MethodDeclarationSyntax> Methods, ImmutableArray<InterfaceDeclarationSyntax> Interfaces) _pathAndHeaderCandidates;
+
+    /// <summary>The parsed path-only interface.</summary>
+    private InterfaceModel _pathOnlyInterface = null!;
+
+    /// <summary>The parsed path-and-header interface.</summary>
+    private InterfaceModel _pathAndHeaderInterface = null!;
+
+    /// <summary>Builds the compilations, syntax candidates, and pre-parsed emitter inputs.</summary>
+    [GlobalSetup]
+    public void Setup()
+    {
+        _pathOnlyCompilation = GeneratorHarness.BuildCompilation(PathOnlySource);
+        _pathOnlyCandidates = GeneratorHarness.CollectCandidates(_pathOnlyCompilation);
+        _pathOnlyInterface = GeneratorHarness.Parse(_pathOnlyCompilation, _pathOnlyCandidates).Interfaces.AsArray()[0];
+
+        _pathAndHeaderCompilation = GeneratorHarness.BuildCompilation(PathAndHeaderSource);
+        _pathAndHeaderCandidates = GeneratorHarness.CollectCandidates(_pathAndHeaderCompilation);
+        _pathAndHeaderInterface = GeneratorHarness.Parse(_pathAndHeaderCompilation, _pathAndHeaderCandidates).Interfaces.AsArray()[0];
+    }
+
+    /// <summary>Parses a path-only method.</summary>
+    /// <returns>The parsed interface count.</returns>
+    [Benchmark(Baseline = true)]
+    [BenchmarkCategory("Parser")]
+    public int ParsePathOnly() =>
+        GeneratorHarness.Parse(_pathOnlyCompilation, _pathOnlyCandidates).Interfaces.Count;
+
+    /// <summary>Parses a method whose path parameter also contributes a header.</summary>
+    /// <returns>The parsed interface count.</returns>
+    [Benchmark]
+    [BenchmarkCategory("Parser")]
+    public int ParsePathAndHeader() =>
+        GeneratorHarness.Parse(_pathAndHeaderCompilation, _pathAndHeaderCandidates).Interfaces.Count;
+
+    /// <summary>Emits a path-only method.</summary>
+    /// <returns>The generated source length.</returns>
+    [Benchmark(Baseline = true)]
+    [BenchmarkCategory("Emitter")]
+    public int EmitPathOnly() => Emitter.EmitInterface(_pathOnlyInterface).Length;
+
+    /// <summary>Emits a method whose path parameter also contributes a header.</summary>
+    /// <returns>The generated source length.</returns>
+    [Benchmark]
+    [BenchmarkCategory("Emitter")]
+    public int EmitPathAndHeader() => Emitter.EmitInterface(_pathAndHeaderInterface).Length;
+}

--- a/src/tests/Refit.Analyzers.Internals.Tests/Refit.Analyzers.Internals.Tests.csproj
+++ b/src/tests/Refit.Analyzers.Internals.Tests/Refit.Analyzers.Internals.Tests.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>$(RefitTestTargets)</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
+    <PackageReference Include="TUnit" />
+    <ProjectReference Include="..\..\Refit.Analyzers.Roslyn48\Refit.Analyzers.Roslyn48.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/tests/Refit.Analyzers.Internals.Tests/RefitInterfaceAnalyzerTests.cs
+++ b/src/tests/Refit.Analyzers.Internals.Tests/RefitInterfaceAnalyzerTests.cs
@@ -1,0 +1,14 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+namespace Refit.Analyzers.Tests;
+
+/// <summary>White-box tests for Refit interface analyzer implementation details.</summary>
+public sealed class RefitInterfaceAnalyzerTests
+{
+    /// <summary>Verifies HTTP path extraction handles missing attribute data.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task GetHttpPathReturnsEmptyForMissingAttribute() =>
+        await Assert.That(RefitInterfaceAnalyzer.GetHttpPath(null)).IsEqualTo(string.Empty);
+}

--- a/src/tests/Refit.Analyzers.Tests/RefitInterfaceAnalyzerTests.cs
+++ b/src/tests/Refit.Analyzers.Tests/RefitInterfaceAnalyzerTests.cs
@@ -341,12 +341,6 @@ public sealed class RefitInterfaceAnalyzerTests
             .Contains(GeneratedRequestBuildingFallbackDiagnosticId);
     }
 
-    /// <summary>Verifies HTTP path extraction handles missing attribute data.</summary>
-    /// <returns>A task representing the asynchronous test.</returns>
-    [Test]
-    public async Task GetHttpPathReturnsEmptyForMissingAttribute() =>
-        await Assert.That(RefitInterfaceAnalyzer.GetHttpPath(null)).IsEqualTo(string.Empty);
-
     /// <summary>Verifies IDisposable inheritance does not produce RF001.</summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Test]

--- a/src/tests/Refit.GeneratorTests/GeneratorComponentTests.EmitterHelpers.cs
+++ b/src/tests/Refit.GeneratorTests/GeneratorComponentTests.EmitterHelpers.cs
@@ -39,6 +39,9 @@ public static partial class GeneratorComponentTests
         /// <summary>The populated part count used by join helper tests.</summary>
         private const int PopulatedPartCount = 2;
 
+        /// <summary>The generated parameter attribute-provider field name used by emitter helper tests.</summary>
+        private const string ParameterInfoFieldName = "parameterInfo";
+
         /// <summary>Verifies escaping every special C# string-literal character.</summary>
         /// <returns>A task representing the asynchronous test.</returns>
         [Test]
@@ -92,12 +95,47 @@ public static partial class GeneratorComponentTests
                 true);
             var source = new PooledStringBuilder();
 
-            Emitter.BuildParameterInfoField(parameter, "Get", "parameterInfo", source);
-            Emitter.AppendIndexedCollectionQueryStatements(source, parameter, query, "parameterInfo", emission);
+            Emitter.BuildParameterInfoField(parameter, "Get", ParameterInfoFieldName, source);
+            Emitter.AppendIndexedCollectionQueryStatements(source, parameter, query, ParameterInfoFieldName, emission);
 
             var generated = source.ToString();
             await Assert.That(generated).Contains("GeneratedParameterAttributeProvider.Empty");
             await Assert.That(generated).Contains("foreach (var item in @items)");
+        }
+
+        /// <summary>Verifies parameter attributes are grouped by type without changing their declaration order.</summary>
+        /// <returns>A task representing the asynchronous test.</returns>
+        [Test]
+        public async Task BuildParameterInfoFieldGroupsRepeatedAttributeTypes()
+        {
+            const string QueryAttributeType = "global::Refit.QueryAttribute";
+            const string AliasAttributeType = "global::Refit.AliasAsAttribute";
+            var emptyArguments = ImmutableEquatableArray<string>.Empty;
+            var emptyNamedArguments = ImmutableEquatableArray<NamedAttributeArgument>.Empty;
+            var attributes = ImmutableEquatableArrayFactory.FromArray(
+                [
+                    new ParameterAttributeModel(QueryAttributeType, emptyArguments, emptyNamedArguments),
+                    new ParameterAttributeModel(AliasAttributeType, emptyArguments, emptyNamedArguments),
+                    new ParameterAttributeModel(QueryAttributeType, emptyArguments, emptyNamedArguments),
+                ]);
+            var parameter = new RequestParameterModel(
+                "id",
+                "int",
+                null,
+                attributes,
+                RequestParameterKind.Path,
+                CanBeNull: false,
+                string.Empty,
+                string.Empty,
+                string.Empty,
+                BodyBufferMode.None);
+            var source = new PooledStringBuilder();
+
+            Emitter.BuildParameterInfoField(parameter, "Get", ParameterInfoFieldName, source);
+
+            await Assert.That(source.ToString()).Contains(
+                "{ typeof(global::Refit.QueryAttribute), new object[] { new global::Refit.QueryAttribute(), new global::Refit.QueryAttribute()} }, " +
+                "{ typeof(global::Refit.AliasAsAttribute), new object[] { new global::Refit.AliasAsAttribute()} }");
         }
 
         /// <summary>Verifies the string-literal escape lookup for special, line-terminator, and verbatim characters.</summary>

--- a/src/tests/Refit.GeneratorTests/ILiveGeneratedApi.cs
+++ b/src/tests/Refit.GeneratorTests/ILiveGeneratedApi.cs
@@ -24,4 +24,19 @@ internal interface ILiveGeneratedApi
         [HeaderCollection] IDictionary<string, string> headers,
         [Property("parameter-tenant")] int tenantId,
         CancellationToken cancellationToken);
+
+    /// <summary>Gets a response with one identifier bound to both the path and a header.</summary>
+    /// <param name="id">The identifier used by both request bindings.</param>
+    /// <returns>The response body.</returns>
+    [Get("/users/{id}")]
+    Task<string> GetPathAndHeader([Header("X-Id")] int id);
+
+    /// <summary>Gets a response with one aliased identifier bound to both the path and a header.</summary>
+    /// <param name="id">The identifier used by both request bindings.</param>
+    /// <returns>The response body.</returns>
+    [Get("/users/{userId}")]
+    Task<string> GetAliasedPathAndHeader(
+        [AliasAs("userId")]
+        [Header("X-User-Id")]
+        int id);
 }

--- a/src/tests/Refit.GeneratorTests/LiveCompilationTests.cs
+++ b/src/tests/Refit.GeneratorTests/LiveCompilationTests.cs
@@ -10,10 +10,43 @@ namespace Refit.GeneratorTests;
 /// <summary>Live compilation tests for generated Refit implementations.</summary>
 public sealed class LiveCompilationTests
 {
+    /// <summary>The client base address shared by the live generated-client tests.</summary>
+    private const string BaseAddress = "https://example.test/base/";
+
     /// <summary>Invokes request-building code generated as part of the test assembly.</summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Test]
     public Task GeneratedRequestBuildingCanBeInvoked() => AssertGeneratedRequestSentAsync();
+
+    /// <summary>Verifies one generated argument supplies both its path placeholder and dynamic header.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task PathAndHeaderBindingUsesSameArgument()
+    {
+        const int Identifier = 42;
+        using var handler = new CapturingHandler();
+        using var client = HttpClientTestFactory.Create(handler, new(BaseAddress));
+        var api = RestService.ForGenerated<ILiveGeneratedApi>(client, new());
+
+        _ = await api.GetPathAndHeader(Identifier);
+
+        await AssertCapturedPathAndHeader(handler, "/base/users/42", "X-Id", "42");
+    }
+
+    /// <summary>Verifies an alias lets one generated argument supply both its path placeholder and dynamic header.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task AliasedPathAndHeaderBindingUsesSameArgument()
+    {
+        const int Identifier = 42;
+        using var handler = new CapturingHandler();
+        using var client = HttpClientTestFactory.Create(handler, new(BaseAddress));
+        var api = RestService.ForGenerated<ILiveGeneratedApi>(client, new());
+
+        _ = await api.GetAliasedPathAndHeader(Identifier);
+
+        await AssertCapturedPathAndHeader(handler, "/base/users/42", "X-User-Id", "42");
+    }
 
     /// <summary>Instantiates the generated client, invokes it, and asserts the captured request.</summary>
     /// <returns>A task representing the asynchronous assertions.</returns>
@@ -24,7 +57,7 @@ public sealed class LiveCompilationTests
         const int ParameterTenantId = 23;
 
         using var handler = new CapturingHandler();
-        using var client = HttpClientTestFactory.Create(handler, new("https://example.test/base/"));
+        using var client = HttpClientTestFactory.Create(handler, new(BaseAddress));
         var settings = new RefitSettings();
         var api = RestService.ForGenerated<ILiveGeneratedApi>(client, settings);
 
@@ -52,6 +85,24 @@ public sealed class LiveCompilationTests
         var propertyTenantKey = new HttpRequestOptionsKey<int>("property-tenant");
         await Assert.That(request.Options.TryGetValue(propertyTenantKey, out var propertyTenant)).IsTrue();
         await Assert.That(propertyTenant).IsEqualTo(PropertyTenantId);
+    }
+
+    /// <summary>Asserts the captured request path and dynamic header value.</summary>
+    /// <param name="handler">The handler that captured the request.</param>
+    /// <param name="expectedPath">The expected absolute-path component.</param>
+    /// <param name="headerName">The dynamic header name.</param>
+    /// <param name="headerValue">The expected dynamic header value.</param>
+    /// <returns>A task representing the asynchronous assertions.</returns>
+    private static async Task AssertCapturedPathAndHeader(
+        CapturingHandler handler,
+        string expectedPath,
+        string headerName,
+        string headerValue)
+    {
+        await Assert.That(handler.LastRequest).IsNotNull();
+        var request = handler.LastRequest!;
+        await Assert.That(request.RequestUri!.AbsolutePath).IsEqualTo(expectedPath);
+        await Assert.That(request.Headers.GetValues(headerName)).IsCollectionEqualTo([headerValue]);
     }
 
     /// <summary>Captures the outgoing request and returns a fixed JSON string response.</summary>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the new behavior?

Source-generated clients now support using one parameter for both a route placeholder and a dynamic header, including routes mapped with `AliasAs`.

## What is the current behavior?

The generator treats these bindings as mutually exclusive and reports an unmatched route placeholder.

Closes #2280.

## What might this PR break?

None expected. Existing single-binding parameters are unchanged.

## Checklist

- [x] I have read the [Contribute guide](https://www.reactiveui.net/contribute/index.html)
- [x] Tests have been added or updated (for bug fixes / features)
- [ ] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the `main` branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional information

- Full solution build: 0 warnings and 0 errors
- Full test suite: 7,469 passed
- Generated request overhead for adding the header: 77.6 ns and 130 B per request
- Generator emit overhead: 0.267 us and 1.03 KB
