### PR TITLE
perf(generator): return the request task instead of awaiting it

### DIFF
--- a/src/InterfaceStubGenerator.Shared/Emitter.Helpers.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.Helpers.cs
@@ -89,21 +89,23 @@ internal static partial class Emitter
             _ => $"new global::System.Net.Http.HttpMethod({ToCSharpStringLiteral(httpMethod)})"
         };
 
-    /// <summary>Gets the invocation text used for a generated method return type.</summary>
+    /// <summary>Gets the statement prefix used for a generated method return type.</summary>
     /// <param name="returnTypeInfo">The method return type shape.</param>
-    /// <returns>The async flag, return prefix, and configure-await suffix.</returns>
+    /// <returns>The return statement prefix, empty for a shape that discards the call's result.</returns>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="returnTypeInfo"/> is unsupported.</exception>
-    internal static (bool IsAsync, string ReturnPrefix, string ConfigureAwaitSuffix) GetReturnInvocationParts(
-        ReturnTypeInfo returnTypeInfo) =>
+    /// <remarks>An awaitable shape hands its task straight back rather than awaiting it. Awaiting here would build a
+    /// second state machine per call that forwards the task the request builder already produced, changing nothing but
+    /// the allocation count; the awaitable is the caller's to consume.</remarks>
+    internal static string GetReturnStatementPrefix(ReturnTypeInfo returnTypeInfo) =>
         returnTypeInfo switch
         {
-            ReturnTypeInfo.AsyncVoid => (true, "await (", ").ConfigureAwait(false)"),
-            ReturnTypeInfo.AsyncResult => (true, "return await (", ").ConfigureAwait(false)"),
-            ReturnTypeInfo.AsyncEnumerable
+            ReturnTypeInfo.AsyncVoid
+            or ReturnTypeInfo.AsyncResult
+            or ReturnTypeInfo.AsyncEnumerable
             or ReturnTypeInfo.Observable
             or ReturnTypeInfo.RequestMessage
-            or ReturnTypeInfo.Return => (false, ReturnStatementPrefix, string.Empty),
-            ReturnTypeInfo.SyncVoid => (false, string.Empty, string.Empty),
+            or ReturnTypeInfo.Return => ReturnStatementPrefix,
+            ReturnTypeInfo.SyncVoid => string.Empty,
             _ => throw new ArgumentOutOfRangeException(
                 nameof(returnTypeInfo),
                 returnTypeInfo,
@@ -223,26 +225,25 @@ internal static partial class Emitter
     /// <param name="isDerivedExplicitImpl">True if the method is a derived explicit implementation.</param>
     /// <param name="isExplicitInterface">True if the method is an explicit interface implementation.</param>
     /// <param name="supportsNullable">Whether the consumer compilation supports nullable reference type syntax.</param>
-    /// <param name="isAsync">True if the method should be emitted as async.</param>
     /// <param name="methodAttributes">Attribute lines emitted between the documentation and the signature.</param>
+    /// <remarks>Every generated method is emitted synchronously: an awaitable return type is handed back to the caller
+    /// rather than awaited, so no generated method carries an async state machine.</remarks>
     internal static void AppendMethodOpening(
         PooledStringBuilder builder,
         in MethodModel methodModel,
         bool isDerivedExplicitImpl,
         bool isExplicitInterface,
         bool supportsNullable,
-        bool isAsync = false,
         string methodAttributes = "")
     {
         var visibility = !isExplicitInterface ? "public " : string.Empty;
-        var asyncKeyword = isAsync ? "async " : string.Empty;
         var explicitInterface = BuildExplicitInterfacePrefix(methodModel, isExplicitInterface);
         var methodIndent = Indent(MethodMemberIndentation);
 
         _ = builder
             .AppendLine()
             .Append(methodIndent).AppendLine("/// <inheritdoc />")
-            .Append(methodAttributes).Append(methodIndent).Append(visibility).Append(asyncKeyword)
+            .Append(methodAttributes).Append(methodIndent).Append(visibility)
             .Append(methodModel.ReturnType).Append(' ').Append(explicitInterface).Append(methodModel.DeclaredMethod)
             .Append('(').Append(BuildParameterList(methodModel.Parameters, supportsNullable)).Append(')').AppendLine();
         AppendConstraints(builder, methodModel.Constraints, isDerivedExplicitImpl || isExplicitInterface, MethodBodyIndentation);
@@ -254,7 +255,6 @@ internal static partial class Emitter
     /// <param name="isDerivedExplicitImpl">True if the method is a derived explicit implementation.</param>
     /// <param name="isExplicitInterface">True if the method is an explicit interface implementation.</param>
     /// <param name="supportsNullable">Whether the consumer compilation supports nullable reference type syntax.</param>
-    /// <param name="isAsync">True if the method should be emitted as async.</param>
     /// <param name="methodAttributes">Attribute lines emitted between the documentation and the signature.</param>
     /// <returns>The generated method opening.</returns>
     internal static string BuildMethodOpening(
@@ -262,11 +262,10 @@ internal static partial class Emitter
         bool isDerivedExplicitImpl,
         bool isExplicitInterface,
         bool supportsNullable,
-        bool isAsync = false,
         string methodAttributes = "")
     {
         var builder = new PooledStringBuilder();
-        AppendMethodOpening(builder, methodModel, isDerivedExplicitImpl, isExplicitInterface, supportsNullable, isAsync, methodAttributes);
+        AppendMethodOpening(builder, methodModel, isDerivedExplicitImpl, isExplicitInterface, supportsNullable, methodAttributes);
         return builder.ToString();
     }
 

--- a/src/InterfaceStubGenerator.Shared/Emitter.Inline.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.Inline.cs
@@ -71,12 +71,12 @@ internal static partial class Emitter
             methodModel,
             uniqueNames);
         var returnType = methodModel.ReturnType;
-        var (isAsync, @return, configureAwait) = GetReturnInvocationParts(methodModel.ReturnTypeMetadata);
+        var @return = GetReturnStatementPrefix(methodModel.ReturnTypeMetadata);
         var isExplicit = methodModel.IsExplicitInterface || !isTopLevel;
         var lookupName = StripExplicitInterfacePrefix(methodModel.Name);
         var typeParameterExpression = BuildTypeParameterExpression(methodModel.Parameters, cachedTypeParameterFieldName);
         var genericTypesArgument = BuildGenericTypesArgument(methodModel);
-        var returnStatement = BuildRefitReturnStatement(methodModel, @return, returnType, configureAwait, funcLocal, argumentsLocal);
+        var returnStatement = BuildRefitReturnStatement(methodModel, @return, returnType, funcLocal, argumentsLocal);
         var methodIndent = Indent(MethodMemberIndentation);
         var bodyIndent = Indent(MethodBodyIndentation);
         var requestBuilderInit =
@@ -89,7 +89,6 @@ internal static partial class Emitter
                 isExplicit,
                 isExplicit,
                 interfaceModel.SupportsNullable,
-                isAsync,
                 BuildReflectionFallbackSuppressions(
                     methodModel.RequiresUnreferencedCode,
                     methodModel.RequiresDynamicCode)))

