### PR TITLE
fix: resolve generated clients when the module initializer runs late

### DIFF
--- a/.github/workflows/netfx-smoke.yml
+++ b/.github/workflows/netfx-smoke.yml
@@ -1,0 +1,34 @@
+name: .NET Framework smoke
+
+on:
+    push:
+        branches: [ main ]
+    pull_request:
+        branches: [ main ]
+
+permissions:
+    contents: read
+
+jobs:
+    netfx-smoke:
+        runs-on: windows-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v7
+
+            - name: Setup .NET
+              uses: actions/setup-dotnet@v6
+              with:
+                  dotnet-version: 11.x
+                  dotnet-quality: preview
+
+            - name: Build the smoke test
+              run: dotnet build src/Refit.NetFrameworkSmoke/Refit.NetFrameworkSmoke.csproj -c Release
+
+            # The generator emits its factory registrations inside #if NET5_0_OR_GREATER, so these targets resolve the
+            # generated client by name instead. Nothing else in the test matrix runs on .NET Framework.
+            - name: Run on net472
+              run: src\Refit.NetFrameworkSmoke\bin\Release\net472\Refit.NetFrameworkSmoke.exe
+
+            - name: Run on net481
+              run: src\Refit.NetFrameworkSmoke\bin\Release\net481\Refit.NetFrameworkSmoke.exe

--- a/.github/workflows/sonarcloud-fork.yml
+++ b/.github/workflows/sonarcloud-fork.yml
@@ -27,7 +27,8 @@ jobs:
             sonarProjectKey: reactiveui_refit
             sonarOrganization: reactiveui
             sonarExclusions: '**/tests/**,**/benchmarks/**,**/examples/**,**/TestResults/**'
-            sonarCoverageExclusions: '**/tests/**,**/benchmarks/**,**/examples/**,**/*Tests/**,**/*Tests.cs,**/Generated/**,**/*.g.cs'
+            # The smoke tests are standalone executables run outside the test harness, so no collector instruments them.
+            sonarCoverageExclusions: '**/tests/**,**/benchmarks/**,**/examples/**,**/*Tests/**,**/*Tests.cs,**/Generated/**,**/*.g.cs,**/Refit.NativeAotSmoke/**,**/Refit.NetFrameworkSmoke/**'
             sonarCpdExclusions: '**/tests/**,**/benchmarks/**,**/examples/**'
             sonarTestExclusions: '**/tests/**,**/benchmarks/**,**/examples/**'
             testTimeout: '15m'

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -19,7 +19,8 @@ jobs:
             sonarProjectKey: reactiveui_refit
             sonarOrganization: reactiveui
             sonarExclusions: '**/tests/**,**/benchmarks/**,**/examples/**,**/TestResults/**'
-            sonarCoverageExclusions: '**/tests/**,**/benchmarks/**,**/examples/**,**/*Tests/**,**/*Tests.cs,**/Generated/**,**/*.g.cs'
+            # The smoke tests are standalone executables run outside the test harness, so no collector instruments them.
+            sonarCoverageExclusions: '**/tests/**,**/benchmarks/**,**/examples/**,**/*Tests/**,**/*Tests.cs,**/Generated/**,**/*.g.cs,**/Refit.NativeAotSmoke/**,**/Refit.NetFrameworkSmoke/**'
             sonarCpdExclusions: '**/tests/**,**/benchmarks/**,**/examples/**'
             sonarTestExclusions: '**/tests/**,**/benchmarks/**,**/examples/**'
             testTimeout: '15m'

--- a/src/Refit.NativeAotSmoke/INoGeneratedClientApi.cs
+++ b/src/Refit.NativeAotSmoke/INoGeneratedClientApi.cs
@@ -1,0 +1,13 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Refit.NativeAotSmoke;
+
+/// <summary>An interface carrying no Refit attributes, so the generator emits no client and no registration for it.</summary>
+internal interface INoGeneratedClientApi
+{
+    /// <summary>Sends a request.</summary>
+    /// <returns>The response body.</returns>
+    Task<string> GetAsync();
+}

--- a/src/Refit.NativeAotSmoke/Program.cs
+++ b/src/Refit.NativeAotSmoke/Program.cs
@@ -72,6 +72,24 @@ if (!handler.SawFormBody)
     throw new InvalidOperationException("The AOT URL-encoded request body was not serialized through generated Refit code.");
 }
 
+// A missed generated-client lookup forces the interface assembly's module initializer and looks again, which is what
+// rescues runtimes that have not run it yet. Prove that forcing path is reachable under Native AOT.
+string? missingClientMessage = null;
+
+try
+{
+    _ = RestService.ForGenerated<INoGeneratedClientApi>(client);
+}
+catch (InvalidOperationException ex)
+{
+    missingClientMessage = ex.Message;
+}
+
+if (missingClientMessage?.Contains("doesn't look like a Refit interface", StringComparison.Ordinal) != true)
+{
+    throw new InvalidOperationException("The AOT lookup for a missing generated client did not report it.");
+}
+
 Console.WriteLine("Native AOT Refit smoke test passed.");
 
 /// <summary>The generated top-level program's declaring type, sealed so the JIT can devirtualize its members.</summary>

--- a/src/Refit.NetFrameworkSmoke/.editorconfig
+++ b/src/Refit.NetFrameworkSmoke/.editorconfig
@@ -1,0 +1,5 @@
+[*.cs]
+
+# SST1449: Avoid writing directly to the console.
+# The smoke test reports its pass/fail result on stdout; that is the whole point of the program.
+dotnet_diagnostic.SST1449.severity = none

