### PR TITLE
feat: keyed refit generated client DI registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -2570,6 +2570,23 @@ services.AddRefitGeneratedClient<IWebApi>(provider => new RefitSettings { /* con
 services.AddRefitGeneratedClient<IWebApi>(settings, "my-named-client");
 ```
 
+`AddKeyedRefitGeneratedClient<T>` is the keyed counterpart, mirroring `AddKeyedRefitClient<T>` for the generated-only
+path. It registers the client (and its `SettingsFor<T>`) under a service key so the same interface can be registered
+more than once with different configuration, and each key gets its own named `HttpClient`:
+
+```csharp
+services.AddKeyedRefitGeneratedClient<IWebApi>("primary")
+        .ConfigureHttpClient(c => c.BaseAddress = new Uri("https://primary.example.com"));
+services.AddKeyedRefitGeneratedClient<IWebApi>("secondary", settings)
+        .ConfigureHttpClient(c => c.BaseAddress = new Uri("https://secondary.example.com"));
+
+// resolve with the key
+var primary = provider.GetRequiredKeyedService<IWebApi>("primary");
+```
+
+The same overload shapes are available as the non-keyed helper - settings, a settings factory resolved from the
+container, and a custom `HttpClient` name - each taking the service key as the first argument.
+
 If no source-generated client exists for the interface, resolving it throws an `InvalidOperationException` that points
 you back to the generator output - the registration never silently falls back to reflection.
 

--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -19,6 +19,15 @@ in the [main README](../README.md).
   Refit throws `OperationCanceledException` instead of continuing with partially consumed content. Other buffering
   failures remain best-effort.
 
+### New in V15.x
+
+* **`AddKeyedRefitGeneratedClient<T>` added to `Refit.HttpClientFactory`.** The generated-only registration helper now
+  has the same keyed parity that `AddRefitClient<T>` has with `AddKeyedRefitClient<T>`. All five overload shapes of
+  `AddRefitGeneratedClient<T>` are available with a leading `serviceKey` argument, registering both the client and its
+  `SettingsFor<T>` as keyed services and giving each key its own named `HttpClient`. Purely additive; existing
+  `AddRefitGeneratedClient<T>` calls are unaffected. See
+  [Generated-only client registration](../README.md#generated-only-client-registration-with-ihttpclientfactory).
+
 ## V14.x.x
 
 ### Breaking changes in V14.x

--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -19,15 +19,6 @@ in the [main README](../README.md).
   Refit throws `OperationCanceledException` instead of continuing with partially consumed content. Other buffering
   failures remain best-effort.
 
-### New in V15.x
-
-* **`AddKeyedRefitGeneratedClient<T>` added to `Refit.HttpClientFactory`.** The generated-only registration helper now
-  has the same keyed parity that `AddRefitClient<T>` has with `AddKeyedRefitClient<T>`. All five overload shapes of
-  `AddRefitGeneratedClient<T>` are available with a leading `serviceKey` argument, registering both the client and its
-  `SettingsFor<T>` as keyed services and giving each key its own named `HttpClient`. Purely additive; existing
-  `AddRefitGeneratedClient<T>` calls are unaffected. See
-  [Generated-only client registration](../README.md#generated-only-client-registration-with-ihttpclientfactory).
-
 ## V14.x.x
 
 ### Breaking changes in V14.x

--- a/src/Refit.HttpClientFactory/HttpClientFactoryCore.cs
+++ b/src/Refit.HttpClientFactory/HttpClientFactoryCore.cs
@@ -304,6 +304,56 @@ internal static class HttpClientFactoryCore
                 serviceProvider.GetRequiredService<SettingsFor<T>>().Settings ?? new RefitSettings()));
     }
 
+    /// <summary>Registers a strongly typed, keyed, source-generated Refit client without any reflection fallback.</summary>
+    /// <typeparam name="T">The Refit interface type to register.</typeparam>
+    /// <param name="services">The service collection to register into.</param>
+    /// <param name="serviceKey">The key under which the client is registered.</param>
+    /// <param name="settings">A factory that produces the Refit settings, or null.</param>
+    /// <param name="httpClientName">A name for the underlying HTTP client, or null.</param>
+    /// <returns>The HTTP client builder for further configuration.</returns>
+    [SuppressMessage(
+        "Design",
+        "SST2307:Generic method type parameters should be inferable from the parameters",
+        Justification = "The Refit interface type is intentionally specified explicitly by callers.")]
+    internal static IHttpClientBuilder AddKeyedRefitGeneratedClientCore<T>(
+        IServiceCollection services,
+        object? serviceKey,
+        Func<IServiceProvider, RefitSettings?>? settings,
+        string? httpClientName)
+        where T : class
+    {
+        ArgumentExceptionHelper.ThrowIfNull(services);
+
+        ArgumentExceptionHelper.ThrowIfNull(serviceKey);
+
+        // register settings
+        _ = services.AddKeyedSingleton(
+            serviceKey,
+            (provider, _) => new SettingsFor<T>(settings?.Invoke(provider)));
+
+        // create HttpClientBuilder
+        var builder = services.AddHttpClient(httpClientName ?? UniqueName.ForType<T>(serviceKey));
+
+        // configure primary and additional handlers from the keyed settings
+        ConfigureKeyedHandlers(
+            builder,
+            serviceProvider => serviceProvider.GetRequiredKeyedService<SettingsFor<T>>(serviceKey));
+
+        // add keyed typed client backed by the source generator only; throws clearly if no generated client exists
+        _ = builder.Services.AddKeyedTransient(
+            serviceKey,
+            (s, _) =>
+            {
+                var httpClientFactory = s.GetRequiredService<IHttpClientFactory>();
+                var httpClient = httpClientFactory.CreateClient(builder.Name);
+                return RestService.ForGenerated<T>(
+                    httpClient,
+                    s.GetRequiredKeyedService<SettingsFor<T>>(serviceKey).Settings ?? new RefitSettings());
+            });
+
+        return builder;
+    }
+
     /// <summary>Resolves and caches the open generic <see cref="RequestBuilder.ForType{T}(RefitSettings?)"/> method.</summary>
     /// <returns>The open generic <c>RequestBuilder.ForType</c> method definition.</returns>
     [RequiresUnreferencedCode("Resolving RequestBuilder.ForType by reflection requires method metadata to be available at runtime.")]

--- a/src/Refit.HttpClientFactory/HttpClientFactoryExtensions.ServiceCollection.cs
+++ b/src/Refit.HttpClientFactory/HttpClientFactoryExtensions.ServiceCollection.cs
@@ -661,5 +661,140 @@ public static partial class HttpClientFactoryExtensions
                 settingsAction,
                 httpClientName);
         }
+
+        /// <summary>
+        /// Adds a source-generated Refit client to the dependency injection container under the specified
+        /// service key, without any reflection fallback, making it safe for Native AOT and trimming. The client
+        /// is built through <c>RestService.ForGenerated&lt;T&gt;</c>; if no generated implementation exists for
+        /// <typeparamref name="T"/>, resolving the client throws an <see cref="InvalidOperationException"/>. The
+        /// usual HttpClientFactory features (base address, handlers, resilience pipelines) remain available on
+        /// the returned builder.
+        /// </summary>
+        /// <typeparam name="T">The type of the Refit interface.</typeparam>
+        /// <param name="serviceKey">A key used to associate with the specific Refit client instance.</param>
+        /// <returns>The HTTP client builder for chaining.</returns>
+        [SuppressMessage(
+            "Design",
+            "SST2307:Generic method type parameters should be inferable from the parameters",
+            Justification = "The Refit interface type is intentionally specified explicitly by callers.")]
+        public IHttpClientBuilder AddKeyedRefitGeneratedClient<T>(object? serviceKey)
+            where T : class
+        {
+            ArgumentExceptionHelper.ThrowIfNull(services);
+
+            ArgumentExceptionHelper.ThrowIfNull(serviceKey);
+
+            return HttpClientFactoryCore.AddKeyedRefitGeneratedClientCore<T>(
+                services,
+                serviceKey,
+                static _ => null,
+                null);
+        }
+
+        /// <summary>Adds a source-generated Refit client to the dependency injection container under the specified service key, without any reflection fallback.</summary>
+        /// <typeparam name="T">The type of the Refit interface.</typeparam>
+        /// <param name="serviceKey">A key used to associate with the specific Refit client instance.</param>
+        /// <param name="settings">The settings used to configure the instance.</param>
+        /// <returns>The HTTP client builder for chaining.</returns>
+        [SuppressMessage(
+            "Design",
+            "SST2307:Generic method type parameters should be inferable from the parameters",
+            Justification = "The Refit interface type is intentionally specified explicitly by callers.")]
+        public IHttpClientBuilder AddKeyedRefitGeneratedClient<T>(
+            object? serviceKey,
+            RefitSettings? settings)
+            where T : class
+        {
+            ArgumentExceptionHelper.ThrowIfNull(services);
+
+            ArgumentExceptionHelper.ThrowIfNull(serviceKey);
+
+            return HttpClientFactoryCore.AddKeyedRefitGeneratedClientCore<T>(
+                services,
+                serviceKey,
+                _ => settings,
+                null);
+        }
+
+        /// <summary>Adds a source-generated Refit client to the dependency injection container under the specified service key, without any reflection fallback.</summary>
+        /// <typeparam name="T">The type of the Refit interface.</typeparam>
+        /// <param name="serviceKey">A key used to associate with the specific Refit client instance.</param>
+        /// <param name="settings">The settings used to configure the instance.</param>
+        /// <param name="httpClientName">Allows the name of the underlying HttpClient to be changed.</param>
+        /// <returns>The HTTP client builder for chaining.</returns>
+        [SuppressMessage(
+            "Design",
+            "SST2307:Generic method type parameters should be inferable from the parameters",
+            Justification = "The Refit interface type is intentionally specified explicitly by callers.")]
+        public IHttpClientBuilder AddKeyedRefitGeneratedClient<T>(
+            object? serviceKey,
+            RefitSettings? settings,
+            string? httpClientName)
+            where T : class
+        {
+            ArgumentExceptionHelper.ThrowIfNull(services);
+
+            ArgumentExceptionHelper.ThrowIfNull(serviceKey);
+
+            return HttpClientFactoryCore.AddKeyedRefitGeneratedClientCore<T>(
+                services,
+                serviceKey,
+                _ => settings,
+                httpClientName);
+        }
+
+        /// <summary>Adds a source-generated Refit client to the dependency injection container under the specified service key, without any reflection fallback.</summary>
+        /// <typeparam name="T">The type of the Refit interface.</typeparam>
+        /// <param name="serviceKey">A key used to associate with the specific Refit client instance.</param>
+        /// <param name="settingsAction">An action used to configure the Refit settings from the service provider.</param>
+        /// <returns>The HTTP client builder for chaining.</returns>
+        [System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
+        [SuppressMessage(
+            "Design",
+            "SST2307:Generic method type parameters should be inferable from the parameters",
+            Justification = "The Refit interface type is intentionally specified explicitly by callers.")]
+        public IHttpClientBuilder AddKeyedRefitGeneratedClient<T>(
+            object? serviceKey,
+            Func<IServiceProvider, RefitSettings?>? settingsAction)
+            where T : class
+        {
+            ArgumentExceptionHelper.ThrowIfNull(services);
+
+            ArgumentExceptionHelper.ThrowIfNull(serviceKey);
+
+            return HttpClientFactoryCore.AddKeyedRefitGeneratedClientCore<T>(
+                services,
+                serviceKey,
+                settingsAction,
+                null);
+        }
+
+        /// <summary>Adds a source-generated Refit client to the dependency injection container under the specified service key, without any reflection fallback.</summary>
+        /// <typeparam name="T">The type of the Refit interface.</typeparam>
+        /// <param name="serviceKey">A key used to associate with the specific Refit client instance.</param>
+        /// <param name="settingsAction">An action used to configure the Refit settings from the service provider.</param>
+        /// <param name="httpClientName">Allows the name of the underlying HttpClient to be changed.</param>
+        /// <returns>The HTTP client builder for chaining.</returns>
+        [System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
+        [SuppressMessage(
+            "Design",
+            "SST2307:Generic method type parameters should be inferable from the parameters",
+            Justification = "The Refit interface type is intentionally specified explicitly by callers.")]
+        public IHttpClientBuilder AddKeyedRefitGeneratedClient<T>(
+            object? serviceKey,
+            Func<IServiceProvider, RefitSettings?>? settingsAction,
+            string? httpClientName)
+            where T : class
+        {
+            ArgumentExceptionHelper.ThrowIfNull(services);
+
+            ArgumentExceptionHelper.ThrowIfNull(serviceKey);
+
+            return HttpClientFactoryCore.AddKeyedRefitGeneratedClientCore<T>(
+                services,
+                serviceKey,
+                settingsAction,
+                httpClientName);
+        }
     }
 }

--- a/src/Refit.HttpClientFactory/PublicAPI/net10.0/PublicAPI.txt
+++ b/src/Refit.HttpClientFactory/PublicAPI/net10.0/PublicAPI.txt
@@ -72,6 +72,13 @@ public static class HttpClientFactoryExtensions
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Registering Refit clients with HttpClientFactory requires reflected interface and request metadata.")]
         [System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
         public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddKeyedRefitClient<T>(object? serviceKey, System.Func<System.IServiceProvider, Refit.RefitSettings?>? settingsAction, string? httpClientName) where T : class { }
+        public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddKeyedRefitGeneratedClient<T>(object? serviceKey) where T : class { }
+        public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddKeyedRefitGeneratedClient<T>(object? serviceKey, Refit.RefitSettings? settings) where T : class { }
+        [System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
+        public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddKeyedRefitGeneratedClient<T>(object? serviceKey, System.Func<System.IServiceProvider, Refit.RefitSettings?>? settingsAction) where T : class { }
+        public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddKeyedRefitGeneratedClient<T>(object? serviceKey, Refit.RefitSettings? settings, string? httpClientName) where T : class { }
+        [System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
+        public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddKeyedRefitGeneratedClient<T>(object? serviceKey, System.Func<System.IServiceProvider, Refit.RefitSettings?>? settingsAction, string? httpClientName) where T : class { }
         [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Registering Refit clients by Type with HttpClientFactory requires runtime generic type and method instantiation.")]
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Registering Refit clients with HttpClientFactory requires reflected interface and request metadata.")]
         public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddRefitClient(System.Type refitInterfaceType) { }

--- a/src/Refit.HttpClientFactory/PublicAPI/net11.0/PublicAPI.txt
+++ b/src/Refit.HttpClientFactory/PublicAPI/net11.0/PublicAPI.txt
@@ -72,6 +72,13 @@ public static class HttpClientFactoryExtensions
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Registering Refit clients with HttpClientFactory requires reflected interface and request metadata.")]
         [System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
         public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddKeyedRefitClient<T>(object? serviceKey, System.Func<System.IServiceProvider, Refit.RefitSettings?>? settingsAction, string? httpClientName) where T : class { }
+        public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddKeyedRefitGeneratedClient<T>(object? serviceKey) where T : class { }
+        public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddKeyedRefitGeneratedClient<T>(object? serviceKey, Refit.RefitSettings? settings) where T : class { }
+        [System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
+        public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddKeyedRefitGeneratedClient<T>(object? serviceKey, System.Func<System.IServiceProvider, Refit.RefitSettings?>? settingsAction) where T : class { }
+        public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddKeyedRefitGeneratedClient<T>(object? serviceKey, Refit.RefitSettings? settings, string? httpClientName) where T : class { }
+        [System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
+        public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddKeyedRefitGeneratedClient<T>(object? serviceKey, System.Func<System.IServiceProvider, Refit.RefitSettings?>? settingsAction, string? httpClientName) where T : class { }
         [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Registering Refit clients by Type with HttpClientFactory requires runtime generic type and method instantiation.")]
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Registering Refit clients with HttpClientFactory requires reflected interface and request metadata.")]
         public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddRefitClient(System.Type refitInterfaceType) { }

--- a/src/Refit.HttpClientFactory/PublicAPI/net462/PublicAPI.txt
+++ b/src/Refit.HttpClientFactory/PublicAPI/net462/PublicAPI.txt
@@ -31,6 +31,11 @@ public static class HttpClientFactoryExtensions
         public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddKeyedRefitClient<T>(object? serviceKey, System.Func<System.IServiceProvider, Refit.RefitSettings?>? settingsAction) where T : class { }
         public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddKeyedRefitClient<T>(object? serviceKey, Refit.RefitSettings? settings, string? httpClientName) where T : class { }
         public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddKeyedRefitClient<T>(object? serviceKey, System.Func<System.IServiceProvider, Refit.RefitSettings?>? settingsAction, string? httpClientName) where T : class { }
+        public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddKeyedRefitGeneratedClient<T>(object? serviceKey) where T : class { }
+        public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddKeyedRefitGeneratedClient<T>(object? serviceKey, Refit.RefitSettings? settings) where T : class { }
+        public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddKeyedRefitGeneratedClient<T>(object? serviceKey, System.Func<System.IServiceProvider, Refit.RefitSettings?>? settingsAction) where T : class { }
+        public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddKeyedRefitGeneratedClient<T>(object? serviceKey, Refit.RefitSettings? settings, string? httpClientName) where T : class { }
+        public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddKeyedRefitGeneratedClient<T>(object? serviceKey, System.Func<System.IServiceProvider, Refit.RefitSettings?>? settingsAction, string? httpClientName) where T : class { }
         public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddRefitClient(System.Type refitInterfaceType) { }
         public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddRefitClient(System.Type refitInterfaceType, Refit.RefitSettings? settings) { }
         public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddRefitClient(System.Type refitInterfaceType, System.Func<System.IServiceProvider, Refit.RefitSettings?>? settingsAction) { }

--- a/src/Refit.HttpClientFactory/PublicAPI/net470/PublicAPI.txt
+++ b/src/Refit.HttpClientFactory/PublicAPI/net470/PublicAPI.txt
@@ -31,6 +31,11 @@ public static class HttpClientFactoryExtensions
         public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddKeyedRefitClient<T>(object? serviceKey, System.Func<System.IServiceProvider, Refit.RefitSettings?>? settingsAction) where T : class { }
         public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddKeyedRefitClient<T>(object? serviceKey, Refit.RefitSettings? settings, string? httpClientName) where T : class { }
         public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddKeyedRefitClient<T>(object? serviceKey, System.Func<System.IServiceProvider, Refit.RefitSettings?>? settingsAction, string? httpClientName) where T : class { }
+        public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddKeyedRefitGeneratedClient<T>(object? serviceKey) where T : class { }
+        public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddKeyedRefitGeneratedClient<T>(object? serviceKey, Refit.RefitSettings? settings) where T : class { }
+        public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddKeyedRefitGeneratedClient<T>(object? serviceKey, System.Func<System.IServiceProvider, Refit.RefitSettings?>? settingsAction) where T : class { }
+        public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddKeyedRefitGeneratedClient<T>(object? serviceKey, Refit.RefitSettings? settings, string? httpClientName) where T : class { }
+        public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddKeyedRefitGeneratedClient<T>(object? serviceKey, System.Func<System.IServiceProvider, Refit.RefitSettings?>? settingsAction, string? httpClientName) where T : class { }
         public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddRefitClient(System.Type refitInterfaceType) { }
         public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddRefitClient(System.Type refitInterfaceType, Refit.RefitSettings? settings) { }
         public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddRefitClient(System.Type refitInterfaceType, System.Func<System.IServiceProvider, Refit.RefitSettings?>? settingsAction) { }

--- a/src/Refit.HttpClientFactory/PublicAPI/net471/PublicAPI.txt
+++ b/src/Refit.HttpClientFactory/PublicAPI/net471/PublicAPI.txt
@@ -31,6 +31,11 @@ public static class HttpClientFactoryExtensions
         public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddKeyedRefitClient<T>(object? serviceKey, System.Func<System.IServiceProvider, Refit.RefitSettings?>? settingsAction) where T : class { }
         public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddKeyedRefitClient<T>(object? serviceKey, Refit.RefitSettings? settings, string? httpClientName) where T : class { }
         public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddKeyedRefitClient<T>(object? serviceKey, System.Func<System.IServiceProvider, Refit.RefitSettings?>? settingsAction, string? httpClientName) where T : class { }
+        public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddKeyedRefitGeneratedClient<T>(object? serviceKey) where T : class { }
+        public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddKeyedRefitGeneratedClient<T>(object? serviceKey, Refit.RefitSettings? settings) where T : class { }
+        public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddKeyedRefitGeneratedClient<T>(object? serviceKey, System.Func<System.IServiceProvider, Refit.RefitSettings?>? settingsAction) where T : class { }
+        public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddKeyedRefitGeneratedClient<T>(object? serviceKey, Refit.RefitSettings? settings, string? httpClientName) where T : class { }
+        public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddKeyedRefitGeneratedClient<T>(object? serviceKey, System.Func<System.IServiceProvider, Refit.RefitSettings?>? settingsAction, string? httpClientName) where T : class { }
         public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddRefitClient(System.Type refitInterfaceType) { }
         public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddRefitClient(System.Type refitInterfaceType, Refit.RefitSettings? settings) { }
         public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddRefitClient(System.Type refitInterfaceType, System.Func<System.IServiceProvider, Refit.RefitSettings?>? settingsAction) { }

--- a/src/Refit.HttpClientFactory/PublicAPI/net472/PublicAPI.txt
+++ b/src/Refit.HttpClientFactory/PublicAPI/net472/PublicAPI.txt
@@ -31,6 +31,11 @@ public static class HttpClientFactoryExtensions
         public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddKeyedRefitClient<T>(object? serviceKey, System.Func<System.IServiceProvider, Refit.RefitSettings?>? settingsAction) where T : class { }
         public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddKeyedRefitClient<T>(object? serviceKey, Refit.RefitSettings? settings, string? httpClientName) where T : class { }
         public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddKeyedRefitClient<T>(object? serviceKey, System.Func<System.IServiceProvider, Refit.RefitSettings?>? settingsAction, string? httpClientName) where T : class { }
+        public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddKeyedRefitGeneratedClient<T>(object? serviceKey) where T : class { }
+        public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddKeyedRefitGeneratedClient<T>(object? serviceKey, Refit.RefitSettings? settings) where T : class { }
+        public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddKeyedRefitGeneratedClient<T>(object? serviceKey, System.Func<System.IServiceProvider, Refit.RefitSettings?>? settingsAction) where T : class { }
+        public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddKeyedRefitGeneratedClient<T>(object? serviceKey, Refit.RefitSettings? settings, string? httpClientName) where T : class { }
+        public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddKeyedRefitGeneratedClient<T>(object? serviceKey, System.Func<System.IServiceProvider, Refit.RefitSettings?>? settingsAction, string? httpClientName) where T : class { }
         public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddRefitClient(System.Type refitInterfaceType) { }
         public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddRefitClient(System.Type refitInterfaceType, Refit.RefitSettings? settings) { }
         public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddRefitClient(System.Type refitInterfaceType, System.Func<System.IServiceProvider, Refit.RefitSettings?>? settingsAction) { }

--- a/src/Refit.HttpClientFactory/PublicAPI/net48/PublicAPI.txt
+++ b/src/Refit.HttpClientFactory/PublicAPI/net48/PublicAPI.txt
@@ -31,6 +31,11 @@ public static class HttpClientFactoryExtensions
         public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddKeyedRefitClient<T>(object? serviceKey, System.Func<System.IServiceProvider, Refit.RefitSettings?>? settingsAction) where T : class { }
         public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddKeyedRefitClient<T>(object? serviceKey, Refit.RefitSettings? settings, string? httpClientName) where T : class { }
         public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddKeyedRefitClient<T>(object? serviceKey, System.Func<System.IServiceProvider, Refit.RefitSettings?>? settingsAction, string? httpClientName) where T : class { }
+        public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddKeyedRefitGeneratedClient<T>(object? serviceKey) where T : class { }
+        public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddKeyedRefitGeneratedClient<T>(object? serviceKey, Refit.RefitSettings? settings) where T : class { }
+        public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddKeyedRefitGeneratedClient<T>(object? serviceKey, System.Func<System.IServiceProvider, Refit.RefitSettings?>? settingsAction) where T : class { }
+        public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddKeyedRefitGeneratedClient<T>(object? serviceKey, Refit.RefitSettings? settings, string? httpClientName) where T : class { }
+        public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddKeyedRefitGeneratedClient<T>(object? serviceKey, System.Func<System.IServiceProvider, Refit.RefitSettings?>? settingsAction, string? httpClientName) where T : class { }
         public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddRefitClient(System.Type refitInterfaceType) { }
         public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddRefitClient(System.Type refitInterfaceType, Refit.RefitSettings? settings) { }
         public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddRefitClient(System.Type refitInterfaceType, System.Func<System.IServiceProvider, Refit.RefitSettings?>? settingsAction) { }

--- a/src/Refit.HttpClientFactory/PublicAPI/net481/PublicAPI.txt
+++ b/src/Refit.HttpClientFactory/PublicAPI/net481/PublicAPI.txt
@@ -31,6 +31,11 @@ public static class HttpClientFactoryExtensions
         public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddKeyedRefitClient<T>(object? serviceKey, System.Func<System.IServiceProvider, Refit.RefitSettings?>? settingsAction) where T : class { }
         public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddKeyedRefitClient<T>(object? serviceKey, Refit.RefitSettings? settings, string? httpClientName) where T : class { }
         public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddKeyedRefitClient<T>(object? serviceKey, System.Func<System.IServiceProvider, Refit.RefitSettings?>? settingsAction, string? httpClientName) where T : class { }
+        public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddKeyedRefitGeneratedClient<T>(object? serviceKey) where T : class { }
+        public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddKeyedRefitGeneratedClient<T>(object? serviceKey, Refit.RefitSettings? settings) where T : class { }
+        public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddKeyedRefitGeneratedClient<T>(object? serviceKey, System.Func<System.IServiceProvider, Refit.RefitSettings?>? settingsAction) where T : class { }
+        public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddKeyedRefitGeneratedClient<T>(object? serviceKey, Refit.RefitSettings? settings, string? httpClientName) where T : class { }
+        public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddKeyedRefitGeneratedClient<T>(object? serviceKey, System.Func<System.IServiceProvider, Refit.RefitSettings?>? settingsAction, string? httpClientName) where T : class { }
         public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddRefitClient(System.Type refitInterfaceType) { }
         public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddRefitClient(System.Type refitInterfaceType, Refit.RefitSettings? settings) { }
         public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddRefitClient(System.Type refitInterfaceType, System.Func<System.IServiceProvider, Refit.RefitSettings?>? settingsAction) { }

--- a/src/Refit.HttpClientFactory/PublicAPI/net8.0/PublicAPI.txt
+++ b/src/Refit.HttpClientFactory/PublicAPI/net8.0/PublicAPI.txt
@@ -64,6 +64,11 @@ public static class HttpClientFactoryExtensions
         public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddKeyedRefitClient<T>(object? serviceKey, Refit.RefitSettings? settings, string? httpClientName) where T : class { }
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Registering Refit clients with HttpClientFactory requires reflected interface and request metadata.")]
         public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddKeyedRefitClient<T>(object? serviceKey, System.Func<System.IServiceProvider, Refit.RefitSettings?>? settingsAction, string? httpClientName) where T : class { }
+        public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddKeyedRefitGeneratedClient<T>(object? serviceKey) where T : class { }
+        public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddKeyedRefitGeneratedClient<T>(object? serviceKey, Refit.RefitSettings? settings) where T : class { }
+        public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddKeyedRefitGeneratedClient<T>(object? serviceKey, System.Func<System.IServiceProvider, Refit.RefitSettings?>? settingsAction) where T : class { }
+        public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddKeyedRefitGeneratedClient<T>(object? serviceKey, Refit.RefitSettings? settings, string? httpClientName) where T : class { }
+        public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddKeyedRefitGeneratedClient<T>(object? serviceKey, System.Func<System.IServiceProvider, Refit.RefitSettings?>? settingsAction, string? httpClientName) where T : class { }
         [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Registering Refit clients by Type with HttpClientFactory requires runtime generic type and method instantiation.")]
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Registering Refit clients with HttpClientFactory requires reflected interface and request metadata.")]
         public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddRefitClient(System.Type refitInterfaceType) { }

--- a/src/Refit.HttpClientFactory/PublicAPI/net9.0/PublicAPI.txt
+++ b/src/Refit.HttpClientFactory/PublicAPI/net9.0/PublicAPI.txt
@@ -72,6 +72,13 @@ public static class HttpClientFactoryExtensions
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Registering Refit clients with HttpClientFactory requires reflected interface and request metadata.")]
         [System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
         public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddKeyedRefitClient<T>(object? serviceKey, System.Func<System.IServiceProvider, Refit.RefitSettings?>? settingsAction, string? httpClientName) where T : class { }
+        public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddKeyedRefitGeneratedClient<T>(object? serviceKey) where T : class { }
+        public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddKeyedRefitGeneratedClient<T>(object? serviceKey, Refit.RefitSettings? settings) where T : class { }
+        [System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
+        public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddKeyedRefitGeneratedClient<T>(object? serviceKey, System.Func<System.IServiceProvider, Refit.RefitSettings?>? settingsAction) where T : class { }
+        public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddKeyedRefitGeneratedClient<T>(object? serviceKey, Refit.RefitSettings? settings, string? httpClientName) where T : class { }
+        [System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
+        public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddKeyedRefitGeneratedClient<T>(object? serviceKey, System.Func<System.IServiceProvider, Refit.RefitSettings?>? settingsAction, string? httpClientName) where T : class { }
         [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Registering Refit clients by Type with HttpClientFactory requires runtime generic type and method instantiation.")]
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Registering Refit clients with HttpClientFactory requires reflected interface and request metadata.")]
         public Microsoft.Extensions.DependencyInjection.IHttpClientBuilder AddRefitClient(System.Type refitInterfaceType) { }

--- a/src/tests/Refit.Tests/HttpClientFactoryExtensionsTests.KeyedGeneratedClient.cs
+++ b/src/tests/Refit.Tests/HttpClientFactoryExtensionsTests.KeyedGeneratedClient.cs
@@ -1,0 +1,270 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+using System.Net;
+using System.Net.Http;
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Refit.Tests;
+
+/// <summary>Tests for the keyed, generated-only Refit dependency-injection extension methods.</summary>
+public partial class HttpClientFactoryExtensionsTests
+{
+    /// <summary>The service key used for the keyed generated-client registrations under test.</summary>
+    private const string GeneratedServiceKey = "generated-keyed";
+
+    /// <summary>Verifies the keyed generated-only DI helper resolves a source-generated client under its key and injects the supplied settings.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task AddKeyedRefitGeneratedClientResolvesGeneratedImplementation()
+    {
+        RestService.RegisterGeneratedSettingsFactory<IGeneratedSettingsFactoryApi>(
+            static (client, settings) => new GeneratedSettingsFactoryApiClient(client, settings));
+
+        var settings = new RefitSettings(new SystemTextJsonContentSerializer());
+        var serviceCollection = new ServiceCollection();
+        var builder = serviceCollection.AddKeyedRefitGeneratedClient<IGeneratedSettingsFactoryApi>(
+            GeneratedServiceKey,
+            settings);
+        _ = builder.ConfigureHttpClient(static c => c.BaseAddress = new("http://generated-keyed/"));
+
+        await Assert.That(serviceCollection).Contains(
+            static z => z.ServiceType == typeof(SettingsFor<IGeneratedSettingsFactoryApi>)
+                && z.IsKeyedService);
+
+        var serviceProvider = serviceCollection.BuildServiceProvider();
+        var resolved = serviceProvider.GetRequiredKeyedService<IGeneratedSettingsFactoryApi>(
+            GeneratedServiceKey);
+
+        var generated = await Assert.That(resolved).IsTypeOf<GeneratedSettingsFactoryApiClient>();
+        await Assert.That(generated!.Settings).IsSameReferenceAs(settings);
+        await Assert.That(generated.Client.BaseAddress).IsEqualTo(new("http://generated-keyed/"));
+    }
+
+    /// <summary>Verifies the keyed generated-only registration is not resolvable without the key.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task AddKeyedRefitGeneratedClientIsNotResolvableWithoutKey()
+    {
+        RestService.RegisterGeneratedSettingsFactory<IGeneratedSettingsFactoryApi>(
+            static (client, settings) => new GeneratedSettingsFactoryApiClient(client, settings));
+
+        var serviceCollection = new ServiceCollection();
+        _ = serviceCollection.AddKeyedRefitGeneratedClient<IGeneratedSettingsFactoryApi>(
+            GeneratedServiceKey);
+
+        var serviceProvider = serviceCollection.BuildServiceProvider();
+
+        await Assert.That(serviceProvider.GetService<IGeneratedSettingsFactoryApi>()).IsNull();
+    }
+
+    /// <summary>Verifies the settings-factory overload of the keyed generated-only DI helper resolves settings from the provider.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task AddKeyedRefitGeneratedClientUsesSettingsFactoryFromProvider()
+    {
+        RestService.RegisterGeneratedSettingsFactory<IGeneratedSettingsFactoryApi>(
+            static (client, settings) => new GeneratedSettingsFactoryApiClient(client, settings));
+
+        var serializer = new SystemTextJsonContentSerializer();
+        var serviceCollection = new ServiceCollection();
+        _ = serviceCollection.AddSingleton(new ClientOptions { Serializer = serializer });
+        _ = serviceCollection.AddKeyedRefitGeneratedClient<IGeneratedSettingsFactoryApi>(
+            GeneratedServiceKey,
+            static provider => new RefitSettings(provider.GetRequiredService<ClientOptions>().Serializer!));
+
+        var serviceProvider = serviceCollection.BuildServiceProvider();
+        var resolved = serviceProvider.GetRequiredKeyedService<IGeneratedSettingsFactoryApi>(
+            GeneratedServiceKey);
+
+        var generated = await Assert.That(resolved).IsTypeOf<GeneratedSettingsFactoryApiClient>();
+        await Assert.That(generated!.Settings.ContentSerializer).IsSameReferenceAs(serializer);
+    }
+
+    /// <summary>Verifies the key-only overload resolves a client with default settings and the default primary handler.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task AddKeyedRefitGeneratedClientWithoutSettingsResolvesWithDefaults()
+    {
+        RestService.RegisterGeneratedSettingsFactory<IGeneratedSettingsFactoryApi>(
+            static (client, settings) => new GeneratedSettingsFactoryApiClient(client, settings));
+
+        var serviceCollection = new ServiceCollection();
+        _ = serviceCollection.AddKeyedRefitGeneratedClient<IGeneratedSettingsFactoryApi>(
+            GeneratedServiceKey);
+
+        var serviceProvider = serviceCollection.BuildServiceProvider();
+        var resolved = serviceProvider.GetRequiredKeyedService<IGeneratedSettingsFactoryApi>(
+            GeneratedServiceKey);
+
+        var generated = await Assert.That(resolved).IsTypeOf<GeneratedSettingsFactoryApiClient>();
+
+        // No settings were supplied, so ForGenerated receives a fresh default RefitSettings instance.
+        await Assert.That(generated!.Settings).IsNotNull();
+    }
+
+    /// <summary>Verifies the settings-and-name overload honors the custom client name and builds the handler from the supplied settings.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task AddKeyedRefitGeneratedClientWithSettingsAndNameUsesCustomNameAndHandler()
+    {
+        RestService.RegisterGeneratedSettingsFactory<IGeneratedSettingsFactoryApi>(
+            static (client, settings) => new GeneratedSettingsFactoryApiClient(client, settings));
+
+        var recordingHandler = new RecordingHandler();
+        var settings = new RefitSettings { HttpMessageHandlerFactory = () => recordingHandler };
+        var serviceCollection = new ServiceCollection();
+        var builder = serviceCollection.AddKeyedRefitGeneratedClient<IGeneratedSettingsFactoryApi>(
+            GeneratedServiceKey,
+            settings,
+            "generated-keyed-named-client");
+
+        await Assert.That(builder.Name).IsEqualTo("generated-keyed-named-client");
+
+        var serviceProvider = serviceCollection.BuildServiceProvider();
+        var resolved = serviceProvider.GetRequiredKeyedService<IGeneratedSettingsFactoryApi>(
+            GeneratedServiceKey);
+
+        var generated = await Assert.That(resolved).IsTypeOf<GeneratedSettingsFactoryApiClient>();
+        await Assert.That(generated!.Settings).IsSameReferenceAs(settings);
+    }
+
+    /// <summary>Verifies the settings-factory-and-name overload honors the custom client name.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task AddKeyedRefitGeneratedClientWithSettingsFactoryAndNameUsesCustomName()
+    {
+        RestService.RegisterGeneratedSettingsFactory<IGeneratedSettingsFactoryApi>(
+            static (client, settings) => new GeneratedSettingsFactoryApiClient(client, settings));
+
+        var serviceCollection = new ServiceCollection();
+        var builder = serviceCollection.AddKeyedRefitGeneratedClient<IGeneratedSettingsFactoryApi>(
+            GeneratedServiceKey,
+            static _ => new RefitSettings(),
+            "generated-keyed-factory-named-client");
+
+        await Assert.That(builder.Name).IsEqualTo("generated-keyed-factory-named-client");
+
+        var serviceProvider = serviceCollection.BuildServiceProvider();
+        var resolved = serviceProvider.GetRequiredKeyedService<IGeneratedSettingsFactoryApi>(
+            GeneratedServiceKey);
+
+        _ = await Assert.That(resolved).IsTypeOf<GeneratedSettingsFactoryApiClient>();
+    }
+
+    /// <summary>Verifies two keys for the same interface produce independently configured HTTP clients.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task AddKeyedRefitGeneratedClientIsolatesRegistrationsPerKey()
+    {
+        RestService.RegisterGeneratedSettingsFactory<IGeneratedSettingsFactoryApi>(
+            static (client, settings) => new GeneratedSettingsFactoryApiClient(client, settings));
+
+        var serviceCollection = new ServiceCollection();
+        _ = serviceCollection
+            .AddKeyedRefitGeneratedClient<IGeneratedSettingsFactoryApi>("primary")
+            .ConfigureHttpClient(static c => c.BaseAddress = new("http://primary/"));
+        _ = serviceCollection
+            .AddKeyedRefitGeneratedClient<IGeneratedSettingsFactoryApi>("secondary")
+            .ConfigureHttpClient(static c => c.BaseAddress = new("http://secondary/"));
+
+        var serviceProvider = serviceCollection.BuildServiceProvider();
+        var primary = (GeneratedSettingsFactoryApiClient)serviceProvider
+            .GetRequiredKeyedService<IGeneratedSettingsFactoryApi>("primary");
+        var secondary = (GeneratedSettingsFactoryApiClient)serviceProvider
+            .GetRequiredKeyedService<IGeneratedSettingsFactoryApi>("secondary");
+
+        await Assert.That(primary.Client.BaseAddress).IsEqualTo(new("http://primary/"));
+        await Assert.That(secondary.Client.BaseAddress).IsEqualTo(new("http://secondary/"));
+    }
+
+    /// <summary>Verifies the keyed generated registration composes the configured handler and the authorization getter.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task AddKeyedRefitGeneratedClientComposesConfiguredHandlerAndAuthorizationGetter()
+    {
+        RestService.RegisterGeneratedSettingsFactory<IGeneratedSettingsFactoryApi>(
+            static (client, settings) => new GeneratedSettingsFactoryApiClient(client, settings));
+
+        var recordingHandler = new RecordingHandler();
+        var services = new ServiceCollection();
+        var builder = services.AddKeyedRefitGeneratedClient<IGeneratedSettingsFactoryApi>(
+            GeneratedServiceKey,
+            new RefitSettings
+            {
+                HttpMessageHandlerFactory = () => recordingHandler,
+                AuthorizationHeaderValueGetter = static (_, _) => new ValueTask<string>("generated-keyed-token")
+            });
+        var serviceProvider = services.BuildServiceProvider();
+        var client = serviceProvider.GetRequiredService<IHttpClientFactory>().CreateClient(builder.Name);
+        client.DefaultRequestHeaders.Authorization = new("Bearer", "placeholder");
+
+        using var response = await client.GetAsync(new Uri("https://example.test"));
+
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
+        await Assert.That(recordingHandler.AuthorizationParameter).IsEqualTo("generated-keyed-token");
+    }
+
+    /// <summary>Verifies every keyed generated overload rejects a null service collection and a null service key.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task AddKeyedRefitGeneratedClientRejectsNullArguments()
+    {
+        IServiceCollection nullServices = null!;
+
+        await Assert.That(
+                () => nullServices.AddKeyedRefitGeneratedClient<IGeneratedSettingsFactoryApi>(GeneratedServiceKey))
+            .ThrowsExactly<ArgumentNullException>();
+        await Assert.That(
+                () => nullServices.AddKeyedRefitGeneratedClient<IGeneratedSettingsFactoryApi>(
+                    GeneratedServiceKey,
+                    new RefitSettings()))
+            .ThrowsExactly<ArgumentNullException>();
+        await Assert.That(
+                () => nullServices.AddKeyedRefitGeneratedClient<IGeneratedSettingsFactoryApi>(
+                    GeneratedServiceKey,
+                    new RefitSettings(),
+                    ServiceClientName))
+            .ThrowsExactly<ArgumentNullException>();
+        await Assert.That(
+                () => nullServices.AddKeyedRefitGeneratedClient<IGeneratedSettingsFactoryApi>(
+                    GeneratedServiceKey,
+                    static _ => null))
+            .ThrowsExactly<ArgumentNullException>();
+        await Assert.That(
+                () => nullServices.AddKeyedRefitGeneratedClient<IGeneratedSettingsFactoryApi>(
+                    GeneratedServiceKey,
+                    static _ => null,
+                    ServiceClientName))
+            .ThrowsExactly<ArgumentNullException>();
+
+        var services = new ServiceCollection();
+
+        await Assert.That(
+                () => services.AddKeyedRefitGeneratedClient<IGeneratedSettingsFactoryApi>(null!))
+            .ThrowsExactly<ArgumentNullException>();
+        await Assert.That(
+                () => services.AddKeyedRefitGeneratedClient<IGeneratedSettingsFactoryApi>(
+                    null!,
+                    new RefitSettings()))
+            .ThrowsExactly<ArgumentNullException>();
+        await Assert.That(
+                () => services.AddKeyedRefitGeneratedClient<IGeneratedSettingsFactoryApi>(
+                    null!,
+                    new RefitSettings(),
+                    ServiceClientName))
+            .ThrowsExactly<ArgumentNullException>();
+        await Assert.That(
+                () => services.AddKeyedRefitGeneratedClient<IGeneratedSettingsFactoryApi>(
+                    null!,
+                    static _ => null))
+            .ThrowsExactly<ArgumentNullException>();
+        await Assert.That(
+                () => services.AddKeyedRefitGeneratedClient<IGeneratedSettingsFactoryApi>(
+                    null!,
+                    static _ => null,
+                    ServiceClientName))
+            .ThrowsExactly<ArgumentNullException>();
+    }
+}


### PR DESCRIPTION
<!-- Please read our [Contribute guide](https://www.reactiveui.net/contribute/index.html) before opening a PR, and give this PR a title that follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `fix:`, `feat:`, `docs:`, `build:`). -->

## What kind of change does this PR introduce?
<!-- Bug fix, feature, docs update, refactor, ci, build, ... -->

Fixes #2296.

## What is the new behavior?
<!-- The most important section: describe what this PR changes things TO. For a feature, explain the new functionality; for a fix, describe the corrected behavior. -->

Adds `AddKeyedRefitGeneratedClient<T>` to `Refit.HttpClientFactory`, the keyed counterpart to
`AddRefitGeneratedClient<T>`. Before this, `Refit.HttpClientFactory` offered keyed registration only on the
reflection-capable path (`AddRefitClient` / `AddKeyedRefitClient`), so Native AOT and trimmed applications —
which are steered toward `AddRefitGeneratedClient<T>` — could not register the same interface more than once
with different configuration without giving up the AOT-clean path.

## What is the current behavior?
<!-- The OLD, pre-PR behavior on the target branch — i.e. what this PR changes away from. Link any related issue here and use "Closes #123" to auto-close it on merge. -->

There are only reflection based overloads for registering keyed clients.

## What might this PR break?
<!-- Call out any breaking changes, behavioural changes, or migration steps consumers need. Write "None" if there are none. -->

Nothing

## Checklist
- [x] I have read the [Contribute guide](https://www.reactiveui.net/contribute/index.html)
- [x] Tests have been added or updated (for bug fixes / features)
- [x] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the `main` branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional information
<!-- Screenshots, benchmarks, links, or anything else that helps reviewers. -->
