### PR TITLE
fix: differentiate explicitly empty string delimiter from "no delimiter"

### DIFF
--- a/src/InterfaceStubGenerator.Shared/Parser.Request.Body.cs
+++ b/src/InterfaceStubGenerator.Shared/Parser.Request.Body.cs
@@ -300,14 +300,16 @@ internal static partial class Parser
         BodyBufferMode BufferMode);
 
     /// <summary>Form-relevant data parsed from a <c>[Query]</c> attribute on a parameter or body property.</summary>
-    /// <param name="Delimiter">The delimiter combined with the prefix.</param>
+    /// <param name="Delimiter">The delimiter combined with the prefix, or <see langword="null"/> when no
+    /// <c>[Query]</c> attribute was present. An explicitly supplied empty delimiter is preserved as
+    /// <see cref="string.Empty"/> and must not be confused with the absent case.</param>
     /// <param name="Prefix">The field name prefix, if any.</param>
     /// <param name="Format">The value format, if any.</param>
     /// <param name="CollectionFormatValue">The explicit collection format value, if any.</param>
     /// <param name="SerializeNull">Whether null values are serialized as empty fields.</param>
     /// <param name="TreatAsString">Whether the raw value is stringified via <c>ToString()</c> before formatting.</param>
     internal readonly record struct QueryFormData(
-        string Delimiter,
+        string? Delimiter,
         string? Prefix,
         string? Format,
         int? CollectionFormatValue,

--- a/src/InterfaceStubGenerator.Shared/Parser.Request.Path.cs
+++ b/src/InterfaceStubGenerator.Shared/Parser.Request.Path.cs
@@ -104,7 +104,7 @@ internal static partial class Parser
             ElementCanBeNull: false,
             BuildValueFormat(flattenType, null, formattableSymbol, context),
             residual.ToImmutableEquatableArray(),
-            NestingDelimiter: string.IsNullOrEmpty(data.Delimiter) ? "." : data.Delimiter);
+            NestingDelimiter: data.Delimiter ?? DefaultNestingDelimiter);
         return true;
     }
 

--- a/src/InterfaceStubGenerator.Shared/Parser.Request.Query.cs
+++ b/src/InterfaceStubGenerator.Shared/Parser.Request.Query.cs
@@ -17,6 +17,14 @@ internal static partial class Parser
     /// <summary>The maximum nested-object depth flattened inline before the whole parameter falls back to reflection.</summary>
     private const int MaxNestingDepth = 32;
 
+    /// <summary>The delimiter joining nested query keys when no <c>[Query]</c> attribute supplies one.</summary>
+    /// <remarks>
+    /// This is only the fallback for the absent-attribute case. A <c>[Query]</c> attribute always carries a delimiter -
+    /// <c>QueryAttribute.Delimiter</c> itself defaults to <c>"."</c> - so an explicitly supplied empty delimiter
+    /// must be honoured rather than replaced with this value.
+    /// </remarks>
+    private const string DefaultNestingDelimiter = ".";
+
     /// <summary>The metadata name of <c>Refit.CollectionFormat</c>.</summary>
     private const string CollectionFormatTypeName = "Refit.CollectionFormat";
 
@@ -258,7 +266,7 @@ internal static partial class Parser
             ElementCanBeNull: false,
             BuildValueFormat(parameter.Type, format, formattableSymbol, context),
             properties,
-            NestingDelimiter: string.IsNullOrEmpty(data.Delimiter) ? "." : data.Delimiter);
+            NestingDelimiter: data.Delimiter ?? DefaultNestingDelimiter);
     }
 
     /// <summary>Builds the query model for a collection-of-simple-elements parameter, or null for any other shape.</summary>
@@ -358,7 +366,7 @@ internal static partial class Parser
             CanElementBeNull(elementType!),
             BuildValueFormat(elementType!, format, formattableSymbol, context),
             elementProperties,
-            NestingDelimiter: string.IsNullOrEmpty(data.Delimiter) ? "." : data.Delimiter);
+            NestingDelimiter: data.Delimiter ?? DefaultNestingDelimiter);
     }
 
     /// <summary>Builds the query model for a <c>[QueryConverter]</c> parameter, or null when the type is unresolved.</summary>