--- a/src/Refit.NetFrameworkSmoke/INetFrameworkSmokeApi.cs
+++ b/src/Refit.NetFrameworkSmoke/INetFrameworkSmokeApi.cs
@@ -1,0 +1,29 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Refit.NetFrameworkSmoke;
+
+/// <summary>The Refit interface exercised by the .NET Framework smoke test. Every method generates inline, so the
+/// smoke test never needs the reflection request builder.</summary>
+internal interface INetFrameworkSmokeApi
+{
+    /// <summary>Fetches a todo by identifier.</summary>
+    /// <param name="id">The todo identifier.</param>
+    /// <returns>The fetched todo.</returns>
+    [Get("/todos/{id}")]
+    Task<Todo> GetTodoAsync(int id);
+
+    /// <summary>Creates a todo.</summary>
+    /// <param name="todo">The todo to create.</param>
+    /// <returns>The created todo.</returns>
+    [Post("/todos")]
+    Task<Todo> CreateTodoAsync([Body] Todo todo);
+
+    /// <summary>Searches todos.</summary>
+    /// <param name="q">The search term.</param>
+    /// <param name="page">The page number.</param>
+    /// <returns>The raw response body.</returns>
+    [Get("/search")]
+    Task<string> SearchAsync(string q, int page);
+}

--- a/src/Refit.NetFrameworkSmoke/INoGeneratedClientApi.cs
+++ b/src/Refit.NetFrameworkSmoke/INoGeneratedClientApi.cs
@@ -1,0 +1,13 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Refit.NetFrameworkSmoke;
+
+/// <summary>An interface carrying no Refit attributes, so the generator emits no client for it.</summary>
+internal interface INoGeneratedClientApi
+{
+    /// <summary>Sends a request.</summary>
+    /// <returns>The response body.</returns>
+    Task<string> GetAsync();
+}

--- a/src/Refit.NetFrameworkSmoke/NetFrameworkSmokeHandler.cs
+++ b/src/Refit.NetFrameworkSmoke/NetFrameworkSmokeHandler.cs
@@ -1,0 +1,51 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+using System.Net;
+using System.Text;
+
+namespace Refit.NetFrameworkSmoke;
+
+/// <summary>A test HTTP message handler that serves canned responses for the .NET Framework smoke test.</summary>
+internal sealed class NetFrameworkSmokeHandler : HttpMessageHandler
+{
+    /// <summary>Gets a value indicating whether a POST body containing the expected payload was observed.</summary>
+    internal bool SawPostBody { get; private set; }
+
+    /// <summary>Gets a value indicating whether the generated query string matched the expected shape.</summary>
+    internal bool SawExpectedQuery { get; private set; }
+
+    /// <inheritdoc/>
+    protected override async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        if (request.RequestUri?.AbsolutePath == "/todos")
+        {
+            var body = request.Content is null
+                ? string.Empty
+                : await request.Content.ReadAsStringAsync().ConfigureAwait(false);
+
+            SawPostBody = body.IndexOf("prove net framework", StringComparison.Ordinal) >= 0;
+
+            return Json("{\"id\":42,\"title\":\"prove net framework\"}");
+        }
+
+        if (request.RequestUri?.AbsolutePath == "/search")
+        {
+            SawExpectedQuery = request.RequestUri.PathAndQuery == "/search?q=a%20b&page=3";
+
+            return new(HttpStatusCode.OK) { Content = new StringContent("found", Encoding.UTF8, "text/plain") };
+        }
+
+        return request.RequestUri?.AbsolutePath == "/todos/42"
+            ? Json("{\"id\":42,\"title\":\"fetched on net framework\"}")
+            : new(HttpStatusCode.NotFound);
+    }
+
+    /// <summary>Builds an OK response with the given JSON content.</summary>
+    /// <param name="content">The JSON content for the response body.</param>
+    /// <returns>The constructed JSON response message.</returns>
+    private static HttpResponseMessage Json(string content) =>
+        new(HttpStatusCode.OK) { Content = new StringContent(content, Encoding.UTF8, "application/json") };
+}