--- a/src/InterfaceStubGenerator.Shared/Emitter.ReflectionArguments.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.ReflectionArguments.cs
@@ -229,7 +229,6 @@ internal static partial class Emitter
     /// <param name="methodModel">The method model being emitted.</param>
     /// <param name="returnPrefix">The return statement prefix.</param>
     /// <param name="returnType">The generated return type.</param>
-    /// <param name="configureAwait">The generated configure-await suffix.</param>
     /// <param name="funcLocal">The generated request-func local name.</param>
     /// <param name="argumentsLocal">The generated arguments-array local name.</param>
     /// <returns>The generated return statement.</returns>
@@ -237,13 +236,12 @@ internal static partial class Emitter
         in MethodModel methodModel,
         string returnPrefix,
         string returnType,
-        string configureAwait,
         string funcLocal,
         string argumentsLocal)
     {
         var bodyIndent = Indent(MethodBodyIndentation);
         return methodModel.ReturnTypeMetadata == ReturnTypeInfo.SyncVoid
             ? $"{bodyIndent}{funcLocal}(this.Client, {argumentsLocal});\n"
-            : $"{bodyIndent}{returnPrefix}({returnType}){funcLocal}(this.Client, {argumentsLocal}){configureAwait};\n";
+            : $"{bodyIndent}{returnPrefix}({returnType}){funcLocal}(this.Client, {argumentsLocal});\n";
     }
 }

