### PR TITLE
fix(headers): stop rewriting raw header values

### DIFF
--- a/src/Refit.Reflection/RequestBuilderImplementation.QueryAndHeaders.Helpers.cs
+++ b/src/Refit.Reflection/RequestBuilderImplementation.QueryAndHeaders.Helpers.cs
@@ -97,17 +97,14 @@ internal partial class RequestBuilderImplementation
         // we want to allow removal/redefinition of headers.
         // We also don't want to double up content headers which may have been
         // set for us automatically.
-        // NB: We have to enumerate the header names to check existence because
-        // Contains throws if it's the wrong header type for the collection.
-        // HTTP header names are case-insensitive, so compare them that way; otherwise a
-        // differently cased header (e.g. "Content-type" vs "Content-Type") is not removed
-        // and ends up duplicated.
-        if (ContainsHeader(request.Headers, name))
+        // The existence check is case-insensitive, because HTTP header names are; otherwise a differently cased header
+        // (e.g. "Content-type" vs "Content-Type") is not removed and ends up duplicated.
+        if (HttpHeaderApplier.ContainsHeader(request.Headers, name))
         {
             _ = request.Headers.Remove(name);
         }
 
-        if (request.Content is not null && ContainsHeader(request.Content.Headers, name))
+        if (request.Content is not null && HttpHeaderApplier.ContainsHeader(request.Content.Headers, name))
         {
             _ = request.Content.Headers.Remove(name);
         }

--- a/src/Refit.Reflection/RequestBuilderImplementation.QueryAndHeaders.cs
+++ b/src/Refit.Reflection/RequestBuilderImplementation.QueryAndHeaders.cs
@@ -291,23 +291,6 @@ internal partial class RequestBuilderImplementation
     /// <returns><see langword="true"/> for GET and HEAD; otherwise <see langword="false"/>.</returns>
     internal static bool IsBodyless(HttpMethod method) => method == HttpMethod.Get || method == HttpMethod.Head;
 