--- a/src/Refit.NetFrameworkSmoke/Program.cs
+++ b/src/Refit.NetFrameworkSmoke/Program.cs
@@ -1,0 +1,80 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+using Refit;
+using Refit.NetFrameworkSmoke;
+
+const int ExpectedTodoId = 42;
+
+const int SearchPage = 3;
+
+const string MissingClientFragment = "doesn't look like a Refit interface";
+
+var handler = new NetFrameworkSmokeHandler();
+
+using var client = new HttpClient(handler) { BaseAddress = new("https://netfx.refit.test") };
+
+// .NET Framework has no [ModuleInitializer], so the generator emits no factory registrations here and the registries
+// stay empty. ForGenerated has to resolve the generated implementation by name for any of this to work at all.
+var api = RestService.ForGenerated<INetFrameworkSmokeApi>(client);
+
+var fetched = await api.GetTodoAsync(ExpectedTodoId).ConfigureAwait(false);
+
+if (fetched.Id != ExpectedTodoId || fetched.Title != "fetched on net framework")
+{
+    throw new InvalidOperationException("The .NET Framework GET response was not deserialized correctly.");
+}
+
+var created = await api.CreateTodoAsync(new(ExpectedTodoId, "prove net framework")).ConfigureAwait(false);
+
+if (created.Id != ExpectedTodoId || created.Title != "prove net framework")
+{
+    throw new InvalidOperationException("The .NET Framework POST response was not deserialized correctly.");
+}
+
+if (!handler.SawPostBody)
+{
+    throw new InvalidOperationException("The .NET Framework request body was not serialized through Refit.");
+}
+
+var searched = await api.SearchAsync("a b", SearchPage).ConfigureAwait(false);
+
+if (searched != "found" || !handler.SawExpectedQuery)
+{
+    throw new InvalidOperationException("The .NET Framework generated query string was not constructed correctly.");
+}
+
+// Resolving the same interface twice must reuse the cached generated type rather than resolving it again.
+if (RestService.ForGenerated<INetFrameworkSmokeApi>(client) is null)
+{
+    throw new InvalidOperationException("The .NET Framework repeat lookup did not return a generated client.");
+}
+
+// An interface the generator never saw must still report that clearly instead of failing some other way.
+string? missingClientMessage = null;
+
+try
+{
+    _ = RestService.ForGenerated<INoGeneratedClientApi>(client);
+}
+catch (InvalidOperationException ex)
+{
+    missingClientMessage = ex.Message;
+}
+
+if (missingClientMessage?.IndexOf(MissingClientFragment, StringComparison.Ordinal) < 0
+    || missingClientMessage is null)
+{
+    throw new InvalidOperationException("The .NET Framework lookup for a missing generated client did not report it.");
+}
+
+Console.WriteLine("Refit .NET Framework smoke test passed.");
+
+/// <summary>The generated top-level program's declaring type, sealed so the JIT can devirtualize its members.</summary>
+internal sealed partial class Program
+{
+    /// <summary>Initializes a new instance of the <see cref="Program"/> class. Unused; the entry point is the generated top-level <c>Main</c>.</summary>
+    private Program()
+    {
+    }
+}

--- a/src/Refit.NetFrameworkSmoke/Refit.NetFrameworkSmoke.csproj
+++ b/src/Refit.NetFrameworkSmoke/Refit.NetFrameworkSmoke.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>$(RefitFrameworkTargets)</TargetFrameworks>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Refit\Refit.csproj" />
+    <ProjectReference Include="..\InterfaceStubGenerator.Roslyn50\InterfaceStubGenerator.Roslyn50.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+  </ItemGroup>
+</Project>

--- a/src/Refit.NetFrameworkSmoke/Todo.cs
+++ b/src/Refit.NetFrameworkSmoke/Todo.cs
@@ -1,0 +1,10 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Refit.NetFrameworkSmoke;
+
+/// <summary>A todo item exchanged with the smoke test endpoint.</summary>
+/// <param name="Id">The todo identifier.</param>
+/// <param name="Title">The todo title.</param>
+internal sealed record Todo(int Id, string Title);

--- a/src/Refit.slnx
+++ b/src/Refit.slnx
@@ -56,6 +56,7 @@
     <Project Path="Refit.CodeFixes.Roslyn50/Refit.CodeFixes.Roslyn50.csproj" />
     <Project Path="Refit.HttpClientFactory/Refit.HttpClientFactory.csproj" />
     <Project Path="Refit.NativeAotSmoke/Refit.NativeAotSmoke.csproj" />
+    <Project Path="Refit.NetFrameworkSmoke/Refit.NetFrameworkSmoke.csproj" />
     <Project Path="Refit.Reflection/Refit.Reflection.csproj" />
     <Project Path="Refit.Newtonsoft.Json/Refit.Newtonsoft.Json.csproj" />
     <Project Path="Refit.Testing/Refit.Testing.csproj" />

--- a/src/Refit/RestService.cs
+++ b/src/Refit/RestService.cs
@@ -4,6 +4,7 @@
 using System.Collections.Concurrent;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 
 namespace Refit;
 
@@ -20,6 +21,9 @@ public static class RestService
     /// <summary>Holds source-generated factories that only need settings and avoid request-builder reflection.</summary>
     private static readonly ConcurrentDictionary<Type, Func<HttpClient, RefitSettings, object>> _generatedSettingsFactories =
         new();
+
+    /// <summary>Caches the module-initializer runner so resolving a client allocates no delegate.</summary>
+    private static readonly Action<Type> _generatedRegistrationRunner = RunGeneratedRegistrations;
 
     /// <summary>Registers a source-generated Refit implementation factory.</summary>
     /// <param name="refitInterfaceType">The Refit interface type.</param>
@@ -86,27 +90,18 @@ public static class RestService
         ArgumentExceptionHelper.ThrowIfNull(client);
         ArgumentExceptionHelper.ThrowIfNull(settings);
 
-        if (GeneratedSettingsFactory<T>.Factory is { } settingsFactory)
+#if NET5_0_OR_GREATER
+        if (TryResolveGeneratedClient<T>(client, settings, _generatedRegistrationRunner, out var instance))
         {
-            return settingsFactory(client, settings);
-        }
-
-        if (_generatedSettingsFactories.TryGetValue(typeof(T), out var untypedSettingsFactory))
-        {
-            return (T)untypedSettingsFactory(client, settings);
-        }
-
-        if (_generatedFactories.TryGetValue(typeof(T), out var untypedFactory))
-        {
-            return (T)untypedFactory(client, new GeneratedOnlyRequestBuilder(settings));
-        }
-
-        if (GeneratedFactory<T>.Factory is { } factory)
-        {
-            return factory(client, new GeneratedOnlyRequestBuilder(settings));
+            return instance;
         }
 
         throw CreateMissingGeneratedFactoryException(typeof(T));
