### PR TITLE
feat(body): compress request bodies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1013,6 +1013,47 @@ var settings = new RefitSettings(new SystemTextJsonContentSerializer(options))
 Both modes require the content serializer to implement `ISynchronousContentSerializer` (the default
 `SystemTextJsonContentSerializer` does); otherwise the body falls back to the default asynchronous serialization.
 
+### Compressing the request body
+
+Set `Compression` on `[Body]` to send the body under a content coding. Refit compresses whatever the serializer
+produced and sets `Content-Encoding` to match, so the coding composes with every serialization method:
+
+```csharp
+public interface IUploadApi
+{
+    [Post("/measurements")]
+    Task Upload([Body(Compression = RequestCompression.GZip)] Measurement[] batch);
+
+    [Post("/measurements")]
+    Task UploadSmallest([Body(
+        Compression = RequestCompression.Brotli,
+        CompressionLevel = CompressionLevel.SmallestSize)] Measurement[] batch);
+}
+```
+
+To compress every body from one client, set it on the settings instead. A `[Body]` parameter naming its own coding
+overrides that, and `RequestCompression.None` on the parameter opts a single method out:
+
+```csharp
+var settings = new RefitSettings
+{
+    RequestCompression = RequestCompression.GZip,
+    RequestCompressionLevel = CompressionLevel.Optimal,
+};
+```
+
+There is no negotiation for a compressed request body, so only turn this on against a server you know accepts one.
+The compressed length is unknown until the body has been written, so these requests are sent chunked.
+
+Codings are not available on every target framework, and asking for one the running framework cannot produce throws
+`PlatformNotSupportedException` when the request is built rather than quietly sending the body uncompressed:
+
+| Coding | `Content-Encoding` | Available on |
+| --- | --- | --- |
+| `RequestCompression.GZip` | `gzip` | every target |
+| `RequestCompression.Brotli` | `br` | .NET 8.0 and later |
+| `RequestCompression.Zstandard` | `zstd` | .NET 11.0 and later |
+
 For instance, here is how to create a new `RefitSettings` instance using the `Newtonsoft.Json`-based serializer (you'll
 also need to add a `PackageReference` to `Refit.Newtonsoft.Json`):
 

