### PR TITLE
perf: create `GeneratedParameterAttribute` for single and many attrib…

### DIFF
--- a/src/InterfaceStubGenerator.Shared/Emitter.Inline.ParameterInfo.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.Inline.ParameterInfo.cs
@@ -2,6 +2,8 @@
 // ReactiveUI and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System.Linq;
+
 namespace Refit.Generator;
 
 /// <summary>Emits the cached parameter attribute-provider fields and the parameters argument for the inline path.</summary>
@@ -93,17 +95,34 @@ internal static partial class Emitter
 
         _ = sb.AppendLine().Append(memberIndent).Append("/// <summary>Cached attribute provider for the generated ")
             .Append(ToXmlDocumentationText(method)).Append(" method's ").Append(ToXmlDocumentationText(parameter.Name)).AppendLine(" parameter.</summary>")
-            .Append(memberIndent).Append("private static readonly global::Refit.GeneratedParameterAttributeProvider ").Append(paramInfoFieldName).Append(" = ");
+            .Append(memberIndent).Append("private static readonly global::System.Reflection.ICustomAttributeProvider ").Append(paramInfoFieldName).Append(" = ");
 
         // A parameter with no attributes shares the singleton empty provider instead of allocating an empty dictionary.
         if (grouped.Count == 0)
         {
-            _ = sb.AppendLine("global::Refit.GeneratedParameterAttributeProvider.Empty;");
+            _ = sb.AppendLine("global::Refit.GeneratedRequestRunner.EmptyAttributeProvider;");
+            return;
+        }
+
+        if (grouped.Count == 1)
+        {
+            var attribute = grouped.First();
+            _ = sb.Append("global::Refit.GeneratedRequestRunner.BuildAttributeProvider(").Append(attribute.Key).Append(", new object[] { ");
+            var argIndex = 0;
+            foreach (var arg in attribute.Value)
+            {
+                // Multiple attributes of the same type must be comma-separated inside the array.
+                _ = AppendSeparator(argIndex, sb);
+                argIndex++;
+                AppendAttributeValue(arg, sb);
+            }
+
+            _ = sb.Append("});");
             return;
         }
 
         const string dictType = "global::System.Collections.Generic.Dictionary<global::System.Type, object[]>";
