### PR TITLE
fix(generator): keep the analyzers loadable in Visual Studio

### DIFF
--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -7,6 +7,13 @@
     <EnableVSTestReferences>false</EnableVSTestReferences>
   </PropertyGroup>
 
+  <!-- SourceLink drags in System.IO.Hashing, which floors System.Memory at assembly version 4.0.2.0.
+       Visual Studio's .NET Framework compiler host only binds 4.0.1.2, so the components fail to load
+       there (CS8784). See PackagedAnalyzerReferenceTests. -->
+  <ItemGroup Condition="'$(IsRoslynComponent)' == 'true'">
+    <PackageReference Remove="Microsoft.SourceLink.GitHub"/>
+  </ItemGroup>
+
   <Target Name="ValidateNugetProperties" Condition="!$(IsTestProject) or $(IsTestProject) == ''" BeforeTargets="Compile">
     <Error Condition="$(PackageDescription) == '' or $(PackageDescription) == $(DefaultPackageDescription)" Text="The Nuget PackageDescription property needs to be set for the project. Currently : '$(PackageDescription)'"/>
   </Target>

--- a/src/tests/Refit.GeneratorTests/AnalyzerPackagingTests.cs
+++ b/src/tests/Refit.GeneratorTests/AnalyzerPackagingTests.cs
@@ -18,9 +18,6 @@ namespace Refit.GeneratorTests;
 /// </summary>
 public class AnalyzerPackagingTests
 {
-    /// <summary>The package path prefix that marks an item as a shipped analyzer.</summary>
-    private const string AnalyzerPackagePathPrefix = "analyzers/";
-
     /// <summary>The property in refit.props holding the Roslyn version of the shipped analyzer slot.</summary>
     private const string MinimumCompilerVersionProperty = "_RefitMinimumCompilerVersion";
 
@@ -29,7 +26,7 @@ public class AnalyzerPackagingTests
     [Test]
     public async Task PackageDeclaresExactlyOneRoslynAnalyzerSlot()
     {
-        var slots = GetPackagedAnalyzers()
+        var slots = RefitPackageLayout.GetPackagedAnalyzers()
             .Select(static analyzer => analyzer.PackagePath)
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .Order(StringComparer.OrdinalIgnoreCase)
@@ -44,7 +41,7 @@ public class AnalyzerPackagingTests
     [Test]
     public async Task PackagedAnalyzerAssembliesAreShippedOnce()
     {
-        var duplicated = GetPackagedAnalyzers()
+        var duplicated = RefitPackageLayout.GetPackagedAnalyzers()
             .GroupBy(static analyzer => analyzer.FileName, StringComparer.OrdinalIgnoreCase)
             .Where(static group => group.Count() > 1)
             .Select(static group => group.Key)
@@ -63,67 +60,22 @@ public class AnalyzerPackagingTests
     [Test]
     public async Task MinimumCompilerVersionMatchesThePackagedAnalyzerSlot()
     {
-        var slots = GetPackagedAnalyzers()
+        var slots = RefitPackageLayout.GetPackagedAnalyzers()
             .Select(static analyzer => analyzer.PackagePath)
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .Order(StringComparer.OrdinalIgnoreCase);
 
-        var declaredMinimum = XDocument
-            .Load(FindRepositoryFile("Refit/targets/refit.props"))
+        // Joined rather than compared element-wise so a stray extra slot shows up in the diff.
+        await Assert.That(string.Join(", ", slots))
+            .IsEqualTo($"analyzers/dotnet/roslyn{ReadMinimumCompilerVersion()}/cs");
+    }
+
+    /// <summary>Reads the Roslyn version of the shipped analyzer slot from refit.props.</summary>
+    /// <returns>The declared version, such as <c>4.8</c>.</returns>
+    internal static string ReadMinimumCompilerVersion() =>
+        XDocument
+            .Load(RefitPackageLayout.FindRepositoryFile("Refit/targets/refit.props"))
             .Descendants(MinimumCompilerVersionProperty)
             .Select(static element => element.Value.Trim())
             .Single();
-
-        // Joined rather than compared element-wise so a stray extra slot shows up in the diff.
-        await Assert.That(string.Join(", ", slots))
-            .IsEqualTo($"analyzers/dotnet/roslyn{declaredMinimum}/cs");
-    }
-
-    /// <summary>Reads the analyzer items the Refit package ships.</summary>
-    /// <returns>The packaged analyzer package path and assembly file name pairs.</returns>
-    private static List<(string PackagePath, string FileName)> GetPackagedAnalyzers()
-    {
-        var analyzers = new List<(string PackagePath, string FileName)>();
-
-        foreach (var element in XDocument.Load(FindRepositoryFile("Refit/Refit.csproj")).Descendants("None"))
-        {
-            var packagePath = Normalize(element.Attribute("PackagePath")?.Value);
-            if (!packagePath.StartsWith(AnalyzerPackagePathPrefix, StringComparison.OrdinalIgnoreCase))
-            {
-                continue;
-            }
-
-            var include = Normalize(element.Attribute("Include")?.Value);
-            analyzers.Add((packagePath, include[(include.LastIndexOf('/') + 1)..]));
-        }
-
-        return analyzers;
-    }
-
-    /// <summary>Normalizes an MSBuild path attribute to forward slashes.</summary>
-    /// <param name="value">The raw attribute value.</param>
-    /// <returns>The normalized value, or an empty string when the attribute is absent.</returns>
-    private static string Normalize(string? value) =>
-        value?.Replace('\\', '/') ?? string.Empty;
-
-    /// <summary>Resolves a path under the repository source directory.</summary>
-    /// <param name="relativePath">The path relative to the directory holding Refit.slnx.</param>
-    /// <returns>The absolute path.</returns>
-    /// <exception cref="InvalidOperationException">No Refit.slnx was found above the test binary.</exception>
-    private static string FindRepositoryFile(string relativePath)
-    {
-        // Walked from the test binary rather than taken from [CallerFilePath], which deterministic
-        // CI builds rewrite to a placeholder root.
-        for (var directory = new DirectoryInfo(AppContext.BaseDirectory); directory is not null; directory = directory.Parent)
-        {
-            var candidate = Path.Combine(directory.FullName, "Refit.slnx");
-            if (File.Exists(candidate))
-            {
-                return Path.Combine(directory.FullName, relativePath);
-            }
-        }
-
-        throw new InvalidOperationException(
-            $"Refit.slnx was not found above '{AppContext.BaseDirectory}', so '{relativePath}' could not be resolved.");
-    }
 }

--- a/src/tests/Refit.GeneratorTests/PackagedAnalyzer.cs
+++ b/src/tests/Refit.GeneratorTests/PackagedAnalyzer.cs
@@ -1,0 +1,10 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+namespace Refit.GeneratorTests;
+
+/// <summary>An analyzer assembly the Refit package ships.</summary>
+/// <param name="PackagePath">The folder inside the package the assembly is placed in.</param>
+/// <param name="SourcePath">The build output path, relative to Refit.csproj, still holding $(Configuration).</param>
+/// <param name="FileName">The assembly file name.</param>
+internal readonly record struct PackagedAnalyzer(string PackagePath, string SourcePath, string FileName);

--- a/src/tests/Refit.GeneratorTests/PackagedAnalyzerReferenceTests.cs
+++ b/src/tests/Refit.GeneratorTests/PackagedAnalyzerReferenceTests.cs
@@ -1,0 +1,100 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+using System.Collections.Frozen;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+
+namespace Refit.GeneratorTests;
+
+/// <summary>
+/// Tests the assembly references of the analyzers the Refit package ships.
+/// <para>
+/// The package ships the generator, analyzers and code fixes on their own, with none of their
+/// dependencies, so every reference has to be satisfied by whatever host is running the compiler.
+/// Visual Studio's host is .NET Framework and binds the <c>System.*</c> facades through redirects that
+/// stop at the versions Roslyn itself carries; a reference above that throws <c>FileNotFoundException</c>
+/// on load, which surfaces as CS8784 and no generated clients. A command-line build never reproduces it,
+/// because the .NET host resolves facades from the shared framework whatever version is asked for -
+/// which is why a transitive package bump can raise a reference here and pass CI while breaking the IDE.
+/// </para>
+/// </summary>
+public class PackagedAnalyzerReferenceTests
+{
+    /// <summary>The facade versions the compiler host supplies, keyed by simple assembly name.</summary>
+    private static readonly FrozenDictionary<string, Version> HostSuppliedFacades =
+        new Dictionary<string, Version> { ["System.Memory"] = new(4, 0, 1, 2), ["System.Collections.Immutable"] = new(7, 0, 0, 0) }
+            .ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>Verifies every declared analyzer was built, so the reference check cannot pass vacuously.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task EveryPackagedAnalyzerAssemblyIsBuilt()
+    {
+        var missing = RefitPackageLayout.GetPackagedAnalyzers()
+            .Select(RefitPackageLayout.ResolveBuildOutput)
+            .Where(static path => !File.Exists(path))
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+
+        await Assert.That(missing).IsEmpty();
+    }
+
+    /// <summary>
+    /// Verifies each packaged analyzer references only assemblies the compiler host supplies, at the
+    /// versions it supplies them.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task PackagedAnalyzersReferenceOnlyHostSuppliedAssemblyVersions()
+    {
+        var minimumCompilerVersion = Version.Parse(AnalyzerPackagingTests.ReadMinimumCompilerVersion());
+        var roslynVersion = new Version(minimumCompilerVersion.Major, minimumCompilerVersion.Minor, 0, 0);
+        var unsupported = new List<string>();
+
+        foreach (var analyzer in RefitPackageLayout.GetPackagedAnalyzers())
+        {
+            var path = RefitPackageLayout.ResolveBuildOutput(analyzer);
+            if (!File.Exists(path))
+            {
+                continue;
+            }
+
+            foreach (var (name, version) in ReadAssemblyReferences(path))
+            {
+                var supported = name switch
+                {
+                    "netstandard" => true,
+                    _ when name.StartsWith("Microsoft.CodeAnalysis", StringComparison.Ordinal) => version == roslynVersion,
+                    _ => HostSuppliedFacades.TryGetValue(name, out var supportedVersion) && version == supportedVersion,
+                };
+
+                if (!supported)
+                {
+                    unsupported.Add($"{analyzer.FileName} -> {name}, Version={version}");
+                }
+            }
+        }
+
+        await Assert.That(unsupported.Order(StringComparer.Ordinal).ToArray()).IsEmpty();
+    }
+
+    /// <summary>Reads the assembly references recorded in a managed assembly's metadata.</summary>
+    /// <param name="path">The assembly path.</param>
+    /// <returns>The referenced simple names and versions.</returns>
+    private static List<(string Name, Version Version)> ReadAssemblyReferences(string path)
+    {
+        using var stream = File.OpenRead(path);
+        using var portableExecutable = new PEReader(stream);
+        var metadata = portableExecutable.GetMetadataReader();
+        var references = new List<(string Name, Version Version)>();
+
+        foreach (var handle in metadata.AssemblyReferences)
+        {
+            var reference = metadata.GetAssemblyReference(handle);
+            references.Add((metadata.GetString(reference.Name), reference.Version));
+        }
+
+        return references;
+    }
+}

--- a/src/tests/Refit.GeneratorTests/Refit.GeneratorTests.csproj
+++ b/src/tests/Refit.GeneratorTests/Refit.GeneratorTests.csproj
@@ -22,6 +22,8 @@
     <ProjectReference Include="..\..\InterfaceStubGenerator.Roslyn48\InterfaceStubGenerator.Roslyn48.csproj" OutputItemType="Analyzer" />
     <!-- Referenced for the RefitInterfaceAnalyzer type only (RF006 drift cross-check test); not applied as an analyzer to this project. -->
     <ProjectReference Include="..\..\Refit.Analyzers.Roslyn48\Refit.Analyzers.Roslyn48.csproj" ReferenceOutputAssembly="true" Aliases="RefitAnalyzers" />
+    <!-- Built, not referenced: PackagedAnalyzerReferenceTests inspects every assembly the package ships. -->
+    <ProjectReference Include="..\..\Refit.CodeFixes.Roslyn48\Refit.CodeFixes.Roslyn48.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\..\Refit\Refit.csproj" />
     <ProjectReference Include="..\..\Refit.Reflection\Refit.Reflection.csproj" />
   </ItemGroup>

--- a/src/tests/Refit.GeneratorTests/RefitPackageLayout.cs
+++ b/src/tests/Refit.GeneratorTests/RefitPackageLayout.cs
@@ -1,0 +1,74 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+using System.Xml.Linq;
+
+namespace Refit.GeneratorTests;
+
+/// <summary>Reads the analyzer layout of the Refit package from Refit.csproj.</summary>
+internal static class RefitPackageLayout
+{
+    /// <summary>The package path prefix that marks an item as a shipped analyzer.</summary>
+    private const string AnalyzerPackagePathPrefix = "analyzers/";
+
+    /// <summary>Reads the analyzer items the Refit package ships.</summary>
+    /// <returns>The packaged analyzers, in declaration order.</returns>
+    internal static List<PackagedAnalyzer> GetPackagedAnalyzers()
+    {
+        var analyzers = new List<PackagedAnalyzer>();
+
+        foreach (var element in XDocument.Load(FindRepositoryFile("Refit/Refit.csproj")).Descendants("None"))
+        {
+            var packagePath = Normalize(element.Attribute("PackagePath")?.Value);
+            if (!packagePath.StartsWith(AnalyzerPackagePathPrefix, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            var include = Normalize(element.Attribute("Include")?.Value);
+            analyzers.Add(new(packagePath, include, include[(include.LastIndexOf('/') + 1)..]));
+        }
+
+        return analyzers;
+    }
+
+    /// <summary>Resolves the build output an analyzer is packed from.</summary>
+    /// <param name="analyzer">The packaged analyzer.</param>
+    /// <returns>The absolute path, which may not exist when the component has not been built.</returns>
+    internal static string ResolveBuildOutput(PackagedAnalyzer analyzer)
+    {
+        // The test binary sits in bin/<Configuration>/<tfm>, and the analyzers are packed from the
+        // matching bin/<Configuration>/netstandard2.0 of their own projects.
+        var configuration = new DirectoryInfo(AppContext.BaseDirectory).Parent!.Name;
+        var relative = analyzer.SourcePath.Replace("$(Configuration)", configuration, StringComparison.Ordinal);
+
+        return Path.GetFullPath(Path.Combine(Path.GetDirectoryName(FindRepositoryFile("Refit/Refit.csproj"))!, relative));
+    }
+
+    /// <summary>Resolves a path under the repository source directory.</summary>
+    /// <param name="relativePath">The path relative to the directory holding Refit.slnx.</param>
+    /// <returns>The absolute path.</returns>
+    /// <exception cref="InvalidOperationException">No Refit.slnx was found above the test binary.</exception>
+    internal static string FindRepositoryFile(string relativePath)
+    {
+        // Walked from the test binary rather than taken from [CallerFilePath], which deterministic
+        // CI builds rewrite to a placeholder root.
+        for (var directory = new DirectoryInfo(AppContext.BaseDirectory); directory is not null; directory = directory.Parent)
+        {
+            var candidate = Path.Combine(directory.FullName, "Refit.slnx");
+            if (File.Exists(candidate))
+            {
+                return Path.Combine(directory.FullName, relativePath);
+            }
+        }
+
+        throw new InvalidOperationException(
+            $"Refit.slnx was not found above '{AppContext.BaseDirectory}', so '{relativePath}' could not be resolved.");
+    }
+
+    /// <summary>Normalizes an MSBuild path attribute to forward slashes.</summary>
+    /// <param name="value">The raw attribute value.</param>
+    /// <returns>The normalized value, or an empty string when the attribute is absent.</returns>
+    private static string Normalize(string? value) =>
+        value?.Replace('\\', '/') ?? string.Empty;
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the new behavior?

**The shipped generator, analyzers and code fixes load in Visual Studio again.**

- **The Roslyn component projects no longer reference SourceLink.** It pulls `Microsoft.Build.Tasks.Git` -> `System.IO.Hashing`, which floors `System.Memory` at 4.6.3 for the whole restore graph. Nothing else in those projects raised it, so removing SourceLink drops the compile-time reference back to assembly version 4.0.1.2 - the version the .NET Framework compiler host binds.
- **`PackagedAnalyzerReferenceTests` guards the reference set.** It reads each shipped assembly's metadata and fails on anything the compiler host cannot supply: a reference must be `netstandard`, a `Microsoft.CodeAnalysis*` at the version `refit.props` declares, or a listed facade at its exact version.
  - A companion test asserts all three assemblies were built, so the check cannot pass vacuously. That needed a build-only `ProjectReference` to `Refit.CodeFixes.Roslyn48`, whose output the test project otherwise never produced.
  - `AnalyzerPackagingTests` moved its `Refit.csproj` parsing and repository walking into a shared `RefitPackageLayout` rather than duplicate them.

## What is the current behavior?

**The generator fails to load inside Visual Studio and emits no clients.**

- `InterfaceStubGeneratorV2.dll` and `Refit.Analyzers.dll` reference `System.Memory, Version=4.0.2.0`. Visual Studio's compiler host runs on .NET Framework and its binding redirects stop at 4.0.1.2, so loading throws `FileNotFoundException` and the compiler reports CS8784.
- The analyzer hits the same wall, so the RF diagnostics never run in the IDE either.
- A command-line build is unaffected, because the .NET compiler host resolves the facade from the shared framework whatever version is asked for - which is how a transitive bump reached a release without CI noticing.

Closes #2308

## What might this PR break?

**None for consumers.**

- Source stepping into the shipped analyzer assemblies is no longer source-linked. Their PDBs stay embedded.

## Checklist
- [x] I have read the [Contribute guide](https://www.reactiveui.net/contribute/index.html)
- [x] Tests have been added or updated (for bug fixes / features)
- [ ] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the `main` branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional information

Verified against a real `dotnet pack -c Release` artifact, not just the bin folder:

| assembly | 15.1.0 | this branch |
| --- | --- | --- |
| `InterfaceStubGeneratorV2.dll` | `System.Memory, Version=4.0.2.0` | `4.0.1.2` |
| `Refit.Analyzers.dll` | `System.Memory, Version=4.0.2.0` | `4.0.1.2` |
| `Refit.CodeFixes.dll` | no reference | no reference |

Pinning `System.Memory` while keeping SourceLink is not an option: `System.IO.Hashing` 10.0.11 requires `>= 4.6.3`, so restore fails with NU1605.