--- a/src/InterfaceStubGenerator.Shared/Parser.Request.Query.cs
+++ b/src/InterfaceStubGenerator.Shared/Parser.Request.Query.cs
@@ -252,21 +252,18 @@ internal static partial class Parser
             ? nullableObject.TypeArguments[0]
             : parameter.Type;
 
-        if (TryBuildQueryObjectProperties(objectType, parameterPrefixSegment, formattableSymbol, context) is not { } properties)
-        {
-            return null;
-        }
-
-        return new(
-            urlName,
-            QueryParameterShape.Object,
-            TreatAsString: false,
-            preEncoded,
-            data.CollectionFormatValue,
-            ElementCanBeNull: false,
-            BuildValueFormat(parameter.Type, format, formattableSymbol, context),
-            properties,
-            NestingDelimiter: data.Delimiter ?? DefaultNestingDelimiter);
+        return TryBuildQueryObjectProperties(objectType, parameterPrefixSegment, formattableSymbol, context) is not { } properties
+            ? null
+            : new(
+                urlName,
+                QueryParameterShape.Object,
+                TreatAsString: false,
+                preEncoded,
+                data.CollectionFormatValue,
+                ElementCanBeNull: false,
+                BuildValueFormat(parameter.Type, format, formattableSymbol, context),
+                properties,
+                NestingDelimiter: data.Delimiter ?? DefaultNestingDelimiter);
     }
 
     /// <summary>Builds the query model for a collection-of-simple-elements parameter, or null for any other shape.</summary>
@@ -352,21 +349,18 @@ internal static partial class Parser
             return null;
         }
 
-        if (TryBuildQueryObjectProperties(elementType!, null, formattableSymbol, context) is not { } elementProperties)
-        {
-            return null;
-        }
-
-        return new(
-            urlName,
-            QueryParameterShape.IndexedCollection,
-            TreatAsString: false,
-            preEncoded,
-            data.CollectionFormatValue,
-            CanElementBeNull(elementType!),
-            BuildValueFormat(elementType!, format, formattableSymbol, context),
-            elementProperties,
-            NestingDelimiter: data.Delimiter ?? DefaultNestingDelimiter);
+        return TryBuildQueryObjectProperties(elementType!, null, formattableSymbol, context) is not { } elementProperties
+            ? null
+            : new(
+                urlName,
+                QueryParameterShape.IndexedCollection,
+                TreatAsString: false,
+                preEncoded,
+                data.CollectionFormatValue,
+                CanElementBeNull(elementType!),
+                BuildValueFormat(elementType!, format, formattableSymbol, context),
+                elementProperties,
+                NestingDelimiter: data.Delimiter ?? DefaultNestingDelimiter);
     }
 
     /// <summary>Builds the query model for a <c>[QueryConverter]</c> parameter, or null when the type is unresolved.</summary>