--- a/src/tests/Refit.GeneratorTests/GeneratedRequestBuildingTests.InlineEmissionAndFallbacks.cs
+++ b/src/tests/Refit.GeneratorTests/GeneratedRequestBuildingTests.InlineEmissionAndFallbacks.cs
@@ -23,6 +23,34 @@ public partial class GeneratedRequestBuildingTests
         await Assert.That(generated).DoesNotContain("GeneratedRequestRunner.AddHeaderCollection");
     }
 
+    /// <summary>Verifies a reflection-fallback method hands its task straight back to the caller rather than awaiting
+    /// it, so no generated method carries an async state machine that only forwards the request builder's task.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task SwitchOnFallbackReturnsTheRequestBuilderTaskWithoutAwaiting()
+    {
+        var generated = Fixture.GenerateForBody(
+            """
+            [Get("/query-map")]
+            Task<string> Search(object filters);
+
+            [Get("/ping-map")]
+            Task Ping(object filters);
+            """,
+            GeneratedClientHintName,
+            generatedRequestBuilding: true);
+
+        await Assert.That(generated).Contains(ReflectiveRequestBuilderCall);
+        await Assert.That(generated).Contains("public global::System.Threading.Tasks.Task<string> Search(");
+        await Assert.That(generated).Contains("public global::System.Threading.Tasks.Task Ping(");
+        await Assert.That(generated).Contains("return (global::System.Threading.Tasks.Task<string>)refitFunc(");
+        await Assert.That(generated).Contains("return (global::System.Threading.Tasks.Task)refitFunc(");
+
+        // No state machine and therefore nothing to configure: the awaitable is the caller's to consume.
+        await Assert.That(generated).DoesNotContain("public async ");
+        await Assert.That(generated).DoesNotContain("ConfigureAwait");
+    }
+
     /// <summary>Verifies unsupported inline path forms and metadata fall back to the runtime builder.</summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Test]

--- a/src/tests/Refit.GeneratorTests/GeneratorComponentTests.EmitterHelpers.cs
+++ b/src/tests/Refit.GeneratorTests/GeneratorComponentTests.EmitterHelpers.cs
@@ -24,6 +24,9 @@ public static partial class GeneratorComponentTests
         /// <summary>The non-standard HTTP method attribute name used by candidate-combining tests.</summary>
         private const string CustomMethodName = "Custom";
 
+        /// <summary>The generated return statement prefix.</summary>
+        private const string ReturnPrefix = "return ";
+
         /// <summary>The generated false literal.</summary>
         private const string FalseLiteral = "false";
 
@@ -297,20 +300,20 @@ public static partial class GeneratorComponentTests
             await Assert.That(Emitter.ToHttpMethodExpression("TRACE")).IsEqualTo("new global::System.Net.Http.HttpMethod(\"TRACE\")");
         }
 
-        /// <summary>Verifies generated return invocation text for every return type shape.</summary>
+        /// <summary>Verifies the generated return statement prefix for every return type shape, including that an
+        /// awaitable shape returns its task rather than awaiting it.</summary>
         /// <returns>A task representing the asynchronous test.</returns>
         [Test]
-        public async Task ReturnInvocationParts_HandleKnownAndInvalidValues()
+        public async Task ReturnStatementPrefix_HandlesKnownAndInvalidValues()
         {
-            await Assert.That(Emitter.GetReturnInvocationParts(ReturnTypeInfo.AsyncVoid))
-                .IsEqualTo((true, "await (", ").ConfigureAwait(false)"));
-            await Assert.That(Emitter.GetReturnInvocationParts(ReturnTypeInfo.AsyncResult))
-                .IsEqualTo((true, "return await (", ").ConfigureAwait(false)"));
-            await Assert.That(Emitter.GetReturnInvocationParts(ReturnTypeInfo.Return))
-                .IsEqualTo((false, "return ", string.Empty));
-            await Assert.That(Emitter.GetReturnInvocationParts(ReturnTypeInfo.SyncVoid))
-                .IsEqualTo((false, string.Empty, string.Empty));
-            await Assert.That(static () => Emitter.GetReturnInvocationParts((ReturnTypeInfo)int.MaxValue))
+            await Assert.That(Emitter.GetReturnStatementPrefix(ReturnTypeInfo.AsyncVoid)).IsEqualTo(ReturnPrefix);
+            await Assert.That(Emitter.GetReturnStatementPrefix(ReturnTypeInfo.AsyncResult)).IsEqualTo(ReturnPrefix);
+            await Assert.That(Emitter.GetReturnStatementPrefix(ReturnTypeInfo.AsyncEnumerable)).IsEqualTo(ReturnPrefix);
+            await Assert.That(Emitter.GetReturnStatementPrefix(ReturnTypeInfo.Observable)).IsEqualTo(ReturnPrefix);
+            await Assert.That(Emitter.GetReturnStatementPrefix(ReturnTypeInfo.RequestMessage)).IsEqualTo(ReturnPrefix);
+            await Assert.That(Emitter.GetReturnStatementPrefix(ReturnTypeInfo.Return)).IsEqualTo(ReturnPrefix);
+            await Assert.That(Emitter.GetReturnStatementPrefix(ReturnTypeInfo.SyncVoid)).IsEqualTo(string.Empty);
+            await Assert.That(static () => Emitter.GetReturnStatementPrefix((ReturnTypeInfo)int.MaxValue))
                 .ThrowsExactly<ArgumentOutOfRangeException>();
         }
 