-    /// <summary>Checks whether a header collection contains a key without throwing for unsupported header types.</summary>
-    /// <param name="headers">The header collection to inspect.</param>
-    /// <param name="name">The header name.</param>
-    /// <returns><see langword="true"/> when the header key exists; otherwise <see langword="false"/>.</returns>
-    internal static bool ContainsHeader(System.Net.Http.Headers.HttpHeaders headers, string name)
-    {
-        foreach (var header in headers)
-        {
-            if (string.Equals(header.Key, name, StringComparison.OrdinalIgnoreCase))
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
     /// <summary>Gets the cached query-property metadata for the given type.</summary>
     /// <param name="type">The object type to inspect.</param>
     /// <returns>The readable public instance properties with their attribute-derived facts.</returns>

--- a/src/Refit/GeneratedRequestRunner.cs
+++ b/src/Refit/GeneratedRequestRunner.cs
@@ -473,12 +473,12 @@ public static partial class GeneratedRequestRunner
     /// </param>
     public static void SetHeader(HttpRequestMessage request, string name, string? value, bool validateHeaders)
     {
-        if (ContainsHeader(request.Headers, name))
+        if (HttpHeaderApplier.ContainsHeader(request.Headers, name))
         {
             _ = request.Headers.Remove(name);
         }
 
-        if (request.Content is not null && ContainsHeader(request.Content.Headers, name))
+        if (request.Content is not null && HttpHeaderApplier.ContainsHeader(request.Content.Headers, name))
         {
             _ = request.Content.Headers.Remove(name);
         }
@@ -777,30 +777,6 @@ public static partial class GeneratedRequestRunner
     /// <returns><see langword="true"/> for bodyless methods.</returns>
     internal static bool IsBodyless(HttpMethod method) =>
         method == HttpMethod.Get || method == HttpMethod.Head;
-
-    /// <summary>Checks whether a header collection contains a key without throwing for unsupported header types.</summary>
-    /// <param name="headers">The header collection to inspect.</param>
-    /// <param name="name">The header name.</param>
-    /// <returns><see langword="true"/> when the header key exists; otherwise <see langword="false"/>.</returns>
-    internal static bool ContainsHeader(System.Net.Http.Headers.HttpHeaders headers, string name)
-    {
-#if NET6_0_OR_GREATER
-        // NonValidated checks key presence (case-insensitively, like the store) without parsing or materializing the
-        // stored header values, and never throws for unsupported header shapes, so it preserves the tolerant behavior
-        // of the manual scan while avoiding the per-check value enumeration.
-        return headers.NonValidated.Contains(name);
-#else
-        foreach (var header in headers)
-        {
-            if (string.Equals(header.Key, name, StringComparison.OrdinalIgnoreCase))
-            {
-                return true;
-            }
-        }
-
-        return false;
-#endif
-    }
 
     /// <summary>Removes CR and LF characters from a generated header name or value.</summary>
     /// <param name="value">The header name or value.</param>

--- a/src/Refit/HttpHeaderApplier.cs
+++ b/src/Refit/HttpHeaderApplier.cs
@@ -41,6 +41,41 @@ internal static class HttpHeaderApplier
         _ = request.Content.Headers.TryAddWithoutValidation(name, value);
     }
 
+    /// <summary>Checks whether a header collection already carries a key, without disturbing the values it holds.</summary>
+    /// <param name="headers">The header collection to inspect.</param>
+    /// <param name="name">The header name.</param>
+    /// <returns><see langword="true"/> when the header key exists; otherwise <see langword="false"/>.</returns>
+    /// <remarks>
+    /// Enumerating <see cref="System.Net.Http.Headers.HttpHeaders"/> forces lazy parsing of every value already stored,
+    /// which rewrites anything added through <c>TryAddWithoutValidation</c> into its parsed form before the request is
+    /// sent - so a raw value such as <c>application/vnd.api.json;version=3.4.1</c> silently gains a space after the
+    /// semicolon once a second header is applied. This check therefore never enumerates.
+    /// </remarks>
+    internal static bool ContainsHeader(System.Net.Http.Headers.HttpHeaders headers, string name)
+    {
+#if NET6_0_OR_GREATER
+        // NonValidated checks key presence (case-insensitively, like the store) without parsing or materializing any
+        // stored value, and never throws for a name this collection does not accept.
+        return headers.NonValidated.Contains(name);
+#else
+        // .NET Framework has no NonValidated view. Contains touches only the named header, leaving every other stored
+        // value raw, but it throws when the name belongs to the other collection or is not a legal token. Neither name
+        // can be present here - TryAddWithoutValidation rejects the latter outright - so both mean "absent".
+        try
+        {
+            return headers.Contains(name);
+        }
+        catch (InvalidOperationException)
+        {
+            return false;
+        }
+        catch (FormatException)
+        {
+            return false;
+        }
+#endif
+    }
+
     /// <summary>Adds a header with framework validation, reporting whether it belongs to this collection.</summary>
     /// <param name="headers">The header collection to add to.</param>
     /// <param name="name">The header name.</param>

--- a/src/tests/Refit.Reflection.Tests/IMultipleStaticHeaderApi.cs
+++ b/src/tests/Refit.Reflection.Tests/IMultipleStaticHeaderApi.cs
@@ -1,0 +1,22 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Refit.Reflection.Tests;
+
+/// <summary>An API declaring an <c>Accept</c> media type whose parameter separator carries no space, once on its own and
+/// once beside a second header, so the number of declared headers is the only difference between the two calls.</summary>
+public interface IMultipleStaticHeaderApi
+{
+    /// <summary>Declares the raw media type as the method's only header.</summary>
+    /// <returns>The response body.</returns>
+    [Get("/report")]
+    [Headers("Accept: application/vnd.api.json;version=3.4.1")]
+    Task<string> OneHeader();
+
+    /// <summary>Declares the same raw media type alongside a second header.</summary>
+    /// <returns>The response body.</returns>
+    [Get("/report")]
+    [Headers("Accept: application/vnd.api.json;version=3.4.1", "X-Trace: abc")]
+    Task<string> TwoHeaders();
+}

--- a/src/tests/Refit.Reflection.Tests/ReflectionRawHeaderValueTests.cs
+++ b/src/tests/Refit.Reflection.Tests/ReflectionRawHeaderValueTests.cs
@@ -1,0 +1,44 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Refit.Reflection.Tests;
+
+/// <summary>Pins that a declared header value reaches the request exactly as written, however many headers the method
+/// declares. Values are added without validation, so the framework parser must never get to reformat one.</summary>
+public sealed class ReflectionRawHeaderValueTests
+{
+    /// <summary>The header whose value the parser would reformat if it materialized it.</summary>
+    private const string RawHeaderName = "Accept";
+
+    /// <summary>The declared media type, with no space after the parameter separator.</summary>
+    private const string RawHeaderValue = "application/vnd.api.json;version=3.4.1";
+
+    /// <summary>Verifies a lone declared header reaches the request verbatim.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public Task SingleDeclaredHeaderKeepsItsValueVerbatim() =>
+        AssertRawAcceptAsync(nameof(IMultipleStaticHeaderApi.OneHeader));
+
+    /// <summary>Verifies a declared header reaches the request verbatim when a second header follows it.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public Task DeclaredHeaderKeepsItsValueVerbatimBesideASecondHeader() =>
+        AssertRawAcceptAsync(nameof(IMultipleStaticHeaderApi.TwoHeaders));
+
+    /// <summary>Builds a request for the named method and asserts its stored <c>Accept</c> value was never reformatted.</summary>
+    /// <param name="methodName">The interface method to build.</param>
+    /// <returns>A task representing the asynchronous assertion.</returns>
+    private static async Task AssertRawAcceptAsync(string methodName)
+    {
+        var builder = new RequestBuilderImplementation<IMultipleStaticHeaderApi>();
+
+        using var request = await builder.BuildRequestFactoryForMethod(methodName)([]);
+
+        // NonValidated reports what is actually stored, so it distinguishes the declared value from the parsed one.
+        var stored = request.Headers.NonValidated.TryGetValues(RawHeaderName, out var values);
+
+        await Assert.That(stored).IsTrue();
+        await Assert.That(values.ToString()).IsEqualTo(RawHeaderValue);
+    }
+}

--- a/src/tests/Refit.Tests/GeneratedRequestRunnerTests.RequestDispatch.cs
+++ b/src/tests/Refit.Tests/GeneratedRequestRunnerTests.RequestDispatch.cs
@@ -90,6 +90,18 @@ public partial class GeneratedRequestRunnerTests
     public Task SetHeaderWithoutValidationDropsContentHeaderWithoutContent() =>
         HeaderValidationScenarios.DropsContentHeaderWithoutContentWithoutValidation(GeneratedRequestRunner.SetHeader, RelativeResourcePath);
 
+    /// <summary>Verifies that applying a later header leaves an earlier verbatim value byte for byte as it was supplied.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public Task SetHeaderKeepsEarlierRawValueWhenALaterHeaderIsApplied() =>
+        RawHeaderValueScenarios.KeepsEarlierRawValueWhenALaterHeaderIsApplied(GeneratedRequestRunner.SetHeader, RelativeResourcePath);
+
+    /// <summary>Verifies that replacing a header leaves the other headers already applied untouched.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public Task SetHeaderKeepsEarlierRawValueWhenALaterHeaderIsReplaced() =>
+        RawHeaderValueScenarios.KeepsEarlierRawValueWhenALaterHeaderIsReplaced(GeneratedRequestRunner.SetHeader, RelativeResourcePath);
+
     /// <summary>Verifies that header collections are optional and replace earlier values by key.</summary>
     /// <returns>A task that represents the asynchronous operation.</returns>
     [Test]

--- a/src/tests/Refit.Tests/RawHeaderValueScenarios.cs
+++ b/src/tests/Refit.Tests/RawHeaderValueScenarios.cs
@@ -1,0 +1,65 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Refit.Tests;
+
+/// <summary>Raw-header-preservation arrange-act-assert bodies shared by the reflection request builder and the
+/// source-generated request runner. Each scenario takes the path's header-apply delegate so both real code paths run
+/// the same assertions while the body lives in one place.</summary>
+internal static class RawHeaderValueScenarios
+{
+    /// <summary>A header whose value the framework parser would reformat if it ever materialized it.</summary>
+    private const string RawHeaderName = "Accept";
+
+    /// <summary>A media type with no space after the parameter separator, which the parser would reinsert.</summary>
+    private const string RawHeaderValue = "application/vnd.api.json;version=3.4.1";
+
+    /// <summary>A second header, applied after the raw one, whose application must not disturb it.</summary>
+    private const string TrailingHeaderName = "X-Trace";
+
+    /// <summary>The value of the second header.</summary>
+    private const string TrailingHeaderValue = "abc";
+
+    /// <summary>Applying a later header leaves an earlier verbatim value byte for byte as it was supplied.</summary>
+    /// <param name="applyHeader">The header-apply path under test.</param>
+    /// <param name="requestUri">The request URI matching the path's addressing convention.</param>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    /// <remarks>
+    /// The existence check that precedes each apply used to enumerate the collection, which forces the framework to
+    /// parse every value already stored and write the parsed form back. A method declaring one header never showed it;
+    /// two or more rewrote the first on the wire.
+    /// </remarks>
+    internal static async Task KeepsEarlierRawValueWhenALaterHeaderIsApplied(ApplyHeader applyHeader, string requestUri)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+
+        applyHeader(request, RawHeaderName, RawHeaderValue, validateHeaders: false);
+        applyHeader(request, TrailingHeaderName, TrailingHeaderValue, validateHeaders: false);
+
+        // NonValidated reports what is actually stored, so it distinguishes the supplied value from the parsed one.
+        var stored = request.Headers.NonValidated.TryGetValues(RawHeaderName, out var values);
+
+        await Assert.That(stored).IsTrue();
+        await Assert.That(values.ToString()).IsEqualTo(RawHeaderValue);
+    }
+
+    /// <summary>Replacing a header leaves the other headers already applied untouched.</summary>
+    /// <param name="applyHeader">The header-apply path under test.</param>
+    /// <param name="requestUri">The request URI matching the path's addressing convention.</param>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    internal static async Task KeepsEarlierRawValueWhenALaterHeaderIsReplaced(ApplyHeader applyHeader, string requestUri)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+
+        applyHeader(request, RawHeaderName, RawHeaderValue, validateHeaders: false);
+        applyHeader(request, TrailingHeaderName, TrailingHeaderValue, validateHeaders: false);
+        applyHeader(request, TrailingHeaderName, "def", validateHeaders: false);
+
+        var stored = request.Headers.NonValidated.TryGetValues(RawHeaderName, out var values);
+
+        await Assert.That(stored).IsTrue();
+        await Assert.That(values.ToString()).IsEqualTo(RawHeaderValue);
+        await Assert.That(request.Headers.GetValues(TrailingHeaderName)).IsEquivalentTo(["def"]);
+    }
+}