--- a/README.md
+++ b/README.md
@@ -1042,6 +1042,24 @@ var settings = new RefitSettings
 };
 ```
 
+For knobs a level cannot express — window size, strategy, a Zstandard dictionary — set the compressor's own options.
+Options set for a coding replace the level for that coding; the codings left unset still compress by level:
+
+```csharp
+var settings = new RefitSettings
+{
+    RequestCompression = RequestCompression.Brotli,
+    RequestCompressionOptions = new()
+    {
+        Brotli = new() { Quality = 9, WindowLog2 = 22 },
+        GZip = new() { CompressionLevel = 6 },
+    },
+};
+```
+
+`RequestCompressionOptions` needs .NET 9.0 or later, where `ZLibCompressionOptions` and `BrotliCompressionOptions`
+were introduced; its `Zstandard` property needs .NET 11.0.
+
 There is no negotiation for a compressed request body, so only turn this on against a server you know accepts one.
 The compressed length is unknown until the body has been written, so these requests are sent chunked.
 

--- a/src/InterfaceStubGenerator.Shared/Emitter.Inline.Content.cs
+++ b/src/InterfaceStubGenerator.Shared/Emitter.Inline.Content.cs
@@ -25,14 +25,16 @@ internal static partial class Emitter
         var requestLocal = plan.RequestLocal;
         var settingsLocal = plan.SettingsLocal;
         var bodyParameter = plan.BodyParameter!.Value;
+        var compression = BuildContentCompression(bodyParameter, requestLocal, settingsLocal, bodyIndent);
         if (bodyParameter.BodySerializationMethod == "UrlEncoded")
         {
             if (IsUnrollableFormBody(bodyParameter))
             {
-                return BuildInlineFormUnroll(bodyParameter, requestLocal, supportsNullable, emission, plan.Locals);
+                return BuildInlineFormUnroll(bodyParameter, requestLocal, supportsNullable, emission, plan.Locals)
+                    + compression;
             }
 
-            return formFieldsFieldName is not null
+            return (formFieldsFieldName is not null
                 ? $$"""
                     {{bodyIndent}}{{requestLocal}}.Content = global::Refit.GeneratedRequestRunner.CreateUrlEncodedBodyContent<{{bodyParameter.Type}}>(
                     {{bodyIndent}}    {{settingsLocal}},
@@ -45,7 +47,7 @@ internal static partial class Emitter
                     {{bodyIndent}}    {{settingsLocal}},
                     {{bodyIndent}}    @{{bodyParameter.Name}});
 
-                    """;
+                    """) + compression;
         }
 
         if (bodyParameter.BodySerializationMethod == "JsonLines")
@@ -55,7 +57,7 @@ internal static partial class Emitter
                 {{bodyIndent}}    {{settingsLocal}},
                 {{bodyIndent}}    @{{bodyParameter.Name}});
 
-                """;
+                """ + compression;
         }
 
         var streamBodyExpression = BuildStreamBodyExpression(bodyParameter, settingsLocal);
@@ -68,7 +70,37 @@ internal static partial class Emitter
             {{bodyIndent}}    {{serializationMethodExpression}},
             {{bodyIndent}}    {{streamBodyExpression}});
 
-            """;
+            """ + compression;
+    }
+
+    /// <summary>Emits the content-coding wrap for a body, or nothing when no coding can apply.</summary>
+    /// <param name="bodyParameter">The body parameter model.</param>
+    /// <param name="requestLocal">The generated request message local name.</param>
+    /// <param name="settingsLocal">The generated settings local name.</param>
+    /// <param name="bodyIndent">The method body indentation.</param>
+    /// <returns>The wrap statement, or an empty string.</returns>
+    /// <remarks>
+    /// A body that declares <c>None</c> can never be compressed, so nothing is emitted for it. Every other body emits
+    /// the wrap, because <c>Default</c> resolves against <c>RefitSettings</c> at request time.
+    /// </remarks>
+    internal static string BuildContentCompression(
+        in RequestParameterModel bodyParameter,
+        string requestLocal,
+        string settingsLocal,
+        string bodyIndent)
+    {
+        var compression = bodyParameter.Compression ?? "Default";
+
+        return compression == "None"
+            ? string.Empty
+            : $$"""
+                {{bodyIndent}}{{requestLocal}}.Content = global::Refit.GeneratedRequestRunner.CompressBodyContent(
+                {{bodyIndent}}    {{requestLocal}}.Content,
+                {{bodyIndent}}    {{settingsLocal}},
+                {{bodyIndent}}    global::Refit.RequestCompression.{{compression}},
+                {{bodyIndent}}    global::System.IO.Compression.CompressionLevel.{{bodyParameter.CompressionLevel ?? "Optimal"}});
+
+                """;
     }
 
     /// <summary>Emits straight-line form-url-encoded body serialization for an all-scalar body, mirroring the descriptor

--- a/src/InterfaceStubGenerator.Shared/Models/RequestParameterModel.cs
+++ b/src/InterfaceStubGenerator.Shared/Models/RequestParameterModel.cs
@@ -60,6 +60,14 @@ internal readonly record struct RequestParameterModel(
     /// placeholder with a formatted property value.</summary>
     internal ImmutableEquatableArray<PathObjectBindingModel>? PathObjectBindings { get; init; }
 
+    /// <summary>Gets the <c>Refit.RequestCompression</c> member name the body declared, or <see langword="null"/> for a
+    /// parameter that is not a body. <c>Default</c> means the request takes its coding from the settings.</summary>
+    internal string? Compression { get; init; }
+
+    /// <summary>Gets the <c>System.IO.Compression.CompressionLevel</c> member name the body declared, or
+    /// <see langword="null"/> for a parameter that is not a body.</summary>
+    internal string? CompressionLevel { get; init; }
+
     /// <summary>Gets the multipart part descriptor when this parameter contributes a <c>[Multipart]</c> form part —
     /// set for <see cref="RequestParameterKind.MultipartPart"/> parameters and <see langword="null"/> otherwise.</summary>
     internal MultipartPartModel? MultipartPart { get; init; }

--- a/src/InterfaceStubGenerator.Shared/Parser.Request.Body.cs
+++ b/src/InterfaceStubGenerator.Shared/Parser.Request.Body.cs
@@ -275,13 +275,20 @@ internal static partial class Parser
 
         foreach (var named in attribute.NamedArguments)
         {
-            if (named.Key == "Compression" && named.Value.Value is int compressionValue)
+            // Both arguments are enum-typed, so anything else is a value the compiler already rejected; leave the
+            // defaults in place rather than reading a constant that is not there.
+            if (named.Value.Kind != TypedConstantKind.Enum)
             {
-                compression = GetRequestCompressionName(compressionValue);
+                continue;
             }
-            else if (named.Key == "CompressionLevel" && named.Value.Value is int levelValue)
+
+            if (named.Key == "Compression")
             {
-                compressionLevel = GetCompressionLevelName(levelValue);
+                compression = GetRequestCompressionName((int)named.Value.Value!);
+            }
+            else if (named.Key == "CompressionLevel")
+            {
+                compressionLevel = GetCompressionLevelName((int)named.Value.Value!);
             }
         }
 

--- a/src/InterfaceStubGenerator.Shared/Parser.Request.Body.cs
+++ b/src/InterfaceStubGenerator.Shared/Parser.Request.Body.cs
@@ -270,6 +270,21 @@ internal static partial class Parser
             }
         }
 
+        var compression = "Default";
+        var compressionLevel = "Optimal";
+
+        foreach (var named in attribute.NamedArguments)
+        {
+            if (named.Key == "Compression" && named.Value.Value is int compressionValue)
+            {
+                compression = GetRequestCompressionName(compressionValue);
+            }
+            else if (named.Key == "CompressionLevel" && named.Value.Value is int levelValue)
+            {
+                compressionLevel = GetCompressionLevelName(levelValue);
+            }
+        }
+
         var bufferMode = buffered switch
         {
             true => BodyBufferMode.Buffered,
@@ -277,7 +292,7 @@ internal static partial class Parser
             _ => BodyBufferMode.Settings
         };
 
-        return new(serializationMethod, bufferMode);
+        return new(serializationMethod, bufferMode, compression, compressionLevel);
     }
 
     /// <summary>Tries to parse a body serialization method constructor argument.</summary>
@@ -300,9 +315,13 @@ internal static partial class Parser
     /// <summary>Parsed body attribute data.</summary>
     /// <param name="SerializationMethod">The body serialization method name.</param>
     /// <param name="BufferMode">The body buffering mode.</param>
+    /// <param name="Compression">The <c>RequestCompression</c> member name the body declared.</param>
+    /// <param name="CompressionLevel">The <c>CompressionLevel</c> member name the body declared.</param>
     internal readonly record struct BodyAttributeInfo(
         string SerializationMethod,
-        BodyBufferMode BufferMode);
+        BodyBufferMode BufferMode,
+        string Compression,
+        string CompressionLevel);
 
     /// <summary>Form-relevant data parsed from a <c>[Query]</c> attribute on a parameter or body property.</summary>
     /// <param name="Delimiter">The delimiter combined with the prefix, or <see langword="null"/> when no

--- a/src/InterfaceStubGenerator.Shared/Parser.Request.Helpers.cs
+++ b/src/InterfaceStubGenerator.Shared/Parser.Request.Helpers.cs
@@ -17,6 +17,27 @@ internal static partial class Parser
     /// <summary>The underlying value for <c>BodySerializationMethod.JsonLines</c>.</summary>
     private const int BodySerializationJsonLines = 4;
 
+    /// <summary>The underlying value for <c>RequestCompression.None</c>.</summary>
+    private const int RequestCompressionNone = 1;
+
+    /// <summary>The underlying value for <c>RequestCompression.GZip</c>.</summary>
+    private const int RequestCompressionGZip = 2;
+
+    /// <summary>The underlying value for <c>RequestCompression.Brotli</c>.</summary>
+    private const int RequestCompressionBrotli = 3;
+
+    /// <summary>The underlying value for <c>RequestCompression.Zstandard</c>.</summary>
+    private const int RequestCompressionZstandard = 4;
+
+    /// <summary>The underlying value for <c>CompressionLevel.Fastest</c>.</summary>
+    private const int CompressionLevelFastest = 1;
+
+    /// <summary>The underlying value for <c>CompressionLevel.NoCompression</c>.</summary>
+    private const int CompressionLevelNoCompression = 2;
+
+    /// <summary>The underlying value for <c>CompressionLevel.SmallestSize</c>.</summary>
+    private const int CompressionLevelSmallestSize = 3;
+
     /// <summary>Determines whether a symbol's containing namespace equals a dotted namespace name, without allocating.</summary>
     /// <param name="symbol">The symbol whose containing namespace is compared, or null.</param>
     /// <param name="dottedNamespace">The expected namespace as a dotted name, for example <c>System.Threading.Tasks</c>.</param>
@@ -234,6 +255,31 @@ internal static partial class Parser
             BodySerializationSerialized => "Serialized",
             BodySerializationJsonLines => "JsonLines",
             _ => string.Empty
+        };
+
+    /// <summary>Gets the Refit request compression enum member name for an underlying value.</summary>
+    /// <param name="value">The enum value.</param>
+    /// <returns>The enum member name, or <c>Default</c> for a value this generator does not know.</returns>
+    internal static string GetRequestCompressionName(int value) =>
+        value switch
+        {
+            RequestCompressionNone => "None",
+            RequestCompressionGZip => "GZip",
+            RequestCompressionBrotli => "Brotli",
+            RequestCompressionZstandard => "Zstandard",
+            _ => "Default"
+        };
+
+    /// <summary>Gets the <c>System.IO.Compression.CompressionLevel</c> member name for an underlying value.</summary>
+    /// <param name="value">The enum value.</param>
+    /// <returns>The enum member name, or <c>Optimal</c> for a value this generator does not know.</returns>
+    internal static string GetCompressionLevelName(int value) =>
+        value switch
+        {
+            CompressionLevelFastest => "Fastest",
+            CompressionLevelNoCompression => "NoCompression",
+            CompressionLevelSmallestSize => "SmallestSize",
+            _ => "Optimal"
         };
 
     /// <summary>Determines whether all body bindings are supported by the initial inline emitter.</summary>

--- a/src/InterfaceStubGenerator.Shared/Parser.Request.ParameterKinds.cs
+++ b/src/InterfaceStubGenerator.Shared/Parser.Request.ParameterKinds.cs
@@ -195,7 +195,7 @@ internal static partial class Parser
                     string.Empty,
                     string.Empty,
                     bodyInfo.SerializationMethod,
-                bodyInfo.BufferMode) { FormFields = formFields, };
+                bodyInfo.BufferMode) { FormFields = formFields, Compression = bodyInfo.Compression, CompressionLevel = bodyInfo.CompressionLevel, };
             return true;
         }
 

--- a/src/Refit.Reflection/RequestBuilderImplementation.Payload.cs
+++ b/src/Refit.Reflection/RequestBuilderImplementation.Payload.cs
@@ -19,6 +19,27 @@ internal partial class RequestBuilderImplementation
     [RequiresDynamicCode("Serializing a body by runtime Type requires runtime generic method instantiation.")]
     internal void AddBodyToRequest(RestMethodInfoInternal restMethod, object param, HttpRequestMessage ret)
     {
+        SelectBodyContent(restMethod, param, ret);
+
+        if (ret.Content is null)
+        {
+            return;
+        }
+
+        ret.Content = GeneratedRequestRunner.CompressBodyContent(
+            ret.Content,
+            _settings,
+            restMethod.BodyCompression,
+            restMethod.BodyCompressionLevel);
+    }
+
+    /// <summary>Sets the request content from the body parameter, before any content coding is applied.</summary>
+    /// <param name="restMethod">The rest method being invoked.</param>
+    /// <param name="param">The body argument value.</param>
+    /// <param name="ret">The request message to populate.</param>
+    [RequiresDynamicCode("Serializing a body by runtime Type requires runtime generic method instantiation.")]
+    internal void SelectBodyContent(RestMethodInfoInternal restMethod, object param, HttpRequestMessage ret)
+    {
         if (param is HttpContent httpContentParam)
         {
             ret.Content = httpContentParam;

--- a/src/Refit.Reflection/RestMethodInfoInternal.AttributeReading.cs
+++ b/src/Refit.Reflection/RestMethodInfoInternal.AttributeReading.cs
@@ -218,6 +218,19 @@ internal partial class RestMethodInfoInternal
         return (bodyAttribute, bodyParameterIndex, false);
     }
 
+    /// <summary>Reads the content coding an explicit <see cref="BodyAttribute"/> declared.</summary>
+    /// <param name="sets">The classified attribute set for each parameter.</param>
+    /// <returns>The declared coding and level. An implicit body declares neither, so it follows the settings.</returns>
+    internal static (RequestCompression Compression, System.IO.Compression.CompressionLevel Level) FindBodyCompression(
+        ParameterAttributeSet[] sets)
+    {
+        var (bodyAttribute, _, _) = FindBodyAttribute(sets);
+
+        return bodyAttribute is null
+            ? (RequestCompression.Default, System.IO.Compression.CompressionLevel.Optimal)
+            : (bodyAttribute.Compression, bodyAttribute.CompressionLevel);
+    }
+
     /// <summary>Finds the parameter that carries the authorization value.</summary>
     /// <param name="sets">The classified attribute set for each parameter.</param>
     /// <returns>The authorization parameter information, or null when there is no authorize parameter.</returns>

--- a/src/Refit.Reflection/RestMethodInfoInternal.cs
+++ b/src/Refit.Reflection/RestMethodInfoInternal.cs
@@ -93,6 +93,7 @@ internal partial class RestMethodInfoInternal
         UrlParameterInfo = ResolveUrlParameter(ParameterInfoArray, parameterAttributeSets, RelativePath);
         (ParameterMap, FragmentPath) = BuildParameterMap(RelativePath, ParameterInfoArray, RefitSettings.AllowUnmatchedRouteParameters || methodInfo.IsGenericMethodDefinition);
         BodyParameterInfo = FindBodyParameter(ParameterInfoArray, parameterAttributeSets, IsMultipart, hma.Method);
+        (BodyCompression, BodyCompressionLevel) = FindBodyCompression(parameterAttributeSets);
         AuthorizeParameterInfo = FindAuthorizationParameter(parameterAttributeSets);
 
         Headers = ParseHeaders(targetInterface, methodInfo);
@@ -159,6 +160,12 @@ internal partial class RestMethodInfoInternal
 
     /// <summary>Gets the body parameter information, or null when there is no body parameter.</summary>
     internal Tuple<BodySerializationMethod, bool, int>? BodyParameterInfo { get; }
+
+    /// <summary>Gets the content coding the <c>[Body]</c> parameter declared, <c>Default</c> to follow the settings.</summary>
+    internal RequestCompression BodyCompression { get; }
+
+    /// <summary>Gets how hard <see cref="BodyCompression"/> compresses.</summary>
+    internal System.IO.Compression.CompressionLevel BodyCompressionLevel { get; }
 
     /// <summary>Gets the authorization parameter information, or null when there is no authorize parameter.</summary>
     internal Tuple<string, int>? AuthorizeParameterInfo { get; }

--- a/src/Refit/BodyAttribute.cs
+++ b/src/Refit/BodyAttribute.cs
@@ -54,4 +54,16 @@ public sealed class BodyAttribute : Attribute
     /// </value>
     public BodySerializationMethod SerializationMethod { get; } =
         BodySerializationMethod.Default;
+
+    /// <summary>Gets or sets the content coding applied to this body, overriding <see cref="RefitSettings.RequestCompression"/>.</summary>
+    /// <remarks>
+    /// Leave unset to follow the settings. <see cref="RequestCompression.None"/> opts this method out of a coding the
+    /// settings turned on. Not every coding exists on every target framework - see <see cref="RequestCompression"/>.
+    /// </remarks>
+    public RequestCompression Compression { get; set; } = RequestCompression.Default;
+
+    /// <summary>Gets or sets how hard <see cref="Compression"/> compresses (defaults to <see cref="System.IO.Compression.CompressionLevel.Optimal"/>).</summary>
+    /// <remarks>Read only when <see cref="Compression"/> names a coding; otherwise the settings supply the level too.</remarks>
+    public System.IO.Compression.CompressionLevel CompressionLevel { get; set; } =
+        System.IO.Compression.CompressionLevel.Optimal;
 }

--- a/src/Refit/CompressedContent.cs
+++ b/src/Refit/CompressedContent.cs
@@ -1,0 +1,92 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.IO.Compression;
+using System.Net;
+using System.Net.Http;
+
+namespace Refit;
+
+/// <summary>Compresses another content's bytes as they are written to the request stream.</summary>
+/// <remarks>
+/// Stands in for the framework's <c>GZipCompressedContent</c> and <c>BrotliCompressedContent</c> on targets that
+/// predate them. .NET 11.0 and later use those types directly instead; this one is never constructed there.
+/// </remarks>
+internal sealed class CompressedContent : HttpContent
+{
+    /// <summary>The content whose bytes are compressed.</summary>
+    private readonly HttpContent _inner;
+
+    /// <summary>The coding to apply.</summary>
+    private readonly RequestCompression _compression;
+
+    /// <summary>How hard to compress.</summary>
+    private readonly CompressionLevel _level;
+
+    /// <summary>Initializes a new instance of the <see cref="CompressedContent"/> class.</summary>
+    /// <param name="inner">The content whose bytes are compressed.</param>
+    /// <param name="compression">The coding to apply.</param>
+    /// <param name="level">How hard to compress.</param>
+    internal CompressedContent(HttpContent inner, RequestCompression compression, CompressionLevel level)
+    {
+        _inner = inner;
+        _compression = compression;
+        _level = level;
+
+        // The entity headers describe the entity, not the coding, so they carry over unchanged; Content-Length does
+        // not, because the compressed length is unknown until the body has been written.
+        foreach (var header in inner.Headers)
+        {
+            if (!string.Equals(header.Key, "Content-Length", StringComparison.OrdinalIgnoreCase))
+            {
+                _ = Headers.TryAddWithoutValidation(header.Key, header.Value);
+            }
+        }
+
+        Headers.ContentEncoding.Add(RequestContentCoding.Token(compression));
+    }
+
+    /// <inheritdoc/>
+    protected override async Task SerializeToStreamAsync(Stream stream, TransportContext? context)
+    {
+        // leaveOpen, because the request stream belongs to the transport; only the compressor is finished here, and
+        // finishing it is what writes the trailer that makes the body readable.
+        Stream compressor = _compression switch
+        {
+            RequestCompression.GZip => new GZipStream(stream, _level, leaveOpen: true),
+#if NET8_0_OR_GREATER
+            RequestCompression.Brotli => new BrotliStream(stream, _level, leaveOpen: true),
+#endif
+            _ => throw RequestContentCoding.Unsupported(_compression),
+        };
+
+#if NET8_0_OR_GREATER
+        await using (compressor.ConfigureAwait(false))
+#else
+        using (compressor)
+#endif
+        {
+            await _inner.CopyToAsync(compressor).ConfigureAwait(false);
+        }
+    }
+
+    /// <inheritdoc/>
+    protected override bool TryComputeLength(out long length)
+    {
+        // Unknown until the body is written, so the request is sent chunked.
+        length = -1;
+        return false;
+    }
+
+    /// <inheritdoc/>
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            _inner.Dispose();
+        }
+
+        base.Dispose(disposing);
+    }
+}

--- a/src/Refit/CompressedContent.cs
+++ b/src/Refit/CompressedContent.cs
@@ -47,6 +47,11 @@ internal sealed class CompressedContent : HttpContent
         Headers.ContentEncoding.Add(RequestContentCoding.Token(compression));
     }
 
+#if NET9_0_OR_GREATER
+    /// <summary>Gets the per-coding compressor settings that override the level, or <see langword="null"/>.</summary>
+    internal RequestCompressionOptions? Options { get; init; }
+#endif
+
     /// <inheritdoc/>
     protected override async Task SerializeToStreamAsync(Stream stream, TransportContext? context)
     {
@@ -54,6 +59,10 @@ internal sealed class CompressedContent : HttpContent
         // finishing it is what writes the trailer that makes the body readable.
         Stream compressor = _compression switch
         {
+#if NET9_0_OR_GREATER
+            RequestCompression.GZip when Options?.GZip is { } gzip => new GZipStream(stream, gzip, leaveOpen: true),
+            RequestCompression.Brotli when Options?.Brotli is { } brotli => new BrotliStream(stream, brotli, leaveOpen: true),
+#endif
             RequestCompression.GZip => new GZipStream(stream, _level, leaveOpen: true),
 #if NET8_0_OR_GREATER
             RequestCompression.Brotli => new BrotliStream(stream, _level, leaveOpen: true),

--- a/src/Refit/GeneratedRequestRunner.BodyContent.cs
+++ b/src/Refit/GeneratedRequestRunner.BodyContent.cs
@@ -42,7 +42,7 @@ public static partial class GeneratedRequestRunner
 
         return resolved is RequestCompression.Default or RequestCompression.None
             ? content
-            : RequestContentCoding.Wrap(content, resolved, resolvedLevel);
+            : RequestContentCoding.Wrap(content, settings, resolved, resolvedLevel);
     }
 
     /// <summary>Serializes a generated request body using Refit body rules.</summary>

--- a/src/Refit/GeneratedRequestRunner.BodyContent.cs
+++ b/src/Refit/GeneratedRequestRunner.BodyContent.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for full license information.
 using System.Collections;
 using System.Diagnostics.CodeAnalysis;
+using System.IO.Compression;
 using System.Net.Http;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -23,6 +24,26 @@ public static partial class GeneratedRequestRunner
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static HttpContent CreateStreamContent(Stream stream) =>
         new StreamContent(new NonDisposingStream(stream));
+
+    /// <summary>Applies the request body coding a body parameter or the settings asked for.</summary>
+    /// <param name="content">The content to compress.</param>
+    /// <param name="settings">The Refit settings supplying the instance-wide default.</param>
+    /// <param name="compression">The coding the body parameter declared, or <see cref="RequestCompression.Default"/> to take the settings'.</param>
+    /// <param name="level">How hard to compress, used only when <paramref name="compression"/> names a coding.</param>
+    /// <returns>The compressing content, or <paramref name="content"/> unchanged when no coding applies.</returns>
+    /// <exception cref="PlatformNotSupportedException">This target framework cannot produce the resolved coding.</exception>
+    public static HttpContent CompressBodyContent(
+        HttpContent content,
+        RefitSettings settings,
+        RequestCompression compression,
+        CompressionLevel level)
+    {
+        var (resolved, resolvedLevel) = RequestContentCoding.Resolve(settings, compression, level);
+
+        return resolved is RequestCompression.Default or RequestCompression.None
+            ? content
+            : RequestContentCoding.Wrap(content, resolved, resolvedLevel);
+    }
 
     /// <summary>Serializes a generated request body using Refit body rules.</summary>
     /// <typeparam name="TBody">The declared body type.</typeparam>

--- a/src/Refit/PublicAPI/net10.0/PublicAPI.txt
+++ b/src/Refit/PublicAPI/net10.0/PublicAPI.txt
@@ -132,6 +132,8 @@ public sealed class BodyAttribute : System.Attribute
     public BodyAttribute(bool buffered) { }
     public BodyAttribute(Refit.BodySerializationMethod serializationMethod, bool buffered) { }
     public bool? Buffered { get; }
+    public Refit.RequestCompression Compression { get; set; }
+    public System.IO.Compression.CompressionLevel CompressionLevel { get; set; }
     public Refit.BodySerializationMethod SerializationMethod { get; }
 }
 public enum BodySerializationMethod
@@ -279,6 +281,7 @@ public static class GeneratedRequestRunner
     public static string BuildRequestPath<T>(string relativePathTemplate, bool allowUnmatchedParameter, (int StartIdx, int EndIdx) range, T value) where T : System.ISpanFormattable { }
     public static string BuildRequestPath<T>(string relativePathTemplate, bool allowUnmatchedParameter, (int StartIdx, int EndIdx) range, T value, string? format) where T : System.ISpanFormattable { }
     public static bool CanUnrollForm(object? body) { }
+    public static System.Net.Http.HttpContent CompressBodyContent(System.Net.Http.HttpContent content, Refit.RefitSettings settings, Refit.RequestCompression compression, System.IO.Compression.CompressionLevel level) { }
     public static System.Net.Http.HttpContent CreateBodyContent<TBody>(Refit.RefitSettings settings, TBody body, Refit.BodySerializationMethod serializationMethod, bool streamBody) { }
     public static System.Net.Http.HttpContent CreateJsonLinesBodyContent<TBody>(Refit.RefitSettings settings, TBody body) { }
     [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
@@ -617,6 +620,8 @@ public class RefitSettings
     public System.Collections.Generic.Dictionary<string, object>? HttpRequestMessageOptions { get; init; }
     public int? MaxExceptionContentLength { get; set; }
     public Refit.RequestBodySerializationMode RequestBodySerialization { get; set; }
+    public Refit.RequestCompression RequestCompression { get; set; }
+    public System.IO.Compression.CompressionLevel RequestCompressionLevel { get; set; }
     public System.Collections.Generic.IList<System.Type> ReturnTypeAdapters { get; }
     public System.Func<System.Net.Http.HttpRequestMessage, System.Exception, System.Threading.CancellationToken, System.Exception> TransportExceptionFactory { get; set; }
     public Refit.IUrlParameterFormatter UrlParameterFormatter { get; set; }
@@ -653,6 +658,14 @@ public static class RequestBuilder
     [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Building requests from reflected interface methods requires interface and request object metadata to be available at runtime.")]
     [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
     public static Refit.IRequestBuilder<T> ForType<T>(Refit.RefitSettings? settings) { }
+}
+public enum RequestCompression
+{
+    Default = 0,
+    None = 1,
+    GZip = 2,
+    Brotli = 3,
+    Zstandard = 4,
 }
 [System.Diagnostics.DebuggerDisplay("{ToString(),nq}")]
 public record RestMethodInfo : System.IEquatable<Refit.RestMethodInfo>

--- a/src/Refit/PublicAPI/net10.0/PublicAPI.txt
+++ b/src/Refit/PublicAPI/net10.0/PublicAPI.txt
@@ -622,6 +622,7 @@ public class RefitSettings
     public Refit.RequestBodySerializationMode RequestBodySerialization { get; set; }
     public Refit.RequestCompression RequestCompression { get; set; }
     public System.IO.Compression.CompressionLevel RequestCompressionLevel { get; set; }
+    public Refit.RequestCompressionOptions? RequestCompressionOptions { get; set; }
     public System.Collections.Generic.IList<System.Type> ReturnTypeAdapters { get; }
     public System.Func<System.Net.Http.HttpRequestMessage, System.Exception, System.Threading.CancellationToken, System.Exception> TransportExceptionFactory { get; set; }
     public Refit.IUrlParameterFormatter UrlParameterFormatter { get; set; }
@@ -666,6 +667,13 @@ public enum RequestCompression
     GZip = 2,
     Brotli = 3,
     Zstandard = 4,
+}
+[System.Diagnostics.DebuggerDisplay("{GZip} {Brotli}")]
+public sealed class RequestCompressionOptions
+{
+    public RequestCompressionOptions() { }
+    public System.IO.Compression.BrotliCompressionOptions? Brotli { get; set; }
+    public System.IO.Compression.ZLibCompressionOptions? GZip { get; set; }
 }
 [System.Diagnostics.DebuggerDisplay("{ToString(),nq}")]
 public record RestMethodInfo : System.IEquatable<Refit.RestMethodInfo>

--- a/src/Refit/PublicAPI/net11.0/PublicAPI.txt
+++ b/src/Refit/PublicAPI/net11.0/PublicAPI.txt
@@ -132,6 +132,8 @@ public sealed class BodyAttribute : System.Attribute
     public BodyAttribute(bool buffered) { }
     public BodyAttribute(Refit.BodySerializationMethod serializationMethod, bool buffered) { }
     public bool? Buffered { get; }
+    public Refit.RequestCompression Compression { get; set; }
+    public System.IO.Compression.CompressionLevel CompressionLevel { get; set; }
     public Refit.BodySerializationMethod SerializationMethod { get; }
 }
 public enum BodySerializationMethod
@@ -279,6 +281,7 @@ public static class GeneratedRequestRunner
     public static string BuildRequestPath<T>(string relativePathTemplate, bool allowUnmatchedParameter, (int StartIdx, int EndIdx) range, T value) where T : System.ISpanFormattable { }
     public static string BuildRequestPath<T>(string relativePathTemplate, bool allowUnmatchedParameter, (int StartIdx, int EndIdx) range, T value, string? format) where T : System.ISpanFormattable { }
     public static bool CanUnrollForm(object? body) { }
+    public static System.Net.Http.HttpContent CompressBodyContent(System.Net.Http.HttpContent content, Refit.RefitSettings settings, Refit.RequestCompression compression, System.IO.Compression.CompressionLevel level) { }
     public static System.Net.Http.HttpContent CreateBodyContent<TBody>(Refit.RefitSettings settings, TBody body, Refit.BodySerializationMethod serializationMethod, bool streamBody) { }
     public static System.Net.Http.HttpContent CreateJsonLinesBodyContent<TBody>(Refit.RefitSettings settings, TBody body) { }
     [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
@@ -617,6 +620,8 @@ public class RefitSettings
     public System.Collections.Generic.Dictionary<string, object>? HttpRequestMessageOptions { get; init; }
     public int? MaxExceptionContentLength { get; set; }
     public Refit.RequestBodySerializationMode RequestBodySerialization { get; set; }
+    public Refit.RequestCompression RequestCompression { get; set; }
+    public System.IO.Compression.CompressionLevel RequestCompressionLevel { get; set; }
     public System.Collections.Generic.IList<System.Type> ReturnTypeAdapters { get; }
     public System.Func<System.Net.Http.HttpRequestMessage, System.Exception, System.Threading.CancellationToken, System.Exception> TransportExceptionFactory { get; set; }
     public Refit.IUrlParameterFormatter UrlParameterFormatter { get; set; }
@@ -653,6 +658,14 @@ public static class RequestBuilder
     [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Building requests from reflected interface methods requires interface and request object metadata to be available at runtime.")]
     [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
     public static Refit.IRequestBuilder<T> ForType<T>(Refit.RefitSettings? settings) { }
+}
+public enum RequestCompression
+{
+    Default = 0,
+    None = 1,
+    GZip = 2,
+    Brotli = 3,
+    Zstandard = 4,
 }
 [System.Diagnostics.DebuggerDisplay("{ToString(),nq}")]
 public record RestMethodInfo : System.IEquatable<Refit.RestMethodInfo>

--- a/src/Refit/PublicAPI/net11.0/PublicAPI.txt
+++ b/src/Refit/PublicAPI/net11.0/PublicAPI.txt
@@ -622,6 +622,7 @@ public class RefitSettings
     public Refit.RequestBodySerializationMode RequestBodySerialization { get; set; }
     public Refit.RequestCompression RequestCompression { get; set; }
     public System.IO.Compression.CompressionLevel RequestCompressionLevel { get; set; }
+    public Refit.RequestCompressionOptions? RequestCompressionOptions { get; set; }
     public System.Collections.Generic.IList<System.Type> ReturnTypeAdapters { get; }
     public System.Func<System.Net.Http.HttpRequestMessage, System.Exception, System.Threading.CancellationToken, System.Exception> TransportExceptionFactory { get; set; }
     public Refit.IUrlParameterFormatter UrlParameterFormatter { get; set; }
@@ -666,6 +667,14 @@ public enum RequestCompression
     GZip = 2,
     Brotli = 3,
     Zstandard = 4,
+}
+[System.Diagnostics.DebuggerDisplay("{GZip} {Brotli}")]
+public sealed class RequestCompressionOptions
+{
+    public RequestCompressionOptions() { }
+    public System.IO.Compression.BrotliCompressionOptions? Brotli { get; set; }
+    public System.IO.Compression.ZLibCompressionOptions? GZip { get; set; }
+    public System.IO.Compression.ZstandardCompressionOptions? Zstandard { get; set; }
 }
 [System.Diagnostics.DebuggerDisplay("{ToString(),nq}")]
 public record RestMethodInfo : System.IEquatable<Refit.RestMethodInfo>

--- a/src/Refit/PublicAPI/net462/PublicAPI.txt
+++ b/src/Refit/PublicAPI/net462/PublicAPI.txt
@@ -118,6 +118,8 @@ public sealed class BodyAttribute : System.Attribute
     public BodyAttribute(bool buffered) { }
     public BodyAttribute(Refit.BodySerializationMethod serializationMethod, bool buffered) { }
     public bool? Buffered { get; }
+    public Refit.RequestCompression Compression { get; set; }
+    public System.IO.Compression.CompressionLevel CompressionLevel { get; set; }
     public Refit.BodySerializationMethod SerializationMethod { get; }
 }
 public enum BodySerializationMethod
@@ -260,6 +262,7 @@ public static class GeneratedRequestRunner
     public static string BuildRequestPath(string relativePathTemplate, bool allowUnmatchedParameter, System.ReadOnlySpan<((int StartIdx, int EndIdx) Range, string? Value)> uriParams) { }
     public static string BuildRequestPath(string relativePathTemplate, bool allowUnmatchedParameter, System.ReadOnlySpan<((int StartIdx, int EndIdx) Range, string? Value, bool PreEncoded)> uriParams) { }
     public static bool CanUnrollForm(object? body) { }
+    public static System.Net.Http.HttpContent CompressBodyContent(System.Net.Http.HttpContent content, Refit.RefitSettings settings, Refit.RequestCompression compression, System.IO.Compression.CompressionLevel level) { }
     public static System.Net.Http.HttpContent CreateBodyContent<TBody>(Refit.RefitSettings settings, TBody body, Refit.BodySerializationMethod serializationMethod, bool streamBody) { }
     public static System.Net.Http.HttpContent CreateJsonLinesBodyContent<TBody>(Refit.RefitSettings settings, TBody body) { }
     [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
@@ -585,6 +588,8 @@ public class RefitSettings
     public System.Collections.Generic.Dictionary<string, object>? HttpRequestMessageOptions { get; init; }
     public int? MaxExceptionContentLength { get; set; }
     public Refit.RequestBodySerializationMode RequestBodySerialization { get; set; }
+    public Refit.RequestCompression RequestCompression { get; set; }
+    public System.IO.Compression.CompressionLevel RequestCompressionLevel { get; set; }
     public System.Collections.Generic.IList<System.Type> ReturnTypeAdapters { get; }
     public System.Func<System.Net.Http.HttpRequestMessage, System.Exception, System.Threading.CancellationToken, System.Exception> TransportExceptionFactory { get; set; }
     public Refit.IUrlParameterFormatter UrlParameterFormatter { get; set; }
@@ -615,6 +620,14 @@ public static class RequestBuilder
     public static Refit.IRequestBuilder<T> ForType<T>() { }
     [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
     public static Refit.IRequestBuilder<T> ForType<T>(Refit.RefitSettings? settings) { }
+}
+public enum RequestCompression
+{
+    Default = 0,
+    None = 1,
+    GZip = 2,
+    Brotli = 3,
+    Zstandard = 4,
 }
 [System.Diagnostics.DebuggerDisplay("{ToString(),nq}")]
 public record RestMethodInfo : System.IEquatable<Refit.RestMethodInfo>

--- a/src/Refit/PublicAPI/net470/PublicAPI.txt
+++ b/src/Refit/PublicAPI/net470/PublicAPI.txt
@@ -118,6 +118,8 @@ public sealed class BodyAttribute : System.Attribute
     public BodyAttribute(bool buffered) { }
     public BodyAttribute(Refit.BodySerializationMethod serializationMethod, bool buffered) { }
     public bool? Buffered { get; }
+    public Refit.RequestCompression Compression { get; set; }
+    public System.IO.Compression.CompressionLevel CompressionLevel { get; set; }
     public Refit.BodySerializationMethod SerializationMethod { get; }
 }
 public enum BodySerializationMethod
@@ -260,6 +262,7 @@ public static class GeneratedRequestRunner
     public static string BuildRequestPath(string relativePathTemplate, bool allowUnmatchedParameter, System.ReadOnlySpan<((int StartIdx, int EndIdx) Range, string? Value)> uriParams) { }
     public static string BuildRequestPath(string relativePathTemplate, bool allowUnmatchedParameter, System.ReadOnlySpan<((int StartIdx, int EndIdx) Range, string? Value, bool PreEncoded)> uriParams) { }
     public static bool CanUnrollForm(object? body) { }
+    public static System.Net.Http.HttpContent CompressBodyContent(System.Net.Http.HttpContent content, Refit.RefitSettings settings, Refit.RequestCompression compression, System.IO.Compression.CompressionLevel level) { }
     public static System.Net.Http.HttpContent CreateBodyContent<TBody>(Refit.RefitSettings settings, TBody body, Refit.BodySerializationMethod serializationMethod, bool streamBody) { }
     public static System.Net.Http.HttpContent CreateJsonLinesBodyContent<TBody>(Refit.RefitSettings settings, TBody body) { }
     [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
@@ -585,6 +588,8 @@ public class RefitSettings
     public System.Collections.Generic.Dictionary<string, object>? HttpRequestMessageOptions { get; init; }
     public int? MaxExceptionContentLength { get; set; }
     public Refit.RequestBodySerializationMode RequestBodySerialization { get; set; }
+    public Refit.RequestCompression RequestCompression { get; set; }
+    public System.IO.Compression.CompressionLevel RequestCompressionLevel { get; set; }
     public System.Collections.Generic.IList<System.Type> ReturnTypeAdapters { get; }
     public System.Func<System.Net.Http.HttpRequestMessage, System.Exception, System.Threading.CancellationToken, System.Exception> TransportExceptionFactory { get; set; }
     public Refit.IUrlParameterFormatter UrlParameterFormatter { get; set; }
@@ -615,6 +620,14 @@ public static class RequestBuilder
     public static Refit.IRequestBuilder<T> ForType<T>() { }
     [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
     public static Refit.IRequestBuilder<T> ForType<T>(Refit.RefitSettings? settings) { }
+}
+public enum RequestCompression
+{
+    Default = 0,
+    None = 1,
+    GZip = 2,
+    Brotli = 3,
+    Zstandard = 4,
 }
 [System.Diagnostics.DebuggerDisplay("{ToString(),nq}")]
 public record RestMethodInfo : System.IEquatable<Refit.RestMethodInfo>

--- a/src/Refit/PublicAPI/net471/PublicAPI.txt
+++ b/src/Refit/PublicAPI/net471/PublicAPI.txt
@@ -118,6 +118,8 @@ public sealed class BodyAttribute : System.Attribute
     public BodyAttribute(bool buffered) { }
     public BodyAttribute(Refit.BodySerializationMethod serializationMethod, bool buffered) { }
     public bool? Buffered { get; }
+    public Refit.RequestCompression Compression { get; set; }
+    public System.IO.Compression.CompressionLevel CompressionLevel { get; set; }
     public Refit.BodySerializationMethod SerializationMethod { get; }
 }
 public enum BodySerializationMethod
@@ -260,6 +262,7 @@ public static class GeneratedRequestRunner
     public static string BuildRequestPath(string relativePathTemplate, bool allowUnmatchedParameter, System.ReadOnlySpan<((int StartIdx, int EndIdx) Range, string? Value)> uriParams) { }
     public static string BuildRequestPath(string relativePathTemplate, bool allowUnmatchedParameter, System.ReadOnlySpan<((int StartIdx, int EndIdx) Range, string? Value, bool PreEncoded)> uriParams) { }
     public static bool CanUnrollForm(object? body) { }
+    public static System.Net.Http.HttpContent CompressBodyContent(System.Net.Http.HttpContent content, Refit.RefitSettings settings, Refit.RequestCompression compression, System.IO.Compression.CompressionLevel level) { }
     public static System.Net.Http.HttpContent CreateBodyContent<TBody>(Refit.RefitSettings settings, TBody body, Refit.BodySerializationMethod serializationMethod, bool streamBody) { }
     public static System.Net.Http.HttpContent CreateJsonLinesBodyContent<TBody>(Refit.RefitSettings settings, TBody body) { }
     [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
@@ -585,6 +588,8 @@ public class RefitSettings
     public System.Collections.Generic.Dictionary<string, object>? HttpRequestMessageOptions { get; init; }
     public int? MaxExceptionContentLength { get; set; }
     public Refit.RequestBodySerializationMode RequestBodySerialization { get; set; }
+    public Refit.RequestCompression RequestCompression { get; set; }
+    public System.IO.Compression.CompressionLevel RequestCompressionLevel { get; set; }
     public System.Collections.Generic.IList<System.Type> ReturnTypeAdapters { get; }
     public System.Func<System.Net.Http.HttpRequestMessage, System.Exception, System.Threading.CancellationToken, System.Exception> TransportExceptionFactory { get; set; }
     public Refit.IUrlParameterFormatter UrlParameterFormatter { get; set; }
@@ -615,6 +620,14 @@ public static class RequestBuilder
     public static Refit.IRequestBuilder<T> ForType<T>() { }
     [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
     public static Refit.IRequestBuilder<T> ForType<T>(Refit.RefitSettings? settings) { }
+}
+public enum RequestCompression
+{
+    Default = 0,
+    None = 1,
+    GZip = 2,
+    Brotli = 3,
+    Zstandard = 4,
 }
 [System.Diagnostics.DebuggerDisplay("{ToString(),nq}")]
 public record RestMethodInfo : System.IEquatable<Refit.RestMethodInfo>

--- a/src/Refit/PublicAPI/net472/PublicAPI.txt
+++ b/src/Refit/PublicAPI/net472/PublicAPI.txt
@@ -118,6 +118,8 @@ public sealed class BodyAttribute : System.Attribute
     public BodyAttribute(bool buffered) { }
     public BodyAttribute(Refit.BodySerializationMethod serializationMethod, bool buffered) { }
     public bool? Buffered { get; }
+    public Refit.RequestCompression Compression { get; set; }
+    public System.IO.Compression.CompressionLevel CompressionLevel { get; set; }
     public Refit.BodySerializationMethod SerializationMethod { get; }
 }
 public enum BodySerializationMethod
@@ -260,6 +262,7 @@ public static class GeneratedRequestRunner
     public static string BuildRequestPath(string relativePathTemplate, bool allowUnmatchedParameter, System.ReadOnlySpan<((int StartIdx, int EndIdx) Range, string? Value)> uriParams) { }
     public static string BuildRequestPath(string relativePathTemplate, bool allowUnmatchedParameter, System.ReadOnlySpan<((int StartIdx, int EndIdx) Range, string? Value, bool PreEncoded)> uriParams) { }
     public static bool CanUnrollForm(object? body) { }
+    public static System.Net.Http.HttpContent CompressBodyContent(System.Net.Http.HttpContent content, Refit.RefitSettings settings, Refit.RequestCompression compression, System.IO.Compression.CompressionLevel level) { }
     public static System.Net.Http.HttpContent CreateBodyContent<TBody>(Refit.RefitSettings settings, TBody body, Refit.BodySerializationMethod serializationMethod, bool streamBody) { }
     public static System.Net.Http.HttpContent CreateJsonLinesBodyContent<TBody>(Refit.RefitSettings settings, TBody body) { }
     [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
@@ -585,6 +588,8 @@ public class RefitSettings
     public System.Collections.Generic.Dictionary<string, object>? HttpRequestMessageOptions { get; init; }
     public int? MaxExceptionContentLength { get; set; }
     public Refit.RequestBodySerializationMode RequestBodySerialization { get; set; }
+    public Refit.RequestCompression RequestCompression { get; set; }
+    public System.IO.Compression.CompressionLevel RequestCompressionLevel { get; set; }
     public System.Collections.Generic.IList<System.Type> ReturnTypeAdapters { get; }
     public System.Func<System.Net.Http.HttpRequestMessage, System.Exception, System.Threading.CancellationToken, System.Exception> TransportExceptionFactory { get; set; }
     public Refit.IUrlParameterFormatter UrlParameterFormatter { get; set; }
@@ -615,6 +620,14 @@ public static class RequestBuilder
     public static Refit.IRequestBuilder<T> ForType<T>() { }
     [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
     public static Refit.IRequestBuilder<T> ForType<T>(Refit.RefitSettings? settings) { }
+}
+public enum RequestCompression
+{
+    Default = 0,
+    None = 1,
+    GZip = 2,
+    Brotli = 3,
+    Zstandard = 4,
 }
 [System.Diagnostics.DebuggerDisplay("{ToString(),nq}")]
 public record RestMethodInfo : System.IEquatable<Refit.RestMethodInfo>

--- a/src/Refit/PublicAPI/net48/PublicAPI.txt
+++ b/src/Refit/PublicAPI/net48/PublicAPI.txt
@@ -118,6 +118,8 @@ public sealed class BodyAttribute : System.Attribute
     public BodyAttribute(bool buffered) { }
     public BodyAttribute(Refit.BodySerializationMethod serializationMethod, bool buffered) { }
     public bool? Buffered { get; }
+    public Refit.RequestCompression Compression { get; set; }
+    public System.IO.Compression.CompressionLevel CompressionLevel { get; set; }
     public Refit.BodySerializationMethod SerializationMethod { get; }
 }
 public enum BodySerializationMethod
@@ -260,6 +262,7 @@ public static class GeneratedRequestRunner
     public static string BuildRequestPath(string relativePathTemplate, bool allowUnmatchedParameter, System.ReadOnlySpan<((int StartIdx, int EndIdx) Range, string? Value)> uriParams) { }
     public static string BuildRequestPath(string relativePathTemplate, bool allowUnmatchedParameter, System.ReadOnlySpan<((int StartIdx, int EndIdx) Range, string? Value, bool PreEncoded)> uriParams) { }
     public static bool CanUnrollForm(object? body) { }
+    public static System.Net.Http.HttpContent CompressBodyContent(System.Net.Http.HttpContent content, Refit.RefitSettings settings, Refit.RequestCompression compression, System.IO.Compression.CompressionLevel level) { }
     public static System.Net.Http.HttpContent CreateBodyContent<TBody>(Refit.RefitSettings settings, TBody body, Refit.BodySerializationMethod serializationMethod, bool streamBody) { }
     public static System.Net.Http.HttpContent CreateJsonLinesBodyContent<TBody>(Refit.RefitSettings settings, TBody body) { }
     [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
@@ -585,6 +588,8 @@ public class RefitSettings
     public System.Collections.Generic.Dictionary<string, object>? HttpRequestMessageOptions { get; init; }
     public int? MaxExceptionContentLength { get; set; }
     public Refit.RequestBodySerializationMode RequestBodySerialization { get; set; }
+    public Refit.RequestCompression RequestCompression { get; set; }
+    public System.IO.Compression.CompressionLevel RequestCompressionLevel { get; set; }
     public System.Collections.Generic.IList<System.Type> ReturnTypeAdapters { get; }
     public System.Func<System.Net.Http.HttpRequestMessage, System.Exception, System.Threading.CancellationToken, System.Exception> TransportExceptionFactory { get; set; }
     public Refit.IUrlParameterFormatter UrlParameterFormatter { get; set; }
@@ -615,6 +620,14 @@ public static class RequestBuilder
     public static Refit.IRequestBuilder<T> ForType<T>() { }
     [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
     public static Refit.IRequestBuilder<T> ForType<T>(Refit.RefitSettings? settings) { }
+}
+public enum RequestCompression
+{
+    Default = 0,
+    None = 1,
+    GZip = 2,
+    Brotli = 3,
+    Zstandard = 4,
 }
 [System.Diagnostics.DebuggerDisplay("{ToString(),nq}")]
 public record RestMethodInfo : System.IEquatable<Refit.RestMethodInfo>

--- a/src/Refit/PublicAPI/net481/PublicAPI.txt
+++ b/src/Refit/PublicAPI/net481/PublicAPI.txt
@@ -118,6 +118,8 @@ public sealed class BodyAttribute : System.Attribute
     public BodyAttribute(bool buffered) { }
     public BodyAttribute(Refit.BodySerializationMethod serializationMethod, bool buffered) { }
     public bool? Buffered { get; }
+    public Refit.RequestCompression Compression { get; set; }
+    public System.IO.Compression.CompressionLevel CompressionLevel { get; set; }
     public Refit.BodySerializationMethod SerializationMethod { get; }
 }
 public enum BodySerializationMethod
@@ -260,6 +262,7 @@ public static class GeneratedRequestRunner
     public static string BuildRequestPath(string relativePathTemplate, bool allowUnmatchedParameter, System.ReadOnlySpan<((int StartIdx, int EndIdx) Range, string? Value)> uriParams) { }
     public static string BuildRequestPath(string relativePathTemplate, bool allowUnmatchedParameter, System.ReadOnlySpan<((int StartIdx, int EndIdx) Range, string? Value, bool PreEncoded)> uriParams) { }
     public static bool CanUnrollForm(object? body) { }
+    public static System.Net.Http.HttpContent CompressBodyContent(System.Net.Http.HttpContent content, Refit.RefitSettings settings, Refit.RequestCompression compression, System.IO.Compression.CompressionLevel level) { }
     public static System.Net.Http.HttpContent CreateBodyContent<TBody>(Refit.RefitSettings settings, TBody body, Refit.BodySerializationMethod serializationMethod, bool streamBody) { }
     public static System.Net.Http.HttpContent CreateJsonLinesBodyContent<TBody>(Refit.RefitSettings settings, TBody body) { }
     [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
@@ -585,6 +588,8 @@ public class RefitSettings
     public System.Collections.Generic.Dictionary<string, object>? HttpRequestMessageOptions { get; init; }
     public int? MaxExceptionContentLength { get; set; }
     public Refit.RequestBodySerializationMode RequestBodySerialization { get; set; }
+    public Refit.RequestCompression RequestCompression { get; set; }
+    public System.IO.Compression.CompressionLevel RequestCompressionLevel { get; set; }
     public System.Collections.Generic.IList<System.Type> ReturnTypeAdapters { get; }
     public System.Func<System.Net.Http.HttpRequestMessage, System.Exception, System.Threading.CancellationToken, System.Exception> TransportExceptionFactory { get; set; }
     public Refit.IUrlParameterFormatter UrlParameterFormatter { get; set; }
@@ -615,6 +620,14 @@ public static class RequestBuilder
     public static Refit.IRequestBuilder<T> ForType<T>() { }
     [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
     public static Refit.IRequestBuilder<T> ForType<T>(Refit.RefitSettings? settings) { }
+}
+public enum RequestCompression
+{
+    Default = 0,
+    None = 1,
+    GZip = 2,
+    Brotli = 3,
+    Zstandard = 4,
 }
 [System.Diagnostics.DebuggerDisplay("{ToString(),nq}")]
 public record RestMethodInfo : System.IEquatable<Refit.RestMethodInfo>

--- a/src/Refit/PublicAPI/net8.0/PublicAPI.txt
+++ b/src/Refit/PublicAPI/net8.0/PublicAPI.txt
@@ -131,6 +131,8 @@ public sealed class BodyAttribute : System.Attribute
     public BodyAttribute(bool buffered) { }
     public BodyAttribute(Refit.BodySerializationMethod serializationMethod, bool buffered) { }
     public bool? Buffered { get; }
+    public Refit.RequestCompression Compression { get; set; }
+    public System.IO.Compression.CompressionLevel CompressionLevel { get; set; }
     public Refit.BodySerializationMethod SerializationMethod { get; }
 }
 public enum BodySerializationMethod
@@ -278,6 +280,7 @@ public static class GeneratedRequestRunner
     public static string BuildRequestPath<T>(string relativePathTemplate, bool allowUnmatchedParameter, (int StartIdx, int EndIdx) range, T value) where T : System.ISpanFormattable { }
     public static string BuildRequestPath<T>(string relativePathTemplate, bool allowUnmatchedParameter, (int StartIdx, int EndIdx) range, T value, string? format) where T : System.ISpanFormattable { }
     public static bool CanUnrollForm(object? body) { }
+    public static System.Net.Http.HttpContent CompressBodyContent(System.Net.Http.HttpContent content, Refit.RefitSettings settings, Refit.RequestCompression compression, System.IO.Compression.CompressionLevel level) { }
     public static System.Net.Http.HttpContent CreateBodyContent<TBody>(Refit.RefitSettings settings, TBody body, Refit.BodySerializationMethod serializationMethod, bool streamBody) { }
     public static System.Net.Http.HttpContent CreateJsonLinesBodyContent<TBody>(Refit.RefitSettings settings, TBody body) { }
     [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
@@ -616,6 +619,8 @@ public class RefitSettings
     public System.Collections.Generic.Dictionary<string, object>? HttpRequestMessageOptions { get; init; }
     public int? MaxExceptionContentLength { get; set; }
     public Refit.RequestBodySerializationMode RequestBodySerialization { get; set; }
+    public Refit.RequestCompression RequestCompression { get; set; }
+    public System.IO.Compression.CompressionLevel RequestCompressionLevel { get; set; }
     public System.Collections.Generic.IList<System.Type> ReturnTypeAdapters { get; }
     public System.Func<System.Net.Http.HttpRequestMessage, System.Exception, System.Threading.CancellationToken, System.Exception> TransportExceptionFactory { get; set; }
     public Refit.IUrlParameterFormatter UrlParameterFormatter { get; set; }
@@ -652,6 +657,14 @@ public static class RequestBuilder
     [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Building requests from reflected interface methods requires interface and request object metadata to be available at runtime.")]
     [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
     public static Refit.IRequestBuilder<T> ForType<T>(Refit.RefitSettings? settings) { }
+}
+public enum RequestCompression
+{
+    Default = 0,
+    None = 1,
+    GZip = 2,
+    Brotli = 3,
+    Zstandard = 4,
 }
 [System.Diagnostics.DebuggerDisplay("{ToString(),nq}")]
 public record RestMethodInfo : System.IEquatable<Refit.RestMethodInfo>

--- a/src/Refit/PublicAPI/net9.0/PublicAPI.txt
+++ b/src/Refit/PublicAPI/net9.0/PublicAPI.txt
@@ -131,6 +131,8 @@ public sealed class BodyAttribute : System.Attribute
     public BodyAttribute(bool buffered) { }
     public BodyAttribute(Refit.BodySerializationMethod serializationMethod, bool buffered) { }
     public bool? Buffered { get; }
+    public Refit.RequestCompression Compression { get; set; }
+    public System.IO.Compression.CompressionLevel CompressionLevel { get; set; }
     public Refit.BodySerializationMethod SerializationMethod { get; }
 }
 public enum BodySerializationMethod
@@ -278,6 +280,7 @@ public static class GeneratedRequestRunner
     public static string BuildRequestPath<T>(string relativePathTemplate, bool allowUnmatchedParameter, (int StartIdx, int EndIdx) range, T value) where T : System.ISpanFormattable { }
     public static string BuildRequestPath<T>(string relativePathTemplate, bool allowUnmatchedParameter, (int StartIdx, int EndIdx) range, T value, string? format) where T : System.ISpanFormattable { }
     public static bool CanUnrollForm(object? body) { }
+    public static System.Net.Http.HttpContent CompressBodyContent(System.Net.Http.HttpContent content, Refit.RefitSettings settings, Refit.RequestCompression compression, System.IO.Compression.CompressionLevel level) { }
     public static System.Net.Http.HttpContent CreateBodyContent<TBody>(Refit.RefitSettings settings, TBody body, Refit.BodySerializationMethod serializationMethod, bool streamBody) { }
     public static System.Net.Http.HttpContent CreateJsonLinesBodyContent<TBody>(Refit.RefitSettings settings, TBody body) { }
     [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
@@ -616,6 +619,8 @@ public class RefitSettings
     public System.Collections.Generic.Dictionary<string, object>? HttpRequestMessageOptions { get; init; }
     public int? MaxExceptionContentLength { get; set; }
     public Refit.RequestBodySerializationMode RequestBodySerialization { get; set; }
+    public Refit.RequestCompression RequestCompression { get; set; }
+    public System.IO.Compression.CompressionLevel RequestCompressionLevel { get; set; }
     public System.Collections.Generic.IList<System.Type> ReturnTypeAdapters { get; }
     public System.Func<System.Net.Http.HttpRequestMessage, System.Exception, System.Threading.CancellationToken, System.Exception> TransportExceptionFactory { get; set; }
     public Refit.IUrlParameterFormatter UrlParameterFormatter { get; set; }
@@ -652,6 +657,14 @@ public static class RequestBuilder
     [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Building requests from reflected interface methods requires interface and request object metadata to be available at runtime.")]
     [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
     public static Refit.IRequestBuilder<T> ForType<T>(Refit.RefitSettings? settings) { }
+}
+public enum RequestCompression
+{
+    Default = 0,
+    None = 1,
+    GZip = 2,
+    Brotli = 3,
+    Zstandard = 4,
 }
 [System.Diagnostics.DebuggerDisplay("{ToString(),nq}")]
 public record RestMethodInfo : System.IEquatable<Refit.RestMethodInfo>

--- a/src/Refit/PublicAPI/net9.0/PublicAPI.txt
+++ b/src/Refit/PublicAPI/net9.0/PublicAPI.txt
@@ -621,6 +621,7 @@ public class RefitSettings
     public Refit.RequestBodySerializationMode RequestBodySerialization { get; set; }
     public Refit.RequestCompression RequestCompression { get; set; }
     public System.IO.Compression.CompressionLevel RequestCompressionLevel { get; set; }
+    public Refit.RequestCompressionOptions? RequestCompressionOptions { get; set; }
     public System.Collections.Generic.IList<System.Type> ReturnTypeAdapters { get; }
     public System.Func<System.Net.Http.HttpRequestMessage, System.Exception, System.Threading.CancellationToken, System.Exception> TransportExceptionFactory { get; set; }
     public Refit.IUrlParameterFormatter UrlParameterFormatter { get; set; }
@@ -665,6 +666,13 @@ public enum RequestCompression
     GZip = 2,
     Brotli = 3,
     Zstandard = 4,
+}
+[System.Diagnostics.DebuggerDisplay("{GZip} {Brotli}")]
+public sealed class RequestCompressionOptions
+{
+    public RequestCompressionOptions() { }
+    public System.IO.Compression.BrotliCompressionOptions? Brotli { get; set; }
+    public System.IO.Compression.ZLibCompressionOptions? GZip { get; set; }
 }
 [System.Diagnostics.DebuggerDisplay("{ToString(),nq}")]
 public record RestMethodInfo : System.IEquatable<Refit.RestMethodInfo>

--- a/src/Refit/Refit.csproj
+++ b/src/Refit/Refit.csproj
@@ -58,6 +58,7 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net462' Or '$(TargetFramework)' == 'net470' Or '$(TargetFramework)' == 'net471' Or '$(TargetFramework)' == 'net472' Or '$(TargetFramework)' == 'net48' Or '$(TargetFramework)' == 'net481'">
     <Reference Include="System.Web"/>
+    <Reference Include="System.IO.Compression"/>
     <ProjectReference Include="..\InterfaceStubGenerator.Roslyn48\InterfaceStubGenerator.Roslyn48.csproj" ReferenceOutputAssembly="false"/>
     <ProjectReference Include="..\Refit.Analyzers.Roslyn48\Refit.Analyzers.Roslyn48.csproj" ReferenceOutputAssembly="false"/>
     <ProjectReference Include="..\Refit.CodeFixes.Roslyn48\Refit.CodeFixes.Roslyn48.csproj" ReferenceOutputAssembly="false"/>

--- a/src/Refit/RefitSettings.cs
+++ b/src/Refit/RefitSettings.cs
@@ -276,6 +276,13 @@ public class RefitSettings
     public System.IO.Compression.CompressionLevel RequestCompressionLevel { get; set; } =
         System.IO.Compression.CompressionLevel.Optimal;
 
+#if NET9_0_OR_GREATER
+    /// <summary>Gets or sets the per-coding compressor settings, or null to compress by level alone.</summary>
+    /// <remarks>Options set for a coding override the level for that coding, including where a <c>[Body]</c> parameter
+    /// named the coding and its own level.</remarks>
+    public RequestCompressionOptions? RequestCompressionOptions { get; set; }
+#endif
+
     /// <summary>Gets optional Key-Value pairs, which are displayed in the property <see cref="HttpRequestMessage.Properties"/>.</summary>
     public Dictionary<string, object>? HttpRequestMessageOptions { get; init; }
 

--- a/src/Refit/RefitSettings.cs
+++ b/src/Refit/RefitSettings.cs
@@ -264,6 +264,18 @@ public class RefitSettings
     /// </summary>
     public RequestBodySerializationMode RequestBodySerialization { get; set; } = RequestBodySerializationMode.Default;
 
+    /// <summary>
+    /// Gets or sets the content coding applied to every request body (defaults to <see cref="RequestCompression.None"/>).
+    /// A <c>[Body]</c> parameter naming its own coding overrides this, and <see cref="RequestCompression.None"/> on the
+    /// parameter opts that one method out.
+    /// </summary>
+    /// <remarks>Only turn this on against a server that accepts a compressed request body; there is no negotiation for it.</remarks>
+    public RequestCompression RequestCompression { get; set; } = RequestCompression.None;
+
+    /// <summary>Gets or sets how hard <see cref="RequestCompression"/> compresses (defaults to <see cref="System.IO.Compression.CompressionLevel.Optimal"/>).</summary>
+    public System.IO.Compression.CompressionLevel RequestCompressionLevel { get; set; } =
+        System.IO.Compression.CompressionLevel.Optimal;
+
     /// <summary>Gets optional Key-Value pairs, which are displayed in the property <see cref="HttpRequestMessage.Properties"/>.</summary>
     public Dictionary<string, object>? HttpRequestMessageOptions { get; init; }
 

--- a/src/Refit/RequestCompression.cs
+++ b/src/Refit/RequestCompression.cs
@@ -1,0 +1,30 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Refit;
+
+/// <summary>The content coding applied to a request body before it is sent.</summary>
+/// <remarks>
+/// Not every coding exists on every target framework: <see cref="GZip"/> is always available, <see cref="Brotli"/>
+/// needs .NET 8.0 or later, and <see cref="Zstandard"/> needs .NET 11.0 or later. Asking for a coding the running
+/// framework cannot produce throws <see cref="PlatformNotSupportedException"/> when the request is built, rather than
+/// silently sending the body uncompressed.
+/// </remarks>
+public enum RequestCompression
+{
+    /// <summary>Take the coding from <see cref="RefitSettings.RequestCompression"/>.</summary>
+    Default = 0,
+
+    /// <summary>Send the body uncompressed, whatever <see cref="RefitSettings.RequestCompression"/> says.</summary>
+    None = 1,
+
+    /// <summary>Compress with gzip and send <c>Content-Encoding: gzip</c>.</summary>
+    GZip = 2,
+
+    /// <summary>Compress with Brotli and send <c>Content-Encoding: br</c>. Requires .NET 8.0 or later.</summary>
+    Brotli = 3,
+
+    /// <summary>Compress with Zstandard and send <c>Content-Encoding: zstd</c>. Requires .NET 11.0 or later.</summary>
+    Zstandard = 4,
+}

--- a/src/Refit/RequestCompressionOptions.cs
+++ b/src/Refit/RequestCompressionOptions.cs
@@ -1,0 +1,30 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+#if NET9_0_OR_GREATER
+using System.IO.Compression;
+
+namespace Refit;
+
+/// <summary>The per-coding compressor settings used in place of <see cref="RefitSettings.RequestCompressionLevel"/>.</summary>
+/// <remarks>
+/// Each coding has its own options type carrying knobs a level cannot express - window size, strategy, a Zstandard
+/// dictionary. Setting the options for a coding overrides the level for that coding only; the codings left null still
+/// compress by level. The options types themselves arrived with .NET 9.0, and Zstandard's with .NET 11.0, so this type
+/// does not exist on earlier targets.
+/// </remarks>
+[System.Diagnostics.DebuggerDisplay("{GZip} {Brotli}")]
+public sealed class RequestCompressionOptions
+{
+    /// <summary>Gets or sets the gzip compressor settings, or <see langword="null"/> to compress by level.</summary>
+    public ZLibCompressionOptions? GZip { get; set; }
+
+    /// <summary>Gets or sets the Brotli compressor settings, or <see langword="null"/> to compress by level.</summary>
+    public BrotliCompressionOptions? Brotli { get; set; }
+
+#if NET11_0_OR_GREATER
+    /// <summary>Gets or sets the Zstandard compressor settings, or <see langword="null"/> to compress by level.</summary>
+    public ZstandardCompressionOptions? Zstandard { get; set; }
+#endif
+}
+#endif

--- a/src/Refit/RequestContentCoding.cs
+++ b/src/Refit/RequestContentCoding.cs
@@ -44,26 +44,49 @@ internal static class RequestContentCoding
 
     /// <summary>Wraps content in the compressor for a coding.</summary>
     /// <param name="content">The content to compress.</param>
+    /// <param name="settings">The Refit settings supplying the per-coding compressor options.</param>
     /// <param name="compression">The resolved coding, never <see cref="RequestCompression.Default"/> or <see cref="RequestCompression.None"/>.</param>
-    /// <param name="level">How hard to compress.</param>
+    /// <param name="level">How hard to compress, used for any coding the settings left without options.</param>
     /// <returns>The compressing content.</returns>
     /// <exception cref="PlatformNotSupportedException">This framework cannot produce the coding.</exception>
-    internal static HttpContent Wrap(HttpContent content, RequestCompression compression, CompressionLevel level) =>
+    internal static HttpContent Wrap(
+        HttpContent content,
+        RefitSettings settings,
+        RequestCompression compression,
+        CompressionLevel level)
+    {
 #if NET11_0_OR_GREATER
-        compression switch
+        var options = settings.RequestCompressionOptions;
+
+        return compression switch
         {
-            RequestCompression.GZip => new GZipCompressedContent(content, level),
-            RequestCompression.Brotli => new BrotliCompressedContent(content, level),
-            RequestCompression.Zstandard => new ZstandardCompressedContent(content, level),
+            RequestCompression.GZip => options?.GZip is { } gzip
+                ? new GZipCompressedContent(content, gzip)
+                : new GZipCompressedContent(content, level),
+            RequestCompression.Brotli => options?.Brotli is { } brotli
+                ? new BrotliCompressedContent(content, brotli)
+                : new BrotliCompressedContent(content, level),
+            RequestCompression.Zstandard => options?.Zstandard is { } zstandard
+                ? new ZstandardCompressedContent(content, zstandard)
+                : new ZstandardCompressedContent(content, level),
             _ => throw Unsupported(compression),
         };
+#elif NET9_0_OR_GREATER
+        return compression is RequestCompression.GZip or RequestCompression.Brotli
+            ? new CompressedContent(content, compression, level) { Options = settings.RequestCompressionOptions }
+            : throw Unsupported(compression);
 #elif NET8_0_OR_GREATER
-        compression is RequestCompression.GZip or RequestCompression.Brotli
+        _ = settings;
+
+        return compression is RequestCompression.GZip or RequestCompression.Brotli
             ? new CompressedContent(content, compression, level)
             : throw Unsupported(compression);
 #else
-        compression is RequestCompression.GZip
+        _ = settings;
+
+        return compression is RequestCompression.GZip
             ? new CompressedContent(content, compression, level)
             : throw Unsupported(compression);
 #endif
+    }
 }

--- a/src/Refit/RequestContentCoding.cs
+++ b/src/Refit/RequestContentCoding.cs
@@ -1,0 +1,69 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.IO.Compression;
+using System.Net.Http;
+
+namespace Refit;
+
+/// <summary>Resolves a request body coding and wraps content in it.</summary>
+internal static class RequestContentCoding
+{
+    /// <summary>Gets the <c>Content-Encoding</c> token a coding sends.</summary>
+    /// <param name="compression">The coding.</param>
+    /// <returns>The token.</returns>
+    /// <exception cref="PlatformNotSupportedException">The coding has no token because it encodes nothing.</exception>
+    internal static string Token(RequestCompression compression) =>
+        compression switch
+        {
+            RequestCompression.GZip => "gzip",
+            RequestCompression.Brotli => "br",
+            RequestCompression.Zstandard => "zstd",
+            _ => throw Unsupported(compression),
+        };
+
+    /// <summary>Builds the error for a coding this framework cannot produce.</summary>
+    /// <param name="compression">The requested coding.</param>
+    /// <returns>The exception to throw.</returns>
+    internal static PlatformNotSupportedException Unsupported(RequestCompression compression) =>
+        new($"Request compression '{compression}' is not available on this target framework. gzip is always available, Brotli requires .NET 8.0 or later, and Zstandard requires .NET 11.0 or later.");
+
+    /// <summary>Resolves the coding and level for a body, letting the parameter override the settings.</summary>
+    /// <param name="settings">The Refit settings supplying the instance-wide default.</param>
+    /// <param name="compression">The coding the body parameter declared.</param>
+    /// <param name="level">The level the body parameter declared, used only when it also declared a coding.</param>
+    /// <returns>The coding to apply and how hard to compress.</returns>
+    internal static (RequestCompression Compression, CompressionLevel Level) Resolve(
+        RefitSettings settings,
+        RequestCompression compression,
+        CompressionLevel level) =>
+        compression == RequestCompression.Default
+            ? (settings.RequestCompression, settings.RequestCompressionLevel)
+            : (compression, level);
+
+    /// <summary>Wraps content in the compressor for a coding.</summary>
+    /// <param name="content">The content to compress.</param>
+    /// <param name="compression">The resolved coding, never <see cref="RequestCompression.Default"/> or <see cref="RequestCompression.None"/>.</param>
+    /// <param name="level">How hard to compress.</param>
+    /// <returns>The compressing content.</returns>
+    /// <exception cref="PlatformNotSupportedException">This framework cannot produce the coding.</exception>
+    internal static HttpContent Wrap(HttpContent content, RequestCompression compression, CompressionLevel level) =>
+#if NET11_0_OR_GREATER
+        compression switch
+        {
+            RequestCompression.GZip => new GZipCompressedContent(content, level),
+            RequestCompression.Brotli => new BrotliCompressedContent(content, level),
+            RequestCompression.Zstandard => new ZstandardCompressedContent(content, level),
+            _ => throw Unsupported(compression),
+        };
+#elif NET8_0_OR_GREATER
+        compression is RequestCompression.GZip or RequestCompression.Brotli
+            ? new CompressedContent(content, compression, level)
+            : throw Unsupported(compression);
+#else
+        compression is RequestCompression.GZip
+            ? new CompressedContent(content, compression, level)
+            : throw Unsupported(compression);
+#endif
+}

--- a/src/tests/Refit.GeneratorTests/GeneratorComponentTests.ParserHelpers.cs
+++ b/src/tests/Refit.GeneratorTests/GeneratorComponentTests.ParserHelpers.cs
@@ -44,6 +44,27 @@ public static partial class GeneratorComponentTests
         /// <summary>An unsupported body serialization enum value.</summary>
         private const int UnsupportedSerializationValue = 99;
 
+        /// <summary>The name of the member each mapping helper falls back to.</summary>
+        private const string DefaultMemberName = "Default";
+
+        /// <summary>The enum value for gzip request compression.</summary>
+        private const int GZipCompressionValue = 2;
+
+        /// <summary>The enum value for Brotli request compression.</summary>
+        private const int BrotliCompressionValue = 3;
+
+        /// <summary>The enum value for Zstandard request compression.</summary>
+        private const int ZstandardCompressionValue = 4;
+
+        /// <summary>The enum value for the level that stores without compressing.</summary>
+        private const int NoCompressionLevelValue = 2;
+
+        /// <summary>The enum value for the smallest-size compression level.</summary>
+        private const int SmallestSizeLevelValue = 3;
+
+        /// <summary>An enum value outside every member the generator knows.</summary>
+        private const int UnrecognizedEnumValue = 99;
+
         /// <summary>Verifies inline path normalization and constant path classification.</summary>
         /// <returns>A task representing the asynchronous test.</returns>
         [Test]
@@ -114,7 +135,7 @@ public static partial class GeneratorComponentTests
         [Test]
         public async Task BodyAndDisposalHelpers_ClassifySupportedValues()
         {
-            await Assert.That(Parser.GetBodySerializationMethodName(0)).IsEqualTo("Default");
+            await Assert.That(Parser.GetBodySerializationMethodName(0)).IsEqualTo(DefaultMemberName);
             await Assert.That(Parser.GetBodySerializationMethodName(1)).IsEqualTo("Json");
             await Assert.That(Parser.GetBodySerializationMethodName(UrlEncodedSerializationValue)).IsEqualTo(UrlEncodedSerializationMethod);
             await Assert.That(Parser.GetBodySerializationMethodName(SerializedSerializationValue)).IsEqualTo("Serialized");
@@ -130,6 +151,26 @@ public static partial class GeneratorComponentTests
             await Assert.That(Parser.ShouldDisposeResponse("global::System.Net.Http.HttpContent")).IsFalse();
             await Assert.That(Parser.ShouldDisposeResponse("global::System.IO.Stream")).IsFalse();
             await Assert.That(Parser.ShouldDisposeResponse("global::System.String")).IsTrue();
+        }
+
+        /// <summary>Verifies the request-compression and compression-level enum members map to their names, and that an
+        /// unknown value maps to the member the runtime treats as unset rather than emitting an unresolvable name.</summary>
+        /// <returns>A task representing the asynchronous test.</returns>
+        [Test]
+        public async Task CompressionHelpers_MapEnumValuesToMemberNames()
+        {
+            await Assert.That(Parser.GetRequestCompressionName(0)).IsEqualTo(DefaultMemberName);
+            await Assert.That(Parser.GetRequestCompressionName(1)).IsEqualTo("None");
+            await Assert.That(Parser.GetRequestCompressionName(GZipCompressionValue)).IsEqualTo("GZip");
+            await Assert.That(Parser.GetRequestCompressionName(BrotliCompressionValue)).IsEqualTo("Brotli");
+            await Assert.That(Parser.GetRequestCompressionName(ZstandardCompressionValue)).IsEqualTo("Zstandard");
+            await Assert.That(Parser.GetRequestCompressionName(UnrecognizedEnumValue)).IsEqualTo(DefaultMemberName);
+
+            await Assert.That(Parser.GetCompressionLevelName(0)).IsEqualTo("Optimal");
+            await Assert.That(Parser.GetCompressionLevelName(1)).IsEqualTo("Fastest");
+            await Assert.That(Parser.GetCompressionLevelName(NoCompressionLevelValue)).IsEqualTo("NoCompression");
+            await Assert.That(Parser.GetCompressionLevelName(SmallestSizeLevelValue)).IsEqualTo("SmallestSize");
+            await Assert.That(Parser.GetCompressionLevelName(UnrecognizedEnumValue)).IsEqualTo("Optimal");
         }
 
         /// <summary>Verifies containing-namespace matching handles a null symbol, exact matches, tail matches, and mismatches.</summary>

--- a/src/tests/Refit.GeneratorTests/RequestCompressionGenerationTests.cs
+++ b/src/tests/Refit.GeneratorTests/RequestCompressionGenerationTests.cs
@@ -1,0 +1,209 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+namespace Refit.GeneratorTests;
+
+/// <summary>Generator tests for the request body content coding a <c>[Body]</c> parameter declares.</summary>
+public class RequestCompressionGenerationTests
+{
+    /// <summary>The generated client hint name the compression fixtures assert on.</summary>
+    private const string GeneratedClientHintName = "IGeneratedClient.g.cs";
+
+    /// <summary>The emitted coding argument for a body that declared none, which defers to the settings.</summary>
+    private const string DefaultCodingArgument = "global::Refit.RequestCompression.Default";
+
+    /// <summary>The emitted level argument for a body that declared none.</summary>
+    private const string OptimalLevelArgument = "global::System.IO.Compression.CompressionLevel.Optimal";
+
+    /// <summary>The generated call that applies the coding.</summary>
+    private const string CompressCall = "GeneratedRequestRunner.CompressBodyContent";
+
+    /// <summary>Verifies a declared coding and level are emitted as the members the attribute named.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task DeclaredCodingAndLevelAreEmitted()
+    {
+        var generated = Fixture.GenerateForDeclaration(
+            """
+            public interface IGeneratedClient
+            {
+                [Post("/users")]
+                Task<string> Post([Body(Compression = RequestCompression.Brotli, CompressionLevel = System.IO.Compression.CompressionLevel.SmallestSize)] string body);
+            }
+            """,
+            GeneratedClientHintName,
+            generatedRequestBuilding: true);
+
+        await Assert.That(generated).Contains(CompressCall);
+        await Assert.That(generated).Contains("global::Refit.RequestCompression.Brotli");
+        await Assert.That(generated).Contains("global::System.IO.Compression.CompressionLevel.SmallestSize");
+    }
+
+    /// <summary>Verifies each coding the attribute can name reaches the generated call.</summary>
+    /// <param name="declared">The member named on the attribute.</param>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    [Arguments("GZip")]
+    [Arguments("Brotli")]
+    [Arguments("Zstandard")]
+    public async Task EveryDeclaredCodingIsEmitted(string declared)
+    {
+        var generated = Fixture.GenerateForDeclaration(
+            $$"""
+            public interface IGeneratedClient
+            {
+                [Post("/users")]
+                Task<string> Post([Body(Compression = RequestCompression.{{declared}})] string body);
+            }
+            """,
+            GeneratedClientHintName,
+            generatedRequestBuilding: true);
+
+        await Assert.That(generated).Contains($"global::Refit.RequestCompression.{declared}");
+    }
+
+    /// <summary>Verifies each level the attribute can name reaches the generated call.</summary>
+    /// <param name="declared">The member named on the attribute.</param>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    [Arguments("Optimal")]
+    [Arguments("Fastest")]
+    [Arguments("NoCompression")]
+    [Arguments("SmallestSize")]
+    public async Task EveryDeclaredLevelIsEmitted(string declared)
+    {
+        var generated = Fixture.GenerateForDeclaration(
+            $$"""
+            public interface IGeneratedClient
+            {
+                [Post("/users")]
+                Task<string> Post([Body(Compression = RequestCompression.GZip, CompressionLevel = System.IO.Compression.CompressionLevel.{{declared}})] string body);
+            }
+            """,
+            GeneratedClientHintName,
+            generatedRequestBuilding: true);
+
+        await Assert.That(generated).Contains($"global::System.IO.Compression.CompressionLevel.{declared}");
+    }
+
+    /// <summary>Verifies a body declaring no coding still emits the call, so the settings can supply one at request time.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task UndeclaredCodingEmitsTheCallSoSettingsStillApply()
+    {
+        var generated = Fixture.GenerateForDeclaration(
+            """
+            public interface IGeneratedClient
+            {
+                [Post("/users")]
+                Task<string> Post([Body] string body);
+            }
+            """,
+            GeneratedClientHintName,
+            generatedRequestBuilding: true);
+
+        await Assert.That(generated).Contains(CompressCall);
+        await Assert.That(generated).Contains(DefaultCodingArgument);
+        await Assert.That(generated).Contains(OptimalLevelArgument);
+    }
+
+    /// <summary>Verifies a body declaring <c>None</c> emits no call at all, since no coding can ever apply to it.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task DeclaredNoneEmitsNoCall()
+    {
+        var generated = Fixture.GenerateForDeclaration(
+            """
+            public interface IGeneratedClient
+            {
+                [Post("/users")]
+                Task<string> Post([Body(Compression = RequestCompression.None)] string body);
+            }
+            """,
+            GeneratedClientHintName,
+            generatedRequestBuilding: true);
+
+        await Assert.That(generated).DoesNotContain(CompressCall);
+    }
+
+    /// <summary>Verifies a named argument the compiler already rejected leaves the defaults in place instead of
+    /// crashing the generator or emitting a member name read from a value that is not there.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task AnErroneousNamedArgumentFallsBackToTheDefaults()
+    {
+        var generated = Fixture.GenerateForDeclaration(
+            """
+            public interface IGeneratedClient
+            {
+                [Post("/users")]
+                Task<string> Post([Body(Compression = "not an enum", CompressionLevel = "not an enum")] string body);
+            }
+            """,
+            GeneratedClientHintName,
+            generatedRequestBuilding: true);
+
+        await Assert.That(generated).Contains(DefaultCodingArgument);
+        await Assert.That(generated).Contains(OptimalLevelArgument);
+    }
+
+    /// <summary>Verifies a level declared without a coding still reaches the generated call.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task ALevelDeclaredWithoutACodingIsStillEmitted()
+    {
+        var generated = Fixture.GenerateForDeclaration(
+            """
+            public interface IGeneratedClient
+            {
+                [Post("/users")]
+                Task<string> Post([Body(CompressionLevel = System.IO.Compression.CompressionLevel.Fastest)] string body);
+            }
+            """,
+            GeneratedClientHintName,
+            generatedRequestBuilding: true);
+
+        await Assert.That(generated).Contains(DefaultCodingArgument);
+        await Assert.That(generated).Contains("global::System.IO.Compression.CompressionLevel.Fastest");
+    }
+
+    /// <summary>Verifies the coding applies to a URL-encoded form body, which builds its content on its own path.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task CodingAppliesToAUrlEncodedFormBody()
+    {
+        var generated = Fixture.GenerateForDeclaration(
+            """
+            public interface IGeneratedClient
+            {
+                [Post("/users")]
+                Task<string> Post([Body(BodySerializationMethod.UrlEncoded, Compression = RequestCompression.GZip)] string body);
+            }
+            """,
+            GeneratedClientHintName,
+            generatedRequestBuilding: true);
+
+        await Assert.That(generated).Contains(CompressCall);
+        await Assert.That(generated).Contains("global::Refit.RequestCompression.GZip");
+    }
+
+    /// <summary>Verifies the coding applies to a JSON Lines body, which builds its content on its own path.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task CodingAppliesToAJsonLinesBody()
+    {
+        var generated = Fixture.GenerateForDeclaration(
+            """
+            public interface IGeneratedClient
+            {
+                [Post("/users")]
+                Task<string> Post([Body(BodySerializationMethod.JsonLines, Compression = RequestCompression.GZip)] System.Collections.Generic.IEnumerable<string> body);
+            }
+            """,
+            GeneratedClientHintName,
+            generatedRequestBuilding: true);
+
+        await Assert.That(generated).Contains(CompressCall);
+        await Assert.That(generated).Contains("global::Refit.RequestCompression.GZip");
+    }
+}

--- a/src/tests/Refit.GeneratorTests/_snapshots/InterfaceStubGeneratorTests.FindInterfacesSmokeTest#IGitHubApi.g.verified.cs
+++ b/src/tests/Refit.GeneratorTests/_snapshots/InterfaceStubGeneratorTests.FindInterfacesSmokeTest#IGitHubApi.g.verified.cs
@@ -427,6 +427,11 @@ namespace Refit.Implementation
                     @user,
                     global::Refit.BodySerializationMethod.Serialized,
                     !refitSettings.Buffered);
+                refitRequest.Content = global::Refit.GeneratedRequestRunner.CompressBodyContent(
+                    refitRequest.Content,
+                    refitSettings,
+                    global::Refit.RequestCompression.Default,
+                    global::System.IO.Compression.CompressionLevel.Optimal);
                 global::Refit.GeneratedRequestRunner.SetHeader(refitRequest, "User-Agent", "Refit Integration Tests", refitSettings.ValidateHeaders);
                 global::Refit.GeneratedRequestRunner.AddConfiguredRequestOptions(refitRequest, refitSettings, typeof(global::Refit.Tests.IGitHubApi));
                 global::Refit.GeneratedRequestRunner.AddRequestProperty<string>(refitRequest, global::Refit.HttpRequestMessageOptions.MethodName, "CreateUser");
@@ -458,6 +463,11 @@ namespace Refit.Implementation
                     @user,
                     global::Refit.BodySerializationMethod.Serialized,
                     !refitSettings.Buffered);
+                refitRequest.Content = global::Refit.GeneratedRequestRunner.CompressBodyContent(
+                    refitRequest.Content,
+                    refitSettings,
+                    global::Refit.RequestCompression.Default,
+                    global::System.IO.Compression.CompressionLevel.Optimal);
                 global::Refit.GeneratedRequestRunner.SetHeader(refitRequest, "User-Agent", "Refit Integration Tests", refitSettings.ValidateHeaders);
                 global::Refit.GeneratedRequestRunner.AddConfiguredRequestOptions(refitRequest, refitSettings, typeof(global::Refit.Tests.IGitHubApi));
                 global::Refit.GeneratedRequestRunner.AddRequestProperty<string>(refitRequest, global::Refit.HttpRequestMessageOptions.MethodName, "CreateUserWithMetadata");

--- a/src/tests/Refit.Reflection.Tests/ICompressedBodyApi.cs
+++ b/src/tests/Refit.Reflection.Tests/ICompressedBodyApi.cs
@@ -1,0 +1,28 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+using System.IO.Compression;
+
+namespace Refit.Reflection.Tests;
+
+/// <summary>An API declaring a request body coding on the body parameter, one method per coding decision.</summary>
+public interface ICompressedBodyApi
+{
+    /// <summary>Sends a gzip-coded body.</summary>
+    /// <param name="body">The body value.</param>
+    /// <returns>The response body.</returns>
+    [Post("/gzip")]
+    Task<string> GZip([Body(Compression = RequestCompression.GZip, CompressionLevel = CompressionLevel.SmallestSize)] string body);
+
+    /// <summary>Sends a body with no coding declared, so the settings decide.</summary>
+    /// <param name="body">The body value.</param>
+    /// <returns>The response body.</returns>
+    [Post("/inherited")]
+    Task<string> Inherited([Body] string body);
+
+    /// <summary>Sends an uncoded body whatever the settings say.</summary>
+    /// <param name="body">The body value.</param>
+    /// <returns>The response body.</returns>
+    [Post("/uncompressed")]
+    Task<string> Uncompressed([Body(Compression = RequestCompression.None)] string body);
+}

--- a/src/tests/Refit.Reflection.Tests/ReflectionRequestCompressionTests.cs
+++ b/src/tests/Refit.Reflection.Tests/ReflectionRequestCompressionTests.cs
@@ -1,0 +1,121 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+using System.IO.Compression;
+using System.Net;
+
+namespace Refit.Reflection.Tests;
+
+/// <summary>Pins that the reflection request builder applies the content coding a <c>[Body]</c> parameter declares, and
+/// falls back to the settings when it declares none.</summary>
+public sealed class ReflectionRequestCompressionTests
+{
+    /// <summary>The base address the compression fixtures dispatch against.</summary>
+    private const string BaseUrl = "http://api/";
+
+    /// <summary>The body value every request in this fixture sends.</summary>
+    private const string BodyText = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+    /// <summary>Verifies a declared coding reaches the wire and announces itself.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task DeclaredCodingIsApplied()
+    {
+        var sent = await SendAsync(nameof(ICompressedBodyApi.GZip), new());
+
+        await Assert.That(sent.ContentEncoding).IsEquivalentTo(["gzip"]);
+        await Assert.That(sent.Body.Length).IsLessThan(BodyText.Length);
+    }
+
+    /// <summary>Verifies a body that declares no coding takes the one the settings name.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task UndeclaredCodingComesFromTheSettings()
+    {
+        var settings = new RefitSettings { RequestCompression = RequestCompression.GZip, RequestCompressionLevel = CompressionLevel.Fastest };
+
+        var sent = await SendAsync(nameof(ICompressedBodyApi.Inherited), settings);
+
+        await Assert.That(sent.ContentEncoding).IsEquivalentTo(["gzip"]);
+    }
+
+    /// <summary>Verifies a body declaring no coding is sent uncoded when the settings name none either.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task UndeclaredCodingSendsUncodedWhenTheSettingsNameNone()
+    {
+        var sent = await SendAsync(nameof(ICompressedBodyApi.Inherited), new());
+
+        await Assert.That(sent.ContentEncoding).IsEmpty();
+        await Assert.That(System.Text.Encoding.UTF8.GetString(sent.Body)).IsEqualTo(BodyText);
+    }
+
+    /// <summary>Verifies a body declaring <see cref="RequestCompression.None"/> overrides a coding the settings turned on.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task DeclaredNoneOverridesTheSettingsCoding()
+    {
+        var settings = new RefitSettings { RequestCompression = RequestCompression.GZip };
+
+        var sent = await SendAsync(nameof(ICompressedBodyApi.Uncompressed), settings);
+
+        await Assert.That(sent.ContentEncoding).IsEmpty();
+        await Assert.That(System.Text.Encoding.UTF8.GetString(sent.Body)).IsEqualTo(BodyText);
+    }
+
+    /// <summary>Verifies the coded bytes on the wire decompress back to the declared body.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task CodedBodyRoundTrips()
+    {
+        var sent = await SendAsync(nameof(ICompressedBodyApi.GZip), new());
+
+        await using var source = new MemoryStream(sent.Body);
+        await using var decompressor = new GZipStream(source, CompressionMode.Decompress);
+        using var reader = new StreamReader(decompressor);
+
+        await Assert.That(await reader.ReadToEndAsync()).IsEqualTo(BodyText);
+    }
+
+    /// <summary>Dispatches the named method and returns what reached the wire.</summary>
+    /// <param name="methodName">The interface method to invoke.</param>
+    /// <param name="settings">The settings the builder runs with.</param>
+    /// <returns>The captured content coding and body bytes.</returns>
+    private static async Task<(string[] ContentEncoding, byte[] Body)> SendAsync(
+        string methodName,
+        RefitSettings settings)
+    {
+        var factory = RequestBuilder.ForType<ICompressedBodyApi>(settings).BuildRestResultFuncForMethod(methodName);
+        using var handler = new BodyCapturingHandler();
+        using var client = HttpClientTestFactory.Create(handler, new(BaseUrl));
+
+        // The runner disposes the request once the call completes, so the body has to be read as it is sent.
+        await (Task)factory(client, [BodyText])!;
+
+        return (handler.ContentEncoding, handler.Body);
+    }
+
+    /// <summary>Captures the coding and the raw bytes of the request body before the request is disposed.</summary>
+    private sealed class BodyCapturingHandler : HttpMessageHandler
+    {
+        /// <summary>Gets the <c>Content-Encoding</c> tokens the request carried.</summary>
+        public string[] ContentEncoding { get; private set; } = [];
+
+        /// <summary>Gets the bytes the request body serialized to.</summary>
+        public byte[] Body { get; private set; } = [];
+
+        /// <inheritdoc/>
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            if (request.Content is not null)
+            {
+                ContentEncoding = [.. request.Content.Headers.ContentEncoding];
+                Body = await request.Content.ReadAsByteArrayAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            return new(HttpStatusCode.OK) { Content = new StringContent("\"ok\"") };
+        }
+    }
+}

--- a/src/tests/Refit.Tests/GeneratedRequestCompressionTests.cs
+++ b/src/tests/Refit.Tests/GeneratedRequestCompressionTests.cs
@@ -1,0 +1,119 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+using System.IO.Compression;
+using System.Net;
+
+namespace Refit.Tests;
+
+/// <summary>End-to-end coverage that a source-generated client applies the content coding its <c>[Body]</c> parameter
+/// declares, and falls back to the settings when it declares none.</summary>
+public class GeneratedRequestCompressionTests
+{
+    /// <summary>The base address the generated compression fixtures dispatch against.</summary>
+    private const string BaseUrl = "http://nowhere.com";
+
+    /// <summary>The body value every request in this fixture sends.</summary>
+    private const string BodyText = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+    /// <summary>Verifies a declared coding reaches the wire and announces itself.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task DeclaredCodingIsApplied()
+    {
+        var sent = await SendAsync(static api => api.GZip(BodyText), new());
+
+        await Assert.That(sent.ContentEncoding).IsEquivalentTo(["gzip"]);
+        await Assert.That(sent.Body.Length).IsLessThan(BodyText.Length);
+    }
+
+    /// <summary>Verifies a body that declares no coding takes the one the settings name.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task UndeclaredCodingComesFromTheSettings()
+    {
+        var settings = new RefitSettings { RequestCompression = RequestCompression.GZip };
+
+        var sent = await SendAsync(static api => api.Inherited(BodyText), settings);
+
+        await Assert.That(sent.ContentEncoding).IsEquivalentTo(["gzip"]);
+    }
+
+    /// <summary>Verifies a body declaring no coding is sent uncoded when the settings name none either.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task UndeclaredCodingSendsUncodedWhenTheSettingsNameNone()
+    {
+        var sent = await SendAsync(static api => api.Inherited(BodyText), new());
+
+        await Assert.That(sent.ContentEncoding).IsEmpty();
+        await Assert.That(System.Text.Encoding.UTF8.GetString(sent.Body)).IsEqualTo(BodyText);
+    }
+
+    /// <summary>Verifies a body declaring <see cref="RequestCompression.None"/> overrides a coding the settings turned on.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task DeclaredNoneOverridesTheSettingsCoding()
+    {
+        var settings = new RefitSettings { RequestCompression = RequestCompression.GZip };
+
+        var sent = await SendAsync(static api => api.Uncompressed(BodyText), settings);
+
+        await Assert.That(sent.ContentEncoding).IsEmpty();
+        await Assert.That(System.Text.Encoding.UTF8.GetString(sent.Body)).IsEqualTo(BodyText);
+    }
+
+    /// <summary>Verifies the coded bytes on the wire decompress back to the declared body.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task CodedBodyRoundTrips()
+    {
+        var sent = await SendAsync(static api => api.GZip(BodyText), new());
+
+        await using var source = new MemoryStream(sent.Body);
+        await using var decompressor = new GZipStream(source, CompressionMode.Decompress);
+        using var reader = new StreamReader(decompressor);
+
+        await Assert.That(await reader.ReadToEndAsync()).IsEqualTo(BodyText);
+    }
+
+    /// <summary>Dispatches a generated call and returns what reached the wire.</summary>
+    /// <param name="call">The generated call to make.</param>
+    /// <param name="settings">The settings the client runs with.</param>
+    /// <returns>The captured content coding and body bytes.</returns>
+    private static async Task<(string[] ContentEncoding, byte[] Body)> SendAsync(
+        Func<ICompressedBodyGeneratedApi, Task<string>> call,
+        RefitSettings settings)
+    {
+        using var handler = new BodyCapturingHandler();
+        using var client = HttpClientTestFactory.Create(handler, new(BaseUrl));
+
+        _ = await call(RestService.For<ICompressedBodyGeneratedApi>(client, settings));
+
+        return (handler.ContentEncoding, handler.Body);
+    }
+
+    /// <summary>Captures the coding and the raw bytes of the request body before the request is disposed.</summary>
+    private sealed class BodyCapturingHandler : HttpMessageHandler
+    {
+        /// <summary>Gets the <c>Content-Encoding</c> tokens the request carried.</summary>
+        public string[] ContentEncoding { get; private set; } = [];
+
+        /// <summary>Gets the bytes the request body serialized to.</summary>
+        public byte[] Body { get; private set; } = [];
+
+        /// <inheritdoc/>
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            if (request.Content is not null)
+            {
+                ContentEncoding = [.. request.Content.Headers.ContentEncoding];
+                Body = await request.Content.ReadAsByteArrayAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            return new(HttpStatusCode.OK) { Content = new StringContent("\"ok\"") };
+        }
+    }
+}

--- a/src/tests/Refit.Tests/ICompressedBodyGeneratedApi.cs
+++ b/src/tests/Refit.Tests/ICompressedBodyGeneratedApi.cs
@@ -1,0 +1,28 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+using System.IO.Compression;
+
+namespace Refit.Tests;
+
+/// <summary>An API whose generated client declares a request body coding, one method per coding decision.</summary>
+public interface ICompressedBodyGeneratedApi
+{
+    /// <summary>Sends a gzip-coded body.</summary>
+    /// <param name="body">The body value.</param>
+    /// <returns>The response body.</returns>
+    [Post("/gzip")]
+    Task<string> GZip([Body(Compression = RequestCompression.GZip, CompressionLevel = CompressionLevel.SmallestSize)] string body);
+
+    /// <summary>Sends a body with no coding declared, so the settings decide.</summary>
+    /// <param name="body">The body value.</param>
+    /// <returns>The response body.</returns>
+    [Post("/inherited")]
+    Task<string> Inherited([Body] string body);
+
+    /// <summary>Sends an uncoded body whatever the settings say.</summary>
+    /// <param name="body">The body value.</param>
+    /// <returns>The response body.</returns>
+    [Post("/uncompressed")]
+    Task<string> Uncompressed([Body(Compression = RequestCompression.None)] string body);
+}

--- a/src/tests/Refit.Tests/RequestCompressionTests.cs
+++ b/src/tests/Refit.Tests/RequestCompressionTests.cs
@@ -139,6 +139,34 @@ public class RequestCompressionTests
         await Assert.That(await reader.ReadToEndAsync()).IsEqualTo(BodyText);
     }
 
+#if NET9_0_OR_GREATER
+    /// <summary>Verifies per-coding options replace the level for the coding they name.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task PerCodingOptionsReplaceTheLevel()
+    {
+        // Zero is the zlib "store, do not compress" level, and the declared level asks for the smallest output.
+        var settings = new RefitSettings { RequestCompressionOptions = new() { GZip = new() { CompressionLevel = 0 } } };
+
+        var byOptions = await CompressAsync(settings, RequestCompression.GZip, CompressionLevel.SmallestSize);
+        var byLevel = await CompressAsync(new(), RequestCompression.GZip, CompressionLevel.SmallestSize);
+
+        await Assert.That(byOptions.Length).IsGreaterThan(byLevel.Length);
+    }
+
+    /// <summary>Verifies a coding the options left unset still compresses by level.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task CodingWithoutOptionsStillCompressesByLevel()
+    {
+        var settings = new RefitSettings { RequestCompressionOptions = new() { Brotli = new() { Quality = 0 } } };
+
+        var bytes = await CompressAsync(settings, RequestCompression.GZip, CompressionLevel.SmallestSize);
+
+        await Assert.That(bytes.Length).IsLessThan(BodyText.Length);
+    }
+#endif
+
     /// <summary>Verifies the compressed content reports no length, so the request is sent chunked.</summary>
     /// <returns>A task that represents the asynchronous operation.</returns>
     [Test]
@@ -153,4 +181,22 @@ public class RequestCompressionTests
 
         await Assert.That(compressed.Headers.ContentLength).IsNull();
     }
+
+#if NET9_0_OR_GREATER
+    /// <summary>Compresses the shared body and returns the bytes that would reach the wire.</summary>
+    /// <param name="settings">The settings supplying any per-coding options.</param>
+    /// <param name="compression">The coding to apply.</param>
+    /// <param name="level">The level to apply where the options do not override it.</param>
+    /// <returns>The compressed bytes.</returns>
+    private static async Task<byte[]> CompressAsync(
+        RefitSettings settings,
+        RequestCompression compression,
+        CompressionLevel level)
+    {
+        using var content = new StringContent(BodyText);
+        using var compressed = GeneratedRequestRunner.CompressBodyContent(content, settings, compression, level);
+
+        return await compressed.ReadAsByteArrayAsync();
+    }
+#endif
 }

--- a/src/tests/Refit.Tests/RequestCompressionTests.cs
+++ b/src/tests/Refit.Tests/RequestCompressionTests.cs
@@ -1,0 +1,156 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+using System.IO.Compression;
+
+namespace Refit.Tests;
+
+/// <summary>Applying a content coding to a request body: what reaches the wire, what <c>Content-Encoding</c> says, and
+/// which codings a given target framework can produce.</summary>
+public class RequestCompressionTests
+{
+    /// <summary>The media type the coded content must carry through from the inner content.</summary>
+    private const string JsonMediaType = "application/json";
+
+    /// <summary>A body long enough that every coding makes it shorter.</summary>
+    private const string BodyText =
+        """{"name":"refit","description":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}""";
+
+    /// <summary>Verifies each supported coding compresses the body and announces itself.</summary>
+    /// <param name="compression">The coding under test.</param>
+    /// <param name="expectedToken">The <c>Content-Encoding</c> token it must send.</param>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    [Arguments(RequestCompression.GZip, "gzip")]
+#if NET8_0_OR_GREATER
+    [Arguments(RequestCompression.Brotli, "br")]
+#endif
+#if NET11_0_OR_GREATER
+    [Arguments(RequestCompression.Zstandard, "zstd")]
+#endif
+    public async Task SupportedCodingCompressesTheBodyAndAnnouncesItself(
+        RequestCompression compression,
+        string expectedToken)
+    {
+        using var content = new StringContent(BodyText, System.Text.Encoding.UTF8, JsonMediaType);
+        using var compressed = GeneratedRequestRunner.CompressBodyContent(
+            content,
+            new(),
+            compression,
+            CompressionLevel.Optimal);
+
+        var bytes = await compressed.ReadAsByteArrayAsync();
+
+        await Assert.That(compressed.Headers.ContentEncoding).IsEquivalentTo([expectedToken]);
+        await Assert.That(compressed.Headers.ContentType?.MediaType).IsEqualTo(JsonMediaType);
+        await Assert.That(bytes.Length).IsLessThan(BodyText.Length);
+    }
+
+#if !NET11_0_OR_GREATER
+    /// <summary>Verifies a coding this framework cannot produce fails loudly instead of sending the body uncompressed.
+    /// Every coding exists on .NET 11.0 and later, so there is nothing left to reject there.</summary>
+    /// <param name="compression">The coding under test.</param>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    [Arguments(RequestCompression.Zstandard)]
+#if !NET8_0_OR_GREATER
+    [Arguments(RequestCompression.Brotli)]
+#endif
+    public async Task UnsupportedCodingThrows(RequestCompression compression)
+    {
+        using var content = new StringContent(BodyText);
+
+        await Assert.That(() => GeneratedRequestRunner.CompressBodyContent(
+                content,
+                new(),
+                compression,
+                CompressionLevel.Optimal))
+            .Throws<PlatformNotSupportedException>();
+    }
+#endif
+
+    /// <summary>Verifies an unset coding leaves the content alone when the settings ask for none.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task DefaultCodingLeavesTheContentAloneWhenTheSettingsAskForNone()
+    {
+        using var content = new StringContent(BodyText);
+
+        var result = GeneratedRequestRunner.CompressBodyContent(
+            content,
+            new(),
+            RequestCompression.Default,
+            CompressionLevel.Optimal);
+
+        await Assert.That(result).IsSameReferenceAs(content);
+    }
+
+    /// <summary>Verifies an unset coding falls back to the one the settings name.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task DefaultCodingFallsBackToTheSettings()
+    {
+        using var content = new StringContent(BodyText);
+        var settings = new RefitSettings { RequestCompression = RequestCompression.GZip, RequestCompressionLevel = CompressionLevel.SmallestSize };
+
+        using var result = GeneratedRequestRunner.CompressBodyContent(
+            content,
+            settings,
+            RequestCompression.Default,
+            CompressionLevel.Optimal);
+
+        await Assert.That(result).IsNotSameReferenceAs(content);
+        await Assert.That(result.Headers.ContentEncoding).IsEquivalentTo(["gzip"]);
+    }
+
+    /// <summary>Verifies an explicit <see cref="RequestCompression.None"/> opts out of a coding the settings turned on.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task ExplicitNoneOptsOutOfTheSettingsCoding()
+    {
+        using var content = new StringContent(BodyText);
+        var settings = new RefitSettings { RequestCompression = RequestCompression.GZip };
+
+        var result = GeneratedRequestRunner.CompressBodyContent(
+            content,
+            settings,
+            RequestCompression.None,
+            CompressionLevel.Optimal);
+
+        await Assert.That(result).IsSameReferenceAs(content);
+    }
+
+    /// <summary>Verifies the compressed bytes decompress back to the original body.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task CompressedBodyRoundTrips()
+    {
+        using var content = new StringContent(BodyText, System.Text.Encoding.UTF8, JsonMediaType);
+        using var compressed = GeneratedRequestRunner.CompressBodyContent(
+            content,
+            new(),
+            RequestCompression.GZip,
+            CompressionLevel.Optimal);
+
+        await using var source = new MemoryStream(await compressed.ReadAsByteArrayAsync());
+        await using var decompressor = new GZipStream(source, CompressionMode.Decompress);
+        using var reader = new StreamReader(decompressor);
+
+        await Assert.That(await reader.ReadToEndAsync()).IsEqualTo(BodyText);
+    }
+
+    /// <summary>Verifies the compressed content reports no length, so the request is sent chunked.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task CompressedBodyReportsNoContentLength()
+    {
+        using var content = new StringContent(BodyText);
+        using var compressed = GeneratedRequestRunner.CompressBodyContent(
+            content,
+            new(),
+            RequestCompression.GZip,
+            CompressionLevel.Optimal);
+
+        await Assert.That(compressed.Headers.ContentLength).IsNull();
+    }
+}

--- a/src/tests/Refit.Tests/RequestCompressionTests.cs
+++ b/src/tests/Refit.Tests/RequestCompressionTests.cs
@@ -12,6 +12,9 @@ public class RequestCompressionTests
     /// <summary>The media type the coded content must carry through from the inner content.</summary>
     private const string JsonMediaType = "application/json";
 
+    /// <summary>A mid-range quality for the codings whose options express effort as a number.</summary>
+    private const int MidQuality = 5;
+
     /// <summary>A body long enough that every coding makes it shorter.</summary>
     private const string BodyText =
         """{"name":"refit","description":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}""";
@@ -165,7 +168,96 @@ public class RequestCompressionTests
 
         await Assert.That(bytes.Length).IsLessThan(BodyText.Length);
     }
+
+    /// <summary>Verifies each coding that accepts options still announces itself and shrinks the body when given them.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task BrotliCompressesThroughItsOwnOptions()
+    {
+        var settings = new RefitSettings { RequestCompressionOptions = new() { Brotli = new() { Quality = MidQuality } } };
+
+        using var content = new StringContent(BodyText);
+        using var compressed = GeneratedRequestRunner.CompressBodyContent(
+            content,
+            settings,
+            RequestCompression.Brotli,
+            CompressionLevel.NoCompression);
+
+        var bytes = await compressed.ReadAsByteArrayAsync();
+
+        await Assert.That(compressed.Headers.ContentEncoding).IsEquivalentTo(["br"]);
+        await Assert.That(bytes.Length).IsLessThan(BodyText.Length);
+    }
 #endif
+
+#if NET11_0_OR_GREATER
+    /// <summary>Verifies Zstandard compresses through its own options, which only exist from .NET 11.0.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task ZstandardCompressesThroughItsOwnOptions()
+    {
+        var settings = new RefitSettings { RequestCompressionOptions = new() { Zstandard = new() { Quality = MidQuality } } };
+
+        using var content = new StringContent(BodyText);
+        using var compressed = GeneratedRequestRunner.CompressBodyContent(
+            content,
+            settings,
+            RequestCompression.Zstandard,
+            CompressionLevel.NoCompression);
+
+        var bytes = await compressed.ReadAsByteArrayAsync();
+
+        await Assert.That(compressed.Headers.ContentEncoding).IsEquivalentTo(["zstd"]);
+        await Assert.That(bytes.Length).IsLessThan(BodyText.Length);
+    }
+#endif
+
+    /// <summary>Verifies the wrapper refuses a coding it has no compressor for.</summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    public async Task TheWrapperRefusesACodingItCannotCompress()
+    {
+        using var inner = new StringContent(BodyText);
+        using var compressed = new CompressedContent(inner, RequestCompression.Zstandard, CompressionLevel.Optimal);
+
+        // The coding still names a token, so the refusal has to come from the compressor, not the header.
+        await Assert.That(compressed.Headers.ContentEncoding).IsEquivalentTo(["zstd"]);
+        await Assert.That(async () => await compressed.ReadAsByteArrayAsync()).Throws<PlatformNotSupportedException>();
+    }
+
+    /// <summary>Verifies each coding maps to the token it sends on the wire.</summary>
+    /// <param name="compression">The coding under test.</param>
+    /// <param name="expectedToken">The token it maps to.</param>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    [Arguments(RequestCompression.GZip, "gzip")]
+    [Arguments(RequestCompression.Brotli, "br")]
+    [Arguments(RequestCompression.Zstandard, "zstd")]
+    public async Task EveryCodingMapsToItsToken(RequestCompression compression, string expectedToken) =>
+        await Assert.That(RequestContentCoding.Token(compression)).IsEqualTo(expectedToken);
+
+    /// <summary>Verifies a value that names no coding has no token, since there is nothing to announce.</summary>
+    /// <param name="compression">The value under test.</param>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    [Arguments(RequestCompression.Default)]
+    [Arguments(RequestCompression.None)]
+    public async Task AValueThatNamesNoCodingHasNoToken(RequestCompression compression) =>
+        await Assert.That(() => RequestContentCoding.Token(compression)).Throws<PlatformNotSupportedException>();
+
+    /// <summary>Verifies the wrap rejects a value that names no coding.</summary>
+    /// <param name="compression">The value under test.</param>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Test]
+    [Arguments(RequestCompression.Default)]
+    [Arguments(RequestCompression.None)]
+    public async Task TheWrapRejectsAValueThatNamesNoCoding(RequestCompression compression)
+    {
+        using var content = new StringContent(BodyText);
+
+        await Assert.That(() => RequestContentCoding.Wrap(content, new(), compression, CompressionLevel.Optimal))
+            .Throws<PlatformNotSupportedException>();
+    }
 
     /// <summary>Verifies the compressed content reports no length, so the request is sent chunked.</summary>
     /// <returns>A task that represents the asynchronous operation.</returns>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature.

## What is the new behavior?

**A method can send its request body under a content coding, per endpoint or per client.**

- **`[Body(Compression = ...)]` sets the coding for one method.** Refit compresses whatever the serializer produced and sets `Content-Encoding` to match, so the coding composes with every `BodySerializationMethod` - JSON, JSON Lines, URL-encoded forms and raw strings alike.

  ```csharp
  [Post("/measurements")]
  Task Upload([Body(Compression = RequestCompression.GZip)] Measurement[] batch);

  [Post("/measurements")]
  Task UploadSmallest([Body(
      Compression = RequestCompression.Brotli,
      CompressionLevel = CompressionLevel.SmallestSize)] Measurement[] batch);
  ```

- **`RefitSettings.RequestCompression` sets a client-wide default.** A `[Body]` parameter naming its own coding overrides it, and `RequestCompression.None` on the parameter opts one method out of a coding the settings turned on.

- **The coding is applied by the framework's own wrappers where they exist.** .NET 11.0 uses `GZipCompressedContent`, `BrotliCompressedContent` and `ZstandardCompressedContent`; older targets compress through `GZipStream` or `BrotliStream`. Both request paths - the source-generated client and the reflection request builder - go through one entry point, so they cannot diverge.

- **`RefitSettings.RequestCompressionOptions` sets the compressor's own knobs** - window size, strategy, a Zstandard dictionary - which a `CompressionLevel` cannot express. Options set for a coding replace the level for that coding; codings left unset still compress by level. The options types arrived with .NET 9.0 and Zstandard's with .NET 11.0, so this surface only exists from net9.0 onward.

  ```csharp
  var settings = new RefitSettings
  {
      RequestCompression = RequestCompression.Brotli,
      RequestCompressionOptions = new()
      {
          Brotli = new() { Quality = 9, WindowLog2 = 22 },
          GZip = new() { CompressionLevel = 6 },
      },
  };
  ```

- **An unavailable coding throws rather than sending the body uncompressed.** `PlatformNotSupportedException` is raised when the request is built, naming what the target framework can do:

  | Coding | `Content-Encoding` | Available on |
  | --- | --- | --- |
  | `RequestCompression.GZip` | `gzip` | every target |
  | `RequestCompression.Brotli` | `br` | .NET 8.0 and later |
  | `RequestCompression.Zstandard` | `zstd` | .NET 11.0 and later |

## What is the current behavior?

**Refit sends every request body uncompressed.**

- Compressing one required a `DelegatingHandler` that re-wraps content on the way out, which cannot tell one endpoint from another without inspecting the URI.

Closes #2307

## What might this PR break?

**None.**

- The default on both `[Body]` and `RefitSettings` leaves bodies uncompressed, so an existing client sends exactly what it sent before.
- Generated clients now emit a `CompressBodyContent` call after the body assignment. It returns the content unchanged when no coding applies, which is what makes the settings-level default reach generated code.
- The compressed length is unknown until the body has been written, so a compressed request is sent chunked with no `Content-Length`.

## Checklist
- [x] I have read the [Contribute guide](https://www.reactiveui.net/contribute/index.html)
- [x] Tests have been added or updated (for bug fixes / features)
- [x] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the `main` branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional information

There is no negotiation for a compressed request body, so this is opt-in and the README says to turn it on only against a server known to accept one.

The `.NET 11.0` content wrappers are still preview API. `RequestCompression` is Refit's own enum, so the coding surface is insulated from them; `RequestCompressionOptions` does expose `ZLibCompressionOptions`, `BrotliCompressionOptions` and `ZstandardCompressionOptions` directly, which is deliberate - mirroring those knobs into Refit types would be a surface to maintain forever and would drift from the framework.

Hand-authored files worth reviewing: `RequestContentCoding.cs` (resolution and per-target dispatch), `CompressedContent.cs` (the pre-net11.0 wrapper), `RequestCompressionOptions.cs`, and `Emitter.Inline.Content.cs` (the emitted wrap). The `PublicAPI.txt` diffs are the analyzer's own baseline fixer output.