@@ -332,10 +335,13 @@ public static partial class GeneratorComponentTests
                 false,
                 false);
 
-            var source = Emitter.BuildMethodOpening(method, true, true, supportsNullable: true, isAsync: true);
+            var source = Emitter.BuildMethodOpening(method, true, true, supportsNullable: true);
 
             await Assert.That(source)
-                .Contains("async global::System.Threading.Tasks.Task global::RefitGeneratorTest.IBase.Ping(");
+                .Contains("global::System.Threading.Tasks.Task global::RefitGeneratorTest.IBase.Ping(");
+
+            // A task-returning method hands its task back, so no generated method is emitted async.
+            await Assert.That(source).DoesNotContain("async ");
         }
 
         /// <summary>Verifies emitted XML documentation text escapes special characters.</summary>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Performance optimisation in the source generator.

## What is the new behavior?

**No generated Refit method carries an async state machine; every method hands its task straight back to the caller.**

- **The reflection fallback path emits a plain task-returning method.** A method the generator cannot build inline now emits `return (Task<T>)refitFunc(this.Client, args);` rather than `return await ((Task<T>)refitFunc(...)).ConfigureAwait(false);` inside an `async` method. The awaited form allocated a state machine per call whose only job was to re-wrap the task the request builder had already produced.
- **Both generated request paths now agree.** Inline request building already returned its task, so the emitted shape no longer depends on whether a method happens to be inline-eligible.
- **The emitters lost the async plumbing that had become constant.** The return-shape helper now yields a statement prefix instead of an async flag plus a configure-await suffix, and the method-opening and return-statement emitters drop the parameters that fell out with it.

## What is the current behavior?

Task-returning methods on the reflection fallback path are emitted `async` and await the request builder's task before returning it, allocating a second state machine on every call to that method.

## What might this PR break?

- **Exceptions raised before dispatch now surface synchronously on the fallback path.** A missing request builder, or a failure inside `BuildRestResultFuncForMethod`, previously surfaced as a faulted task; it now throws from the call itself. Callers that invoke a fallback method without awaiting it, and rely on catching around the `await`, need to catch around the call. Inline-built methods already behaved this way.
- **Stack traces no longer contain the generated method frame for fallback methods.** The failed call is still identifiable from the exception: `ApiExceptionBase.HttpMethod`, `.Uri`, and the `Refit.MethodName` / `Refit.RelativePathTemplate` request options.

## Checklist
- [x] I have read the [Contribute guide](https://www.reactiveui.net/contribute/index.html)
- [x] Tests have been added or updated (for bug fixes / features)
- [ ] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the `main` branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional information

The fallback emission shape had no test coverage, so the change would have gone unnoticed by the suite. `SwitchOnFallbackReturnsTheRequestBuilderTaskWithoutAwaiting` now pins it.

A sweep of the runtime for the same pattern found nothing to remove. Every remaining `async` method needs its state machine: a `using` or `try` scope that has to outlive the await, sequential awaits, work after the await, or an async iterator. Two methods forward a single call but convert `ValueTask<T>` to `Task<T>` across the boundary, where eliding would mean an unconditional `AsTask()` allocation in place of a state-machine box that is only allocated when the await actually suspends.