--- a/src/tests/Refit.Tests/RequestBuilderTests.Helpers.cs
+++ b/src/tests/Refit.Tests/RequestBuilderTests.Helpers.cs
@@ -319,6 +319,18 @@ public partial class RequestBuilderTests
     public Task SetHeaderWithoutValidationDropsContentHeaderWithoutContent() =>
         HeaderValidationScenarios.DropsContentHeaderWithoutContentWithoutValidation(RequestBuilderImplementation.SetHeader, ApiBaseUrlWithSlash);
 
+    /// <summary>Applying a later header leaves an earlier verbatim value byte for byte as it was supplied.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public Task SetHeaderKeepsEarlierRawValueWhenALaterHeaderIsApplied() =>
+        RawHeaderValueScenarios.KeepsEarlierRawValueWhenALaterHeaderIsApplied(RequestBuilderImplementation.SetHeader, ApiBaseUrlWithSlash);
+
+    /// <summary>Replacing a header leaves the other headers already applied untouched.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public Task SetHeaderKeepsEarlierRawValueWhenALaterHeaderIsReplaced() =>
+        RawHeaderValueScenarios.KeepsEarlierRawValueWhenALaterHeaderIsReplaced(RequestBuilderImplementation.SetHeader, ApiBaseUrlWithSlash);
+
     /// <summary>Verifies indexed query maps format null and populated property values through their runtime types.</summary>
     /// <returns>A task representing the asynchronous test.</returns>
     [Test]


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the new behavior?