-        _ = sb.Append("new global::Refit.GeneratedParameterAttributeProvider(new ").Append(dictType).Append("() {");
+        _ = sb.Append("new global::Refit.BuildAttributeProvider(new ").Append(dictType).Append("() {");
         var i = 0;
         foreach (var kv in grouped)
         {
@@ -146,7 +165,7 @@ internal static partial class Emitter
 
             if (parameter.Attributes.Count == 0)
             {
-                dict.Add(parameter.Name, "global::Refit.GeneratedParameterAttributeProvider.Empty");
+                dict.Add(parameter.Name, "global::Refit.GeneratedRequestRunner.EmptyAttributeProvider");
                 continue;
             }
 

--- a/src/Refit/GeneratedParameterAttributeProviderMany.cs
+++ b/src/Refit/GeneratedParameterAttributeProviderMany.cs
@@ -8,11 +8,8 @@ namespace Refit;
 
 /// <summary>Provides parameter attributes for generated code.</summary>
 /// <param name="attributes">The attribute information.</param>
-public sealed class GeneratedParameterAttributeProvider(Dictionary<Type, object[]> attributes) : ICustomAttributeProvider
+internal sealed class GeneratedParameterAttributeProviderMany(Dictionary<Type, object[]> attributes) : ICustomAttributeProvider
 {
-    /// <summary>A shared provider for parameters that declare no attributes, avoiding a per-parameter empty dictionary.</summary>
-    public static readonly GeneratedParameterAttributeProvider Empty = new([]);
-
     /// <summary>The lazily flattened array of every attribute, memoized on first access.</summary>
     private object[]? _allAttributes;
 

--- a/src/Refit/GeneratedParameterAttributeProviderSingle.cs
+++ b/src/Refit/GeneratedParameterAttributeProviderSingle.cs
@@ -1,0 +1,27 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Reflection;
+
+namespace Refit;
+
+/// <summary>Provides parameter attribute for generated code.</summary>
+/// <param name="type">Type of the custom attribute.</param>
+/// <param name="attributes">The attribute information.</param>
+internal sealed class GeneratedParameterAttributeProviderSingle(Type type, object[] attributes) : ICustomAttributeProvider
+{
+    /// <inheritdoc/>
+    public object[] GetCustomAttributes(bool inherit) => attributes;
+
+    /// <inheritdoc/>
+    public object[] GetCustomAttributes(Type attributeType, bool inherit)
+    {
+        ArgumentExceptionHelper.ThrowIfNull(attributeType);
+
+        return attributeType == type ? attributes : [];
+    }
+
+    /// <inheritdoc/>
+    public bool IsDefined(Type attributeType, bool inherit) => attributeType == type;
+}

--- a/src/Refit/GeneratedRequestRunner.cs
+++ b/src/Refit/GeneratedRequestRunner.cs
@@ -11,6 +11,9 @@ namespace Refit;
 [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
 public static partial class GeneratedRequestRunner
 {
+    /// <summary>A shared provider for parameters that declare no attributes.</summary>
+    public static readonly ICustomAttributeProvider EmptyAttributeProvider = new GeneratedParameterAttributeProviderSingle(typeof(GeneratedParameterAttributeProviderSingle), []);
+
     /// <summary>The underlying value of the obsolete <c>BodySerializationMethod.Json</c> member.</summary>
     private const int ObsoleteJsonBodySerializationMethodValue = 1;
 
@@ -18,6 +21,17 @@ public static partial class GeneratedRequestRunner
     /// host is irrelevant because <see cref="UriComponents.PathAndQuery"/> ignores it; it mirrors the reflection builder's
     /// own base so the two produce byte-identical output.</summary>
     private static readonly Uri QueryUriFormatBase = new("https://api", UriKind.Absolute);
+
+    /// <summary>Creates a <see cref="GeneratedParameterAttributeProviderSingle"/> for parameters with a single attribute type.</summary>
+    /// <param name="type">Type of the custom attribute.</param>
+    /// <param name="attributes">The attribute information.</param>
+    /// <returns>A <see cref="GeneratedParameterAttributeProviderSingle"/> corresponding to a method parameter.</returns>
+    public static ICustomAttributeProvider BuildAttributeProvider(Type type, object[] attributes) => new GeneratedParameterAttributeProviderSingle(type, attributes);
+
+    /// <summary>Creates a <see cref="GeneratedParameterAttributeProviderMany"/> for parameters with many attribute types.</summary>
+    /// <param name="attributes">The attribute information.</param>
+    /// <returns>A <see cref="GeneratedParameterAttributeProviderMany"/> corresponding to a method parameter.</returns>
+    public static ICustomAttributeProvider BuildAttributeProvider(Dictionary<Type, object[]> attributes) => new GeneratedParameterAttributeProviderMany(attributes);
 
     /// <summary>Builds the relative request URI for a generated request, joining the client base address with the method path.</summary>
     /// <param name="client">The HTTP client whose base address is used under legacy resolution.</param>

--- a/src/Refit/PublicAPI/net10.0/PublicAPI.Unshipped.txt
+++ b/src/Refit/PublicAPI/net10.0/PublicAPI.Unshipped.txt
@@ -7,7 +7,6 @@ static Refit.GeneratedRequestRunner.BuildRequestPath<T>(string! relativePathTemp
 static Refit.GeneratedRequestRunner.RoundTripEscapePath(string? value, Refit.RefitSettings! settings, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string!
 static Refit.GeneratedRequestRunner.FormatUrlParameter(Refit.RefitSettings! settings, object? value, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string?
 Refit.GeneratedQueryStringBuilder.GeneratedQueryStringBuilder(string! relativePath, bool hasQuery) -> void
-static readonly Refit.GeneratedParameterAttributeProvider.Empty -> Refit.GeneratedParameterAttributeProvider!
 static Refit.GeneratedRequestRunner.BuildRequestPath(string! relativePathTemplate, bool allowUnmatchedParameter, System.ReadOnlySpan<((int startIdx, int endIdx) range, string? value)> uriParams) -> string!
 static Refit.GeneratedRequestRunner.BuildRequestPath(string! relativePathTemplate, bool allowUnmatchedParameter, System.ReadOnlySpan<((int startIdx, int endIdx) range, string? value, bool preEncoded)> uriParams) -> string!
 static Refit.GeneratedRequestRunner.BuildRelativeUri(System.Net.Http.HttpClient! client, string! relativePath, Refit.UrlResolutionMode urlResolution, System.UriFormat queryUriFormat) -> System.Uri!
@@ -18,3 +17,6 @@ Refit.RestMethodParameterProperty.PropertyChain.set -> void
 static Refit.GeneratedRequestRunner.SerializeMultipartPart<T>(Refit.RefitSettings! settings, T value, string! fieldName) -> System.Net.Http.HttpContent!
 Refit.GeneratedQueryStringBuilder.AddPreEscapedKey(string! name, string? value, bool preEncoded) -> void
 Refit.GeneratedQueryStringBuilder.AddFormattedPreEscapedKey<T>(string! name, T value, string? format, bool preEncoded) -> void
+static readonly Refit.GeneratedRequestRunner.EmptyAttributeProvider -> System.Reflection.ICustomAttributeProvider!
+static Refit.GeneratedRequestRunner.BuildAttributeProvider(System.Type! type, object![]! attributes) -> System.Reflection.ICustomAttributeProvider!
+static Refit.GeneratedRequestRunner.BuildAttributeProvider(System.Collections.Generic.Dictionary<System.Type!, object![]!>! attributes) -> System.Reflection.ICustomAttributeProvider!

--- a/src/Refit/PublicAPI/net470/PublicAPI.Unshipped.txt
+++ b/src/Refit/PublicAPI/net470/PublicAPI.Unshipped.txt
@@ -3,7 +3,6 @@ static Refit.GeneratedRequestRunner.CanUnrollForm(object? body) -> bool
 static Refit.GeneratedRequestRunner.RoundTripEscapePath(string? value, Refit.RefitSettings! settings, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string!
 static Refit.GeneratedRequestRunner.FormatUrlParameter(Refit.RefitSettings! settings, object? value, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string?
 Refit.GeneratedQueryStringBuilder.GeneratedQueryStringBuilder(string! relativePath, bool hasQuery) -> void
-static readonly Refit.GeneratedParameterAttributeProvider.Empty -> Refit.GeneratedParameterAttributeProvider!
 static Refit.GeneratedRequestRunner.BuildRequestPath(string! relativePathTemplate, bool allowUnmatchedParameter, System.ReadOnlySpan<((int startIdx, int endIdx) range, string? value)> uriParams) -> string!
 static Refit.GeneratedRequestRunner.BuildRequestPath(string! relativePathTemplate, bool allowUnmatchedParameter, System.ReadOnlySpan<((int startIdx, int endIdx) range, string? value, bool preEncoded)> uriParams) -> string!
 static Refit.GeneratedRequestRunner.BuildRelativeUri(System.Net.Http.HttpClient! client, string! relativePath, Refit.UrlResolutionMode urlResolution, System.UriFormat queryUriFormat) -> System.Uri!
@@ -13,3 +12,6 @@ Refit.RestMethodParameterProperty.PropertyChain.get -> System.Collections.Generi
 Refit.RestMethodParameterProperty.PropertyChain.set -> void
 static Refit.GeneratedRequestRunner.SerializeMultipartPart<T>(Refit.RefitSettings! settings, T value, string! fieldName) -> System.Net.Http.HttpContent!
 Refit.GeneratedQueryStringBuilder.AddPreEscapedKey(string! name, string? value, bool preEncoded) -> void
+static readonly Refit.GeneratedRequestRunner.EmptyAttributeProvider -> System.Reflection.ICustomAttributeProvider!
+static Refit.GeneratedRequestRunner.BuildAttributeProvider(System.Type! type, object![]! attributes) -> System.Reflection.ICustomAttributeProvider!
+static Refit.GeneratedRequestRunner.BuildAttributeProvider(System.Collections.Generic.Dictionary<System.Type!, object![]!>! attributes) -> System.Reflection.ICustomAttributeProvider!

--- a/src/Refit/PublicAPI/net48/PublicAPI.Unshipped.txt
+++ b/src/Refit/PublicAPI/net48/PublicAPI.Unshipped.txt
@@ -3,7 +3,6 @@ static Refit.GeneratedRequestRunner.CanUnrollForm(object? body) -> bool
 static Refit.GeneratedRequestRunner.RoundTripEscapePath(string? value, Refit.RefitSettings! settings, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string!
 static Refit.GeneratedRequestRunner.FormatUrlParameter(Refit.RefitSettings! settings, object? value, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string?
 Refit.GeneratedQueryStringBuilder.GeneratedQueryStringBuilder(string! relativePath, bool hasQuery) -> void
-static readonly Refit.GeneratedParameterAttributeProvider.Empty -> Refit.GeneratedParameterAttributeProvider!
 static Refit.GeneratedRequestRunner.BuildRequestPath(string! relativePathTemplate, bool allowUnmatchedParameter, System.ReadOnlySpan<((int startIdx, int endIdx) range, string? value)> uriParams) -> string!
 static Refit.GeneratedRequestRunner.BuildRequestPath(string! relativePathTemplate, bool allowUnmatchedParameter, System.ReadOnlySpan<((int startIdx, int endIdx) range, string? value, bool preEncoded)> uriParams) -> string!
 static Refit.GeneratedRequestRunner.BuildRelativeUri(System.Net.Http.HttpClient! client, string! relativePath, Refit.UrlResolutionMode urlResolution, System.UriFormat queryUriFormat) -> System.Uri!
@@ -13,3 +12,6 @@ Refit.RestMethodParameterProperty.PropertyChain.get -> System.Collections.Generi
 Refit.RestMethodParameterProperty.PropertyChain.set -> void
 static Refit.GeneratedRequestRunner.SerializeMultipartPart<T>(Refit.RefitSettings! settings, T value, string! fieldName) -> System.Net.Http.HttpContent!
 Refit.GeneratedQueryStringBuilder.AddPreEscapedKey(string! name, string? value, bool preEncoded) -> void
+static readonly Refit.GeneratedRequestRunner.EmptyAttributeProvider -> System.Reflection.ICustomAttributeProvider!
+static Refit.GeneratedRequestRunner.BuildAttributeProvider(System.Type! type, object![]! attributes) -> System.Reflection.ICustomAttributeProvider!
+static Refit.GeneratedRequestRunner.BuildAttributeProvider(System.Collections.Generic.Dictionary<System.Type!, object![]!>! attributes) -> System.Reflection.ICustomAttributeProvider!

--- a/src/Refit/PublicAPI/net481/PublicAPI.Unshipped.txt
+++ b/src/Refit/PublicAPI/net481/PublicAPI.Unshipped.txt
@@ -3,7 +3,6 @@ static Refit.GeneratedRequestRunner.CanUnrollForm(object? body) -> bool
 static Refit.GeneratedRequestRunner.RoundTripEscapePath(string? value, Refit.RefitSettings! settings, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string!
 static Refit.GeneratedRequestRunner.FormatUrlParameter(Refit.RefitSettings! settings, object? value, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string?
 Refit.GeneratedQueryStringBuilder.GeneratedQueryStringBuilder(string! relativePath, bool hasQuery) -> void
-static readonly Refit.GeneratedParameterAttributeProvider.Empty -> Refit.GeneratedParameterAttributeProvider!
 static Refit.GeneratedRequestRunner.BuildRequestPath(string! relativePathTemplate, bool allowUnmatchedParameter, System.ReadOnlySpan<((int startIdx, int endIdx) range, string? value)> uriParams) -> string!
 static Refit.GeneratedRequestRunner.BuildRequestPath(string! relativePathTemplate, bool allowUnmatchedParameter, System.ReadOnlySpan<((int startIdx, int endIdx) range, string? value, bool preEncoded)> uriParams) -> string!
 static Refit.GeneratedRequestRunner.BuildRelativeUri(System.Net.Http.HttpClient! client, string! relativePath, Refit.UrlResolutionMode urlResolution, System.UriFormat queryUriFormat) -> System.Uri!
@@ -13,3 +12,6 @@ Refit.RestMethodParameterProperty.PropertyChain.get -> System.Collections.Generi
 Refit.RestMethodParameterProperty.PropertyChain.set -> void
 static Refit.GeneratedRequestRunner.SerializeMultipartPart<T>(Refit.RefitSettings! settings, T value, string! fieldName) -> System.Net.Http.HttpContent!
 Refit.GeneratedQueryStringBuilder.AddPreEscapedKey(string! name, string? value, bool preEncoded) -> void
+static readonly Refit.GeneratedRequestRunner.EmptyAttributeProvider -> System.Reflection.ICustomAttributeProvider!
+static Refit.GeneratedRequestRunner.BuildAttributeProvider(System.Type! type, object![]! attributes) -> System.Reflection.ICustomAttributeProvider!
+static Refit.GeneratedRequestRunner.BuildAttributeProvider(System.Collections.Generic.Dictionary<System.Type!, object![]!>! attributes) -> System.Reflection.ICustomAttributeProvider!

--- a/src/Refit/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/Refit/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -6,7 +6,6 @@ static Refit.GeneratedRequestRunner.BuildRequestPath<T>(string! relativePathTemp
 static Refit.GeneratedRequestRunner.RoundTripEscapePath(string? value, Refit.RefitSettings! settings, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string!
 static Refit.GeneratedRequestRunner.FormatUrlParameter(Refit.RefitSettings! settings, object? value, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string?
 Refit.GeneratedQueryStringBuilder.GeneratedQueryStringBuilder(string! relativePath, bool hasQuery) -> void
-static readonly Refit.GeneratedParameterAttributeProvider.Empty -> Refit.GeneratedParameterAttributeProvider!
 static Refit.GeneratedRequestRunner.BuildRequestPath(string! relativePathTemplate, bool allowUnmatchedParameter, System.ReadOnlySpan<((int startIdx, int endIdx) range, string? value)> uriParams) -> string!
 static Refit.GeneratedRequestRunner.BuildRequestPath(string! relativePathTemplate, bool allowUnmatchedParameter, System.ReadOnlySpan<((int startIdx, int endIdx) range, string? value, bool preEncoded)> uriParams) -> string!
 static Refit.GeneratedRequestRunner.BuildRelativeUri(System.Net.Http.HttpClient! client, string! relativePath, Refit.UrlResolutionMode urlResolution, System.UriFormat queryUriFormat) -> System.Uri!
@@ -18,3 +17,6 @@ static Refit.GeneratedRequestRunner.SerializeMultipartPart<T>(Refit.RefitSetting
 Refit.GeneratedQueryStringBuilder.AddPreEscapedKey(string! name, string? value, bool preEncoded) -> void
 Refit.GeneratedQueryStringBuilder.AddFormattedPreEscapedKey<T>(string! name, T value, string? format, bool preEncoded) -> void
 static Refit.GeneratedRequestRunner.BuildRequestPath<T>(string! relativePathTemplate, bool allowUnmatchedParameter, (int startIdx, int endIdx) range, T value, string? format) -> string!
+static readonly Refit.GeneratedRequestRunner.EmptyAttributeProvider -> System.Reflection.ICustomAttributeProvider!
+static Refit.GeneratedRequestRunner.BuildAttributeProvider(System.Type! type, object![]! attributes) -> System.Reflection.ICustomAttributeProvider!
+static Refit.GeneratedRequestRunner.BuildAttributeProvider(System.Collections.Generic.Dictionary<System.Type!, object![]!>! attributes) -> System.Reflection.ICustomAttributeProvider!

--- a/src/Refit/PublicAPI/net9.0/PublicAPI.Unshipped.txt
+++ b/src/Refit/PublicAPI/net9.0/PublicAPI.Unshipped.txt
@@ -7,7 +7,6 @@ static Refit.GeneratedRequestRunner.BuildRequestPath<T>(string! relativePathTemp
 static Refit.GeneratedRequestRunner.RoundTripEscapePath(string? value, Refit.RefitSettings! settings, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string!
 static Refit.GeneratedRequestRunner.FormatUrlParameter(Refit.RefitSettings! settings, object? value, System.Reflection.ICustomAttributeProvider! attributeProvider, System.Type! type) -> string?
 Refit.GeneratedQueryStringBuilder.GeneratedQueryStringBuilder(string! relativePath, bool hasQuery) -> void
-static readonly Refit.GeneratedParameterAttributeProvider.Empty -> Refit.GeneratedParameterAttributeProvider!
 static Refit.GeneratedRequestRunner.BuildRequestPath(string! relativePathTemplate, bool allowUnmatchedParameter, System.ReadOnlySpan<((int startIdx, int endIdx) range, string? value)> uriParams) -> string!
 static Refit.GeneratedRequestRunner.BuildRequestPath(string! relativePathTemplate, bool allowUnmatchedParameter, System.ReadOnlySpan<((int startIdx, int endIdx) range, string? value, bool preEncoded)> uriParams) -> string!
 static Refit.GeneratedRequestRunner.BuildRelativeUri(System.Net.Http.HttpClient! client, string! relativePath, Refit.UrlResolutionMode urlResolution, System.UriFormat queryUriFormat) -> System.Uri!
@@ -18,3 +17,6 @@ Refit.RestMethodParameterProperty.PropertyChain.set -> void
 static Refit.GeneratedRequestRunner.SerializeMultipartPart<T>(Refit.RefitSettings! settings, T value, string! fieldName) -> System.Net.Http.HttpContent!
 Refit.GeneratedQueryStringBuilder.AddPreEscapedKey(string! name, string? value, bool preEncoded) -> void
 Refit.GeneratedQueryStringBuilder.AddFormattedPreEscapedKey<T>(string! name, T value, string? format, bool preEncoded) -> void
+static readonly Refit.GeneratedRequestRunner.EmptyAttributeProvider -> System.Reflection.ICustomAttributeProvider!
+static Refit.GeneratedRequestRunner.BuildAttributeProvider(System.Type! type, object![]! attributes) -> System.Reflection.ICustomAttributeProvider!
+static Refit.GeneratedRequestRunner.BuildAttributeProvider(System.Collections.Generic.Dictionary<System.Type!, object![]!>! attributes) -> System.Reflection.ICustomAttributeProvider!

--- a/src/benchmarks/Refit.Benchmarks/ReflectionMetadataBenchmarks.cs
+++ b/src/benchmarks/Refit.Benchmarks/ReflectionMetadataBenchmarks.cs
@@ -10,7 +10,7 @@ namespace Refit.Benchmarks;
 
 /// <summary>
 /// Allocation micro-benchmarks for the runtime reflection metadata helpers: <c>ReflectionPropertyHelpers</c> readable
-/// property enumeration (all-readable fast path and the filtered slow path) and <see cref="GeneratedParameterAttributeProvider"/>
+/// property enumeration (all-readable fast path and the filtered slow path) and <see cref="ManyParameterAttributeProvider"/>
 /// attribute flattening and lookups (uncached first access, memoized access, and type-filtered access).
 /// </summary>
 [MemoryDiagnoser]
@@ -35,7 +35,7 @@ public class ReflectionMetadataBenchmarks
     private readonly Type _filteredType = typeof(PartiallyReadableModel);
 
     /// <summary>A pre-built provider whose attributes are already flattened, used by the memoized-access benchmark.</summary>
-    private GeneratedParameterAttributeProvider _cachedProvider = null!;
+    private ManyParameterAttributeProvider _cachedProvider = null!;
 
     /// <summary>Warms the memoized provider before the benchmarks run.</summary>
     [GlobalSetup]
@@ -63,13 +63,13 @@ public class ReflectionMetadataBenchmarks
     /// <returns>The flattened attribute count.</returns>
     [Benchmark]
     [BenchmarkCategory("Attributes")]
-    public int FlattenAttributes() => GeneratedParameterAttributeProvider.FlattenAttributes(_attributes).Length;
+    public int FlattenAttributes() => ManyParameterAttributeProvider.FlattenAttributes(_attributes).Length;
 
     /// <summary>Flattens all attributes on first access through a fresh provider (uncached).</summary>
     /// <returns>The flattened attribute count.</returns>
     [Benchmark]
     [BenchmarkCategory("Attributes")]
-    public int GetAllAttributesUncached() => new GeneratedParameterAttributeProvider(_attributes).GetCustomAttributes(true).Length;
+    public int GetAllAttributesUncached() => new ManyParameterAttributeProvider(_attributes).GetCustomAttributes(true).Length;
 
     /// <summary>Returns the memoized flattened attributes on a warmed provider.</summary>
     /// <returns>The flattened attribute count.</returns>

--- a/src/tests/Refit.Tests/GeneratedParameterAttributeProvider.GetCustomAttributesTests.cs
+++ b/src/tests/Refit.Tests/GeneratedParameterAttributeProvider.GetCustomAttributesTests.cs
@@ -11,7 +11,7 @@ public partial class GeneratedParameterAttributeProviderTests
     [Test]
     public void GetCustomAttributesThrowsForNullType()
     {
-        var provider = new GeneratedParameterAttributeProvider(new Dictionary<Type, object[]>());
+        var provider = new ManyParameterAttributeProvider(new Dictionary<Type, object[]>());
 
 #nullable disable
         _ = Assert.Throws<ArgumentNullException>(() => _ = provider.GetCustomAttributes(null, false));
@@ -23,7 +23,7 @@ public partial class GeneratedParameterAttributeProviderTests
     [Test]
     public async Task GetCustomAttributesReturnsEmptyArrayForEmptyProvider()
     {
-        var provider = new GeneratedParameterAttributeProvider(new Dictionary<Type, object[]>());
+        var provider = new ManyParameterAttributeProvider(new Dictionary<Type, object[]>());
 
         var result = provider.GetCustomAttributes(typeof(QueryAttribute), false);
 
@@ -36,7 +36,7 @@ public partial class GeneratedParameterAttributeProviderTests
     public async Task GetCustomAttributesReturnsAttributesArray()
     {
         var provider =
-            new GeneratedParameterAttributeProvider(new Dictionary<Type, object[]>
+            new ManyParameterAttributeProvider(new Dictionary<Type, object[]>
             {
                 { typeof(QueryAttribute), [new QueryAttribute()] }
             });
@@ -52,7 +52,7 @@ public partial class GeneratedParameterAttributeProviderTests
     public async Task GetCustomAttributesWithNoTypeReturnsAttributesArray()
     {
         var provider =
-            new GeneratedParameterAttributeProvider(new Dictionary<Type, object[]>
+            new ManyParameterAttributeProvider(new Dictionary<Type, object[]>
             {
                 { typeof(QueryAttribute), [new QueryAttribute()] },
                 { typeof(AliasAsAttribute), [new AliasAsAttribute("foo")] }

--- a/src/tests/Refit.Tests/GeneratedParameterAttributeProvider.IsDefinedTests.cs
+++ b/src/tests/Refit.Tests/GeneratedParameterAttributeProvider.IsDefinedTests.cs
@@ -12,7 +12,7 @@ public partial class GeneratedParameterAttributeProviderTests
     [Test]
     public async Task IsDefinedReturnsFalseForEmptyProvider()
     {
-        var provider = new GeneratedParameterAttributeProvider(new Dictionary<Type, object[]>());
+        var provider = new ManyParameterAttributeProvider(new Dictionary<Type, object[]>());
 
         var isDefined = provider.IsDefined(typeof(QueryAttribute), false);
 
@@ -24,7 +24,7 @@ public partial class GeneratedParameterAttributeProviderTests
     [Test]
     public async Task IsDefinedReturnsFalseForUnavailableTypeInProvider()
     {
-        var provider = new GeneratedParameterAttributeProvider(
+        var provider = new ManyParameterAttributeProvider(
             new Dictionary<Type, object[]> { { typeof(AliasAsAttribute), [new AliasAsAttribute("foo")] } });
 
         var isDefined = provider.IsDefined(typeof(QueryAttribute), false);
@@ -37,7 +37,7 @@ public partial class GeneratedParameterAttributeProviderTests
     [Test]
     public async Task IsDefinedReturnsTrueForAvailableTypeInProvider()
     {
-        var provider = new GeneratedParameterAttributeProvider(
+        var provider = new ManyParameterAttributeProvider(
             new Dictionary<Type, object[]> { { typeof(QueryAttribute), [new QueryAttribute()] } });
 
         var isDefined = provider.IsDefined(typeof(QueryAttribute), false);

--- a/src/tests/Refit.Tests/TestUrlFormatter.cs
+++ b/src/tests/Refit.Tests/TestUrlFormatter.cs
@@ -91,7 +91,7 @@ public class TestUrlFormatter : IUrlParameterFormatter
 
     /// <summary>
     /// Compares two providers of different kinds by the attributes they expose. Generated request
-    /// building supplies a synthetic <see cref="GeneratedParameterAttributeProvider"/> instead of the
+    /// building supplies a synthetic <see cref="ManyParameterAttributeProvider"/> instead of the
     /// reflection <see cref="ParameterInfo"/>, so the formatter matches on the attribute metadata both
     /// providers carry rather than on the concrete provider type.
     /// </summary>


### PR DESCRIPTION
Moves `GeneratedParameterAttributeProvider` to `GeneratedParameterAttributeProviderMany` and adds `GeneratedParameterAttributeProviderSingle` for parameters with only one attribute type.

This is a major nit pick, but it saves on having numerous dictionaries (200 bytes) attached to a static reference. I imagine it might be beneficial for AOT and save a miniscule amount of time during garbage collection