--- a/src/tests/Refit.GeneratorTests/IndexedCollectionGenerationTests.cs
+++ b/src/tests/Refit.GeneratorTests/IndexedCollectionGenerationTests.cs
@@ -163,10 +163,7 @@ public sealed class IndexedCollectionGenerationTests
     [Test]
     public async Task EmptyIndexedDelimiterConcatenatesWithoutSeparator()
     {
-        var result = Fixture.RunGenerator(
-            EmptyDelimiterIndexedSource,
-            generatedRequestBuilding: true
-        );
+        var result = Fixture.RunGenerator(EmptyDelimiterIndexedSource, generatedRequestBuilding: true);
 
         await Assert.That(result.CompilesWithoutErrors).IsTrue();
         await Assert.That(result.GeneratedSources[Hint]).Contains(ExpectedItemsQueryKeyPrefix);

--- a/src/tests/Refit.GeneratorTests/IndexedCollectionGenerationTests.cs
+++ b/src/tests/Refit.GeneratorTests/IndexedCollectionGenerationTests.cs
@@ -81,6 +81,9 @@ public sealed class IndexedCollectionGenerationTests
         }
         """;
 
+    /// <summary>The expected query key prefix for an Indexed collection parameter, which is <c>items[{</c> for the test sources above.</summary>
+    private const string ExpectedItemsQueryKeyPrefix = "items[{";
+
     /// <summary>Source where the element type has a nested object property - should fall back to reflection
     /// because the nested type is complex and the reflection builder walks runtime types.</summary>
     private const string IndexedWithSimpleScalarCollectionSource =
@@ -150,15 +153,37 @@ public sealed class IndexedCollectionGenerationTests
         await Assert.That(result.GeneratedSources[Hint]).DoesNotContain(ReflectiveFallback);
     }
 
-    /// <summary>Verifies an empty Indexed nesting delimiter falls back to the standard dot delimiter.</summary>
+    /// <summary>
+    /// Verifies an explicitly empty Indexed nesting delimiter joins the indexed key to the element's property name
+    /// with no separator at all, rather than falling back to the dot. The reflection builder composes this key as
+    /// <c>indexedKey + attr.Delimiter + propertyKey</c> with the delimiter used verbatim, so substituting the dot
+    /// for an explicitly empty delimiter would make the generated client disagree with it.
+    /// </summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Test]
-    public async Task EmptyIndexedDelimiterUsesDotFallback()
+    public async Task EmptyIndexedDelimiterConcatenatesWithoutSeparator()
     {
-        var result = Fixture.RunGenerator(EmptyDelimiterIndexedSource, generatedRequestBuilding: true);
+        var result = Fixture.RunGenerator(
+            EmptyDelimiterIndexedSource,
+            generatedRequestBuilding: true
+        );
 
         await Assert.That(result.CompilesWithoutErrors).IsTrue();
-        await Assert.That(result.GeneratedSources[Hint]).Contains("items[{");
+        await Assert.That(result.GeneratedSources[Hint]).Contains(ExpectedItemsQueryKeyPrefix);
+        await Assert.That(result.GeneratedSources[Hint]).Contains("}Id");
+        await Assert.That(result.GeneratedSources[Hint]).DoesNotContain("}.Id");
+    }
+
+    /// <summary>Verifies an Indexed parameter that supplies no delimiter still composes its keys under the dot,
+    /// which is the delimiter <c>[Query]</c> itself defaults to.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task UnspecifiedIndexedDelimiterUsesDot()
+    {
+        var result = Fixture.RunGenerator(NullableIndexedSource, generatedRequestBuilding: true);
+
+        await Assert.That(result.CompilesWithoutErrors).IsTrue();
+        await Assert.That(result.GeneratedSources[Hint]).Contains(ExpectedItemsQueryKeyPrefix);
         await Assert.That(result.GeneratedSources[Hint]).Contains("}.Id");
     }
 
@@ -195,7 +220,7 @@ public sealed class IndexedCollectionGenerationTests
 
         await Assert.That(result.CompilesWithoutErrors).IsTrue();
 
-        await Assert.That(generated).Contains("items[{");
+        await Assert.That(generated).Contains(ExpectedItemsQueryKeyPrefix);
     }
 
     /// <summary>Verifies a Indexed parameter whose element type is a scalar (not complex) generates inline
@@ -229,7 +254,7 @@ public sealed class IndexedCollectionGenerationTests
     }
 
     /// <summary>Verifies a Indexed parameter whose element type is a collection with a complex element type falls back to reflective generation.</summary>
-    /// <returns>A task representing the asynchronous test.</returns>    
+    /// <returns>A task representing the asynchronous test.</returns>
     [Test]
     public async Task IndexedWithComplexIndexElementFallsBackToReflective()
     {

--- a/src/tests/Refit.Tests/IQueryObjectApi.cs
+++ b/src/tests/Refit.Tests/IQueryObjectApi.cs
@@ -61,6 +61,19 @@ public interface IQueryObjectApi
     [Get("/nested")]
     Task<string> FlattenNested([Query] NestedQueryObject query);
 
+    /// <summary>Flattens a query object with a nested object property under an explicitly empty delimiter, so the
+    /// nested keys are concatenated with no separator at all.</summary>
+    /// <param name="query">The query object.</param>
+    /// <returns>The response body.</returns>
+    [Get("/nested/empty")]
+    Task<string> FlattenNestedWithEmptyDelimiter([Query(delimiter: "")] NestedQueryObject query);
+
+    /// <summary>Flattens a query object with a nested object property under a custom non-dotted delimiter.</summary>
+    /// <param name="query">The query object.</param>
+    /// <returns>The response body.</returns>
+    [Get("/nested/colon")]
+    Task<string> FlattenNestedWithCustomDelimiter([Query(delimiter: ":")] NestedQueryObject query);
+
     /// <summary>Flattens a query object with a nullable nested value-type property under a dotted key.</summary>
     /// <param name="query">The query object.</param>
     /// <returns>The response body.</returns>

--- a/src/tests/Refit.Tests/QueryObjectFlatteningTests.cs
+++ b/src/tests/Refit.Tests/QueryObjectFlatteningTests.cs
@@ -210,6 +210,39 @@ public class QueryObjectFlatteningTests
             query);
     }
 
+    /// <summary>
+    /// Verifies an explicitly empty <c>[Query]</c> delimiter joins nested keys with nothing at all, rather than
+    /// falling back to the default dot. An absent attribute and an explicitly empty delimiter are different things.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task EmptyDelimiterJoinsNestedKeysWithoutSeparator()
+    {
+        var query = new NestedQueryObject { Name = "ada", Address = new AddressQuery { City = "wien", Zip = "1010" } };
+
+        await AssertParityAsync(
+            "/nested/empty?Name=ada&AddressCity=wien&Addressz=1010",
+            api => api.FlattenNestedWithEmptyDelimiter(query),
+            new RequestBuilderImplementation<IQueryObjectApi>()
+                .BuildRequestFactoryForMethod(nameof(IQueryObjectApi.FlattenNestedWithEmptyDelimiter)),
+            query);
+    }
+
+    /// <summary>Verifies a custom non-dotted <c>[Query]</c> delimiter joins nested keys, matching the reflection builder.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task CustomDelimiterJoinsNestedKeys()
+    {
+        var query = new NestedQueryObject { Name = "ada", Address = new AddressQuery { City = "wien", Zip = "1010" } };
+
+        await AssertParityAsync(
+            "/nested/colon?Name=ada&Address%3ACity=wien&Address%3Az=1010",
+            api => api.FlattenNestedWithCustomDelimiter(query),
+            new RequestBuilderImplementation<IQueryObjectApi>()
+                .BuildRequestFactoryForMethod(nameof(IQueryObjectApi.FlattenNestedWithCustomDelimiter)),
+            query);
+    }
+
     /// <summary>Verifies a custom key formatter is applied to every nested key segment, matching the reflection builder.</summary>
     /// <returns>A task that represents the asynchronous operation.</returns>
     [Test]


### PR DESCRIPTION

<!-- Please read our [Contribute guide](https://www.reactiveui.net/contribute/index.html) before opening a PR, and give this PR a title that follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `fix:`, `feat:`, `docs:`, `build:`). -->

## What kind of change does this PR introduce?
<!-- Bug fix, feature, docs update, refactor, ci, build, ... -->

Fixes #2294.

## What is the new behavior?
<!-- The most important section: describe what this PR changes things TO. For a feature, explain the new functionality; for a fix, describe the corrected behavior. -->

`QueryFormData` is `default` when no `[Query]` attribute is present, so `Delimiter is null` in that case — the `IsNullOrEmpty` guard was there for the absent case, but it swallows `""` along with it. Now `data.Delimiter ?? DefaultNestingDelimiter`, with `Delimiter` retyped to `string?` so the absent case is expressed as null rather than leaning on emptiness. Three call sites: object query, `CollectionFormat.Indexed` collections, and path-residual queries.

## What is the current behavior?
<!-- The OLD, pre-PR behavior on the target branch — i.e. what this PR changes away from. Link any related issue here and use "Closes #123" to auto-close it on merge. -->

The source generated and reflection client generates different queries for empty string delimiters.

## What might this PR break?
<!-- Call out any breaking changes, behavioural changes, or migration steps consumers need. Write "None" if there are none. -->

There should be none, as this pr fixes a mismatch between the reflection based client generation and source generated client.

## Checklist
- [x] I have read the [Contribute guide](https://www.reactiveui.net/contribute/index.html)
- [x] Tests have been added or updated (for bug fixes / features)
- [x] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the `main` branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional information
<!-- Screenshots, benchmarks, links, or anything else that helps reviewers. -->