+#else
+        return TryResolveGeneratedClient<T>(client, settings, _generatedRegistrationRunner, out var instance)
+            ? instance
+            : (T)CreateByGeneratedTypeName(typeof(T), client, settings);
+#endif
     }
 
     /// <summary>Create a source-generated Refit implementation without falling back to reflection.</summary>
@@ -153,17 +148,18 @@ public static class RestService
         ArgumentExceptionHelper.ThrowIfNull(client);
         ArgumentExceptionHelper.ThrowIfNull(settings);
 
-        if (_generatedSettingsFactories.TryGetValue(refitInterfaceType, out var settingsFactory))
+#if NET5_0_OR_GREATER
+        if (TryResolveGeneratedClient(refitInterfaceType, client, settings, _generatedRegistrationRunner, out var instance))
         {
-            return settingsFactory(client, settings);
-        }
-
-        if (_generatedFactories.TryGetValue(refitInterfaceType, out var factory))
-        {
-            return factory(client, new GeneratedOnlyRequestBuilder(settings));
+            return instance;
         }
 
         throw CreateMissingGeneratedFactoryException(refitInterfaceType);
+#else
+        return TryResolveGeneratedClient(refitInterfaceType, client, settings, _generatedRegistrationRunner, out var instance)
+            ? instance
+            : CreateByGeneratedTypeName(refitInterfaceType, client, settings);
+#endif
     }
 
     /// <summary>Create a source-generated Refit implementation without falling back to reflection.</summary>
@@ -213,16 +209,13 @@ public static class RestService
             DynamicallyAccessedMemberTypes.NonPublicMethods)]
         T>(HttpClient client, RefitSettings? settings)
     {
+        var resolvedSettings = settings ?? new();
+
         // A generated settings factory means every method builds its request inline, so the reflection
         // request builder (and the Refit.Reflection assembly) is never needed for this interface.
-        if (GeneratedSettingsFactory<T>.Factory is { } settingsFactory)
+        if (TryResolveInlineClient<T>(client, resolvedSettings, _generatedRegistrationRunner, out var instance))
         {
-            return settingsFactory(client, settings ?? new());
-        }
-
-        if (_generatedSettingsFactories.TryGetValue(typeof(T), out var untypedSettingsFactory))
-        {
-            return (T)untypedSettingsFactory(client, settings ?? new());
+            return instance;
         }
 
         var requestBuilder = RequestBuilder.ForType<T>(settings);
@@ -324,11 +317,13 @@ public static class RestService
         HttpClient client,
         RefitSettings? settings)
     {
+        var resolvedSettings = settings ?? new();
+
         // A generated settings factory means every method builds its request inline, so the reflection
         // request builder (and the Refit.Reflection assembly) is never needed for this interface.
-        if (_generatedSettingsFactories.TryGetValue(refitInterfaceType, out var settingsFactory))
+        if (TryResolveInlineClient(refitInterfaceType, client, resolvedSettings, _generatedRegistrationRunner, out var instance))
         {
-            return settingsFactory(client, settings ?? new());
+            return instance;
         }
 
         var requestBuilder = RequestBuilder.ForType(refitInterfaceType, settings);
@@ -424,6 +419,113 @@ public static class RestService
         return new(innerHandler ?? new HttpClientHandler()) { BaseAddress = new(baseAddress) };
     }
 
