### PR TITLE
fix(debugging): stop debugger displays rendering as a bare null

### DIFF
--- a/src/Refit.HttpClientFactory/PublicAPI/net10.0/PublicAPI.txt
+++ b/src/Refit.HttpClientFactory/PublicAPI/net10.0/PublicAPI.txt
@@ -121,7 +121,7 @@ public interface ISettingsFor
 {
     Refit.RefitSettings? Settings { get; }
 }
-[System.Diagnostics.DebuggerDisplay("{Settings}")]
+[System.Diagnostics.DebuggerDisplay("SettingsFor: {Settings}")]
 public class SettingsFor<T> : Refit.ISettingsFor
 {
     public SettingsFor(Refit.RefitSettings? settings) { }

--- a/src/Refit.HttpClientFactory/PublicAPI/net11.0/PublicAPI.txt
+++ b/src/Refit.HttpClientFactory/PublicAPI/net11.0/PublicAPI.txt
@@ -121,7 +121,7 @@ public interface ISettingsFor
 {
     Refit.RefitSettings? Settings { get; }
 }
-[System.Diagnostics.DebuggerDisplay("{Settings}")]
+[System.Diagnostics.DebuggerDisplay("SettingsFor: {Settings}")]
 public class SettingsFor<T> : Refit.ISettingsFor
 {
     public SettingsFor(Refit.RefitSettings? settings) { }

--- a/src/Refit.HttpClientFactory/PublicAPI/net462/PublicAPI.txt
+++ b/src/Refit.HttpClientFactory/PublicAPI/net462/PublicAPI.txt
@@ -57,7 +57,7 @@ public interface ISettingsFor
 {
     Refit.RefitSettings? Settings { get; }
 }
-[System.Diagnostics.DebuggerDisplay("{Settings}")]
+[System.Diagnostics.DebuggerDisplay("SettingsFor: {Settings}")]
 public class SettingsFor<T> : Refit.ISettingsFor
 {
     public SettingsFor(Refit.RefitSettings? settings) { }

--- a/src/Refit.HttpClientFactory/PublicAPI/net470/PublicAPI.txt
+++ b/src/Refit.HttpClientFactory/PublicAPI/net470/PublicAPI.txt
@@ -57,7 +57,7 @@ public interface ISettingsFor
 {
     Refit.RefitSettings? Settings { get; }
 }
-[System.Diagnostics.DebuggerDisplay("{Settings}")]
+[System.Diagnostics.DebuggerDisplay("SettingsFor: {Settings}")]
 public class SettingsFor<T> : Refit.ISettingsFor
 {
     public SettingsFor(Refit.RefitSettings? settings) { }

--- a/src/Refit.HttpClientFactory/PublicAPI/net471/PublicAPI.txt
+++ b/src/Refit.HttpClientFactory/PublicAPI/net471/PublicAPI.txt
@@ -57,7 +57,7 @@ public interface ISettingsFor
 {
     Refit.RefitSettings? Settings { get; }
 }
-[System.Diagnostics.DebuggerDisplay("{Settings}")]
+[System.Diagnostics.DebuggerDisplay("SettingsFor: {Settings}")]
 public class SettingsFor<T> : Refit.ISettingsFor
 {
     public SettingsFor(Refit.RefitSettings? settings) { }

--- a/src/Refit.HttpClientFactory/PublicAPI/net472/PublicAPI.txt
+++ b/src/Refit.HttpClientFactory/PublicAPI/net472/PublicAPI.txt
@@ -57,7 +57,7 @@ public interface ISettingsFor
 {
     Refit.RefitSettings? Settings { get; }
 }
-[System.Diagnostics.DebuggerDisplay("{Settings}")]
+[System.Diagnostics.DebuggerDisplay("SettingsFor: {Settings}")]
 public class SettingsFor<T> : Refit.ISettingsFor
 {
     public SettingsFor(Refit.RefitSettings? settings) { }

--- a/src/Refit.HttpClientFactory/PublicAPI/net48/PublicAPI.txt
+++ b/src/Refit.HttpClientFactory/PublicAPI/net48/PublicAPI.txt
@@ -57,7 +57,7 @@ public interface ISettingsFor
 {
     Refit.RefitSettings? Settings { get; }
 }
-[System.Diagnostics.DebuggerDisplay("{Settings}")]
+[System.Diagnostics.DebuggerDisplay("SettingsFor: {Settings}")]
 public class SettingsFor<T> : Refit.ISettingsFor
 {
     public SettingsFor(Refit.RefitSettings? settings) { }

--- a/src/Refit.HttpClientFactory/PublicAPI/net481/PublicAPI.txt
+++ b/src/Refit.HttpClientFactory/PublicAPI/net481/PublicAPI.txt
@@ -57,7 +57,7 @@ public interface ISettingsFor
 {
     Refit.RefitSettings? Settings { get; }
 }
-[System.Diagnostics.DebuggerDisplay("{Settings}")]
+[System.Diagnostics.DebuggerDisplay("SettingsFor: {Settings}")]
 public class SettingsFor<T> : Refit.ISettingsFor
 {
     public SettingsFor(Refit.RefitSettings? settings) { }

--- a/src/Refit.HttpClientFactory/PublicAPI/net8.0/PublicAPI.txt
+++ b/src/Refit.HttpClientFactory/PublicAPI/net8.0/PublicAPI.txt
@@ -105,7 +105,7 @@ public interface ISettingsFor
 {
     Refit.RefitSettings? Settings { get; }
 }
-[System.Diagnostics.DebuggerDisplay("{Settings}")]
+[System.Diagnostics.DebuggerDisplay("SettingsFor: {Settings}")]
 public class SettingsFor<T> : Refit.ISettingsFor
 {
     public SettingsFor(Refit.RefitSettings? settings) { }

--- a/src/Refit.HttpClientFactory/PublicAPI/net9.0/PublicAPI.txt
+++ b/src/Refit.HttpClientFactory/PublicAPI/net9.0/PublicAPI.txt
@@ -121,7 +121,7 @@ public interface ISettingsFor
 {
     Refit.RefitSettings? Settings { get; }
 }
-[System.Diagnostics.DebuggerDisplay("{Settings}")]
+[System.Diagnostics.DebuggerDisplay("SettingsFor: {Settings}")]
 public class SettingsFor<T> : Refit.ISettingsFor
 {
     public SettingsFor(Refit.RefitSettings? settings) { }

--- a/src/Refit.HttpClientFactory/SettingsFor{T}.cs
+++ b/src/Refit.HttpClientFactory/SettingsFor{T}.cs
@@ -9,7 +9,7 @@ namespace Refit;
 /// <typeparam name="T">The Refit interface type the settings belong to.</typeparam>
 /// <param name="settings">The settings.</param>
 /// <remarks>Initializes a new instance of the <see cref="SettingsFor{T}"/> class.</remarks>
-[System.Diagnostics.DebuggerDisplay("{Settings}")]
+[System.Diagnostics.DebuggerDisplay("SettingsFor: {Settings}")]
 [SuppressMessage(
     "StyleSharp",
     "SST1452:Unused type parameters should be removed",

--- a/src/Refit.Testing/PublicAPI/net10.0/PublicAPI.txt
+++ b/src/Refit.Testing/PublicAPI/net10.0/PublicAPI.txt
@@ -45,7 +45,7 @@ public static class Route
     public static Refit.Testing.RouteMatcher Post(string template) { }
     public static Refit.Testing.RouteMatcher Put(string template) { }
 }
-[System.Diagnostics.DebuggerDisplay("{Method}")]
+[System.Diagnostics.DebuggerDisplay("RouteMatcher: {Method}")]
 public sealed class RouteMatcher
 {
     public RouteMatcher() { }
@@ -62,7 +62,7 @@ public sealed class RouteMatcher
     public System.Func<System.Net.Http.HttpRequestMessage, bool>? Where { get; init; }
     public System.Func<System.Net.Http.HttpRequestMessage, System.Threading.Tasks.Task<bool>>? WhereAsync { get; init; }
 }
-[System.Diagnostics.DebuggerDisplay("{Content}")]
+[System.Diagnostics.DebuggerDisplay("StubApiResponse: {StatusCode}, Content = {Content}")]
 public sealed class StubApiResponse<T> : Refit.IApiResponse<T>
 {
     public StubApiResponse() { }

--- a/src/Refit.Testing/PublicAPI/net11.0/PublicAPI.txt
+++ b/src/Refit.Testing/PublicAPI/net11.0/PublicAPI.txt
@@ -45,7 +45,7 @@ public static class Route
     public static Refit.Testing.RouteMatcher Post(string template) { }
     public static Refit.Testing.RouteMatcher Put(string template) { }
 }
-[System.Diagnostics.DebuggerDisplay("{Method}")]
+[System.Diagnostics.DebuggerDisplay("RouteMatcher: {Method}")]
 public sealed class RouteMatcher
 {
     public RouteMatcher() { }
@@ -62,7 +62,7 @@ public sealed class RouteMatcher
     public System.Func<System.Net.Http.HttpRequestMessage, bool>? Where { get; init; }
     public System.Func<System.Net.Http.HttpRequestMessage, System.Threading.Tasks.Task<bool>>? WhereAsync { get; init; }
 }
-[System.Diagnostics.DebuggerDisplay("{Content}")]
+[System.Diagnostics.DebuggerDisplay("StubApiResponse: {StatusCode}, Content = {Content}")]
 public sealed class StubApiResponse<T> : Refit.IApiResponse<T>
 {
     public StubApiResponse() { }

--- a/src/Refit.Testing/PublicAPI/net462/PublicAPI.txt
+++ b/src/Refit.Testing/PublicAPI/net462/PublicAPI.txt
@@ -45,7 +45,7 @@ public static class Route
     public static Refit.Testing.RouteMatcher Post(string template) { }
     public static Refit.Testing.RouteMatcher Put(string template) { }
 }
-[System.Diagnostics.DebuggerDisplay("{Method}")]
+[System.Diagnostics.DebuggerDisplay("RouteMatcher: {Method}")]
 public sealed class RouteMatcher
 {
     public RouteMatcher() { }
@@ -62,7 +62,7 @@ public sealed class RouteMatcher
     public System.Func<System.Net.Http.HttpRequestMessage, bool>? Where { get; init; }
     public System.Func<System.Net.Http.HttpRequestMessage, System.Threading.Tasks.Task<bool>>? WhereAsync { get; init; }
 }
-[System.Diagnostics.DebuggerDisplay("{Content}")]
+[System.Diagnostics.DebuggerDisplay("StubApiResponse: {StatusCode}, Content = {Content}")]
 public sealed class StubApiResponse<T> : Refit.IApiResponse<T>
 {
     public StubApiResponse() { }

--- a/src/Refit.Testing/PublicAPI/net470/PublicAPI.txt
+++ b/src/Refit.Testing/PublicAPI/net470/PublicAPI.txt
@@ -45,7 +45,7 @@ public static class Route
     public static Refit.Testing.RouteMatcher Post(string template) { }
     public static Refit.Testing.RouteMatcher Put(string template) { }
 }
-[System.Diagnostics.DebuggerDisplay("{Method}")]
+[System.Diagnostics.DebuggerDisplay("RouteMatcher: {Method}")]
 public sealed class RouteMatcher
 {
     public RouteMatcher() { }
@@ -62,7 +62,7 @@ public sealed class RouteMatcher
     public System.Func<System.Net.Http.HttpRequestMessage, bool>? Where { get; init; }
     public System.Func<System.Net.Http.HttpRequestMessage, System.Threading.Tasks.Task<bool>>? WhereAsync { get; init; }
 }
-[System.Diagnostics.DebuggerDisplay("{Content}")]
+[System.Diagnostics.DebuggerDisplay("StubApiResponse: {StatusCode}, Content = {Content}")]
 public sealed class StubApiResponse<T> : Refit.IApiResponse<T>
 {
     public StubApiResponse() { }

--- a/src/Refit.Testing/PublicAPI/net471/PublicAPI.txt
+++ b/src/Refit.Testing/PublicAPI/net471/PublicAPI.txt
@@ -45,7 +45,7 @@ public static class Route
     public static Refit.Testing.RouteMatcher Post(string template) { }
     public static Refit.Testing.RouteMatcher Put(string template) { }
 }
-[System.Diagnostics.DebuggerDisplay("{Method}")]
+[System.Diagnostics.DebuggerDisplay("RouteMatcher: {Method}")]
 public sealed class RouteMatcher
 {
     public RouteMatcher() { }
@@ -62,7 +62,7 @@ public sealed class RouteMatcher
     public System.Func<System.Net.Http.HttpRequestMessage, bool>? Where { get; init; }
     public System.Func<System.Net.Http.HttpRequestMessage, System.Threading.Tasks.Task<bool>>? WhereAsync { get; init; }
 }
-[System.Diagnostics.DebuggerDisplay("{Content}")]
+[System.Diagnostics.DebuggerDisplay("StubApiResponse: {StatusCode}, Content = {Content}")]
 public sealed class StubApiResponse<T> : Refit.IApiResponse<T>
 {
     public StubApiResponse() { }

--- a/src/Refit.Testing/PublicAPI/net472/PublicAPI.txt
+++ b/src/Refit.Testing/PublicAPI/net472/PublicAPI.txt
@@ -45,7 +45,7 @@ public static class Route
     public static Refit.Testing.RouteMatcher Post(string template) { }
     public static Refit.Testing.RouteMatcher Put(string template) { }
 }
-[System.Diagnostics.DebuggerDisplay("{Method}")]
+[System.Diagnostics.DebuggerDisplay("RouteMatcher: {Method}")]
 public sealed class RouteMatcher
 {
     public RouteMatcher() { }
@@ -62,7 +62,7 @@ public sealed class RouteMatcher
     public System.Func<System.Net.Http.HttpRequestMessage, bool>? Where { get; init; }
     public System.Func<System.Net.Http.HttpRequestMessage, System.Threading.Tasks.Task<bool>>? WhereAsync { get; init; }
 }
-[System.Diagnostics.DebuggerDisplay("{Content}")]
+[System.Diagnostics.DebuggerDisplay("StubApiResponse: {StatusCode}, Content = {Content}")]
 public sealed class StubApiResponse<T> : Refit.IApiResponse<T>
 {
     public StubApiResponse() { }

--- a/src/Refit.Testing/PublicAPI/net48/PublicAPI.txt
+++ b/src/Refit.Testing/PublicAPI/net48/PublicAPI.txt
@@ -45,7 +45,7 @@ public static class Route
     public static Refit.Testing.RouteMatcher Post(string template) { }
     public static Refit.Testing.RouteMatcher Put(string template) { }
 }
-[System.Diagnostics.DebuggerDisplay("{Method}")]
+[System.Diagnostics.DebuggerDisplay("RouteMatcher: {Method}")]
 public sealed class RouteMatcher
 {
     public RouteMatcher() { }
@@ -62,7 +62,7 @@ public sealed class RouteMatcher
     public System.Func<System.Net.Http.HttpRequestMessage, bool>? Where { get; init; }
     public System.Func<System.Net.Http.HttpRequestMessage, System.Threading.Tasks.Task<bool>>? WhereAsync { get; init; }
 }
-[System.Diagnostics.DebuggerDisplay("{Content}")]
+[System.Diagnostics.DebuggerDisplay("StubApiResponse: {StatusCode}, Content = {Content}")]
 public sealed class StubApiResponse<T> : Refit.IApiResponse<T>
 {
     public StubApiResponse() { }

--- a/src/Refit.Testing/PublicAPI/net481/PublicAPI.txt
+++ b/src/Refit.Testing/PublicAPI/net481/PublicAPI.txt
@@ -45,7 +45,7 @@ public static class Route
     public static Refit.Testing.RouteMatcher Post(string template) { }
     public static Refit.Testing.RouteMatcher Put(string template) { }
 }
-[System.Diagnostics.DebuggerDisplay("{Method}")]
+[System.Diagnostics.DebuggerDisplay("RouteMatcher: {Method}")]
 public sealed class RouteMatcher
 {
     public RouteMatcher() { }
@@ -62,7 +62,7 @@ public sealed class RouteMatcher
     public System.Func<System.Net.Http.HttpRequestMessage, bool>? Where { get; init; }
     public System.Func<System.Net.Http.HttpRequestMessage, System.Threading.Tasks.Task<bool>>? WhereAsync { get; init; }
 }
-[System.Diagnostics.DebuggerDisplay("{Content}")]
+[System.Diagnostics.DebuggerDisplay("StubApiResponse: {StatusCode}, Content = {Content}")]
 public sealed class StubApiResponse<T> : Refit.IApiResponse<T>
 {
     public StubApiResponse() { }

--- a/src/Refit.Testing/PublicAPI/net8.0/PublicAPI.txt
+++ b/src/Refit.Testing/PublicAPI/net8.0/PublicAPI.txt
@@ -45,7 +45,7 @@ public static class Route
     public static Refit.Testing.RouteMatcher Post(string template) { }
     public static Refit.Testing.RouteMatcher Put(string template) { }
 }
-[System.Diagnostics.DebuggerDisplay("{Method}")]
+[System.Diagnostics.DebuggerDisplay("RouteMatcher: {Method}")]
 public sealed class RouteMatcher
 {
     public RouteMatcher() { }
@@ -62,7 +62,7 @@ public sealed class RouteMatcher
     public System.Func<System.Net.Http.HttpRequestMessage, bool>? Where { get; init; }
     public System.Func<System.Net.Http.HttpRequestMessage, System.Threading.Tasks.Task<bool>>? WhereAsync { get; init; }
 }
-[System.Diagnostics.DebuggerDisplay("{Content}")]
+[System.Diagnostics.DebuggerDisplay("StubApiResponse: {StatusCode}, Content = {Content}")]
 public sealed class StubApiResponse<T> : Refit.IApiResponse<T>
 {
     public StubApiResponse() { }

--- a/src/Refit.Testing/PublicAPI/net9.0/PublicAPI.txt
+++ b/src/Refit.Testing/PublicAPI/net9.0/PublicAPI.txt
@@ -45,7 +45,7 @@ public static class Route
     public static Refit.Testing.RouteMatcher Post(string template) { }
     public static Refit.Testing.RouteMatcher Put(string template) { }
 }
-[System.Diagnostics.DebuggerDisplay("{Method}")]
+[System.Diagnostics.DebuggerDisplay("RouteMatcher: {Method}")]
 public sealed class RouteMatcher
 {
     public RouteMatcher() { }
@@ -62,7 +62,7 @@ public sealed class RouteMatcher
     public System.Func<System.Net.Http.HttpRequestMessage, bool>? Where { get; init; }
     public System.Func<System.Net.Http.HttpRequestMessage, System.Threading.Tasks.Task<bool>>? WhereAsync { get; init; }
 }
-[System.Diagnostics.DebuggerDisplay("{Content}")]
+[System.Diagnostics.DebuggerDisplay("StubApiResponse: {StatusCode}, Content = {Content}")]
 public sealed class StubApiResponse<T> : Refit.IApiResponse<T>
 {
     public StubApiResponse() { }

--- a/src/Refit.Testing/RouteMatcher.cs
+++ b/src/Refit.Testing/RouteMatcher.cs
@@ -19,7 +19,7 @@ namespace Refit.Testing;
 /// whole scheme/host/path. Use <c>"*"</c> to match any path. The query string is matched by
 /// <see cref="Query"/>, not the template.
 /// </remarks>
-[System.Diagnostics.DebuggerDisplay("{Method}")]
+[System.Diagnostics.DebuggerDisplay("RouteMatcher: {Method}")]
 public sealed class RouteMatcher
 {
     /// <summary>Gets the HTTP method to match; <see langword="null"/> matches any method.</summary>

--- a/src/Refit.Testing/StubApiResponse.cs
+++ b/src/Refit.Testing/StubApiResponse.cs
@@ -23,7 +23,7 @@ namespace Refit.Testing;
 /// response. Prefer <see cref="StubHttp"/> for end-to-end tests; reach for this only when the code under
 /// test is handed an <see cref="IApiResponse{T}"/> directly.
 /// </remarks>
-[System.Diagnostics.DebuggerDisplay("{Content}")]
+[System.Diagnostics.DebuggerDisplay("StubApiResponse: {StatusCode}, Content = {Content}")]
 public sealed class StubApiResponse<T> : IApiResponse<T>
 {
     /// <summary>Gets the deserialized response content.</summary>

--- a/src/Refit.Xml/PublicAPI/net10.0/PublicAPI.txt
+++ b/src/Refit.Xml/PublicAPI/net10.0/PublicAPI.txt
@@ -10,7 +10,7 @@ public class XmlContentSerializer : Refit.IHttpContentSerializer, Refit.ISynchro
     public string? GetFieldNameForProperty(System.Reflection.PropertyInfo propertyInfo) { }
     public System.Net.Http.HttpContent ToHttpContent<T>(T item) { }
 }
-[System.Diagnostics.DebuggerDisplay("{XmlDefaultNamespace}")]
+[System.Diagnostics.DebuggerDisplay("XmlContentSerializerSettings: XmlDefaultNamespace = {XmlDefaultNamespace}")]
 public class XmlContentSerializerSettings
 {
     public XmlContentSerializerSettings() { }

--- a/src/Refit.Xml/PublicAPI/net11.0/PublicAPI.txt
+++ b/src/Refit.Xml/PublicAPI/net11.0/PublicAPI.txt
@@ -10,7 +10,7 @@ public class XmlContentSerializer : Refit.IHttpContentSerializer, Refit.ISynchro
     public string? GetFieldNameForProperty(System.Reflection.PropertyInfo propertyInfo) { }
     public System.Net.Http.HttpContent ToHttpContent<T>(T item) { }
 }
-[System.Diagnostics.DebuggerDisplay("{XmlDefaultNamespace}")]
+[System.Diagnostics.DebuggerDisplay("XmlContentSerializerSettings: XmlDefaultNamespace = {XmlDefaultNamespace}")]
 public class XmlContentSerializerSettings
 {
     public XmlContentSerializerSettings() { }

--- a/src/Refit.Xml/PublicAPI/net462/PublicAPI.txt
+++ b/src/Refit.Xml/PublicAPI/net462/PublicAPI.txt
@@ -10,7 +10,7 @@ public class XmlContentSerializer : Refit.IHttpContentSerializer, Refit.ISynchro
     public string? GetFieldNameForProperty(System.Reflection.PropertyInfo propertyInfo) { }
     public System.Net.Http.HttpContent ToHttpContent<T>(T item) { }
 }
-[System.Diagnostics.DebuggerDisplay("{XmlDefaultNamespace}")]
+[System.Diagnostics.DebuggerDisplay("XmlContentSerializerSettings: XmlDefaultNamespace = {XmlDefaultNamespace}")]
 public class XmlContentSerializerSettings
 {
     public XmlContentSerializerSettings() { }

--- a/src/Refit.Xml/PublicAPI/net470/PublicAPI.txt
+++ b/src/Refit.Xml/PublicAPI/net470/PublicAPI.txt
@@ -10,7 +10,7 @@ public class XmlContentSerializer : Refit.IHttpContentSerializer, Refit.ISynchro
     public string? GetFieldNameForProperty(System.Reflection.PropertyInfo propertyInfo) { }
     public System.Net.Http.HttpContent ToHttpContent<T>(T item) { }
 }
-[System.Diagnostics.DebuggerDisplay("{XmlDefaultNamespace}")]
+[System.Diagnostics.DebuggerDisplay("XmlContentSerializerSettings: XmlDefaultNamespace = {XmlDefaultNamespace}")]
 public class XmlContentSerializerSettings
 {
     public XmlContentSerializerSettings() { }

--- a/src/Refit.Xml/PublicAPI/net471/PublicAPI.txt
+++ b/src/Refit.Xml/PublicAPI/net471/PublicAPI.txt
@@ -10,7 +10,7 @@ public class XmlContentSerializer : Refit.IHttpContentSerializer, Refit.ISynchro
     public string? GetFieldNameForProperty(System.Reflection.PropertyInfo propertyInfo) { }
     public System.Net.Http.HttpContent ToHttpContent<T>(T item) { }
 }
-[System.Diagnostics.DebuggerDisplay("{XmlDefaultNamespace}")]
+[System.Diagnostics.DebuggerDisplay("XmlContentSerializerSettings: XmlDefaultNamespace = {XmlDefaultNamespace}")]
 public class XmlContentSerializerSettings
 {
     public XmlContentSerializerSettings() { }

--- a/src/Refit.Xml/PublicAPI/net472/PublicAPI.txt
+++ b/src/Refit.Xml/PublicAPI/net472/PublicAPI.txt
@@ -10,7 +10,7 @@ public class XmlContentSerializer : Refit.IHttpContentSerializer, Refit.ISynchro
     public string? GetFieldNameForProperty(System.Reflection.PropertyInfo propertyInfo) { }
     public System.Net.Http.HttpContent ToHttpContent<T>(T item) { }
 }
-[System.Diagnostics.DebuggerDisplay("{XmlDefaultNamespace}")]
+[System.Diagnostics.DebuggerDisplay("XmlContentSerializerSettings: XmlDefaultNamespace = {XmlDefaultNamespace}")]
 public class XmlContentSerializerSettings
 {
     public XmlContentSerializerSettings() { }

--- a/src/Refit.Xml/PublicAPI/net48/PublicAPI.txt
+++ b/src/Refit.Xml/PublicAPI/net48/PublicAPI.txt
@@ -10,7 +10,7 @@ public class XmlContentSerializer : Refit.IHttpContentSerializer, Refit.ISynchro
     public string? GetFieldNameForProperty(System.Reflection.PropertyInfo propertyInfo) { }
     public System.Net.Http.HttpContent ToHttpContent<T>(T item) { }
 }
-[System.Diagnostics.DebuggerDisplay("{XmlDefaultNamespace}")]
+[System.Diagnostics.DebuggerDisplay("XmlContentSerializerSettings: XmlDefaultNamespace = {XmlDefaultNamespace}")]
 public class XmlContentSerializerSettings
 {
     public XmlContentSerializerSettings() { }

--- a/src/Refit.Xml/PublicAPI/net481/PublicAPI.txt
+++ b/src/Refit.Xml/PublicAPI/net481/PublicAPI.txt
@@ -10,7 +10,7 @@ public class XmlContentSerializer : Refit.IHttpContentSerializer, Refit.ISynchro
     public string? GetFieldNameForProperty(System.Reflection.PropertyInfo propertyInfo) { }
     public System.Net.Http.HttpContent ToHttpContent<T>(T item) { }
 }
-[System.Diagnostics.DebuggerDisplay("{XmlDefaultNamespace}")]
+[System.Diagnostics.DebuggerDisplay("XmlContentSerializerSettings: XmlDefaultNamespace = {XmlDefaultNamespace}")]
 public class XmlContentSerializerSettings
 {
     public XmlContentSerializerSettings() { }

--- a/src/Refit.Xml/PublicAPI/net8.0/PublicAPI.txt
+++ b/src/Refit.Xml/PublicAPI/net8.0/PublicAPI.txt
@@ -10,7 +10,7 @@ public class XmlContentSerializer : Refit.IHttpContentSerializer, Refit.ISynchro
     public string? GetFieldNameForProperty(System.Reflection.PropertyInfo propertyInfo) { }
     public System.Net.Http.HttpContent ToHttpContent<T>(T item) { }
 }
-[System.Diagnostics.DebuggerDisplay("{XmlDefaultNamespace}")]
+[System.Diagnostics.DebuggerDisplay("XmlContentSerializerSettings: XmlDefaultNamespace = {XmlDefaultNamespace}")]
 public class XmlContentSerializerSettings
 {
     public XmlContentSerializerSettings() { }

--- a/src/Refit.Xml/PublicAPI/net9.0/PublicAPI.txt
+++ b/src/Refit.Xml/PublicAPI/net9.0/PublicAPI.txt
@@ -10,7 +10,7 @@ public class XmlContentSerializer : Refit.IHttpContentSerializer, Refit.ISynchro
     public string? GetFieldNameForProperty(System.Reflection.PropertyInfo propertyInfo) { }
     public System.Net.Http.HttpContent ToHttpContent<T>(T item) { }
 }
-[System.Diagnostics.DebuggerDisplay("{XmlDefaultNamespace}")]
+[System.Diagnostics.DebuggerDisplay("XmlContentSerializerSettings: XmlDefaultNamespace = {XmlDefaultNamespace}")]
 public class XmlContentSerializerSettings
 {
     public XmlContentSerializerSettings() { }

--- a/src/Refit.Xml/XmlContentSerializerSettings.cs
+++ b/src/Refit.Xml/XmlContentSerializerSettings.cs
@@ -6,7 +6,7 @@ using System.Xml.Serialization;
 namespace Refit;
 
 /// <summary>Settings that control how <see cref="XmlContentSerializer"/> serializes and deserializes XML content.</summary>
-[System.Diagnostics.DebuggerDisplay("{XmlDefaultNamespace}")]
+[System.Diagnostics.DebuggerDisplay("XmlContentSerializerSettings: XmlDefaultNamespace = {XmlDefaultNamespace}")]
 public class XmlContentSerializerSettings
 {
     /// <summary>Initializes a new instance of the <see cref="XmlContentSerializerSettings"/> class.</summary>

--- a/src/Refit/ApiResponse{T}.cs
+++ b/src/Refit/ApiResponse{T}.cs
@@ -18,7 +18,7 @@ namespace Refit;
 /// <remarks>
 /// Create an instance of <see cref="ApiResponse{T}"/> with type <typeparamref name="T"/>.
 /// </remarks>
-[System.Diagnostics.DebuggerDisplay("{Content}")]
+[System.Diagnostics.DebuggerDisplay("ApiResponse: {StatusCode}, Content = {Content}")]
 public sealed class ApiResponse<T>(
     HttpRequestMessage request,
     HttpResponseMessage? response,

--- a/src/Refit/BodyAttribute.cs
+++ b/src/Refit/BodyAttribute.cs
@@ -15,7 +15,7 @@ namespace Refit;
 /// - If the parameter has the attribute <c>[Body(BodySerializationMethod.UrlEncoded)]</c>, the content will be URL-encoded.<br/>
 /// - For all other types, the object will be serialized using the content serializer specified in the request's <see cref="RefitSettings"/>.
 /// </remarks>
-[System.Diagnostics.DebuggerDisplay("{Buffered}")]
+[System.Diagnostics.DebuggerDisplay("Body: Buffered = {Buffered}")]
 [AttributeUsage(AttributeTargets.Parameter)]
 public sealed class BodyAttribute : Attribute
 {

--- a/src/Refit/MultipartItem.cs
+++ b/src/Refit/MultipartItem.cs
@@ -6,7 +6,7 @@ using System.Net.Http;
 namespace Refit;
 
 /// <summary>Base type for multipart form items that carry a file name and optional content metadata.</summary>
-[System.Diagnostics.DebuggerDisplay("{Name}")]
+[System.Diagnostics.DebuggerDisplay("MultipartItem: {Name}")]
 public abstract class MultipartItem
 {
     /// <summary>Initializes a new instance of the <see cref="MultipartItem"/> class.</summary>

--- a/src/Refit/PropertyAttribute.cs
+++ b/src/Refit/PropertyAttribute.cs
@@ -9,7 +9,7 @@ namespace Refit;
 /// If a string is supplied to the constructor then it will be used as the key in the HttpRequestMessage.Properties dictionary.
 /// If no key is specified then the key will be defaulted to the name of the parameter.
 /// </summary>
-[System.Diagnostics.DebuggerDisplay("{Key}")]
+[System.Diagnostics.DebuggerDisplay("Property: {Key}")]
 [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Property)]
 public sealed class PropertyAttribute : Attribute
 {

--- a/src/Refit/PublicAPI/net10.0/PublicAPI.txt
+++ b/src/Refit/PublicAPI/net10.0/PublicAPI.txt
@@ -56,7 +56,7 @@ public class ApiRequestException : Refit.ApiExceptionBase
     public ApiRequestException(string exceptionMessage, System.Net.Http.HttpRequestMessage message, System.Net.Http.HttpMethod httpMethod, Refit.RefitSettings refitSettings) { }
     public ApiRequestException(string exceptionMessage, System.Net.Http.HttpRequestMessage message, System.Net.Http.HttpMethod httpMethod, Refit.RefitSettings refitSettings, System.Exception? innerException) { }
 }
-[System.Diagnostics.DebuggerDisplay("{Content}")]
+[System.Diagnostics.DebuggerDisplay("ApiResponse: {StatusCode}, Content = {Content}")]
 public sealed class ApiResponse<T> : Refit.IApiResponse<T>
 {
     public ApiResponse(System.Net.Http.HttpResponseMessage response, T? content, Refit.RefitSettings settings) { }
@@ -124,7 +124,7 @@ public sealed class AuthorizeAttribute : System.Attribute
     public string Scheme { get; }
 }
 [System.AttributeUsage(System.AttributeTargets.Parameter)]
-[System.Diagnostics.DebuggerDisplay("{Buffered}")]
+[System.Diagnostics.DebuggerDisplay("Body: Buffered = {Buffered}")]
 public sealed class BodyAttribute : System.Attribute
 {
     public BodyAttribute() { }
@@ -480,7 +480,7 @@ public sealed class MultipartAttribute : System.Attribute
     public MultipartAttribute(string boundaryText = "----MyGreatBoundary") { }
     public string BoundaryText { get; }
 }
-[System.Diagnostics.DebuggerDisplay("{Name}")]
+[System.Diagnostics.DebuggerDisplay("MultipartItem: {Name}")]
 public abstract class MultipartItem
 {
     protected MultipartItem(string fileName, string? contentType) { }
@@ -545,7 +545,7 @@ public class ProblemDetails
     public string? Type { get; set; }
 }
 [System.AttributeUsage(System.AttributeTargets.Property | System.AttributeTargets.Parameter)]
-[System.Diagnostics.DebuggerDisplay("{Key}")]
+[System.Diagnostics.DebuggerDisplay("Property: {Key}")]
 public sealed class PropertyAttribute : System.Attribute
 {
     public PropertyAttribute() { }
@@ -596,7 +596,7 @@ public sealed class QueryUriFormatAttribute : System.Attribute
     public QueryUriFormatAttribute(System.UriFormat uriFormat) { }
     public System.UriFormat UriFormat { get; }
 }
-[System.Diagnostics.DebuggerDisplay("{AuthorizationHeaderValueGetter}")]
+[System.Diagnostics.DebuggerDisplay("RefitSettings: AuthorizationHeaderValueGetter = {AuthorizationHeaderValueGetter}")]
 public class RefitSettings
 {
     public RefitSettings() { }
@@ -685,7 +685,7 @@ public record RestMethodInfo : System.IEquatable<Refit.RestMethodInfo>
     public string RelativePath { get; init; }
     public System.Type ReturnType { get; init; }
 }
-[System.Diagnostics.DebuggerDisplay("{Name}")]
+[System.Diagnostics.DebuggerDisplay("RestMethodParameterInfo: {Name}")]
 public class RestMethodParameterInfo
 {
     public RestMethodParameterInfo(bool isObjectPropertyParameter, System.Reflection.ParameterInfo parameterInfo) { }
@@ -818,7 +818,7 @@ public enum UrlResolutionMode
     RefitLegacy = 0,
     Rfc3986 = 1,
 }
-[System.Diagnostics.DebuggerDisplay("{Content}")]
+[System.Diagnostics.DebuggerDisplay("ValidationApiException: {StatusCode}, Content = {Content}")]
 public class ValidationApiException : Refit.ApiException
 {
     public ValidationApiException(string message) { }

--- a/src/Refit/PublicAPI/net11.0/PublicAPI.txt
+++ b/src/Refit/PublicAPI/net11.0/PublicAPI.txt
@@ -56,7 +56,7 @@ public class ApiRequestException : Refit.ApiExceptionBase
     public ApiRequestException(string exceptionMessage, System.Net.Http.HttpRequestMessage message, System.Net.Http.HttpMethod httpMethod, Refit.RefitSettings refitSettings) { }
     public ApiRequestException(string exceptionMessage, System.Net.Http.HttpRequestMessage message, System.Net.Http.HttpMethod httpMethod, Refit.RefitSettings refitSettings, System.Exception? innerException) { }
 }
-[System.Diagnostics.DebuggerDisplay("{Content}")]
+[System.Diagnostics.DebuggerDisplay("ApiResponse: {StatusCode}, Content = {Content}")]
 public sealed class ApiResponse<T> : Refit.IApiResponse<T>
 {
     public ApiResponse(System.Net.Http.HttpResponseMessage response, T? content, Refit.RefitSettings settings) { }
@@ -124,7 +124,7 @@ public sealed class AuthorizeAttribute : System.Attribute
     public string Scheme { get; }
 }
 [System.AttributeUsage(System.AttributeTargets.Parameter)]
-[System.Diagnostics.DebuggerDisplay("{Buffered}")]
+[System.Diagnostics.DebuggerDisplay("Body: Buffered = {Buffered}")]
 public sealed class BodyAttribute : System.Attribute
 {
     public BodyAttribute() { }
@@ -480,7 +480,7 @@ public sealed class MultipartAttribute : System.Attribute
     public MultipartAttribute(string boundaryText = "----MyGreatBoundary") { }
     public string BoundaryText { get; }
 }
-[System.Diagnostics.DebuggerDisplay("{Name}")]
+[System.Diagnostics.DebuggerDisplay("MultipartItem: {Name}")]
 public abstract class MultipartItem
 {
     protected MultipartItem(string fileName, string? contentType) { }
@@ -545,7 +545,7 @@ public class ProblemDetails
     public string? Type { get; set; }
 }
 [System.AttributeUsage(System.AttributeTargets.Property | System.AttributeTargets.Parameter)]
-[System.Diagnostics.DebuggerDisplay("{Key}")]
+[System.Diagnostics.DebuggerDisplay("Property: {Key}")]
 public sealed class PropertyAttribute : System.Attribute
 {
     public PropertyAttribute() { }
@@ -596,7 +596,7 @@ public sealed class QueryUriFormatAttribute : System.Attribute
     public QueryUriFormatAttribute(System.UriFormat uriFormat) { }
     public System.UriFormat UriFormat { get; }
 }
-[System.Diagnostics.DebuggerDisplay("{AuthorizationHeaderValueGetter}")]
+[System.Diagnostics.DebuggerDisplay("RefitSettings: AuthorizationHeaderValueGetter = {AuthorizationHeaderValueGetter}")]
 public class RefitSettings
 {
     public RefitSettings() { }
@@ -686,7 +686,7 @@ public record RestMethodInfo : System.IEquatable<Refit.RestMethodInfo>
     public string RelativePath { get; init; }
     public System.Type ReturnType { get; init; }
 }
-[System.Diagnostics.DebuggerDisplay("{Name}")]
+[System.Diagnostics.DebuggerDisplay("RestMethodParameterInfo: {Name}")]
 public class RestMethodParameterInfo
 {
     public RestMethodParameterInfo(bool isObjectPropertyParameter, System.Reflection.ParameterInfo parameterInfo) { }
@@ -819,7 +819,7 @@ public enum UrlResolutionMode
     RefitLegacy = 0,
     Rfc3986 = 1,
 }
-[System.Diagnostics.DebuggerDisplay("{Content}")]
+[System.Diagnostics.DebuggerDisplay("ValidationApiException: {StatusCode}, Content = {Content}")]
 public class ValidationApiException : Refit.ApiException
 {
     public ValidationApiException(string message) { }

--- a/src/Refit/PublicAPI/net462/PublicAPI.txt
+++ b/src/Refit/PublicAPI/net462/PublicAPI.txt
@@ -53,7 +53,7 @@ public class ApiRequestException : Refit.ApiExceptionBase
     public ApiRequestException(string exceptionMessage, System.Net.Http.HttpRequestMessage message, System.Net.Http.HttpMethod httpMethod, Refit.RefitSettings refitSettings) { }
     public ApiRequestException(string exceptionMessage, System.Net.Http.HttpRequestMessage message, System.Net.Http.HttpMethod httpMethod, Refit.RefitSettings refitSettings, System.Exception? innerException) { }
 }
-[System.Diagnostics.DebuggerDisplay("{Content}")]
+[System.Diagnostics.DebuggerDisplay("ApiResponse: {StatusCode}, Content = {Content}")]
 public sealed class ApiResponse<T> : Refit.IApiResponse<T>
 {
     public ApiResponse(System.Net.Http.HttpResponseMessage response, T? content, Refit.RefitSettings settings) { }
@@ -110,7 +110,7 @@ public sealed class AuthorizeAttribute : System.Attribute
     public string Scheme { get; }
 }
 [System.AttributeUsage(System.AttributeTargets.Parameter)]
-[System.Diagnostics.DebuggerDisplay("{Buffered}")]
+[System.Diagnostics.DebuggerDisplay("Body: Buffered = {Buffered}")]
 public sealed class BodyAttribute : System.Attribute
 {
     public BodyAttribute() { }
@@ -448,7 +448,7 @@ public sealed class MultipartAttribute : System.Attribute
     public MultipartAttribute(string boundaryText = "----MyGreatBoundary") { }
     public string BoundaryText { get; }
 }
-[System.Diagnostics.DebuggerDisplay("{Name}")]
+[System.Diagnostics.DebuggerDisplay("MultipartItem: {Name}")]
 public abstract class MultipartItem
 {
     protected MultipartItem(string fileName, string? contentType) { }
@@ -513,7 +513,7 @@ public class ProblemDetails
     public string? Type { get; set; }
 }
 [System.AttributeUsage(System.AttributeTargets.Property | System.AttributeTargets.Parameter)]
-[System.Diagnostics.DebuggerDisplay("{Key}")]
+[System.Diagnostics.DebuggerDisplay("Property: {Key}")]
 public sealed class PropertyAttribute : System.Attribute
 {
     public PropertyAttribute() { }
@@ -564,7 +564,7 @@ public sealed class QueryUriFormatAttribute : System.Attribute
     public QueryUriFormatAttribute(System.UriFormat uriFormat) { }
     public System.UriFormat UriFormat { get; }
 }
-[System.Diagnostics.DebuggerDisplay("{AuthorizationHeaderValueGetter}")]
+[System.Diagnostics.DebuggerDisplay("RefitSettings: AuthorizationHeaderValueGetter = {AuthorizationHeaderValueGetter}")]
 public class RefitSettings
 {
     public RefitSettings() { }
@@ -639,7 +639,7 @@ public record RestMethodInfo : System.IEquatable<Refit.RestMethodInfo>
     public string RelativePath { get; init; }
     public System.Type ReturnType { get; init; }
 }
-[System.Diagnostics.DebuggerDisplay("{Name}")]
+[System.Diagnostics.DebuggerDisplay("RestMethodParameterInfo: {Name}")]
 public class RestMethodParameterInfo
 {
     public RestMethodParameterInfo(bool isObjectPropertyParameter, System.Reflection.ParameterInfo parameterInfo) { }
@@ -762,7 +762,7 @@ public enum UrlResolutionMode
     RefitLegacy = 0,
     Rfc3986 = 1,
 }
-[System.Diagnostics.DebuggerDisplay("{Content}")]
+[System.Diagnostics.DebuggerDisplay("ValidationApiException: {StatusCode}, Content = {Content}")]
 public class ValidationApiException : Refit.ApiException
 {
     public ValidationApiException(string message) { }

--- a/src/Refit/PublicAPI/net470/PublicAPI.txt
+++ b/src/Refit/PublicAPI/net470/PublicAPI.txt
@@ -53,7 +53,7 @@ public class ApiRequestException : Refit.ApiExceptionBase
     public ApiRequestException(string exceptionMessage, System.Net.Http.HttpRequestMessage message, System.Net.Http.HttpMethod httpMethod, Refit.RefitSettings refitSettings) { }
     public ApiRequestException(string exceptionMessage, System.Net.Http.HttpRequestMessage message, System.Net.Http.HttpMethod httpMethod, Refit.RefitSettings refitSettings, System.Exception? innerException) { }
 }
-[System.Diagnostics.DebuggerDisplay("{Content}")]
+[System.Diagnostics.DebuggerDisplay("ApiResponse: {StatusCode}, Content = {Content}")]
 public sealed class ApiResponse<T> : Refit.IApiResponse<T>
 {
     public ApiResponse(System.Net.Http.HttpResponseMessage response, T? content, Refit.RefitSettings settings) { }
@@ -110,7 +110,7 @@ public sealed class AuthorizeAttribute : System.Attribute
     public string Scheme { get; }
 }
 [System.AttributeUsage(System.AttributeTargets.Parameter)]
-[System.Diagnostics.DebuggerDisplay("{Buffered}")]
+[System.Diagnostics.DebuggerDisplay("Body: Buffered = {Buffered}")]
 public sealed class BodyAttribute : System.Attribute
 {
     public BodyAttribute() { }
@@ -448,7 +448,7 @@ public sealed class MultipartAttribute : System.Attribute
     public MultipartAttribute(string boundaryText = "----MyGreatBoundary") { }
     public string BoundaryText { get; }
 }
-[System.Diagnostics.DebuggerDisplay("{Name}")]
+[System.Diagnostics.DebuggerDisplay("MultipartItem: {Name}")]
 public abstract class MultipartItem
 {
     protected MultipartItem(string fileName, string? contentType) { }
@@ -513,7 +513,7 @@ public class ProblemDetails
     public string? Type { get; set; }
 }
 [System.AttributeUsage(System.AttributeTargets.Property | System.AttributeTargets.Parameter)]
-[System.Diagnostics.DebuggerDisplay("{Key}")]
+[System.Diagnostics.DebuggerDisplay("Property: {Key}")]
 public sealed class PropertyAttribute : System.Attribute
 {
     public PropertyAttribute() { }
@@ -564,7 +564,7 @@ public sealed class QueryUriFormatAttribute : System.Attribute
     public QueryUriFormatAttribute(System.UriFormat uriFormat) { }
     public System.UriFormat UriFormat { get; }
 }
-[System.Diagnostics.DebuggerDisplay("{AuthorizationHeaderValueGetter}")]
+[System.Diagnostics.DebuggerDisplay("RefitSettings: AuthorizationHeaderValueGetter = {AuthorizationHeaderValueGetter}")]
 public class RefitSettings
 {
     public RefitSettings() { }
@@ -639,7 +639,7 @@ public record RestMethodInfo : System.IEquatable<Refit.RestMethodInfo>
     public string RelativePath { get; init; }
     public System.Type ReturnType { get; init; }
 }
-[System.Diagnostics.DebuggerDisplay("{Name}")]
+[System.Diagnostics.DebuggerDisplay("RestMethodParameterInfo: {Name}")]
 public class RestMethodParameterInfo
 {
     public RestMethodParameterInfo(bool isObjectPropertyParameter, System.Reflection.ParameterInfo parameterInfo) { }
@@ -762,7 +762,7 @@ public enum UrlResolutionMode
     RefitLegacy = 0,
     Rfc3986 = 1,
 }
-[System.Diagnostics.DebuggerDisplay("{Content}")]
+[System.Diagnostics.DebuggerDisplay("ValidationApiException: {StatusCode}, Content = {Content}")]
 public class ValidationApiException : Refit.ApiException
 {
     public ValidationApiException(string message) { }

--- a/src/Refit/PublicAPI/net471/PublicAPI.txt
+++ b/src/Refit/PublicAPI/net471/PublicAPI.txt
@@ -53,7 +53,7 @@ public class ApiRequestException : Refit.ApiExceptionBase
     public ApiRequestException(string exceptionMessage, System.Net.Http.HttpRequestMessage message, System.Net.Http.HttpMethod httpMethod, Refit.RefitSettings refitSettings) { }
     public ApiRequestException(string exceptionMessage, System.Net.Http.HttpRequestMessage message, System.Net.Http.HttpMethod httpMethod, Refit.RefitSettings refitSettings, System.Exception? innerException) { }
 }
-[System.Diagnostics.DebuggerDisplay("{Content}")]
+[System.Diagnostics.DebuggerDisplay("ApiResponse: {StatusCode}, Content = {Content}")]
 public sealed class ApiResponse<T> : Refit.IApiResponse<T>
 {
     public ApiResponse(System.Net.Http.HttpResponseMessage response, T? content, Refit.RefitSettings settings) { }
@@ -110,7 +110,7 @@ public sealed class AuthorizeAttribute : System.Attribute
     public string Scheme { get; }
 }
 [System.AttributeUsage(System.AttributeTargets.Parameter)]
-[System.Diagnostics.DebuggerDisplay("{Buffered}")]
+[System.Diagnostics.DebuggerDisplay("Body: Buffered = {Buffered}")]
 public sealed class BodyAttribute : System.Attribute
 {
     public BodyAttribute() { }
@@ -448,7 +448,7 @@ public sealed class MultipartAttribute : System.Attribute
     public MultipartAttribute(string boundaryText = "----MyGreatBoundary") { }
     public string BoundaryText { get; }
 }
-[System.Diagnostics.DebuggerDisplay("{Name}")]
+[System.Diagnostics.DebuggerDisplay("MultipartItem: {Name}")]
 public abstract class MultipartItem
 {
     protected MultipartItem(string fileName, string? contentType) { }
@@ -513,7 +513,7 @@ public class ProblemDetails
     public string? Type { get; set; }
 }
 [System.AttributeUsage(System.AttributeTargets.Property | System.AttributeTargets.Parameter)]
-[System.Diagnostics.DebuggerDisplay("{Key}")]
+[System.Diagnostics.DebuggerDisplay("Property: {Key}")]
 public sealed class PropertyAttribute : System.Attribute
 {
     public PropertyAttribute() { }
@@ -564,7 +564,7 @@ public sealed class QueryUriFormatAttribute : System.Attribute
     public QueryUriFormatAttribute(System.UriFormat uriFormat) { }
     public System.UriFormat UriFormat { get; }
 }
-[System.Diagnostics.DebuggerDisplay("{AuthorizationHeaderValueGetter}")]
+[System.Diagnostics.DebuggerDisplay("RefitSettings: AuthorizationHeaderValueGetter = {AuthorizationHeaderValueGetter}")]
 public class RefitSettings
 {
     public RefitSettings() { }
@@ -639,7 +639,7 @@ public record RestMethodInfo : System.IEquatable<Refit.RestMethodInfo>
     public string RelativePath { get; init; }
     public System.Type ReturnType { get; init; }
 }
-[System.Diagnostics.DebuggerDisplay("{Name}")]
+[System.Diagnostics.DebuggerDisplay("RestMethodParameterInfo: {Name}")]
 public class RestMethodParameterInfo
 {
     public RestMethodParameterInfo(bool isObjectPropertyParameter, System.Reflection.ParameterInfo parameterInfo) { }
@@ -762,7 +762,7 @@ public enum UrlResolutionMode
     RefitLegacy = 0,
     Rfc3986 = 1,
 }
-[System.Diagnostics.DebuggerDisplay("{Content}")]
+[System.Diagnostics.DebuggerDisplay("ValidationApiException: {StatusCode}, Content = {Content}")]
 public class ValidationApiException : Refit.ApiException
 {
     public ValidationApiException(string message) { }

--- a/src/Refit/PublicAPI/net472/PublicAPI.txt
+++ b/src/Refit/PublicAPI/net472/PublicAPI.txt
@@ -53,7 +53,7 @@ public class ApiRequestException : Refit.ApiExceptionBase
     public ApiRequestException(string exceptionMessage, System.Net.Http.HttpRequestMessage message, System.Net.Http.HttpMethod httpMethod, Refit.RefitSettings refitSettings) { }
     public ApiRequestException(string exceptionMessage, System.Net.Http.HttpRequestMessage message, System.Net.Http.HttpMethod httpMethod, Refit.RefitSettings refitSettings, System.Exception? innerException) { }
 }
-[System.Diagnostics.DebuggerDisplay("{Content}")]
+[System.Diagnostics.DebuggerDisplay("ApiResponse: {StatusCode}, Content = {Content}")]
 public sealed class ApiResponse<T> : Refit.IApiResponse<T>
 {
     public ApiResponse(System.Net.Http.HttpResponseMessage response, T? content, Refit.RefitSettings settings) { }
@@ -110,7 +110,7 @@ public sealed class AuthorizeAttribute : System.Attribute
     public string Scheme { get; }
 }
 [System.AttributeUsage(System.AttributeTargets.Parameter)]
-[System.Diagnostics.DebuggerDisplay("{Buffered}")]
+[System.Diagnostics.DebuggerDisplay("Body: Buffered = {Buffered}")]
 public sealed class BodyAttribute : System.Attribute
 {
     public BodyAttribute() { }
@@ -448,7 +448,7 @@ public sealed class MultipartAttribute : System.Attribute
     public MultipartAttribute(string boundaryText = "----MyGreatBoundary") { }
     public string BoundaryText { get; }
 }
-[System.Diagnostics.DebuggerDisplay("{Name}")]
+[System.Diagnostics.DebuggerDisplay("MultipartItem: {Name}")]
 public abstract class MultipartItem
 {
     protected MultipartItem(string fileName, string? contentType) { }
@@ -513,7 +513,7 @@ public class ProblemDetails
     public string? Type { get; set; }
 }
 [System.AttributeUsage(System.AttributeTargets.Property | System.AttributeTargets.Parameter)]
-[System.Diagnostics.DebuggerDisplay("{Key}")]
+[System.Diagnostics.DebuggerDisplay("Property: {Key}")]
 public sealed class PropertyAttribute : System.Attribute
 {
     public PropertyAttribute() { }
@@ -564,7 +564,7 @@ public sealed class QueryUriFormatAttribute : System.Attribute
     public QueryUriFormatAttribute(System.UriFormat uriFormat) { }
     public System.UriFormat UriFormat { get; }
 }
-[System.Diagnostics.DebuggerDisplay("{AuthorizationHeaderValueGetter}")]
+[System.Diagnostics.DebuggerDisplay("RefitSettings: AuthorizationHeaderValueGetter = {AuthorizationHeaderValueGetter}")]
 public class RefitSettings
 {
     public RefitSettings() { }
@@ -639,7 +639,7 @@ public record RestMethodInfo : System.IEquatable<Refit.RestMethodInfo>
     public string RelativePath { get; init; }
     public System.Type ReturnType { get; init; }
 }
-[System.Diagnostics.DebuggerDisplay("{Name}")]
+[System.Diagnostics.DebuggerDisplay("RestMethodParameterInfo: {Name}")]
 public class RestMethodParameterInfo
 {
     public RestMethodParameterInfo(bool isObjectPropertyParameter, System.Reflection.ParameterInfo parameterInfo) { }
@@ -762,7 +762,7 @@ public enum UrlResolutionMode
     RefitLegacy = 0,
     Rfc3986 = 1,
 }
-[System.Diagnostics.DebuggerDisplay("{Content}")]
+[System.Diagnostics.DebuggerDisplay("ValidationApiException: {StatusCode}, Content = {Content}")]
 public class ValidationApiException : Refit.ApiException
 {
     public ValidationApiException(string message) { }

--- a/src/Refit/PublicAPI/net48/PublicAPI.txt
+++ b/src/Refit/PublicAPI/net48/PublicAPI.txt
@@ -53,7 +53,7 @@ public class ApiRequestException : Refit.ApiExceptionBase
     public ApiRequestException(string exceptionMessage, System.Net.Http.HttpRequestMessage message, System.Net.Http.HttpMethod httpMethod, Refit.RefitSettings refitSettings) { }
     public ApiRequestException(string exceptionMessage, System.Net.Http.HttpRequestMessage message, System.Net.Http.HttpMethod httpMethod, Refit.RefitSettings refitSettings, System.Exception? innerException) { }
 }
-[System.Diagnostics.DebuggerDisplay("{Content}")]
+[System.Diagnostics.DebuggerDisplay("ApiResponse: {StatusCode}, Content = {Content}")]
 public sealed class ApiResponse<T> : Refit.IApiResponse<T>
 {
     public ApiResponse(System.Net.Http.HttpResponseMessage response, T? content, Refit.RefitSettings settings) { }
@@ -110,7 +110,7 @@ public sealed class AuthorizeAttribute : System.Attribute
     public string Scheme { get; }
 }
 [System.AttributeUsage(System.AttributeTargets.Parameter)]
-[System.Diagnostics.DebuggerDisplay("{Buffered}")]
+[System.Diagnostics.DebuggerDisplay("Body: Buffered = {Buffered}")]
 public sealed class BodyAttribute : System.Attribute
 {
     public BodyAttribute() { }
@@ -448,7 +448,7 @@ public sealed class MultipartAttribute : System.Attribute
     public MultipartAttribute(string boundaryText = "----MyGreatBoundary") { }
     public string BoundaryText { get; }
 }
-[System.Diagnostics.DebuggerDisplay("{Name}")]
+[System.Diagnostics.DebuggerDisplay("MultipartItem: {Name}")]
 public abstract class MultipartItem
 {
     protected MultipartItem(string fileName, string? contentType) { }
@@ -513,7 +513,7 @@ public class ProblemDetails
     public string? Type { get; set; }
 }
 [System.AttributeUsage(System.AttributeTargets.Property | System.AttributeTargets.Parameter)]
-[System.Diagnostics.DebuggerDisplay("{Key}")]
+[System.Diagnostics.DebuggerDisplay("Property: {Key}")]
 public sealed class PropertyAttribute : System.Attribute
 {
     public PropertyAttribute() { }
@@ -564,7 +564,7 @@ public sealed class QueryUriFormatAttribute : System.Attribute
     public QueryUriFormatAttribute(System.UriFormat uriFormat) { }
     public System.UriFormat UriFormat { get; }
 }
-[System.Diagnostics.DebuggerDisplay("{AuthorizationHeaderValueGetter}")]
+[System.Diagnostics.DebuggerDisplay("RefitSettings: AuthorizationHeaderValueGetter = {AuthorizationHeaderValueGetter}")]
 public class RefitSettings
 {
     public RefitSettings() { }
@@ -639,7 +639,7 @@ public record RestMethodInfo : System.IEquatable<Refit.RestMethodInfo>
     public string RelativePath { get; init; }
     public System.Type ReturnType { get; init; }
 }
-[System.Diagnostics.DebuggerDisplay("{Name}")]
+[System.Diagnostics.DebuggerDisplay("RestMethodParameterInfo: {Name}")]
 public class RestMethodParameterInfo
 {
     public RestMethodParameterInfo(bool isObjectPropertyParameter, System.Reflection.ParameterInfo parameterInfo) { }
@@ -762,7 +762,7 @@ public enum UrlResolutionMode
     RefitLegacy = 0,
     Rfc3986 = 1,
 }
-[System.Diagnostics.DebuggerDisplay("{Content}")]
+[System.Diagnostics.DebuggerDisplay("ValidationApiException: {StatusCode}, Content = {Content}")]
 public class ValidationApiException : Refit.ApiException
 {
     public ValidationApiException(string message) { }

--- a/src/Refit/PublicAPI/net481/PublicAPI.txt
+++ b/src/Refit/PublicAPI/net481/PublicAPI.txt
@@ -53,7 +53,7 @@ public class ApiRequestException : Refit.ApiExceptionBase
     public ApiRequestException(string exceptionMessage, System.Net.Http.HttpRequestMessage message, System.Net.Http.HttpMethod httpMethod, Refit.RefitSettings refitSettings) { }
     public ApiRequestException(string exceptionMessage, System.Net.Http.HttpRequestMessage message, System.Net.Http.HttpMethod httpMethod, Refit.RefitSettings refitSettings, System.Exception? innerException) { }
 }
-[System.Diagnostics.DebuggerDisplay("{Content}")]
+[System.Diagnostics.DebuggerDisplay("ApiResponse: {StatusCode}, Content = {Content}")]
 public sealed class ApiResponse<T> : Refit.IApiResponse<T>
 {
     public ApiResponse(System.Net.Http.HttpResponseMessage response, T? content, Refit.RefitSettings settings) { }
@@ -110,7 +110,7 @@ public sealed class AuthorizeAttribute : System.Attribute
     public string Scheme { get; }
 }
 [System.AttributeUsage(System.AttributeTargets.Parameter)]
-[System.Diagnostics.DebuggerDisplay("{Buffered}")]
+[System.Diagnostics.DebuggerDisplay("Body: Buffered = {Buffered}")]
 public sealed class BodyAttribute : System.Attribute
 {
     public BodyAttribute() { }
@@ -448,7 +448,7 @@ public sealed class MultipartAttribute : System.Attribute
     public MultipartAttribute(string boundaryText = "----MyGreatBoundary") { }
     public string BoundaryText { get; }
 }
-[System.Diagnostics.DebuggerDisplay("{Name}")]
+[System.Diagnostics.DebuggerDisplay("MultipartItem: {Name}")]
 public abstract class MultipartItem
 {
     protected MultipartItem(string fileName, string? contentType) { }
@@ -513,7 +513,7 @@ public class ProblemDetails
     public string? Type { get; set; }
 }
 [System.AttributeUsage(System.AttributeTargets.Property | System.AttributeTargets.Parameter)]
-[System.Diagnostics.DebuggerDisplay("{Key}")]
+[System.Diagnostics.DebuggerDisplay("Property: {Key}")]
 public sealed class PropertyAttribute : System.Attribute
 {
     public PropertyAttribute() { }
@@ -564,7 +564,7 @@ public sealed class QueryUriFormatAttribute : System.Attribute
     public QueryUriFormatAttribute(System.UriFormat uriFormat) { }
     public System.UriFormat UriFormat { get; }
 }
-[System.Diagnostics.DebuggerDisplay("{AuthorizationHeaderValueGetter}")]
+[System.Diagnostics.DebuggerDisplay("RefitSettings: AuthorizationHeaderValueGetter = {AuthorizationHeaderValueGetter}")]
 public class RefitSettings
 {
     public RefitSettings() { }
@@ -639,7 +639,7 @@ public record RestMethodInfo : System.IEquatable<Refit.RestMethodInfo>
     public string RelativePath { get; init; }
     public System.Type ReturnType { get; init; }
 }
-[System.Diagnostics.DebuggerDisplay("{Name}")]
+[System.Diagnostics.DebuggerDisplay("RestMethodParameterInfo: {Name}")]
 public class RestMethodParameterInfo
 {
     public RestMethodParameterInfo(bool isObjectPropertyParameter, System.Reflection.ParameterInfo parameterInfo) { }
@@ -762,7 +762,7 @@ public enum UrlResolutionMode
     RefitLegacy = 0,
     Rfc3986 = 1,
 }
-[System.Diagnostics.DebuggerDisplay("{Content}")]
+[System.Diagnostics.DebuggerDisplay("ValidationApiException: {StatusCode}, Content = {Content}")]
 public class ValidationApiException : Refit.ApiException
 {
     public ValidationApiException(string message) { }

--- a/src/Refit/PublicAPI/net8.0/PublicAPI.txt
+++ b/src/Refit/PublicAPI/net8.0/PublicAPI.txt
@@ -55,7 +55,7 @@ public class ApiRequestException : Refit.ApiExceptionBase
     public ApiRequestException(string exceptionMessage, System.Net.Http.HttpRequestMessage message, System.Net.Http.HttpMethod httpMethod, Refit.RefitSettings refitSettings) { }
     public ApiRequestException(string exceptionMessage, System.Net.Http.HttpRequestMessage message, System.Net.Http.HttpMethod httpMethod, Refit.RefitSettings refitSettings, System.Exception? innerException) { }
 }
-[System.Diagnostics.DebuggerDisplay("{Content}")]
+[System.Diagnostics.DebuggerDisplay("ApiResponse: {StatusCode}, Content = {Content}")]
 public sealed class ApiResponse<T> : Refit.IApiResponse<T>
 {
     public ApiResponse(System.Net.Http.HttpResponseMessage response, T? content, Refit.RefitSettings settings) { }
@@ -123,7 +123,7 @@ public sealed class AuthorizeAttribute : System.Attribute
     public string Scheme { get; }
 }
 [System.AttributeUsage(System.AttributeTargets.Parameter)]
-[System.Diagnostics.DebuggerDisplay("{Buffered}")]
+[System.Diagnostics.DebuggerDisplay("Body: Buffered = {Buffered}")]
 public sealed class BodyAttribute : System.Attribute
 {
     public BodyAttribute() { }
@@ -479,7 +479,7 @@ public sealed class MultipartAttribute : System.Attribute
     public MultipartAttribute(string boundaryText = "----MyGreatBoundary") { }
     public string BoundaryText { get; }
 }
-[System.Diagnostics.DebuggerDisplay("{Name}")]
+[System.Diagnostics.DebuggerDisplay("MultipartItem: {Name}")]
 public abstract class MultipartItem
 {
     protected MultipartItem(string fileName, string? contentType) { }
@@ -544,7 +544,7 @@ public class ProblemDetails
     public string? Type { get; set; }
 }
 [System.AttributeUsage(System.AttributeTargets.Property | System.AttributeTargets.Parameter)]
-[System.Diagnostics.DebuggerDisplay("{Key}")]
+[System.Diagnostics.DebuggerDisplay("Property: {Key}")]
 public sealed class PropertyAttribute : System.Attribute
 {
     public PropertyAttribute() { }
@@ -595,7 +595,7 @@ public sealed class QueryUriFormatAttribute : System.Attribute
     public QueryUriFormatAttribute(System.UriFormat uriFormat) { }
     public System.UriFormat UriFormat { get; }
 }
-[System.Diagnostics.DebuggerDisplay("{AuthorizationHeaderValueGetter}")]
+[System.Diagnostics.DebuggerDisplay("RefitSettings: AuthorizationHeaderValueGetter = {AuthorizationHeaderValueGetter}")]
 public class RefitSettings
 {
     public RefitSettings() { }
@@ -676,7 +676,7 @@ public record RestMethodInfo : System.IEquatable<Refit.RestMethodInfo>
     public string RelativePath { get; init; }
     public System.Type ReturnType { get; init; }
 }
-[System.Diagnostics.DebuggerDisplay("{Name}")]
+[System.Diagnostics.DebuggerDisplay("RestMethodParameterInfo: {Name}")]
 public class RestMethodParameterInfo
 {
     public RestMethodParameterInfo(bool isObjectPropertyParameter, System.Reflection.ParameterInfo parameterInfo) { }
@@ -809,7 +809,7 @@ public enum UrlResolutionMode
     RefitLegacy = 0,
     Rfc3986 = 1,
 }
-[System.Diagnostics.DebuggerDisplay("{Content}")]
+[System.Diagnostics.DebuggerDisplay("ValidationApiException: {StatusCode}, Content = {Content}")]
 public class ValidationApiException : Refit.ApiException
 {
     public ValidationApiException(string message) { }

--- a/src/Refit/PublicAPI/net9.0/PublicAPI.txt
+++ b/src/Refit/PublicAPI/net9.0/PublicAPI.txt
@@ -55,7 +55,7 @@ public class ApiRequestException : Refit.ApiExceptionBase
     public ApiRequestException(string exceptionMessage, System.Net.Http.HttpRequestMessage message, System.Net.Http.HttpMethod httpMethod, Refit.RefitSettings refitSettings) { }
     public ApiRequestException(string exceptionMessage, System.Net.Http.HttpRequestMessage message, System.Net.Http.HttpMethod httpMethod, Refit.RefitSettings refitSettings, System.Exception? innerException) { }
 }
-[System.Diagnostics.DebuggerDisplay("{Content}")]
+[System.Diagnostics.DebuggerDisplay("ApiResponse: {StatusCode}, Content = {Content}")]
 public sealed class ApiResponse<T> : Refit.IApiResponse<T>
 {
     public ApiResponse(System.Net.Http.HttpResponseMessage response, T? content, Refit.RefitSettings settings) { }
@@ -123,7 +123,7 @@ public sealed class AuthorizeAttribute : System.Attribute
     public string Scheme { get; }
 }
 [System.AttributeUsage(System.AttributeTargets.Parameter)]
-[System.Diagnostics.DebuggerDisplay("{Buffered}")]
+[System.Diagnostics.DebuggerDisplay("Body: Buffered = {Buffered}")]
 public sealed class BodyAttribute : System.Attribute
 {
     public BodyAttribute() { }
@@ -479,7 +479,7 @@ public sealed class MultipartAttribute : System.Attribute
     public MultipartAttribute(string boundaryText = "----MyGreatBoundary") { }
     public string BoundaryText { get; }
 }
-[System.Diagnostics.DebuggerDisplay("{Name}")]
+[System.Diagnostics.DebuggerDisplay("MultipartItem: {Name}")]
 public abstract class MultipartItem
 {
     protected MultipartItem(string fileName, string? contentType) { }
@@ -544,7 +544,7 @@ public class ProblemDetails
     public string? Type { get; set; }
 }
 [System.AttributeUsage(System.AttributeTargets.Property | System.AttributeTargets.Parameter)]
-[System.Diagnostics.DebuggerDisplay("{Key}")]
+[System.Diagnostics.DebuggerDisplay("Property: {Key}")]
 public sealed class PropertyAttribute : System.Attribute
 {
     public PropertyAttribute() { }
@@ -595,7 +595,7 @@ public sealed class QueryUriFormatAttribute : System.Attribute
     public QueryUriFormatAttribute(System.UriFormat uriFormat) { }
     public System.UriFormat UriFormat { get; }
 }
-[System.Diagnostics.DebuggerDisplay("{AuthorizationHeaderValueGetter}")]
+[System.Diagnostics.DebuggerDisplay("RefitSettings: AuthorizationHeaderValueGetter = {AuthorizationHeaderValueGetter}")]
 public class RefitSettings
 {
     public RefitSettings() { }
@@ -684,7 +684,7 @@ public record RestMethodInfo : System.IEquatable<Refit.RestMethodInfo>
     public string RelativePath { get; init; }
     public System.Type ReturnType { get; init; }
 }
-[System.Diagnostics.DebuggerDisplay("{Name}")]
+[System.Diagnostics.DebuggerDisplay("RestMethodParameterInfo: {Name}")]
 public class RestMethodParameterInfo
 {
     public RestMethodParameterInfo(bool isObjectPropertyParameter, System.Reflection.ParameterInfo parameterInfo) { }
@@ -817,7 +817,7 @@ public enum UrlResolutionMode
     RefitLegacy = 0,
     Rfc3986 = 1,
 }
-[System.Diagnostics.DebuggerDisplay("{Content}")]
+[System.Diagnostics.DebuggerDisplay("ValidationApiException: {StatusCode}, Content = {Content}")]
 public class ValidationApiException : Refit.ApiException
 {
     public ValidationApiException(string message) { }

--- a/src/Refit/RefitSettings.cs
+++ b/src/Refit/RefitSettings.cs
@@ -9,7 +9,7 @@ using System.Text.Json;
 namespace Refit;
 
 /// <summary>Defines various parameters on how Refit should work.</summary>
-[System.Diagnostics.DebuggerDisplay("{AuthorizationHeaderValueGetter}")]
+[System.Diagnostics.DebuggerDisplay("RefitSettings: AuthorizationHeaderValueGetter = {AuthorizationHeaderValueGetter}")]
 [SuppressMessage(
     "Reliability",
     "SST2403:'this' escapes from a constructor before the object is fully built",

--- a/src/Refit/RestMethodParameterInfo.cs
+++ b/src/Refit/RestMethodParameterInfo.cs
@@ -6,7 +6,7 @@ using System.Reflection;
 namespace Refit;
 
 /// <summary>Describes a parameter of a REST method.</summary>
-[System.Diagnostics.DebuggerDisplay("{Name}")]
+[System.Diagnostics.DebuggerDisplay("RestMethodParameterInfo: {Name}")]
 public class RestMethodParameterInfo
 {
     /// <summary>Initializes a new instance of the <see cref="RestMethodParameterInfo"/> class with a name.</summary>

--- a/src/Refit/ValidationApiException.cs
+++ b/src/Refit/ValidationApiException.cs
@@ -10,7 +10,7 @@ using System.Text.Json;
 namespace Refit;
 
 /// <summary>An ApiException that is raised according to RFC 7807, which contains problem details for validation exceptions.</summary>
-[System.Diagnostics.DebuggerDisplay("{Content}")]
+[System.Diagnostics.DebuggerDisplay("ValidationApiException: {StatusCode}, Content = {Content}")]
 [SuppressMessage(
     "Design",
     "SST1488:Exception types should declare the standard constructors",

--- a/src/tests/Refit.Tests/DebuggerDisplayTests.cs
+++ b/src/tests/Refit.Tests/DebuggerDisplayTests.cs
@@ -1,0 +1,172 @@
+// Copyright (c) 2019-2026 ReactiveUI and Contributors. All rights reserved.
+// ReactiveUI and Contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+
+namespace Refit.Tests;
+
+/// <summary>
+/// Tests the <see cref="DebuggerDisplayAttribute"/> format strings the shipped types carry.
+/// <para>
+/// A display made of nothing but one member placeholder renders as a bare <c>null</c> the moment that member is null,
+/// which reads in the debugger as though the object itself does not exist. Anyone hovering a response that came back
+/// without content sees <c>null</c> and goes looking for a <see cref="NullReferenceException"/> that was never thrown.
+/// A display whose only placeholder can be null therefore has to carry literal text alongside it.
+/// </para>
+/// </summary>
+public class DebuggerDisplayTests
+{
+    /// <summary>The assemblies whose debugger displays a consumer sees.</summary>
+    private static readonly Assembly[] ShippedAssemblies =
+    [
+        typeof(RefitSettings).Assembly,
+        typeof(Refit.Testing.StubApiResponse<>).Assembly,
+        typeof(SettingsFor<>).Assembly,
+        typeof(XmlContentSerializer).Assembly,
+    ];
+
+    /// <summary>Verifies no display can render as a bare <c>null</c> with nothing to show an object is there.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    [RequiresUnreferencedCode("Walks the members a debugger display names, which trimming may remove.")]
+    public async Task NoDisplayCanRenderAsABareNull()
+    {
+        var offenders = new List<string>();
+
+        foreach (var (type, display) in DisplayedTypes())
+        {
+            if (SoleMemberPlaceholder(display) is not { } member)
+            {
+                continue;
+            }
+
+            if (ResolveMember(type, member) is { } resolved && CanBeNull(resolved))
+            {
+                offenders.Add($"{type.FullName} -> \"{display}\"");
+            }
+        }
+
+        await Assert.That(offenders.Order(StringComparer.Ordinal).ToArray()).IsEmpty();
+    }
+
+    /// <summary>Verifies every placeholder names a member that exists, so no display silently shows an evaluation error.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    [RequiresUnreferencedCode("Walks the members a debugger display names, which trimming may remove.")]
+    public async Task EveryMemberPlaceholderResolves()
+    {
+        var unresolved = new List<string>();
+
+        foreach (var (type, display) in DisplayedTypes())
+        {
+            foreach (var placeholder in Placeholders(display))
+            {
+                // Method-call placeholders such as ToString() are evaluated by the debugger, not looked up here.
+                if (placeholder.Contains('(', StringComparison.Ordinal) || ResolveMember(type, placeholder) is not null)
+                {
+                    continue;
+                }
+
+                unresolved.Add($"{type.FullName} -> \"{display}\" ({placeholder})");
+            }
+        }
+
+        await Assert.That(unresolved.Order(StringComparer.Ordinal).ToArray()).IsEmpty();
+    }
+
+    /// <summary>Enumerates every shipped type carrying a debugger display, with its format string.</summary>
+    /// <returns>The type and display pairs.</returns>
+    [RequiresUnreferencedCode("Enumerates shipped types, which trimming may remove.")]
+    private static IEnumerable<(Type Type, string Display)> DisplayedTypes()
+    {
+        foreach (var assembly in ShippedAssemblies)
+        {
+            foreach (var type in assembly.GetExportedTypes())
+            {
+                if (type.GetCustomAttribute<DebuggerDisplayAttribute>(inherit: false)?.Value is { } display)
+                {
+                    yield return (type, display);
+                }
+            }
+        }
+    }
+
+    /// <summary>Reads the expressions a display interpolates, stripping any format specifier.</summary>
+    /// <param name="display">The format string.</param>
+    /// <returns>The placeholder expressions, in order.</returns>
+    private static List<string> Placeholders(string display)
+    {
+        var found = new List<string>();
+        var open = display.IndexOf('{', StringComparison.Ordinal);
+
+        while (open >= 0)
+        {
+            var close = display.IndexOf('}', open);
+            if (close < 0)
+            {
+                break;
+            }
+
+            var expression = display[(open + 1)..close];
+            var comma = expression.IndexOf(',', StringComparison.Ordinal);
+            found.Add(comma < 0 ? expression : expression[..comma]);
+            open = display.IndexOf('{', close);
+        }
+
+        return found;
+    }
+
+    /// <summary>Reads the member a display names when the display is that placeholder and nothing else.</summary>
+    /// <param name="display">The format string.</param>
+    /// <returns>The member name, or <see langword="null"/> when the display carries literal text or calls a method.</returns>
+    private static string? SoleMemberPlaceholder(string display)
+    {
+        var placeholders = Placeholders(display);
+        if (placeholders.Count != 1 || placeholders[0].Contains('(', StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        // Literal text either side of the placeholder is what keeps a null value legible, so a display that has any
+        // is already safe.
+        return display.StartsWith('{') && display.EndsWith('}') ? placeholders[0] : null;
+    }
+
+    /// <summary>Resolves a placeholder to the property or field it names.</summary>
+    /// <param name="type">The type carrying the display.</param>
+    /// <param name="name">The member name.</param>
+    /// <returns>The member, or <see langword="null"/> when the type exposes none by that name.</returns>
+    [RequiresUnreferencedCode("Looks up a member by name, which trimming may remove.")]
+    private static MemberInfo? ResolveMember(Type type, string name)
+    {
+        const BindingFlags Flags =
+            BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly;
+
+        // Walked most-derived first, because a derived member shadowing a base one is what the debugger evaluates and
+        // a flattened lookup cannot tell the two apart.
+        for (var current = type; current is not null; current = current.BaseType)
+        {
+            if (((MemberInfo?)current.GetProperty(name, Flags) ?? current.GetField(name, Flags)) is { } member)
+            {
+                return member;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>Determines whether a member's value can be null.</summary>
+    /// <param name="member">The property or field a display names.</param>
+    /// <returns><see langword="true"/> when the member is a nullable value type or a nullable-annotated reference type.</returns>
+    private static bool CanBeNull(MemberInfo member)
+    {
+        var context = new NullabilityInfoContext();
+        var info = member is PropertyInfo property ? context.Create(property) : context.Create((FieldInfo)member);
+
+        return Nullable.GetUnderlyingType(info.Type) is not null
+            || info.ReadState == NullabilityState.Nullable
+            || (!info.Type.IsValueType && info.ReadState == NullabilityState.Unknown);
+    }
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the new behavior?

**A debugger display always shows that an object is there, whatever its members hold.**

- **`ApiResponse<T>` leads with the type and the status code.** Hovering a response that came back without content now reads `ApiResponse: NotFound, Content = null` instead of a bare `null`.
- **Ten other shipped types carried the same shape and are fixed with it** - `ValidationApiException`, `StubApiResponse<T>`, `RefitSettings`, `BodyAttribute`, `MultipartItem`, `PropertyAttribute`, `RestMethodParameterInfo`, `SettingsFor<T>`, `RouteMatcher` and `XmlContentSerializerSettings`. Each keeps the member it showed and gains the literal text that makes a null value legible.
- **`DebuggerDisplayTests` keeps it that way.** It walks the shipped assemblies and fails any display whose sole placeholder can be null, and any placeholder naming a member that does not exist. The offender list in this PR is what that test reported, not a hand-picked set.

## What is the current behavior?

**A display made of nothing but one member renders as a bare `null` when that member is null.**

- `ApiResponse<T>` carried `[DebuggerDisplay("{Content}")]`, so a response with no content - a request error, or a 204 - showed as `null` in the debugger. It reads as though the response object itself does not exist, and sends the reader looking for a `NullReferenceException` that was never thrown.

Closes #2313

## What might this PR break?

**None at runtime.**

- Debugger displays have no effect outside a debugging session.
- The public API baselines record `[DebuggerDisplay]`, so the format-string changes show up as baseline diffs across every target. That is the analyzer recording an attribute argument, not a change to any callable surface.

## Checklist
- [x] I have read the [Contribute guide](https://www.reactiveui.net/contribute/index.html)
- [x] Tests have been added or updated (for bug fixes / features)
- [ ] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the `main` branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional information

The reporter suggested prefixing the display, for example `ApiResponse:{Content}`. This goes slightly further for the response and exception types by also showing the status code, which is the state worth seeing precisely when the content is missing.

`{ToString(),nq}` displays are left alone - those types override `ToString()`, and that is the idiomatic form rather than the shape that caused the report.

Hand-authored file worth reviewing: `DebuggerDisplayTests.cs`. Everything else is a one-line attribute change or regenerated baseline output.