**A header value supplied verbatim reaches the wire byte for byte, however many headers the method declares.**

- **The presence check no longer enumerates the header collection.** It goes through `HttpHeaders.NonValidated`, which reports key presence without parsing or materializing any stored value, and never throws for a name the collection does not accept.
- **Both request paths are fixed by one change.** The check moved into `HttpHeaderApplier`, which the reflection request builder and the source-generated request runner already share, so the two copies cannot drift apart again.
- **On net4x, where `NonValidated` does not exist, the check probes the single named header.** That leaves every other stored value untouched. `Contains` throws when the name belongs to the other collection or is not a legal token; neither name can be present, so both are reported as absent.

## What is the current behavior?

**A raw header value is silently reformatted once a method declares more than one header.**

- Enumerating `HttpHeaders` forces lazy parsing of every value already stored and writes the parsed form back, so applying header N rewrote headers 1..N-1.
- `RefitSettings.ValidateHeaders` defaults to `false`, so values go through `TryAddWithoutValidation` and are expected to reach the wire unchanged. Instead:

  ```
  declared    -> Accept: application/vnd.api.json;version=3.4.1
  one header  -> Accept: application/vnd.api.json;version=3.4.1
  two headers -> Accept: application/vnd.api.json; version=3.4.1
  ```

  Both forms are equivalent under RFC 9110, but servers matching the media type as an exact string reject the rewritten value.
- `Refit.Reflection` was affected on every target framework. The generated path was affected on net462 through net481 only, since net6.0+ already used `NonValidated` there.

Closes #2306

## What might this PR break?

**None.**

- Callers that relied on the reformatted value were relying on a value Refit was never asked to produce.

## Checklist
- [x] I have read the [Contribute guide](https://www.reactiveui.net/contribute/index.html)
- [x] Tests have been added or updated (for bug fixes / features)
- [ ] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the `main` branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional information

The new tests fail against the previous implementation and pass against this one. `ReflectionRawHeaderValueTests` reproduces the report at the interface level: the one-header method passes either way, the two-header method only passes with the fix. `RawHeaderValueScenarios` drives the same assertions through both paths' `SetHeader` seam, the way the existing `HeaderValidationScenarios` does.

Assertions read `Headers.NonValidated`, so they see what is actually stored rather than the parsed projection `GetValues` would hand back.