+    /// <summary>Runs the generated-factory registrations declared by the assembly that owns a Refit interface.</summary>
+    /// <param name="refitInterfaceType">The Refit interface type.</param>
+    /// <remarks>
+    /// The generator emits those registrations in a <c>[ModuleInitializer]</c> in the assembly that declares the
+    /// interface. The runtime only promises to run a module initializer before the first static field read or method
+    /// call in that module, and resolving a client only ever does <c>typeof(T)</c>, which is neither. CoreCLR runs
+    /// module initializers eagerly regardless, but Mono - which Blazor WebAssembly runs on - does not, so a lookup can
+    /// miss purely because the initializer has not run yet. Forcing the module constructor is safe to repeat, because
+    /// a module constructor runs at most once.
+    /// </remarks>
+    internal static void RunGeneratedRegistrations(Type refitInterfaceType) =>
+        RuntimeHelpers.RunModuleConstructor(refitInterfaceType.Module.ModuleHandle);
+
+    /// <summary>Resolves a generated implementation, forcing the interface assembly's registrations on a miss.</summary>
+    /// <typeparam name="T">The Refit interface type.</typeparam>
+    /// <param name="client">The <see cref="HttpClient"/> the implementation will use to send requests.</param>
+    /// <param name="settings"><see cref="RefitSettings"/> to use to configure the generated client.</param>
+    /// <param name="runRegistrations">Runs the registrations declared by the interface's assembly.</param>
+    /// <param name="instance">The resolved implementation.</param>
+    /// <returns><see langword="true"/> when a generated implementation was resolved.</returns>
+    internal static bool TryResolveGeneratedClient<T>(
+        HttpClient client,
+        RefitSettings settings,
+        Action<Type> runRegistrations,
+        out T instance)
+    {
+        if (TryCreateGeneratedClient(client, settings, out instance))
+        {
+            return true;
+        }
+
+        runRegistrations(typeof(T));
+
+        return TryCreateGeneratedClient(client, settings, out instance);
+    }
+
+    /// <summary>Resolves a generated implementation, forcing the interface assembly's registrations on a miss.</summary>
+    /// <param name="refitInterfaceType">The Refit interface type.</param>
+    /// <param name="client">The <see cref="HttpClient"/> the implementation will use to send requests.</param>
+    /// <param name="settings"><see cref="RefitSettings"/> to use to configure the generated client.</param>
+    /// <param name="runRegistrations">Runs the registrations declared by the interface's assembly.</param>
+    /// <param name="instance">The resolved implementation.</param>
+    /// <returns><see langword="true"/> when a generated implementation was resolved.</returns>
+    internal static bool TryResolveGeneratedClient(
+        Type refitInterfaceType,
+        HttpClient client,
+        RefitSettings settings,
+        Action<Type> runRegistrations,
+        out object instance)
+    {
+        if (TryCreateGeneratedClient(refitInterfaceType, client, settings, out instance))
+        {
+            return true;
+        }
+
+        runRegistrations(refitInterfaceType);
+
+        return TryCreateGeneratedClient(refitInterfaceType, client, settings, out instance);
+    }
+
+    /// <summary>Resolves a fully inline generated implementation, forcing the interface assembly's registrations on a miss.</summary>
+    /// <typeparam name="T">The Refit interface type.</typeparam>
+    /// <param name="client">The <see cref="HttpClient"/> the implementation will use to send requests.</param>
+    /// <param name="settings"><see cref="RefitSettings"/> to use to configure the generated client.</param>
+    /// <param name="runRegistrations">Runs the registrations declared by the interface's assembly.</param>
+    /// <param name="instance">The resolved implementation.</param>
+    /// <returns><see langword="true"/> when an inline generated implementation was resolved.</returns>
+    internal static bool TryResolveInlineClient<T>(
+        HttpClient client,
+        RefitSettings settings,
+        Action<Type> runRegistrations,
+        out T instance)
+    {
+        if (TryCreateInlineClient(client, settings, out instance))
+        {
+            return true;
+        }
+
+        runRegistrations(typeof(T));
+
+        return TryCreateInlineClient(client, settings, out instance);
+    }
+
+    /// <summary>Resolves a fully inline generated implementation, forcing the interface assembly's registrations on a miss.</summary>
+    /// <param name="refitInterfaceType">The Refit interface type.</param>
+    /// <param name="client">The <see cref="HttpClient"/> the implementation will use to send requests.</param>
+    /// <param name="settings"><see cref="RefitSettings"/> to use to configure the generated client.</param>
+    /// <param name="runRegistrations">Runs the registrations declared by the interface's assembly.</param>
+    /// <param name="instance">The resolved implementation.</param>
+    /// <returns><see langword="true"/> when an inline generated implementation was resolved.</returns>
+    internal static bool TryResolveInlineClient(
+        Type refitInterfaceType,
+        HttpClient client,
+        RefitSettings settings,
+        Action<Type> runRegistrations,
+        out object instance)
+    {
+        if (TryCreateInlineClient(refitInterfaceType, client, settings, out instance))
+        {
+            return true;
+        }
+
+        runRegistrations(refitInterfaceType);
+
+        return TryCreateInlineClient(refitInterfaceType, client, settings, out instance);
+    }
+
     /// <summary>Resolves the generated implementation type for a Refit interface.</summary>
     /// <param name="refitInterfaceType">The Refit interface type.</param>
     /// <returns>The generated implementation type.</returns>
@@ -455,6 +557,127 @@ public static class RestService
 
         return new(message);
     }
