### PR TITLE
fix: Propagate cancellation exceptions during response buffering

### DIFF
--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -3,12 +3,21 @@
 Every breaking change and notable addition, newest first. Each major version links back to the feature documentation
 in the [main README](../README.md).
 
+* [V15.x.x](#v15xx)
 * [V14.x.x](#v14xx)
 * [V13.x.x](#v13xx)
 * [V12.x.x](#v12xx)
 * [V11.x.x](#v11xx)
 * [Updates in 8.0.x](#updates-in-80x)
 * [V6.x.x](#v6xx)
+
+## V15.x.x
+
+### Breaking changes in V15.x
+
+* **Response buffering now propagates caller cancellation.** If a caller cancels while Refit buffers response content,
+  Refit throws `OperationCanceledException` instead of continuing with partially consumed content. Other buffering
+  failures remain best-effort.
 
 ## V14.x.x
 

--- a/src/Refit/RequestExecutionHelpers.cs
+++ b/src/Refit/RequestExecutionHelpers.cs
@@ -637,10 +637,17 @@ internal static partial class RequestExecutionHelpers
             .ConfigureAwait(false);
     }
 
-    /// <summary>Attempts to buffer content into memory, ignoring buffering failures.</summary>
+    /// <summary>Attempts to buffer content into memory, ignoring buffering failures but honouring cancellation.</summary>
     /// <param name="content">The content to buffer.</param>
     /// <param name="cancellationToken">A token to cancel buffering.</param>
     /// <returns>A task that completes once buffering has been attempted.</returns>
+    /// <exception cref="OperationCanceledException">Thrown when the caller cancelled while buffering.</exception>
+    /// <remarks>
+    /// Buffering is best-effort: a failure just means the serializer reads the live stream instead. Cancellation is
+    /// not, because continuing would hand the serializer partially consumed content. The check sits after the catch
+    /// rather than in a filter on it, so it also covers the targets whose <c>LoadIntoBufferAsync</c> polyfill drops
+    /// the token and therefore never throws.
+    /// </remarks>
     internal static async Task TryBufferContentAsync(HttpContent content, CancellationToken cancellationToken)
     {
         try
@@ -651,6 +658,8 @@ internal static partial class RequestExecutionHelpers
         {
             _ = bufferingException;
         }
+
+        cancellationToken.ThrowIfCancellationRequested();
     }
 
     /// <summary>The outcome of attempting to send a request.</summary>

--- a/src/tests/Refit.Tests/GeneratedRequestRunnerTests.ResponseErrorHandling.cs
+++ b/src/tests/Refit.Tests/GeneratedRequestRunnerTests.ResponseErrorHandling.cs
@@ -317,6 +317,45 @@ public partial class GeneratedRequestRunnerTests
             .ThrowsExactly<OperationCanceledException>();
     }
 
+    /// <summary>Verifies cancellation while buffering the response stops before the serializer sees partially consumed content.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task SendAsyncStopsBeforeDeserializationWhenCancelledDuringBuffering()
+    {
+        var serializer = new RecordingContentSerializer
+        {
+            DeserializedValue = new GeneratedResult(DeserializedResultValue)
+        };
+        using var tokenSource = new CancellationTokenSource();
+
+        // Cancel once the response exists, so cancellation lands on buffering rather than on the send itself.
+        var handler = new CapturingHandler(
+            async (_, _) =>
+            {
+                await tokenSource.CancelAsync();
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("buffered")
+                };
+            });
+        using var client = CreateClient(handler);
+        using var request = new HttpRequestMessage(HttpMethod.Get, RelativeResourcePath);
+
+        await Assert
+            .That(
+                () => GeneratedRequestRunner.SendAsync<GeneratedResult, GeneratedResult>(
+                    client,
+                    request,
+                    CreateSettings(serializer),
+                    isApiResponse: false,
+                    shouldDisposeResponse: true,
+                    bufferBody: false,
+                    tokenSource.Token))
+            .ThrowsExactly<OperationCanceledException>();
+
+        await Assert.That(serializer.DeserializeCallCount).IsEqualTo(0);
+    }
+
     /// <summary>Verifies caller-requested cancellation during send is rethrown instead of being wrapped in <see cref="ApiRequestException"/>.</summary>
     /// <returns>A task that represents the asynchronous operation.</returns>
     [Test]


### PR DESCRIPTION
<!-- Please read our [Contribute guide](https://www.reactiveui.net/contribute/index.html) before opening a PR, and give this PR a title that follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `fix:`, `feat:`, `docs:`, `build:`). -->

## What kind of change does this PR introduce?
<!-- Bug fix, feature, docs update, refactor, ci, build, ... -->
Bug fix

## What is the new behavior?
<!-- The most important section: describe what this PR changes things TO. For a feature, explain the new functionality; for a fix, describe the corrected behavior. -->

Caller cancellation during response buffering is propagated. Non-cancellation buffering failures remain best-effort.


## What is the current behavior?

<!-- The OLD, pre-PR behavior on the target branch — i.e. what this PR changes away from. Link
any related issue here and use "Closes #123" to auto-close it on merge. -->

If a request is cancelled while deserializing the response, the cancellation exception is swallowed, allowing deserialization of a partially consumed stream.

## What might this PR break?

<!-- Call out any breaking changes, behavioural changes, or migration steps consumers need. Write "None" if there are none. -->

None


## Checklist

- [x] I have read the [Contribute guide](https://www.reactiveui.net/contribute/index.html)

- [x] Tests have been added or updated (for bug fixes / features)

- [x] Docs have been added or updated (for bug fixes / features)

- [x] Changes target the `main` branch

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)



## Additional information

<!-- Screenshots, benchmarks, links, or anything else that helps reviewers. -->

Added a regression coverage test