+
+    /// <summary>Creates a generated implementation from the registered factories.</summary>
+    /// <typeparam name="T">The Refit interface type.</typeparam>
+    /// <param name="client">The <see cref="HttpClient"/> the implementation will use to send requests.</param>
+    /// <param name="settings"><see cref="RefitSettings"/> to use to configure the generated client.</param>
+    /// <param name="instance">The created implementation.</param>
+    /// <returns><see langword="true"/> when a factory was registered.</returns>
+    private static bool TryCreateGeneratedClient<T>(HttpClient client, RefitSettings settings, out T instance)
+    {
+        if (TryCreateInlineClient(client, settings, out instance))
+        {
+            return true;
+        }
+
+        if (_generatedFactories.TryGetValue(typeof(T), out var untypedFactory))
+        {
+            instance = (T)untypedFactory(client, new GeneratedOnlyRequestBuilder(settings));
+            return true;
+        }
+
+        if (GeneratedFactory<T>.Factory is { } factory)
+        {
+            instance = factory(client, new GeneratedOnlyRequestBuilder(settings));
+            return true;
+        }
+
+        instance = default!;
+        return false;
+    }
+
+    /// <summary>Creates a generated implementation from the registered factories.</summary>
+    /// <param name="refitInterfaceType">The Refit interface type.</param>
+    /// <param name="client">The <see cref="HttpClient"/> the implementation will use to send requests.</param>
+    /// <param name="settings"><see cref="RefitSettings"/> to use to configure the generated client.</param>
+    /// <param name="instance">The created implementation.</param>
+    /// <returns><see langword="true"/> when a factory was registered.</returns>
+    private static bool TryCreateGeneratedClient(
+        Type refitInterfaceType,
+        HttpClient client,
+        RefitSettings settings,
+        out object instance)
+    {
+        if (TryCreateInlineClient(refitInterfaceType, client, settings, out instance))
+        {
+            return true;
+        }
+
+        if (_generatedFactories.TryGetValue(refitInterfaceType, out var factory))
+        {
+            instance = factory(client, new GeneratedOnlyRequestBuilder(settings));
+            return true;
+        }
+
+        instance = default!;
+        return false;
+    }
+
+    /// <summary>Creates a generated implementation whose methods all build their requests inline.</summary>
+    /// <typeparam name="T">The Refit interface type.</typeparam>
+    /// <param name="client">The <see cref="HttpClient"/> the implementation will use to send requests.</param>
+    /// <param name="settings"><see cref="RefitSettings"/> to use to configure the generated client.</param>
+    /// <param name="instance">The created implementation.</param>
+    /// <returns><see langword="true"/> when a settings factory was registered.</returns>
+    private static bool TryCreateInlineClient<T>(HttpClient client, RefitSettings settings, out T instance)
+    {
+        if (GeneratedSettingsFactory<T>.Factory is { } settingsFactory)
+        {
+            instance = settingsFactory(client, settings);
+            return true;
+        }
+
+        if (_generatedSettingsFactories.TryGetValue(typeof(T), out var untypedSettingsFactory))
+        {
+            instance = (T)untypedSettingsFactory(client, settings);
+            return true;
+        }
+
+        instance = default!;
+        return false;
+    }
+
+    /// <summary>Creates a generated implementation whose methods all build their requests inline.</summary>
+    /// <param name="refitInterfaceType">The Refit interface type.</param>
+    /// <param name="client">The <see cref="HttpClient"/> the implementation will use to send requests.</param>
+    /// <param name="settings"><see cref="RefitSettings"/> to use to configure the generated client.</param>
+    /// <param name="instance">The created implementation.</param>
+    /// <returns><see langword="true"/> when a settings factory was registered.</returns>
+    private static bool TryCreateInlineClient(
+        Type refitInterfaceType,
+        HttpClient client,
+        RefitSettings settings,
+        out object instance)
+    {
+        if (_generatedSettingsFactories.TryGetValue(refitInterfaceType, out var settingsFactory))
+        {
+            instance = settingsFactory(client, settings);
+            return true;
+        }
+
+        instance = default!;
+        return false;
+    }
+
+#if !NET5_0_OR_GREATER
+    /// <summary>Creates a generated implementation by resolving its emitted type name.</summary>
+    /// <param name="refitInterfaceType">The Refit interface type.</param>
+    /// <param name="client">The <see cref="HttpClient"/> the implementation will use to send requests.</param>
+    /// <param name="settings"><see cref="RefitSettings"/> to use to configure the generated client.</param>
+    /// <returns>An instance that implements <paramref name="refitInterfaceType"/>.</returns>
+    /// <remarks>
+    /// .NET Framework has no <c>[ModuleInitializer]</c>, so the generator emits no registrations for those targets and
+    /// the factory registries stay empty there. Resolving the generated type by name is the same fallback the
+    /// reflection path already uses, and it keeps the modern targets free of runtime type lookup.
+    /// </remarks>
+    private static object CreateByGeneratedTypeName(Type refitInterfaceType, HttpClient client, RefitSettings settings)
+    {
+        var generatedType = _typeMapping.GetOrAdd(refitInterfaceType, GetGeneratedType);
+
+        return Activator.CreateInstance(generatedType, client, new GeneratedOnlyRequestBuilder(settings))!;
+    }
+#endif
 
     /// <summary>Holds the typed generated factory for a single Refit interface.</summary>
     /// <typeparam name="T">The Refit interface type.</typeparam>

--- a/src/tests/Refit.Tests/ClientRegistrationStub.cs
+++ b/src/tests/Refit.Tests/ClientRegistrationStub.cs
@@ -1,0 +1,16 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Refit.Tests;
+
+/// <summary>A hand-written implementation returned by the factories registered in the client registration tests.</summary>
+public sealed class ClientRegistrationStub
+    : IGeneratedClientRegistrationApi,
+    IGeneratedClientRegistrationByTypeApi,
+    IInlineClientRegistrationApi,
+    IInlineClientRegistrationByTypeApi
+{
+    /// <inheritdoc/>
+    public Task<string> Get() => Task.FromResult(string.Empty);
+}

--- a/src/tests/Refit.Tests/GeneratedClientRegistrationTests.cs
+++ b/src/tests/Refit.Tests/GeneratedClientRegistrationTests.cs
@@ -1,0 +1,180 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+using System;
+using System.Net.Http;
+
+namespace Refit.Tests;
+
+/// <summary>
+/// Verifies client resolution copes with a module initializer that has not run yet. Generated factories register from
+/// a <c>[ModuleInitializer]</c> in the interface's own assembly, and the runtime only promises to run that before the
+/// first static field read or method call in the module. Resolving a client only does <c>typeof(T)</c>, so Mono -
+/// which Blazor WebAssembly runs on - can still have the registration pending when the first lookup happens.
+/// </summary>
+public sealed class GeneratedClientRegistrationTests
+{
+    /// <summary>The base address given to every client under test.</summary>
+    private static readonly Uri _baseAddress = new("http://api/");
+
+    /// <summary>Verifies a generated client registered while the initializer runs is picked up by the retried lookup.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task GeneratedClientResolvesWhenRegistrationArrivesWithTheModuleInitializer()
+    {
+        var stub = new ClientRegistrationStub();
+        using var client = HttpClientTestFactory.Create(_baseAddress);
+
+        var resolved = RestService.TryResolveGeneratedClient<IGeneratedClientRegistrationApi>(
+            client,
+            new(),
+            _ => RestService.RegisterGeneratedFactory<IGeneratedClientRegistrationApi>((_, _) => stub),
+            out var instance);
+
+        await Assert.That(resolved).IsTrue();
+        await Assert.That(instance).IsSameReferenceAs(stub);
+    }
+
+    /// <summary>Verifies the type-keyed generated client is picked up by the retried lookup.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task GeneratedClientResolvesByTypeWhenRegistrationArrivesWithTheModuleInitializer()
+    {
+        var stub = new ClientRegistrationStub();
+        using var client = HttpClientTestFactory.Create(_baseAddress);
+
+        var resolved = RestService.TryResolveGeneratedClient(
+            typeof(IGeneratedClientRegistrationByTypeApi),
+            client,
+            new(),
+            _ => RestService.RegisterGeneratedFactory(
+                typeof(IGeneratedClientRegistrationByTypeApi),
+                (_, _) => stub),
+            out var instance);
+
+        await Assert.That(resolved).IsTrue();
+        await Assert.That(instance).IsSameReferenceAs(stub);
+    }
+
+    /// <summary>Verifies an inline client registered while the initializer runs is used instead of the reflection request builder.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task InlineClientResolvesWhenRegistrationArrivesWithTheModuleInitializer()
+    {
+        var stub = new ClientRegistrationStub();
+        using var client = HttpClientTestFactory.Create(_baseAddress);
+
+        var resolved = RestService.TryResolveInlineClient<IInlineClientRegistrationApi>(
+            client,
+            new(),
+            _ => RestService.RegisterGeneratedSettingsFactory<IInlineClientRegistrationApi>((_, _) => stub),
+            out var instance);
+
+        await Assert.That(resolved).IsTrue();
+        await Assert.That(instance).IsSameReferenceAs(stub);
+    }
+
+    /// <summary>Verifies the type-keyed inline client is picked up by the retried lookup.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task InlineClientResolvesByTypeWhenRegistrationArrivesWithTheModuleInitializer()
+    {
+        var stub = new ClientRegistrationStub();
+        using var client = HttpClientTestFactory.Create(_baseAddress);
+
+        var resolved = RestService.TryResolveInlineClient(
+            typeof(IInlineClientRegistrationByTypeApi),
+            client,
+            new(),
+            _ => RestService.RegisterGeneratedSettingsFactory<IInlineClientRegistrationByTypeApi>((_, _) => stub),
+            out var instance);
+
+        await Assert.That(resolved).IsTrue();
+        await Assert.That(instance).IsSameReferenceAs(stub);
+    }
+
+    /// <summary>Verifies resolution reports failure when the initializer registers nothing for the interface.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task ClientResolutionFailsWhenNoRegistrationArrives()
+    {
+        using var client = HttpClientTestFactory.Create(_baseAddress);
+        var settings = new RefitSettings();
+        var interfaceType = typeof(IAmNotARefitInterface);
+
+        var resolvedGenerated = RestService.TryResolveGeneratedClient<IAmNotARefitInterface>(
+            client,
+            settings,
+            static _ => { },
+            out _);
+
+        var resolvedByType = RestService.TryResolveGeneratedClient(
+            interfaceType,
+            client,
+            settings,
+            static _ => { },
+            out _);
+
+        var resolvedInline = RestService.TryResolveInlineClient<IAmNotARefitInterface>(
+            client,
+            settings,
+            static _ => { },
+            out _);
+
+        var resolvedInlineByType = RestService.TryResolveInlineClient(
+            interfaceType,
+            client,
+            settings,
+            static _ => { },
+            out _);
+
+        await Assert.That(resolvedGenerated).IsFalse();
+        await Assert.That(resolvedByType).IsFalse();
+        await Assert.That(resolvedInline).IsFalse();
+        await Assert.That(resolvedInlineByType).IsFalse();
+    }
+
+    /// <summary>Verifies forcing the interface assembly's module constructor is safe to repeat and keeps the client resolvable.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task RunningGeneratedRegistrationsRepeatedlyKeepsTheClientResolvable()
+    {
+        RestService.RunGeneratedRegistrations(typeof(IRoundTripNotString));
+        RestService.RunGeneratedRegistrations(typeof(IRoundTripNotString));
+
+        using var client = HttpClientTestFactory.Create(_baseAddress);
+
+        await Assert.That(RestService.ForGenerated<IRoundTripNotString>(client)).IsNotNull();
+    }
+
+    /// <summary>Verifies an interface with no generated client still reports that, after the initializer is forced.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task ForGeneratedReportsAMissingGeneratedClient()
+    {
+        using var client = HttpClientTestFactory.Create(_baseAddress);
+
+        await Assert.That(() => RestService.ForGenerated<IAmNotARefitInterface>(client))
+            .ThrowsExactly<InvalidOperationException>()
+            .WithMessage(
+                "IAmNotARefitInterface doesn't look like a Refit interface. Make sure it has at least one method with "
+                + "a Refit HTTP method attribute, the Refit source generator is installed in the project, and your "
+                + "build produced the generated client. For Native AOT or trimmed apps, prefer generated clients plus "
+                + "source-generated System.Text.Json metadata.",
+                StringComparison.Ordinal);
+    }
+
+    /// <summary>Verifies resolving by type also reports a missing generated client.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task ForGeneratedByTypeReportsAMissingGeneratedClient()
+    {
+        using var client = HttpClientTestFactory.Create(_baseAddress);
+        var interfaceType = typeof(IAmNotARefitInterface);
+
+        var settings = new RefitSettings();
+
+        await Assert.That(() => RestService.ForGenerated(interfaceType, client, settings))
+            .ThrowsExactly<InvalidOperationException>();
+    }
+}

--- a/src/tests/Refit.Tests/IGeneratedClientRegistrationApi.cs
+++ b/src/tests/Refit.Tests/IGeneratedClientRegistrationApi.cs
@@ -1,0 +1,14 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Refit.Tests;
+
+/// <summary>An interface carrying no Refit attributes so the generator never registers a client for it, leaving the
+/// registration timing under the test's control.</summary>
+public interface IGeneratedClientRegistrationApi
+{
+    /// <summary>Sends a request.</summary>
+    /// <returns>The response body.</returns>
+    Task<string> Get();
+}

--- a/src/tests/Refit.Tests/IGeneratedClientRegistrationByTypeApi.cs
+++ b/src/tests/Refit.Tests/IGeneratedClientRegistrationByTypeApi.cs
@@ -1,0 +1,14 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Refit.Tests;
+
+/// <summary>An interface carrying no Refit attributes so the generator never registers a client for it, leaving the
+/// registration timing under the test's control.</summary>
+public interface IGeneratedClientRegistrationByTypeApi
+{
+    /// <summary>Sends a request.</summary>
+    /// <returns>The response body.</returns>
+    Task<string> Get();
+}

--- a/src/tests/Refit.Tests/IInlineClientRegistrationApi.cs
+++ b/src/tests/Refit.Tests/IInlineClientRegistrationApi.cs
@@ -1,0 +1,14 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Refit.Tests;
+
+/// <summary>An interface carrying no Refit attributes so the generator never registers a client for it, leaving the
+/// registration timing under the test's control.</summary>
+public interface IInlineClientRegistrationApi
+{
+    /// <summary>Sends a request.</summary>
+    /// <returns>The response body.</returns>
+    Task<string> Get();
+}

--- a/src/tests/Refit.Tests/IInlineClientRegistrationByTypeApi.cs
+++ b/src/tests/Refit.Tests/IInlineClientRegistrationByTypeApi.cs
@@ -1,0 +1,14 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Refit.Tests;
+
+/// <summary>An interface carrying no Refit attributes so the generator never registers a client for it, leaving the
+/// registration timing under the test's control.</summary>
+public interface IInlineClientRegistrationByTypeApi
+{
+    /// <summary>Sends a request.</summary>
+    /// <returns>The response body.</returns>
+    Task<string> Get();
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the new behavior?

- When a generated client lookup finds nothing, Refit now forces the module constructor of the interface's own assembly and looks again. Blazor WebAssembly clients resolve and send requests.
- `RestService.For` does the same before it reaches for the reflection request builder, so it no longer asks for the `Refit.Reflection` package when a perfectly good generated client exists.
- On .NET Framework, where no module initializer is emitted at all, `ForGenerated` resolves the generated type by name. The modern targets keep their reflection-free path.

```csharp
if (TryCreateGeneratedClient(client, settings, out instance))
{
    return true;
}

runRegistrations(typeof(T));

return TryCreateGeneratedClient(client, settings, out instance);
```

## What is the current behavior?

- The generator registers each client from a `[ModuleInitializer]` in the assembly holding the interface. Resolving a client only does `typeof(T)`, which the runtime does not count as a trigger for that initializer.
- CoreCLR runs module initializers eagerly, so this works on the server. Mono, which Blazor WebAssembly runs on, does not, so the registry is still empty and Refit reports `ICommonRepo doesn't look like a Refit interface`.
- `RestService.For` hits the same empty registry, falls through to reflection, and tells people to install `Refit.Reflection` and look for an RF006 that was never reported.
- The whole initializer sits inside `#if NET5_0_OR_GREATER`, so nothing registers on net462 - net481 and `ForGenerated` can never succeed there.

Closes #2287

## What might this PR break?

- Nothing. The extra work only runs on the path that used to throw, so a successful lookup costs exactly what it did before.
- Forcing a module constructor is safe to repeat, because a module constructor runs at most once.

## Checklist
- [x] I have read the [Contribute guide](https://www.reactiveui.net/contribute/index.html)
- [x] Tests have been added or updated (for bug fixes / features)
- [ ] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the `main` branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional information

- New tests cover all four resolution paths when the registration only arrives once the initializer is forced, plus the failure case and the message Refit reports when a client really is missing.
- `Refit.NetFrameworkSmoke` is a new console smoke test that builds for net462 - net481 and exercises `ForGenerated` over a stub handler: a GET, a POST body, a generated query string, a repeat lookup, and the missing-client error. A Windows CI job runs it on net472 and net481, because the test matrix is net8.0 - net11.0 and nothing else touches .NET Framework at runtime.
- The Native AOT smoke test now exercises the forcing path too, and the published binary passes with full trimming and no IL warnings.
- Solution builds clean across all ten target frameworks, all 7533 tests pass, and `RestService.cs` line and branch coverage stays at 100 percent.
